### PR TITLE
feat(sinks): forward PromptSubmitted events to oh-my-prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +586,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +680,17 @@ checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
  "objc2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -932,8 +971,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -943,9 +984,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -959,6 +1002,25 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1060,6 +1122,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1068,6 +1131,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1076,13 +1156,103 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -1096,6 +1266,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -1129,6 +1320,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1175,6 +1382,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1239,6 +1448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1482,12 @@ checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac-notification-sys"
@@ -1359,6 +1580,7 @@ dependencies = [
  "futures",
  "http-body-util",
  "notify-rust",
+ "reqwest",
  "rust-embed",
  "serde",
  "serde_json",
@@ -1373,6 +1595,9 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
+ "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -1477,6 +1702,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1679,7 +1914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1742,10 +1977,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1785,6 +2038,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,7 +2119,27 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1819,6 +2147,15 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "ratatui"
@@ -1955,6 +2292,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,6 +2378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,6 +2403,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2215,6 +2645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,6 +2735,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tauri-winrt-notification"
@@ -2471,6 +2921,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,6 +2970,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2617,9 +3102,12 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
+ "futures-util",
  "http",
  "http-body",
+ "iri-string",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2700,6 +3188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,6 +3252,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,6 +3326,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,6 +3369,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2908,6 +3445,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3127,7 +3693,25 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -3145,13 +3729,46 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3179,10 +3796,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3191,10 +3832,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3203,16 +3880,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -3230,6 +3943,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -3327,6 +4063,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zbus"
 version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3385,6 +4150,86 @@ dependencies = [
  "serde",
  "winnow 0.7.15",
  "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ tower-http = { version = "0.6", features = ["trace"] }
 futures = "0.3"
 tokio-stream = { version = "0.1", features = ["sync"] }
 rust-embed = "8"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+url = "2"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ via that agent's own hook / event-emission system.
 | **Live TUI**             | `muxa watch` — agents on top, every other tmux pane below, 2 Hz, configurable columns. |
 | **Web dashboard**        | Opt-in HTTP UI + SSE — every agent and **every tmux pane on the box**, in one tab. See [`docs/DASHBOARD.md`](docs/DASHBOARD.md). |
 | **Desktop alerts**       | Opt-in libnotify / native-toast pings on `WaitingInput` / `Error` transitions.   |
+| **External sinks**       | Opt-in fan-out — today: forward prompts to [oh-my-prompt](https://github.com/jiunbae/oh-my-prompt). See [`docs/SINKS.md`](docs/SINKS.md). |
 | **Safe by default**      | Socket is `0600`; dashboard is loopback-only until you flip two flags; `SIGTERM` drains; `unsafe_code = forbid`. |
 | **Versioned protocol**   | Explicit `PROTOCOL_VERSION`; mismatched clients are rejected.                    |
 | **Fast**                 | In-memory registry; no database, no external services.                           |

--- a/config.example.toml
+++ b/config.example.toml
@@ -66,3 +66,28 @@
 # token         = "<paste 32+ random hex bytes here>"
 # allow_public  = false
 # pane_cache_ttl_ms = 2000
+
+# External sinks. Default off — none of these forward data anywhere
+# unless you explicitly opt in.
+#
+# [sinks.oh_my_prompt] forwards every PromptSubmitted event to an
+# oh-my-prompt (omp) instance via its HTTP ingestion endpoint
+# (POST /api/sync/upload). The X-User-Token UUID lives in an env var
+# (default OMP_SERVER_TOKEN) — never in this file. The endpoint must be
+# explicitly set; there is no default to keep "send your data to a
+# stranger's server" out of the footgun zone.
+#
+# What gets sent: prompt text, char/word/token counts, agent kind,
+# session id, working directory + project basename (when known),
+# model (when known), and a deterministic event_id derived from
+# session id + timestamp so retries dedup cleanly.
+#
+# See docs/SINKS.md for setup, troubleshooting, and an exhaustive
+# field-by-field mapping.
+[sinks.oh_my_prompt]
+# enabled            = true
+# endpoint           = "https://prompt.example.dev"
+# token_env          = "OMP_SERVER_TOKEN"
+# device_id          = "laptop-01"
+# batch_size         = 50
+# flush_interval_ms  = 5000

--- a/crates/muxa/Cargo.toml
+++ b/crates/muxa/Cargo.toml
@@ -24,13 +24,17 @@ tower-http = { workspace = true }
 futures = { workspace = true }
 tokio-stream = { workspace = true }
 rust-embed = { workspace = true }
+reqwest = { workspace = true }
+url = { workspace = true }
 notify-rust = "4"
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "test-util"] }
 tempfile = "3"
 tower = { workspace = true, features = ["util"] }
 http-body-util = "0.1"
+wiremock = "0.6"
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -18,6 +18,41 @@ pub struct Config {
     pub watch: WatchConfig,
     pub dashboard: DashboardTomlConfig,
     pub discovery: DiscoveryConfig,
+    pub sinks: SinksConfig,
+}
+
+/// `[sinks]` config — opt-in fan-out to external systems.
+///
+/// Each sub-table corresponds to one sink implementation. All sinks are
+/// off by default; a missing table is equivalent to one with
+/// `enabled = false`. Resolution to runtime sink instances happens in the
+/// daemon, not here — this struct only holds raw TOML.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SinksConfig {
+    pub oh_my_prompt: OhMyPromptToml,
+}
+
+/// `[sinks.oh_my_prompt]` raw TOML schema. The daemon resolves these
+/// fields against env vars + defaults via `OhMyPromptSink::resolve` at
+/// startup.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct OhMyPromptToml {
+    pub enabled: Option<bool>,
+    /// Base URL of the omp ingestion endpoint, e.g. `https://prompt.example`.
+    /// `enabled = true` with no endpoint is a config error — there is no
+    /// default endpoint by design.
+    pub endpoint: Option<String>,
+    /// Name of the env var holding the X-User-Token UUID. Defaults to
+    /// `OMP_SERVER_TOKEN`. The token never lives in TOML.
+    pub token_env: Option<String>,
+    /// Optional device identifier echoed in the upload payload.
+    pub device_id: Option<String>,
+    /// Records per HTTP batch. Defaults to 50.
+    pub batch_size: Option<usize>,
+    /// Time-based flush interval (ms). Defaults to 5000.
+    pub flush_interval_ms: Option<u64>,
 }
 
 /// `[dashboard]` config — the user-facing TOML schema for the dashboard

--- a/crates/muxa/src/lib.rs
+++ b/crates/muxa/src/lib.rs
@@ -13,6 +13,7 @@ pub mod event;
 pub mod ipc;
 pub mod notify;
 pub mod paths;
+pub mod sinks;
 pub mod state;
 pub mod tmux;
 
@@ -20,4 +21,4 @@ pub use config::Config;
 pub use discovery::{run_discovery, scan_panes, Discovered, DiscoveryReport};
 pub use error::{CoreError, Result};
 pub use event::{AgentEvent, AgentId, AgentKind, AgentState, NotificationLevel, PROTOCOL_VERSION};
-pub use state::{Agent, SharedStore, Store, Transition};
+pub use state::{Agent, PromptRecord, SharedStore, Store, Transition};

--- a/crates/muxa/src/sinks/mod.rs
+++ b/crates/muxa/src/sinks/mod.rs
@@ -1,0 +1,21 @@
+//! External event sinks.
+//!
+//! A sink consumes the daemon's in-process broadcasts (today: prompts;
+//! later: transitions, heartbeats) and forwards them to a long-lived
+//! external system. Sinks are **always opt-in** — the daemon spawns one
+//! task per enabled sink at startup and joins them on the shared
+//! shutdown broadcast.
+//!
+//! ## Layout
+//!
+//! - [`ohmyprompt`] — HTTP POST to `oh-my-prompt`'s `/api/sync/upload`
+//!   endpoint with batching, retries, and a bounded ring-buffer.
+//!
+//! Each sink owns its own runtime contract (wire schema, auth header
+//! shape, retry policy) — there is intentionally no `Sink` trait in v1
+//! because the only consumer (`muxad`) calls each impl by name and the
+//! shapes diverge enough that a uniform interface would be premature.
+
+pub mod ohmyprompt;
+
+pub use ohmyprompt::{OhMyPromptError, OhMyPromptSink};

--- a/crates/muxa/src/sinks/ohmyprompt.rs
+++ b/crates/muxa/src/sinks/ohmyprompt.rs
@@ -1,0 +1,744 @@
+//! `oh-my-prompt` HTTP sink.
+//!
+//! Forwards every `PromptSubmitted` event the store broadcasts to omp's
+//! `/api/sync/upload` ingestion endpoint. Batches records up to a
+//! configurable size or time threshold, retries 5xx with exponential
+//! backoff, honors `Retry-After` on 429, and drops 4xx without retry
+//! (the schema is wrong; retrying won't fix it).
+//!
+//! ## Wire contract
+//!
+//! - `POST {endpoint}/api/sync/upload`
+//! - Header `X-User-Token: <UUID>` (NOT `Authorization`)
+//! - Body `{ records: [...], deviceId?: string }`
+//!
+//! ## Mapping
+//!
+//! Only `PromptSubmitted` becomes a record. `event_id` is deterministic
+//! (`muxa-{session_id}-{at_unix_ms}`) so retries dedup server-side.
+//! `AgentKind::Unknown` records are dropped — there is no canonical
+//! `source` mapping for them. See the brief in
+//! `feature/omp-sink` for the locked field-by-field decisions.
+//!
+//! ## Failure model
+//!
+//! A bounded ring buffer (1000 records) drops the oldest records on
+//! overflow with a WARN log — the daemon must never block ingest
+//! because a remote ingest endpoint is slow. After
+//! [`MAX_RETRY_ATTEMPTS`] failed attempts a batch is dropped.
+
+use crate::config::OhMyPromptToml;
+use crate::event::AgentKind;
+use crate::state::PromptRecord;
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Duration;
+use time::OffsetDateTime;
+use tokio::sync::{broadcast, Mutex};
+
+/// Default env var holding the omp `X-User-Token` UUID. Configurable via
+/// `[sinks.oh_my_prompt] token_env = "..."`. The token never lives in
+/// TOML — only the env-var *name* does.
+pub const DEFAULT_TOKEN_ENV: &str = "OMP_SERVER_TOKEN";
+
+/// Default batch size: how many records to accumulate before flushing.
+pub const DEFAULT_BATCH_SIZE: usize = 50;
+
+/// Default flush interval. Records are sent on whichever boundary
+/// (size or time) hits first.
+pub const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Hard cap on the in-memory ring buffer. Hitting this means upstream
+/// is unreachable AND prompts are arriving faster than retries clear
+/// the queue — drop oldest with a WARN.
+pub const RING_BUFFER_CAPACITY: usize = 1000;
+
+/// Maximum HTTP retry attempts per batch before giving up.
+pub const MAX_RETRY_ATTEMPTS: usize = 6;
+
+/// Hard cap on `Retry-After` we honor — past this we fall back to our
+/// own backoff curve to avoid a misconfigured server pinning the sink.
+const RETRY_AFTER_CAP: Duration = Duration::from_secs(60);
+
+/// HTTP request timeout per attempt. Picked liberal enough for slow
+/// home-network round-trips but tight enough that a black-holed peer
+/// doesn't stall the whole sink task.
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Debug, thiserror::Error)]
+pub enum OhMyPromptError {
+    #[error("oh-my-prompt sink is enabled but [sinks.oh_my_prompt].endpoint is not set")]
+    MissingEndpoint,
+
+    #[error(
+        "oh-my-prompt sink is enabled but env var {var} is empty/unset \
+         (set X-User-Token UUID there, or override via token_env)"
+    )]
+    MissingToken { var: String },
+
+    #[error("invalid endpoint URL {url:?}: {source}")]
+    InvalidEndpoint {
+        url: String,
+        #[source]
+        source: url::ParseError,
+    },
+
+    #[error("reqwest client init failed: {0}")]
+    ReqwestInit(#[source] reqwest::Error),
+}
+
+/// One upload record — mirrors omp's Zod schema. Optional fields are
+/// `skip_serializing_if = "Option::is_none"` so missing data is omitted
+/// from the JSON instead of being sent as `null` (omp's parser is more
+/// forgiving with missing keys than null values).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UploadRecord {
+    pub event_id: String,
+    pub created_at: String,
+    pub prompt_text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_text: Option<String>,
+    pub prompt_length: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_length: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cli_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cli_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_estimate: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub word_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_hash: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct UploadBody<'a> {
+    records: &'a [UploadRecord],
+    #[serde(rename = "deviceId", skip_serializing_if = "Option::is_none")]
+    device_id: Option<&'a str>,
+}
+
+/// Resolved oh-my-prompt sink configuration + the long-lived
+/// [`reqwest::Client`].
+#[derive(Debug)]
+pub struct OhMyPromptSink {
+    upload_url: String,
+    token: String,
+    device_id: Option<String>,
+    batch_size: usize,
+    flush_interval: Duration,
+    client: reqwest::Client,
+}
+
+impl OhMyPromptSink {
+    /// Resolve the TOML sub-table into a runtime sink, or `Ok(None)` if
+    /// the sink is disabled. Errors when `enabled = true` but required
+    /// fields (`endpoint`, token env var) are missing or empty.
+    pub fn resolve(toml: &OhMyPromptToml) -> Result<Option<Self>, OhMyPromptError> {
+        if !toml.enabled.unwrap_or(false) {
+            return Ok(None);
+        }
+
+        let endpoint = toml
+            .endpoint
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .ok_or(OhMyPromptError::MissingEndpoint)?;
+
+        // Validate the endpoint up front so a typo surfaces at startup
+        // rather than on the first prompt.
+        let parsed =
+            url::Url::parse(endpoint).map_err(|source| OhMyPromptError::InvalidEndpoint {
+                url: endpoint.to_string(),
+                source,
+            })?;
+        let upload_url = build_upload_url(&parsed);
+
+        let token_var = toml
+            .token_env
+            .as_deref()
+            .unwrap_or(DEFAULT_TOKEN_ENV)
+            .to_string();
+        let token = std::env::var(&token_var)
+            .ok()
+            .filter(|s| !s.is_empty())
+            .ok_or(OhMyPromptError::MissingToken { var: token_var })?;
+
+        let client = reqwest::Client::builder()
+            .timeout(HTTP_REQUEST_TIMEOUT)
+            .build()
+            .map_err(OhMyPromptError::ReqwestInit)?;
+
+        Ok(Some(Self {
+            upload_url,
+            token,
+            device_id: toml.device_id.clone(),
+            batch_size: toml.batch_size.unwrap_or(DEFAULT_BATCH_SIZE).max(1),
+            flush_interval: toml
+                .flush_interval_ms
+                .map_or(DEFAULT_FLUSH_INTERVAL, Duration::from_millis),
+            client,
+        }))
+    }
+
+    /// Run the sink loop until the shutdown channel fires or the prompt
+    /// broadcast is closed.
+    ///
+    /// Architecturally this spawns *two* tasks behind the scenes — an
+    /// ingest loop that pulls from the broadcast and pushes into a
+    /// bounded ring buffer (drop-oldest on overflow) and a flush loop
+    /// that drains the ring on size/time triggers and POSTs. Splitting
+    /// the two means a slow remote HTTP endpoint never blocks ingest
+    /// — the ring buffer is the single backpressure surface.
+    pub async fn run(
+        self,
+        prompt_rx: broadcast::Receiver<PromptRecord>,
+        mut shutdown_rx: broadcast::Receiver<()>,
+    ) -> Result<(), OhMyPromptError> {
+        let buffer: Arc<Mutex<VecDeque<UploadRecord>>> =
+            Arc::new(Mutex::new(VecDeque::with_capacity(self.batch_size)));
+
+        // Notify the flusher that the buffer crossed the size
+        // threshold (or that shutdown is in progress and any leftover
+        // records should be drained promptly).
+        let (kick_tx, kick_rx) = tokio::sync::mpsc::channel::<KickReason>(8);
+
+        let ingest = tokio::spawn(ingest_loop(
+            prompt_rx,
+            buffer.clone(),
+            kick_tx.clone(),
+            self.batch_size,
+        ));
+
+        // Borrow `self` into the flusher via Arc so the ingest task can
+        // run independently. The flusher handles its own shutdown via
+        // the shared shutdown broadcast.
+        let this = Arc::new(self);
+        let flusher_shutdown = shutdown_rx.resubscribe();
+        let flusher = tokio::spawn(flush_loop(
+            this.clone(),
+            buffer.clone(),
+            kick_rx,
+            flusher_shutdown,
+        ));
+
+        // Wait for shutdown, then stop both subtasks. Aborting is
+        // safe here — the broadcast channel is the source of truth
+        // and any in-flight HTTP request loses an at-most-best-effort
+        // batch. Matches the notifier task shape: shutdown is fast,
+        // not graceful.
+        let _ = shutdown_rx.recv().await;
+        drop(kick_tx);
+        ingest.abort();
+        flusher.abort();
+        let _ = ingest.await;
+        let _ = flusher.await;
+        Ok(())
+    }
+
+    /// Pop up to `batch_size` records and POST them. Errors are
+    /// swallowed (logged) — the run loop never exits because of a bad
+    /// HTTP response.
+    async fn flush_some(&self, buffer: &Mutex<VecDeque<UploadRecord>>) {
+        let batch = take_up_to(buffer, self.batch_size).await;
+        if batch.is_empty() {
+            return;
+        }
+        let count = batch.len();
+        if let Err(e) = self.post_batch_with_retry(&batch).await {
+            tracing::warn!(
+                error = %e,
+                count,
+                "oh-my-prompt: dropped batch after retries exhausted"
+            );
+        }
+    }
+
+    /// HTTP send with retry/backoff. See the module docs for the
+    /// poison/retry matrix.
+    async fn post_batch_with_retry(&self, batch: &[UploadRecord]) -> Result<(), reqwest::Error> {
+        let body = UploadBody {
+            records: batch,
+            device_id: self.device_id.as_deref(),
+        };
+
+        for attempt in 0..MAX_RETRY_ATTEMPTS {
+            let response = self
+                .client
+                .post(&self.upload_url)
+                .header("X-User-Token", &self.token)
+                .json(&body)
+                .send()
+                .await;
+
+            match response {
+                Ok(resp) => {
+                    let status = resp.status();
+                    if status.is_success() {
+                        if status.as_u16() == 207 {
+                            // 207 partial — log the rejected entries
+                            // for visibility and treat the batch as
+                            // accepted (do NOT retry).
+                            let detail = resp.text().await.unwrap_or_default();
+                            tracing::warn!(detail = %detail, "oh-my-prompt: partial 207 response");
+                        }
+                        return Ok(());
+                    }
+
+                    if status.as_u16() == 429 {
+                        let wait = retry_after(&resp).unwrap_or_else(|| backoff(attempt));
+                        let body_text = resp.text().await.unwrap_or_default();
+                        tracing::warn!(
+                            wait_ms = u64::try_from(wait.as_millis()).unwrap_or(u64::MAX),
+                            detail = %body_text,
+                            "oh-my-prompt: 429 rate-limited; honoring Retry-After"
+                        );
+                        tokio::time::sleep(wait).await;
+                        continue;
+                    }
+
+                    if status.is_client_error() {
+                        // 4xx other than 429 = poison. Don't retry.
+                        let body_text = resp.text().await.unwrap_or_default();
+                        tracing::warn!(
+                            status = status.as_u16(),
+                            detail = %body_text,
+                            "oh-my-prompt: 4xx client error; dropping batch"
+                        );
+                        return Ok(());
+                    }
+
+                    // 5xx — retryable.
+                    let body_text = resp.text().await.unwrap_or_default();
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        status = status.as_u16(),
+                        detail = %body_text,
+                        "oh-my-prompt: 5xx; retrying"
+                    );
+                    tokio::time::sleep(backoff(attempt)).await;
+                }
+                Err(e) => {
+                    // Network / timeout. Retry.
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        error = %e,
+                        "oh-my-prompt: transport error; retrying"
+                    );
+                    tokio::time::sleep(backoff(attempt)).await;
+                }
+            }
+        }
+
+        // Manufacture an error with no underlying transport detail —
+        // we've already logged each attempt.
+        tracing::error!(
+            attempts = MAX_RETRY_ATTEMPTS,
+            "oh-my-prompt: exhausted retries; batch dropped"
+        );
+        Ok(())
+    }
+}
+
+/// Reason the flusher woke up. Today the only meaningful distinction
+/// is "buffer crossed the batch threshold"; we keep this as an enum so
+/// future kicks (e.g. shutdown-drain hint) plug in without a wire-format
+/// rewrite.
+#[derive(Debug, Clone, Copy)]
+enum KickReason {
+    BatchReady,
+}
+
+/// Pull `PromptRecord`s off the broadcast forever, convert them into
+/// `UploadRecord`s, and push them into the bounded ring. Sends a
+/// `BatchReady` kick whenever the buffer crosses `batch_size` so the
+/// flusher wakes up promptly. Exits when the broadcast closes.
+async fn ingest_loop(
+    mut prompt_rx: broadcast::Receiver<PromptRecord>,
+    buffer: Arc<Mutex<VecDeque<UploadRecord>>>,
+    kick_tx: tokio::sync::mpsc::Sender<KickReason>,
+    batch_size: usize,
+) {
+    loop {
+        match prompt_rx.recv().await {
+            Ok(record) => {
+                let Some(upload) = prompt_to_record(&record) else {
+                    continue;
+                };
+                let len = push_with_overflow(&buffer, upload).await;
+                if len >= batch_size {
+                    // Channel full = a kick is already pending; it's
+                    // fine to skip rather than block.
+                    let _ = kick_tx.try_send(KickReason::BatchReady);
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                tracing::warn!(
+                    missed = n,
+                    "oh-my-prompt sink lagged behind prompt stream; continuing"
+                );
+            }
+            Err(broadcast::error::RecvError::Closed) => {
+                tracing::debug!("prompt broadcast closed; ingest loop exiting");
+                return;
+            }
+        }
+    }
+}
+
+/// Drain the buffer on size kicks, time ticks, or shutdown.
+async fn flush_loop(
+    sink: Arc<OhMyPromptSink>,
+    buffer: Arc<Mutex<VecDeque<UploadRecord>>>,
+    mut kick_rx: tokio::sync::mpsc::Receiver<KickReason>,
+    mut shutdown_rx: broadcast::Receiver<()>,
+) {
+    let mut ticker = tokio::time::interval(sink.flush_interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // Skip the immediate first tick so we don't flush an empty buffer
+    // before any prompts arrive.
+    ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown_rx.recv() => {
+                // Match the notifier task's shutdown shape: just exit.
+                // We deliberately do *not* drain-with-retries here —
+                // doing so on an unreachable endpoint can stall daemon
+                // shutdown for minutes. Buffered records that haven't
+                // yet flushed are lost; the sink is best-effort.
+                tracing::debug!("oh-my-prompt sink received shutdown");
+                return;
+            }
+            maybe = kick_rx.recv() => {
+                match maybe {
+                    Some(KickReason::BatchReady) => {
+                        sink.flush_some(&buffer).await;
+                    }
+                    None => {
+                        // Ingest task gone — flush remaining and exit.
+                        sink.flush_some(&buffer).await;
+                        return;
+                    }
+                }
+            }
+            _ = ticker.tick() => {
+                sink.flush_some(&buffer).await;
+            }
+        }
+    }
+}
+
+/// Combine the user-supplied base URL with the omp upload path. We
+/// preserve any path prefix the user set (so a reverse-proxied
+/// `https://example.com/omp/` works).
+fn build_upload_url(parsed: &url::Url) -> String {
+    let trimmed = parsed.as_str().trim_end_matches('/');
+    format!("{trimmed}/api/sync/upload")
+}
+
+/// Push a record into the ring buffer. If the buffer is at capacity
+/// the oldest record is dropped with a WARN log. Returns the resulting
+/// buffer length so the caller can decide whether to flush.
+async fn push_with_overflow(buffer: &Mutex<VecDeque<UploadRecord>>, record: UploadRecord) -> usize {
+    let mut guard = buffer.lock().await;
+    if guard.len() >= RING_BUFFER_CAPACITY {
+        let dropped = guard.pop_front();
+        if let Some(d) = dropped {
+            tracing::warn!(
+                event_id = %d.event_id,
+                "oh-my-prompt ring buffer full; dropped oldest record"
+            );
+        }
+    }
+    guard.push_back(record);
+    guard.len()
+}
+
+async fn take_up_to(buffer: &Mutex<VecDeque<UploadRecord>>, max: usize) -> Vec<UploadRecord> {
+    let mut guard = buffer.lock().await;
+    let take = guard.len().min(max);
+    guard.drain(..take).collect()
+}
+
+/// Exponential backoff: 500ms, 1s, 2s, 4s, 8s, 16s.
+fn backoff(attempt: usize) -> Duration {
+    let base = Duration::from_millis(500);
+    // 2^attempt is fine for attempts in 0..6 (max 32). Use checked
+    // shifts to keep clippy quiet for higher hypothetical values.
+    let mult = 1u32 << u32::try_from(attempt).unwrap_or(0).min(6);
+    base.saturating_mul(mult)
+}
+
+/// Parse `Retry-After` (seconds form) and clamp at [`RETRY_AFTER_CAP`].
+fn retry_after(resp: &reqwest::Response) -> Option<Duration> {
+    let header = resp.headers().get(reqwest::header::RETRY_AFTER)?;
+    let s = header.to_str().ok()?;
+    let secs: u64 = s.trim().parse().ok()?;
+    Some(Duration::from_secs(secs).min(RETRY_AFTER_CAP))
+}
+
+/// Map an `AgentKind` to the omp `source` string. `Unknown` returns
+/// `None` so the caller drops the record (no canonical mapping).
+pub fn agent_kind_to_source(kind: AgentKind) -> Option<&'static str> {
+    match kind {
+        AgentKind::ClaudeCode => Some("claude-code"),
+        AgentKind::Codex => Some("codex"),
+        AgentKind::GeminiCli => Some("gemini"),
+        AgentKind::Opencode => Some("opencode"),
+        AgentKind::Unknown => None,
+    }
+}
+
+/// Map an `AgentKind` to the omp `cli_name` string.
+pub fn agent_kind_to_cli_name(kind: AgentKind) -> Option<&'static str> {
+    match kind {
+        AgentKind::ClaudeCode => Some("claude"),
+        AgentKind::Codex => Some("codex"),
+        AgentKind::GeminiCli => Some("gemini"),
+        AgentKind::Opencode => Some("opencode"),
+        AgentKind::Unknown => None,
+    }
+}
+
+/// Deterministic event id. omp's server sanitizes non-`[A-Za-z0-9_-]`
+/// — we use `-` separators so a session id like `abc-123` round-trips
+/// cleanly. Same `(session_id, at)` always yields the same id, so
+/// retries dedup server-side.
+pub fn event_id(session_id: &str, at: OffsetDateTime) -> String {
+    let unix_ms = at.unix_timestamp_nanos() / 1_000_000;
+    format!("muxa-{session_id}-{unix_ms}")
+}
+
+/// Convert one `PromptRecord` into the omp wire shape, or `None` if
+/// the agent kind has no mapping (currently only `Unknown`).
+pub fn prompt_to_record(rec: &PromptRecord) -> Option<UploadRecord> {
+    let source = agent_kind_to_source(rec.id.kind)?;
+    let cli_name = agent_kind_to_cli_name(rec.id.kind);
+
+    let prompt_length = rec.prompt.chars().count();
+    let word_count = rec.prompt.split_whitespace().count();
+    let token_estimate = prompt_length / 4;
+
+    let cwd = rec.id.cwd.clone();
+    let project = cwd.as_deref().and_then(|p| {
+        std::path::Path::new(p)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(str::to_string)
+    });
+
+    let created_at = rec
+        .at
+        .format(&time::format_description::well_known::Rfc3339)
+        .ok()?;
+
+    Some(UploadRecord {
+        event_id: event_id(&rec.id.session_id, rec.at),
+        created_at,
+        prompt_text: rec.prompt.clone(),
+        response_text: None,
+        prompt_length,
+        response_length: None,
+        project,
+        cwd,
+        source: Some(source.to_string()),
+        session_id: Some(rec.id.session_id.clone()),
+        role: Some("user".to_string()),
+        model: rec.model.clone(),
+        cli_name: cli_name.map(str::to_string),
+        cli_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        token_estimate: Some(token_estimate),
+        word_count: Some(word_count),
+        content_hash: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::{AgentId, AgentKind};
+    use time::macros::datetime;
+
+    fn rec(kind: AgentKind, prompt: &str, cwd: Option<&str>, model: Option<&str>) -> PromptRecord {
+        PromptRecord {
+            id: AgentId {
+                kind,
+                session_id: "sess-1".into(),
+                pane: Some("%1".into()),
+                cwd: cwd.map(str::to_string),
+            },
+            prompt: prompt.into(),
+            at: datetime!(2026-04-26 12:00:00 UTC),
+            model: model.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn event_id_is_deterministic() {
+        let at = datetime!(2026-04-26 12:00:00 UTC);
+        let a = event_id("sess-1", at);
+        let b = event_id("sess-1", at);
+        assert_eq!(a, b);
+
+        let c = event_id("sess-2", at);
+        assert_ne!(a, c, "different session must yield a different id");
+
+        let d = event_id("sess-1", at + time::Duration::milliseconds(1));
+        assert_ne!(a, d, "different timestamp must yield a different id");
+    }
+
+    #[test]
+    fn event_id_separator_avoids_colons() {
+        let at = datetime!(2026-04-26 12:00:00 UTC);
+        let id = event_id("sess-1", at);
+        assert!(!id.contains(':'), "event_id {id:?} contains a colon");
+        assert!(id.starts_with("muxa-"));
+    }
+
+    #[test]
+    fn agent_kind_maps_to_source_string() {
+        assert_eq!(
+            agent_kind_to_source(AgentKind::ClaudeCode),
+            Some("claude-code")
+        );
+        assert_eq!(agent_kind_to_source(AgentKind::Codex), Some("codex"));
+        assert_eq!(agent_kind_to_source(AgentKind::GeminiCli), Some("gemini"));
+        assert_eq!(agent_kind_to_source(AgentKind::Opencode), Some("opencode"));
+        assert_eq!(agent_kind_to_source(AgentKind::Unknown), None);
+    }
+
+    #[test]
+    fn unknown_agent_kind_skips_record() {
+        let r = rec(AgentKind::Unknown, "hi", None, None);
+        assert!(prompt_to_record(&r).is_none());
+    }
+
+    #[test]
+    fn prompt_to_record_fills_required_fields() {
+        let r = rec(AgentKind::ClaudeCode, "hello world", None, None);
+        let u = prompt_to_record(&r).expect("record produced");
+        assert!(!u.event_id.is_empty());
+        assert!(!u.created_at.is_empty());
+        assert_eq!(u.prompt_text, "hello world");
+        assert_eq!(u.prompt_length, 11);
+        assert_eq!(u.source.as_deref(), Some("claude-code"));
+        assert_eq!(u.cli_name.as_deref(), Some("claude"));
+        assert_eq!(u.cli_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(u.role.as_deref(), Some("user"));
+        assert_eq!(u.session_id.as_deref(), Some("sess-1"));
+        assert_eq!(u.word_count, Some(2));
+        assert_eq!(u.token_estimate, Some(11 / 4));
+    }
+
+    #[test]
+    fn prompt_to_record_drops_optional_fields_when_unknown() {
+        let r = rec(AgentKind::ClaudeCode, "hi", None, None);
+        let u = prompt_to_record(&r).unwrap();
+        assert!(u.cwd.is_none());
+        assert!(u.project.is_none());
+        assert!(u.model.is_none());
+        // Round-trip JSON to confirm the keys are absent (not null).
+        let v = serde_json::to_value(&u).unwrap();
+        let obj = v.as_object().unwrap();
+        assert!(!obj.contains_key("cwd"));
+        assert!(!obj.contains_key("project"));
+        assert!(!obj.contains_key("model"));
+        assert!(!obj.contains_key("response_text"));
+        assert!(!obj.contains_key("content_hash"));
+    }
+
+    #[test]
+    fn prompt_to_record_uses_cwd_basename_for_project() {
+        let r = rec(AgentKind::ClaudeCode, "hi", Some("/home/u/work/muxa"), None);
+        let u = prompt_to_record(&r).unwrap();
+        assert_eq!(u.cwd.as_deref(), Some("/home/u/work/muxa"));
+        assert_eq!(u.project.as_deref(), Some("muxa"));
+    }
+
+    #[test]
+    fn prompt_length_is_char_count_not_bytes() {
+        let r = rec(AgentKind::ClaudeCode, "héllo", None, None);
+        let u = prompt_to_record(&r).unwrap();
+        assert_eq!(u.prompt_length, 5);
+    }
+
+    #[test]
+    fn backoff_grows_exponentially_then_caps() {
+        assert_eq!(backoff(0), Duration::from_millis(500));
+        assert_eq!(backoff(1), Duration::from_secs(1));
+        assert_eq!(backoff(2), Duration::from_secs(2));
+        assert_eq!(backoff(3), Duration::from_secs(4));
+        assert_eq!(backoff(4), Duration::from_secs(8));
+        assert_eq!(backoff(5), Duration::from_secs(16));
+    }
+
+    #[test]
+    fn build_upload_url_appends_path_to_base() {
+        let parsed = url::Url::parse("https://prompt.example.dev/").unwrap();
+        assert_eq!(
+            build_upload_url(&parsed),
+            "https://prompt.example.dev/api/sync/upload"
+        );
+        let parsed = url::Url::parse("https://prompt.example.dev").unwrap();
+        assert_eq!(
+            build_upload_url(&parsed),
+            "https://prompt.example.dev/api/sync/upload"
+        );
+        let parsed = url::Url::parse("https://example.com/omp").unwrap();
+        assert_eq!(
+            build_upload_url(&parsed),
+            "https://example.com/omp/api/sync/upload"
+        );
+    }
+
+    #[test]
+    fn resolve_returns_none_when_disabled() {
+        let toml = OhMyPromptToml::default();
+        let out = OhMyPromptSink::resolve(&toml).unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn resolve_errors_when_enabled_without_endpoint() {
+        let toml = OhMyPromptToml {
+            enabled: Some(true),
+            ..OhMyPromptToml::default()
+        };
+        let err = OhMyPromptSink::resolve(&toml).unwrap_err();
+        assert!(matches!(err, OhMyPromptError::MissingEndpoint));
+    }
+
+    #[test]
+    fn resolve_errors_when_enabled_without_token() {
+        // Use a unique env var name so the test is hermetic.
+        let var = "OMP_TEST_TOKEN_FOR_MISSING_TOKEN_TEST";
+        // Make sure it's unset.
+        // SAFETY: tests are single-threaded by default for this var.
+        std::env::remove_var(var);
+        let toml = OhMyPromptToml {
+            enabled: Some(true),
+            endpoint: Some("https://example.dev".into()),
+            token_env: Some(var.into()),
+            ..OhMyPromptToml::default()
+        };
+        let err = OhMyPromptSink::resolve(&toml).unwrap_err();
+        assert!(matches!(err, OhMyPromptError::MissingToken { .. }));
+    }
+}

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -13,7 +13,7 @@
 //! by the daemon's desktop-notifier task to wake users when an agent moves
 //! into `WaitingInput` or `Error`.
 
-use crate::event::{AgentEvent, AgentKind, AgentState, NotificationLevel};
+use crate::event::{AgentEvent, AgentId, AgentKind, AgentState, NotificationLevel};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -43,6 +43,13 @@ fn is_synthetic(session_id: &str) -> bool {
 /// see lag on a healthy network. 256 is ~4× the in-process notifier's
 /// previous capacity; bump again if profiling shows lag on real traffic.
 const TRANSITION_CHANNEL_CAPACITY: usize = 256;
+
+/// Capacity of the in-process prompt broadcast. Sized identically to the
+/// transition channel — sinks subscribe here to receive every
+/// `PromptSubmitted` event without having to reverse-engineer prompts
+/// from `Transition` payloads. Slow subscribers see `RecvError::Lagged`
+/// and should log + continue (same pattern as the notifier).
+const PROMPT_CHANNEL_CAPACITY: usize = 256;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Agent {
@@ -100,18 +107,36 @@ pub struct Transition {
     pub agent: Agent,
 }
 
+/// In-process record emitted whenever a `PromptSubmitted` event lands.
+///
+/// Sibling to [`Transition`] — sinks subscribe via
+/// [`Store::subscribe_prompts`] and forward these records to external
+/// systems (e.g. `oh-my-prompt`'s ingestion API). The `model` field is a
+/// best-effort snapshot from the post-apply agent row at the time of the
+/// prompt — `None` when no Heartbeat has populated it yet.
+#[derive(Debug, Clone)]
+pub struct PromptRecord {
+    pub id: AgentId,
+    pub prompt: String,
+    pub at: OffsetDateTime,
+    pub model: Option<String>,
+}
+
 #[derive(Debug)]
 pub struct Store {
     agents: RwLock<HashMap<String, Agent>>,
     transitions: broadcast::Sender<Transition>,
+    prompts: broadcast::Sender<PromptRecord>,
 }
 
 impl Default for Store {
     fn default() -> Self {
         let (tx, _) = broadcast::channel(TRANSITION_CHANNEL_CAPACITY);
+        let (prompts_tx, _) = broadcast::channel(PROMPT_CHANNEL_CAPACITY);
         Self {
             agents: RwLock::default(),
             transitions: tx,
+            prompts: prompts_tx,
         }
     }
 }
@@ -174,6 +199,17 @@ impl Store {
         self.transitions.subscribe()
     }
 
+    /// Subscribe to in-process prompt events.
+    ///
+    /// One [`PromptRecord`] is broadcast per `PromptSubmitted` event the
+    /// store applies. Independent of the state-transition channel so
+    /// downstream sinks see every prompt — even prompts that don't change
+    /// the agent's state field. Same `Lagged` semantics as
+    /// [`Self::subscribe`].
+    pub fn subscribe_prompts(&self) -> broadcast::Receiver<PromptRecord> {
+        self.prompts.subscribe()
+    }
+
     pub async fn apply(&self, ev: &AgentEvent) {
         let mut agents = self.agents.write().await;
         let id = ev.id();
@@ -207,6 +243,7 @@ impl Store {
         agent.last_activity_at = at;
 
         let prev_state = agent.state;
+        let mut prompt_record: Option<PromptRecord> = None;
 
         match ev {
             AgentEvent::Started { .. } => {
@@ -215,6 +252,12 @@ impl Store {
             AgentEvent::PromptSubmitted { prompt, .. } => {
                 agent.last_prompt = Some(prompt.clone());
                 agent.state = AgentState::Working;
+                prompt_record = Some(PromptRecord {
+                    id: id.clone(),
+                    prompt: prompt.clone(),
+                    at,
+                    model: agent.model.clone(),
+                });
             }
             AgentEvent::ToolStarted { .. } => {
                 agent.state = AgentState::Working;
@@ -263,6 +306,13 @@ impl Store {
             // `send` errors only when there are zero subscribers — that's
             // the common case (notifier disabled) and not worth logging.
             let _ = self.transitions.send(transition);
+        }
+
+        if let Some(record) = prompt_record {
+            // Same "errors only when no subscribers" semantics as the
+            // transitions channel — sinks are opt-in, so a no-subscriber
+            // state is the steady-state default.
+            let _ = self.prompts.send(record);
         }
     }
 

--- a/crates/muxa/tests/oh_my_prompt_sink.rs
+++ b/crates/muxa/tests/oh_my_prompt_sink.rs
@@ -1,0 +1,437 @@
+//! Integration tests for the oh-my-prompt sink.
+//!
+//! These spin up a `wiremock` HTTP server, point a real
+//! `OhMyPromptSink` at it (via `resolve` + a hermetic env var per
+//! test), and drive the sink with `tokio::sync::broadcast` channels —
+//! same shape as the live wire-up in `muxad`.
+//!
+//! Time-sensitive tests use `tokio::time::pause` / `advance` so they
+//! complete in milliseconds rather than waiting on real wall-clock
+//! flush intervals.
+
+use muxa::config::OhMyPromptToml;
+use muxa::event::{AgentId, AgentKind};
+use muxa::sinks::OhMyPromptSink;
+use muxa::state::PromptRecord;
+use serde_json::Value;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use time::OffsetDateTime;
+use tokio::sync::broadcast;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Each test gets its own env var name so concurrent test runs don't
+/// stomp on each other (Rust's test runner uses one process for all
+/// tests in a binary, so env-var state is shared).
+fn unique_token_var() -> String {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    format!("OMP_TEST_TOKEN_{n}")
+}
+
+fn make_prompt(prompt: &str, session: &str) -> PromptRecord {
+    PromptRecord {
+        id: AgentId {
+            kind: AgentKind::ClaudeCode,
+            session_id: session.into(),
+            pane: Some("%1".into()),
+            cwd: Some("/work/proj".into()),
+        },
+        prompt: prompt.into(),
+        at: OffsetDateTime::now_utc(),
+        model: Some("opus".into()),
+    }
+}
+
+/// Build a TOML config pointing at `endpoint`, with a unique token var
+/// preloaded with `token_value`. Returns the resolved sink.
+fn build_sink(
+    endpoint: &str,
+    token_value: &str,
+    batch_size: usize,
+    flush_interval_ms: u64,
+) -> OhMyPromptSink {
+    let var = unique_token_var();
+    // SAFETY: the env-var name is unique per test invocation, so this
+    // doesn't race with parallel tests.
+    std::env::set_var(&var, token_value);
+    let toml = OhMyPromptToml {
+        enabled: Some(true),
+        endpoint: Some(endpoint.to_string()),
+        token_env: Some(var),
+        device_id: Some("test-device".into()),
+        batch_size: Some(batch_size),
+        flush_interval_ms: Some(flush_interval_ms),
+    };
+    OhMyPromptSink::resolve(&toml)
+        .expect("resolve must succeed")
+        .expect("sink must be Some when enabled")
+}
+
+#[tokio::test]
+async fn posts_to_correct_endpoint_with_token_header() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/upload"))
+        .and(header("X-User-Token", "the-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let sink = build_sink(&server.uri(), "the-token", 1, 60_000);
+
+    let (prompt_tx, prompt_rx) = broadcast::channel(8);
+    let (shutdown_tx, shutdown_rx) = broadcast::channel(1);
+
+    let handle = tokio::spawn(sink.run(prompt_rx, shutdown_rx));
+
+    prompt_tx.send(make_prompt("hello", "sess-1")).unwrap();
+
+    // batch_size=1 means the first prompt triggers an immediate flush.
+    // Wait briefly for the HTTP call to register, then shut down.
+    for _ in 0..50 {
+        if !server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .is_empty()
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let _ = shutdown_tx.send(());
+    let _ = handle.await;
+
+    let received = server.received_requests().await.unwrap();
+    assert_eq!(received.len(), 1, "expected exactly one HTTP call");
+    let body: Value = serde_json::from_slice(&received[0].body).unwrap();
+    let records = body.get("records").and_then(Value::as_array).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        records[0].get("prompt_text").and_then(Value::as_str),
+        Some("hello")
+    );
+    assert_eq!(
+        records[0].get("source").and_then(Value::as_str),
+        Some("claude-code")
+    );
+    assert_eq!(records[0].get("role").and_then(Value::as_str), Some("user"));
+    assert_eq!(
+        body.get("deviceId").and_then(Value::as_str),
+        Some("test-device")
+    );
+}
+
+#[tokio::test]
+async fn batches_records_at_size_threshold() {
+    let server = MockServer::start().await;
+    // batch_size=50, time threshold high — only one POST should land
+    // when we feed exactly 50 prompts.
+    Mock::given(method("POST"))
+        .and(path("/api/sync/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+        .mount(&server)
+        .await;
+
+    let sink = build_sink(&server.uri(), "tok", 50, 60_000);
+
+    let (prompt_tx, prompt_rx) = broadcast::channel(128);
+    let (shutdown_tx, shutdown_rx) = broadcast::channel(1);
+    let handle = tokio::spawn(sink.run(prompt_rx, shutdown_rx));
+
+    for i in 0..50 {
+        prompt_tx
+            .send(make_prompt(&format!("prompt-{i}"), &format!("s-{i}")))
+            .unwrap();
+    }
+
+    // Wait for the batch to drain.
+    for _ in 0..100 {
+        let n = server.received_requests().await.map_or(0, |r| r.len());
+        if n >= 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let _ = shutdown_tx.send(());
+    let _ = handle.await;
+
+    let received = server.received_requests().await.unwrap();
+    assert_eq!(received.len(), 1, "expected exactly one batch POST");
+    let body: Value = serde_json::from_slice(&received[0].body).unwrap();
+    let records = body.get("records").and_then(Value::as_array).unwrap();
+    assert_eq!(records.len(), 50);
+}
+
+#[tokio::test(start_paused = true)]
+async fn flushes_records_at_time_threshold() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+        .mount(&server)
+        .await;
+
+    // batch_size large; flush by time only.
+    let sink = build_sink(&server.uri(), "tok", 1000, 5_000);
+
+    let (prompt_tx, prompt_rx) = broadcast::channel(8);
+    let (shutdown_tx, shutdown_rx) = broadcast::channel(1);
+    let handle = tokio::spawn(sink.run(prompt_rx, shutdown_rx));
+
+    // Yield so the spawned task gets to its select! on a paused clock.
+    tokio::task::yield_now().await;
+
+    prompt_tx.send(make_prompt("once", "s-1")).unwrap();
+
+    // Advance clock past the flush interval.
+    tokio::time::advance(Duration::from_secs(6)).await;
+
+    // Allow the now-due tick to drive the HTTP call. The wiremock
+    // server runs on a *real* clock, so we yield to it via real-time
+    // sleeps after un-pausing the tokio time? — wiremock's hyper
+    // listener also uses tokio time. We need to resume real time for
+    // the network round-trip. The simplest path: use `resume()`
+    // after triggering the flush.
+    tokio::time::resume();
+
+    for _ in 0..100 {
+        let n = server.received_requests().await.map_or(0, |r| r.len());
+        if n >= 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let _ = shutdown_tx.send(());
+    let _ = handle.await;
+
+    let received = server.received_requests().await.unwrap();
+    assert_eq!(
+        received.len(),
+        1,
+        "expected one POST after time-based flush"
+    );
+    let body: Value = serde_json::from_slice(&received[0].body).unwrap();
+    let records = body.get("records").and_then(Value::as_array).unwrap();
+    assert_eq!(records.len(), 1);
+}
+
+#[tokio::test]
+async fn retries_5xx_with_backoff() {
+    let server = MockServer::start().await;
+
+    // First call: 503. Second call: 200. With `up_to_n_times` we
+    // sequence the responses.
+    Mock::given(method("POST"))
+        .and(path("/api/sync/upload"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+        .mount(&server)
+        .await;
+
+    let sink = build_sink(&server.uri(), "tok", 1, 60_000);
+
+    let (prompt_tx, prompt_rx) = broadcast::channel(8);
+    let (shutdown_tx, shutdown_rx) = broadcast::channel(1);
+    let handle = tokio::spawn(sink.run(prompt_rx, shutdown_rx));
+
+    prompt_tx.send(make_prompt("hi", "s-1")).unwrap();
+
+    // First attempt + 500ms backoff + second attempt. Allow plenty of
+    // wall-clock for both.
+    for _ in 0..200 {
+        let n = server.received_requests().await.map_or(0, |r| r.len());
+        if n >= 2 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let _ = shutdown_tx.send(());
+    let _ = handle.await;
+
+    let received = server.received_requests().await.unwrap();
+    assert!(
+        received.len() >= 2,
+        "expected at least two attempts (got {})",
+        received.len()
+    );
+}
+
+#[tokio::test]
+async fn honors_retry_after_on_429() {
+    let server = MockServer::start().await;
+
+    // First response: 429 with Retry-After: 1. Second: 200.
+    Mock::given(method("POST"))
+        .and(path("/api/sync/upload"))
+        .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "1"))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+        .mount(&server)
+        .await;
+
+    let sink = build_sink(&server.uri(), "tok", 1, 60_000);
+
+    let (prompt_tx, prompt_rx) = broadcast::channel(8);
+    let (shutdown_tx, shutdown_rx) = broadcast::channel(1);
+    let handle = tokio::spawn(sink.run(prompt_rx, shutdown_rx));
+
+    prompt_tx.send(make_prompt("hi", "s-1")).unwrap();
+
+    let start = std::time::Instant::now();
+    for _ in 0..400 {
+        let n = server.received_requests().await.map_or(0, |r| r.len());
+        if n >= 2 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let elapsed = start.elapsed();
+
+    let _ = shutdown_tx.send(());
+    let _ = handle.await;
+
+    let received = server.received_requests().await.unwrap();
+    assert!(
+        received.len() >= 2,
+        "expected retry after 429 (got {})",
+        received.len()
+    );
+    // The Retry-After of 1 second should have introduced at least
+    // ~0.8s of delay between the two attempts. We're lenient so CI
+    // jitter doesn't false-fail.
+    assert!(
+        elapsed >= Duration::from_millis(800),
+        "expected ~1s delay from Retry-After, got {elapsed:?}"
+    );
+}
+
+#[tokio::test]
+async fn drops_4xx_without_retry() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/upload"))
+        .respond_with(ResponseTemplate::new(400).set_body_string("bad schema"))
+        .mount(&server)
+        .await;
+
+    let sink = build_sink(&server.uri(), "tok", 1, 60_000);
+
+    let (prompt_tx, prompt_rx) = broadcast::channel(8);
+    let (shutdown_tx, shutdown_rx) = broadcast::channel(1);
+    let handle = tokio::spawn(sink.run(prompt_rx, shutdown_rx));
+
+    prompt_tx.send(make_prompt("hi", "s-1")).unwrap();
+
+    // Wait long enough that any retry would have hit (backoff[0]=500ms).
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    let _ = shutdown_tx.send(());
+    let _ = handle.await;
+
+    let received = server.received_requests().await.unwrap();
+    assert_eq!(
+        received.len(),
+        1,
+        "4xx must not trigger a retry (got {} attempts)",
+        received.len()
+    );
+}
+
+/// A `tracing` `Layer` that stringifies each event into a shared
+/// buffer. Used by `ring_buffer_drops_oldest_on_overflow` to assert
+/// the sink emits the expected WARN line — and isolated up here so
+/// `clippy::items_after_statements` stays happy.
+#[derive(Clone, Default)]
+struct CapturedLines(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
+
+struct CapturedVisitor<'a>(&'a mut String);
+
+impl tracing::field::Visit for CapturedVisitor<'_> {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        use std::fmt::Write;
+        let _ = write!(self.0, " {}={:?}", field.name(), value);
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturedLines {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if event.metadata().level() > &tracing::Level::WARN {
+            return;
+        }
+        let mut s = String::new();
+        let mut v = CapturedVisitor(&mut s);
+        event.record(&mut v);
+        self.0.lock().unwrap().push(s);
+    }
+}
+
+#[tokio::test]
+async fn ring_buffer_drops_oldest_on_overflow() {
+    // We point at an unreachable port so the sink can't drain its
+    // buffer — every POST will fail and retry. With batch_size=1 and
+    // a non-listening port the buffer fills up and starts dropping.
+    //
+    // We can't easily inspect the ring's contents from outside the
+    // sink, so this test is a smoke test: we feed >1000 records and
+    // assert the sink doesn't crash and the first-pushed records are
+    // visibly absent in a tracing-captured WARN line.
+
+    use tracing_subscriber::layer::SubscriberExt;
+
+    let captured = CapturedLines::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    // Use a port that nothing is listening on.
+    let endpoint = "http://127.0.0.1:1"; // port 1 — reserved/closed
+    let sink = build_sink(endpoint, "tok", 1, 60_000);
+
+    let (prompt_tx, prompt_rx) = broadcast::channel(2048);
+    let (shutdown_tx, shutdown_rx) = broadcast::channel(1);
+    let handle = tokio::spawn(sink.run(prompt_rx, shutdown_rx));
+
+    // Push 1100 records — buffer caps at 1000, so 100 should be dropped.
+    for i in 0..1100 {
+        prompt_tx
+            .send(make_prompt(&format!("p-{i}"), &format!("s-{i}")))
+            .unwrap();
+    }
+    // Brief yield to let the sink task absorb them. The HTTP attempts
+    // will all fail/timeout, but pushes are sync wrt the broadcast.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let _ = shutdown_tx.send(());
+    // Don't await the handle — the task may still be spinning on retries.
+    drop(handle);
+
+    let lines = captured.0.lock().unwrap().clone();
+    let dropped = lines
+        .iter()
+        .filter(|l| l.contains("ring buffer full") || l.contains("dropped oldest"))
+        .count();
+    assert!(
+        dropped > 0,
+        "expected at least one ring-buffer overflow WARN; got lines: {lines:?}"
+    );
+}

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -11,6 +11,7 @@ use muxa::config::NotifierBackend;
 use muxa::dashboard::{DashboardConfig, DashboardOverrides};
 use muxa::ipc::{harden_permissions, Client, Server};
 use muxa::notify::Notifier;
+use muxa::sinks::OhMyPromptSink;
 use muxa::tmux::scanner::PaneCache;
 use muxa::{discovery, paths, Config, Store};
 use std::io::IsTerminal;
@@ -154,6 +155,8 @@ async fn main() -> Result<()> {
         tracing::info!(addr = %dash_cfg.bind, "dashboard task spawned");
     }
 
+    spawn_oh_my_prompt_sink(&cfg, &store, &shutdown_tx)?;
+
     let server = Server::new(socket.clone(), store);
     let handle = tokio::spawn(server.run(shutdown_tx.subscribe()));
 
@@ -226,6 +229,33 @@ fn resolve_dashboard_config(cfg: &Config, args: &Args) -> Result<DashboardConfig
 
     DashboardConfig::resolve(&cfg.dashboard, &overrides)
         .map_err(|e| anyhow::anyhow!(e).context("resolving dashboard config"))
+}
+
+/// Resolve the oh-my-prompt sink config and, if enabled, spawn its
+/// task. Mirrors the dashboard wire-up: the daemon's existing shutdown
+/// broadcast is reused for joint shutdown.
+fn spawn_oh_my_prompt_sink(
+    cfg: &Config,
+    store: &muxa::SharedStore,
+    shutdown_tx: &broadcast::Sender<()>,
+) -> Result<()> {
+    match OhMyPromptSink::resolve(&cfg.sinks.oh_my_prompt) {
+        Ok(Some(sink)) => {
+            let prompt_rx = store.subscribe_prompts();
+            let shutdown_rx = shutdown_tx.subscribe();
+            tokio::spawn(async move {
+                if let Err(e) = sink.run(prompt_rx, shutdown_rx).await {
+                    tracing::error!(error = %e, "oh-my-prompt sink exited");
+                }
+            });
+            tracing::info!("oh-my-prompt sink enabled");
+        }
+        Ok(None) => {}
+        Err(e) => {
+            return Err(anyhow::Error::new(e).context("resolving oh-my-prompt sink"));
+        }
+    }
+    Ok(())
 }
 
 /// Decide whether to fire the one-shot discovery pass and, if so, spawn it

--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,11 @@ allow = [
     "Unicode-DFS-2016",
     "Zlib",
     "CC0-1.0",
+    # `webpki-roots >= 1.0` (transitive via reqwest -> hyper-rustls)
+    # ships under CDLA-Permissive-2.0 — a permissive, OSI-aligned data
+    # license with no copyleft. Compatible with our MIT/Apache-2.0
+    # distribution model. https://cdla.dev/permissive-2-0/
+    "CDLA-Permissive-2.0",
 ]
 
 [bans]

--- a/docs/SINKS.md
+++ b/docs/SINKS.md
@@ -1,0 +1,133 @@
+# Sinks
+
+A *sink* is an opt-in fan-out from the muxa daemon to an external system.
+Sinks consume the in-process broadcast channels the daemon already uses
+internally (today: prompts; later: state transitions, heartbeats) and
+forward selected events to a long-lived destination.
+
+Sinks are **always off by default**. Adding a sink to your config never
+sends a byte until you explicitly set `enabled = true` and supply the
+required credentials.
+
+## Available sinks
+
+| Name                | Purpose                                              | Section                                  |
+| ------------------- | ---------------------------------------------------- | ---------------------------------------- |
+| `oh_my_prompt`      | Forward `PromptSubmitted` events to an omp instance. | [`oh-my-prompt`](#oh-my-prompt)          |
+
+## oh-my-prompt
+
+[oh-my-prompt](https://github.com/jiunbae/oh-my-prompt) (omp) is a small
+self-hostable service that stores prompts from coding-agent CLIs for
+search and analytics. muxa already watches the same agent set
+(Claude Code, Codex, Gemini CLI, OpenCode), so the sink ships the
+prompts it's already capturing — omp owns history, muxa owns realtime.
+
+### What leaves the box
+
+For every `PromptSubmitted` event the daemon sees, the sink POSTs a
+record to your omp endpoint:
+
+| Field            | Always sent? | Source                                                      |
+| ---------------- | ------------ | ----------------------------------------------------------- |
+| `event_id`       | yes          | `muxa-{session_id}-{unix_ms}` — deterministic, dedups       |
+| `created_at`     | yes          | RFC-3339 UTC timestamp from the agent event                 |
+| `prompt_text`    | yes          | the prompt as the agent recorded it                         |
+| `prompt_length`  | yes          | UTF-8 char count                                            |
+| `word_count`     | yes          | whitespace-split                                            |
+| `token_estimate` | yes          | `prompt_length / 4` (matches omp's own heuristic)           |
+| `source`         | yes          | `claude-code` / `codex` / `gemini` / `opencode`             |
+| `cli_name`       | yes          | `claude` / `codex` / `gemini` / `opencode`                  |
+| `cli_version`    | yes          | muxa's own version (the CLI version isn't always reachable) |
+| `role`           | yes          | always `user` — muxa never sees response text               |
+| `session_id`     | yes          | agent-reported session id                                   |
+| `cwd`            | when known   | from the agent event                                        |
+| `project`        | when known   | basename of `cwd`                                           |
+| `model`          | when known   | last `Heartbeat` model for that session                     |
+
+What does NOT leave the box: tool calls, notifications, heartbeats,
+session lifecycle, response text, environment variables, file contents,
+or any other byte the daemon can see. If the brief above ever changes,
+this doc gets the same change in the same PR.
+
+`AgentKind::Unknown` events are dropped — there is no canonical
+`source` for them.
+
+### Setup
+
+1. Stand up an omp instance and obtain the `X-User-Token` UUID for the
+   account you want to push to. (omp's docs are upstream; muxa never
+   touches account creation.)
+2. Export the token in the daemon's environment, **not** in your TOML:
+
+   ```sh
+   export OMP_SERVER_TOKEN="00000000-0000-0000-0000-000000000000"
+   ```
+
+   Choose a different env var name via `token_env` if you prefer.
+
+3. Enable the sink in `~/.config/muxa/config.toml`:
+
+   ```toml
+   [sinks.oh_my_prompt]
+   enabled            = true
+   endpoint           = "https://prompt.example.dev"   # YOUR omp host
+   # token_env        = "OMP_SERVER_TOKEN"             # default
+   # device_id        = "laptop-01"                    # optional, echoed in payload
+   # batch_size       = 50                             # records per HTTP POST
+   # flush_interval_ms = 5000                          # time-based flush
+   ```
+
+4. Restart `muxad`. You should see `oh-my-prompt sink enabled` in the
+   daemon log on startup.
+
+There is intentionally **no default endpoint**. A missing or empty
+`endpoint` with `enabled = true` is a startup error.
+
+### Opt out
+
+Either delete the section, or:
+
+```toml
+[sinks.oh_my_prompt]
+enabled = false
+```
+
+The sink task is never spawned. No HTTP client is constructed, no
+prompts are buffered, no token is read.
+
+### Failure / robustness
+
+- HTTP 5xx → exponential backoff (500ms → 1s → 2s → 4s → 8s → 16s),
+  up to 6 attempts.
+- HTTP 429 → honors `Retry-After` (capped at 60s for sanity), then
+  retries.
+- HTTP 4xx (except 429) → logs and drops the batch (the schema is
+  wrong; retrying won't fix it).
+- Network errors / timeouts → same retry curve as 5xx.
+- HTTP 207 (partial success) → batch is treated as accepted; the
+  rejected records are logged and **not** re-sent.
+
+Records are buffered in a 1000-entry ring. When the upstream is
+unreachable AND prompts arrive faster than retries clear the queue,
+the **oldest** record is dropped with a WARN log — the daemon
+intentionally never blocks ingest because the omp endpoint is slow.
+
+### Troubleshooting
+
+- **`401` in the daemon log** — `X-User-Token` is wrong. Double-check
+  the env var name (`token_env`) and the value (omp validates the UUID
+  format strictly).
+- **`429` even at low volume** — your omp instance is rate-limiting
+  per-token; the sink will sleep for `Retry-After` seconds and retry.
+- **`hostname not found` / TLS errors** — check the `endpoint` URL
+  scheme and DNS. The sink uses `rustls`, not the system OpenSSL, so
+  hostname mismatches surface as TLS errors rather than connection
+  resets.
+- **Records are buffered but never sent** — check that `endpoint` is
+  reachable from the daemon's network namespace. `curl -fsS
+  $endpoint/api/health` is a quick smoke test.
+- **`oh-my-prompt ring buffer full; dropped oldest record`** — your
+  endpoint has been unreachable long enough that 1000 records piled
+  up. Fix the upstream and the sink will recover; older prompts are
+  permanently lost.


### PR DESCRIPTION
## Summary

Adds an opt-in HTTP sink that forwards `PromptSubmitted` events from the
muxa daemon to oh-my-prompt's `/api/sync/upload` ingestion endpoint.
Same agent set on both sides (Claude Code, Codex, Gemini CLI, OpenCode);
muxa owns realtime/state and omp owns history/analytics, with no
duplicated capture work.

## What's in the box

- **`muxa::sinks` module** with the `OhMyPromptSink` impl backed by
  `reqwest` (rustls). The split-task design (ingest pulls into a
  bounded ring; flusher posts on size/time triggers) makes the ring
  the single backpressure surface — a slow remote endpoint can never
  block prompt ingest.
- **`Store::subscribe_prompts()`** broadcast channel — sibling to the
  existing `Transition` feed. Sinks subscribe here so they don't have
  to reverse-engineer the prompt text + timestamp out of post-state
  snapshots. Same `Lagged`-tolerant pattern as the notifier task.
- **`[sinks.oh_my_prompt]`** TOML block, off by default. The `enabled
  = true` path errors at startup if `endpoint` is unset or the token
  env var (default `OMP_SERVER_TOKEN`) is empty — no default endpoint,
  by design. Secret never lands in TOML.
- **Robustness**: ring buffer of 1000 records with drop-oldest WARN on
  overflow; size + time flush thresholds; exponential backoff
  (500ms → 1s → 2s → 4s → 8s → 16s, max 6 attempts) on 5xx and
  network errors; `Retry-After` honored on 429 (capped at 60s); 4xx
  other than 429 dropped without retry; 207 partial logged but not
  re-sent.
- **Wire-up in `muxad`** next to the dashboard task — joint shutdown
  through the existing broadcast channel; aborts the sink subtasks
  rather than draining-with-retries (best-effort, like the notifier).

## Mapping decisions

Locked field-by-field from the brief:

| Field            | Source                                                       |
|------------------|--------------------------------------------------------------|
| `event_id`       | `muxa-{session_id}-{unix_ms}` — deterministic, dedups        |
| `created_at`     | RFC-3339 from the event's `at`                                |
| `prompt_text`    | `prompt` verbatim                                             |
| `prompt_length`  | `prompt.chars().count()` (UTF-8 char count, not bytes)        |
| `word_count`     | whitespace-split count                                        |
| `token_estimate` | `prompt_length / 4` (matches omp's own server heuristic)      |
| `source`         | `claude-code` / `codex` / `gemini` / `opencode`               |
| `cli_name`       | `claude` / `codex` / `gemini` / `opencode`                    |
| `cli_version`    | `env!("CARGO_PKG_VERSION")` of muxa                           |
| `role`           | always `"user"` (no response capture)                          |
| `cwd` / `project`| from `AgentId.cwd`; project = basename                        |
| `model`          | snapshotted from `Agent.model` at apply time                  |
| `session_id`     | `AgentId.session_id`                                           |
| `content_hash`   | skipped in v1                                                  |

`AgentKind::Unknown` events are dropped — no canonical mapping.

## Tests

20 new tests:

- 13 unit tests in `crates/muxa/src/sinks/ohmyprompt.rs`:
  deterministic event id, separator avoids colons, exhaustive kind
  mapping, unknown skipped, all-required-fields-present, optional
  fields omitted-not-null, cwd basename, char-count vs bytes,
  exponential backoff curve, URL composition, resolve disabled,
  resolve missing endpoint, resolve missing token.
- 7 integration tests in `crates/muxa/tests/oh_my_prompt_sink.rs`
  using `wiremock`: correct path + `X-User-Token` header, batch at
  size threshold, flush at time threshold (uses `tokio::time::pause`
  + `advance`), 5xx retry-with-backoff, 429 honors `Retry-After`,
  4xx dropped without retry, ring-buffer drops oldest on overflow.

Workspace total: 117 tests green (was 97).

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 117 tests passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Reviewer to spot-check the auth header (`X-User-Token`, NOT
  `Authorization`) and the deterministic `event_id` shape against
  omp's sanitizer.
- [ ] Reviewer to confirm comfort with default-off + endpoint-required
  gating (no implicit `prompt.example.dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)