### PR TITLE
feat(state): capture assistant response on Stop via transcript tail

### DIFF
--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -937,6 +937,7 @@ mod tests {
             cwd: None,
             state,
             last_prompt: prompt.map(Into::into),
+            last_response: None,
             last_notification: None,
             model: model.map(Into::into),
             context_used_pct: ctx,

--- a/crates/muxa/src/adapters/claude.rs
+++ b/crates/muxa/src/adapters/claude.rs
@@ -15,8 +15,10 @@
 //! ```
 
 use super::hook::{truncate, AdapterError, HookAdapter};
+use super::transcript;
 use crate::event::{AgentEvent, AgentId, AgentKind, NotificationLevel};
 use serde::Deserialize;
+use std::path::PathBuf;
 use time::OffsetDateTime;
 
 pub struct ClaudeAdapter;
@@ -33,6 +35,11 @@ pub struct Input {
     pub message: Option<String>,
     #[serde(default)]
     pub prompt: Option<String>,
+    /// Path to the JSONL session transcript. Provided by Claude Code on
+    /// every hook event; we use it on `Stop` to extract the assistant's
+    /// last response since the hook payload itself doesn't carry one.
+    #[serde(default)]
+    pub transcript_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -106,7 +113,14 @@ impl HookAdapter for ClaudeAdapter {
                     at,
                 }
             }
-            Event::Stop => AgentEvent::TurnStopped { id, at },
+            Event::Stop => {
+                let response = input
+                    .transcript_path
+                    .as_deref()
+                    .and_then(transcript::last_assistant_text)
+                    .map(|t| truncate(t, 4_000));
+                AgentEvent::TurnStopped { id, response, at }
+            }
             Event::SessionEnd => AgentEvent::SessionEnded { id, at },
         }
     }
@@ -162,5 +176,83 @@ pub fn statusline_heartbeat(input: StatusLineInput, pane: Option<String>) -> Age
         context_used_pct: input.context_window.and_then(|c| c.used_percentage),
         cost_usd: input.cost.and_then(|c| c.total_cost_usd),
         at: OffsetDateTime::now_utc(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn stop_input(transcript_path: Option<PathBuf>) -> Input {
+        Input {
+            session_id: "s".into(),
+            cwd: None,
+            tool_name: None,
+            notification_type: None,
+            message: None,
+            prompt: None,
+            transcript_path,
+        }
+    }
+
+    #[test]
+    fn stop_without_transcript_path_emits_none_response() {
+        let ev = ClaudeAdapter::normalize(Event::Stop, stop_input(None), None);
+        match ev {
+            AgentEvent::TurnStopped { response, .. } => assert!(response.is_none()),
+            _ => panic!("expected TurnStopped"),
+        }
+    }
+
+    #[test]
+    fn stop_with_transcript_path_pulls_last_assistant_text() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"hello from the model"}}]}}}}"#
+        )
+        .unwrap();
+        let ev = ClaudeAdapter::normalize(Event::Stop, stop_input(Some(f.path().into())), None);
+        match ev {
+            AgentEvent::TurnStopped { response, .. } => {
+                assert_eq!(response.as_deref(), Some("hello from the model"));
+            }
+            _ => panic!("expected TurnStopped"),
+        }
+    }
+
+    #[test]
+    fn stop_with_long_response_truncates_to_4kb() {
+        let mut f = NamedTempFile::new().unwrap();
+        let huge = "x".repeat(10_000);
+        // Embed the long string in a JSON-safe way.
+        let line = format!(
+            r#"{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"{huge}"}}]}}}}"#
+        );
+        writeln!(f, "{line}").unwrap();
+        let ev = ClaudeAdapter::normalize(Event::Stop, stop_input(Some(f.path().into())), None);
+        match ev {
+            AgentEvent::TurnStopped { response, .. } => {
+                let text = response.expect("response present");
+                // truncate() bound is 4_000 bytes + a single ellipsis (3
+                // bytes in UTF-8) — anything larger means the truncation
+                // hook isn't running.
+                assert!(text.len() <= 4_000 + 3, "got {} bytes", text.len());
+                assert!(text.ends_with('…'));
+            }
+            _ => panic!("expected TurnStopped"),
+        }
+    }
+
+    #[test]
+    fn stop_with_unreadable_path_emits_none_response() {
+        let path = PathBuf::from("/tmp/no-such-transcript-zzz.jsonl");
+        let ev = ClaudeAdapter::normalize(Event::Stop, stop_input(Some(path)), None);
+        match ev {
+            AgentEvent::TurnStopped { response, .. } => assert!(response.is_none()),
+            _ => panic!("expected TurnStopped"),
+        }
     }
 }

--- a/crates/muxa/src/adapters/codex.rs
+++ b/crates/muxa/src/adapters/codex.rs
@@ -97,7 +97,11 @@ impl HookAdapter for CodexAdapter {
                 ),
                 at,
             },
-            Event::Stop => AgentEvent::TurnStopped { id, at },
+            Event::Stop => AgentEvent::TurnStopped {
+                id,
+                response: None,
+                at,
+            },
         }
     }
 }

--- a/crates/muxa/src/adapters/gemini.rs
+++ b/crates/muxa/src/adapters/gemini.rs
@@ -105,7 +105,11 @@ impl HookAdapter for GeminiAdapter {
                     at,
                 }
             }
-            Event::AfterAgent => AgentEvent::TurnStopped { id, at },
+            Event::AfterAgent => AgentEvent::TurnStopped {
+                id,
+                response: None,
+                at,
+            },
             Event::SessionEnd => AgentEvent::SessionEnded { id, at },
         }
     }

--- a/crates/muxa/src/adapters/mod.rs
+++ b/crates/muxa/src/adapters/mod.rs
@@ -14,6 +14,7 @@ pub mod codex;
 pub mod gemini;
 pub mod hook;
 pub mod opencode;
+pub mod transcript;
 
 pub use hook::{run_hook, AdapterError, HookAdapter};
 

--- a/crates/muxa/src/adapters/transcript.rs
+++ b/crates/muxa/src/adapters/transcript.rs
@@ -1,0 +1,185 @@
+//! Claude Code transcript JSONL parser.
+//!
+//! Claude Code's `Stop` hook fires at the end of every assistant turn but
+//! does not include the response body in the hook payload — it gives only
+//! a `transcript_path` pointing at a JSONL file. Each line is a JSON object;
+//! assistant messages have shape:
+//!
+//! ```json
+//! {
+//!   "type": "assistant",
+//!   "message": {
+//!     "role": "assistant",
+//!     "content": [
+//!       {"type": "thinking", ...},
+//!       {"type": "text", "text": "..."},
+//!       {"type": "tool_use", ...}
+//!     ]
+//!   }
+//! }
+//! ```
+//!
+//! [`last_assistant_text`] returns the concatenated `text` content of the
+//! *last* such entry — that's the response just delivered by the turn we
+//! were notified about.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::path::Path;
+
+/// Read at most this many bytes from the tail of the transcript. Long
+/// sessions can run to multi-MB; one assistant turn is realistically well
+/// under 100 KB even with verbose reasoning, so 256 KB is comfortable
+/// headroom while keeping the hook handler's CPU/IO bounded.
+const TAIL_BYTES: u64 = 256 * 1024;
+
+/// Extract the last assistant turn's user-visible text from `path`.
+///
+/// Returns `None` for any failure mode (file missing, malformed lines,
+/// no assistant entry in the tail window) — the caller treats this as
+/// "we couldn't capture a response" and proceeds. Failure is silent by
+/// design: hook handlers run synchronously inside the agent CLI, and
+/// noisy errors there bleed into the user's terminal.
+pub fn last_assistant_text(path: &Path) -> Option<String> {
+    let mut f = File::open(path).ok()?;
+    let len = f.metadata().ok()?.len();
+    let start = len.saturating_sub(TAIL_BYTES);
+    f.seek(SeekFrom::Start(start)).ok()?;
+
+    let reader = BufReader::new(f);
+    let mut last_text: Option<String> = None;
+    // When we seek into the middle of a long file, the first emitted line
+    // is almost certainly a fragment. `serde_json::from_str` rejects it,
+    // and `extract_assistant_text` returns None — so the partial line is
+    // silently skipped without special-casing.
+    for line in reader.lines().map_while(Result::ok) {
+        if let Some(text) = extract_assistant_text(&line) {
+            last_text = Some(text);
+        }
+    }
+    last_text
+}
+
+/// Parse one transcript line. Returns `Some(text)` only when the line is
+/// a complete assistant entry with at least one non-empty text segment.
+fn extract_assistant_text(line: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
+    if v.get("type")?.as_str()? != "assistant" {
+        return None;
+    }
+    let content = v.get("message")?.get("content")?.as_array()?;
+    let mut out = String::new();
+    for c in content {
+        if c.get("type").and_then(serde_json::Value::as_str) != Some("text") {
+            continue;
+        }
+        if let Some(text) = c.get("text").and_then(serde_json::Value::as_str) {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(text);
+        }
+    }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write(lines: &[&str]) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        for l in lines {
+            writeln!(f, "{l}").unwrap();
+        }
+        f
+    }
+
+    #[test]
+    fn returns_none_for_missing_file() {
+        let path = Path::new("/tmp/definitely-not-a-real-transcript-99999.jsonl");
+        assert!(last_assistant_text(path).is_none());
+    }
+
+    #[test]
+    fn returns_none_for_empty_file() {
+        let f = NamedTempFile::new().unwrap();
+        assert!(last_assistant_text(f.path()).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_no_assistant_entries() {
+        let f = write(&[
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
+            r#"{"type":"queue-operation","operation":"remove"}"#,
+        ]);
+        assert!(last_assistant_text(f.path()).is_none());
+    }
+
+    #[test]
+    fn picks_text_from_last_assistant_entry() {
+        let f = write(&[
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"first"}]}}"#,
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"reply"}]}}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"second"}]}}"#,
+        ]);
+        assert_eq!(last_assistant_text(f.path()).as_deref(), Some("second"));
+    }
+
+    #[test]
+    fn concatenates_multiple_text_segments_with_newlines() {
+        let f = write(&[
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"a"},{"type":"thinking","thinking":"…"},{"type":"text","text":"b"}]}}"#,
+        ]);
+        assert_eq!(last_assistant_text(f.path()).as_deref(), Some("a\nb"));
+    }
+
+    #[test]
+    fn skips_assistant_entry_with_only_thinking_or_tool_use() {
+        let f = write(&[
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"…"},{"type":"tool_use","id":"t","name":"Bash","input":{}}]}}"#,
+        ]);
+        // No `text` segment — treated as "no response" rather than empty string.
+        assert!(last_assistant_text(f.path()).is_none());
+    }
+
+    #[test]
+    fn malformed_lines_are_skipped() {
+        let f = write(&[
+            "not json at all",
+            r#"{"type":"assistant"}"#, // missing message.content
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"good"}]}}"#,
+            r"{", // truncated
+        ]);
+        assert_eq!(last_assistant_text(f.path()).as_deref(), Some("good"));
+    }
+
+    #[test]
+    fn tail_seek_drops_partial_first_line_without_data_loss() {
+        // Build a file larger than TAIL_BYTES so the seek skips the
+        // earliest entries entirely. Earlier assistant entries fall
+        // outside the window and must not be returned.
+        let mut f = NamedTempFile::new().unwrap();
+        // First entry is way back at byte 0 — outside any reasonable tail.
+        writeln!(
+            f,
+            r#"{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"too-old"}}]}}}}"#
+        ).unwrap();
+        // Pad with junk lines to push the next real entry past TAIL_BYTES.
+        let pad = "x".repeat(1024);
+        for _ in 0..(usize::try_from(TAIL_BYTES).unwrap() / 1024 + 4) {
+            writeln!(f, "{pad}").unwrap();
+        }
+        writeln!(
+            f,
+            r#"{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"recent"}}]}}}}"#
+        ).unwrap();
+        assert_eq!(last_assistant_text(f.path()).as_deref(), Some("recent"));
+    }
+}

--- a/crates/muxa/src/event.rs
+++ b/crates/muxa/src/event.rs
@@ -89,6 +89,13 @@ pub enum AgentEvent {
     },
     TurnStopped {
         id: AgentId,
+        /// Assistant's response text for the turn that just ended, when
+        /// the adapter was able to read it from the transcript. Optional
+        /// (and `#[serde(default)]`) so adapters that can't capture a
+        /// response — and older protocol peers that predate this field —
+        /// stay wire-compatible.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        response: Option<String>,
         #[serde(with = "time::serde::rfc3339")]
         at: OffsetDateTime,
     },
@@ -161,5 +168,42 @@ mod tests {
     fn kind_serializes_snake_case() {
         let json = serde_json::to_string(&AgentKind::GeminiCli).unwrap();
         assert_eq!(json, "\"gemini_cli\"");
+    }
+
+    /// Older muxa peers emit `TurnStopped` without the `response` field.
+    /// `#[serde(default)]` must let the new client deserialize them
+    /// instead of erroring out — otherwise a daemon and CLI on different
+    /// versions can't talk.
+    #[test]
+    fn turn_stopped_deserializes_without_response_field() {
+        let json = r#"{
+            "type": "turn_stopped",
+            "id": {"kind": "claude_code", "session_id": "s", "pane": null, "cwd": null},
+            "at": "2026-04-24T12:00:00Z"
+        }"#;
+        let ev: AgentEvent = serde_json::from_str(json).unwrap();
+        match ev {
+            AgentEvent::TurnStopped { response, .. } => assert_eq!(response, None),
+            _ => panic!("expected TurnStopped"),
+        }
+    }
+
+    #[test]
+    fn turn_stopped_without_response_omits_field_in_json() {
+        let ev = AgentEvent::TurnStopped {
+            id: AgentId {
+                kind: AgentKind::ClaudeCode,
+                session_id: "s".into(),
+                pane: None,
+                cwd: None,
+            },
+            response: None,
+            at: datetime!(2026-04-24 12:00:00 UTC),
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        // `skip_serializing_if = "Option::is_none"` keeps the wire payload
+        // identical to the pre-`response` schema for adapters that don't
+        // capture a response.
+        assert!(!json.contains("response"), "json was: {json}");
     }
 }

--- a/crates/muxa/src/notify.rs
+++ b/crates/muxa/src/notify.rs
@@ -148,6 +148,7 @@ mod tests {
             cwd: None,
             state,
             last_prompt: Some("refactor the ipc module to use tokio io_uring".into()),
+            last_response: None,
             last_notification: None,
             model: None,
             context_used_pct: None,

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -59,6 +59,12 @@ pub struct Agent {
     pub cwd: Option<String>,
     pub state: AgentState,
     pub last_prompt: Option<String>,
+    /// Last assistant response captured for this agent. Populated by the
+    /// `TurnStopped` ingest path when the adapter could read the
+    /// transcript; remains `None` for adapters that don't expose response
+    /// text (e.g., Codex/Gemini today). Optional so the field is purely
+    /// additive on the wire and in the UI.
+    pub last_response: Option<String>,
     pub last_notification: Option<String>,
     pub model: Option<String>,
     pub context_used_pct: Option<f32>,
@@ -84,6 +90,7 @@ impl Agent {
             cwd,
             state: AgentState::Starting,
             last_prompt: None,
+            last_response: None,
             last_notification: None,
             model: None,
             context_used_pct: None,
@@ -271,7 +278,10 @@ impl Store {
                     NotificationLevel::Info | NotificationLevel::Warning => {}
                 }
             }
-            AgentEvent::TurnStopped { .. } => {
+            AgentEvent::TurnStopped { response, .. } => {
+                if let Some(text) = response {
+                    agent.last_response = Some(text.clone());
+                }
                 if agent.state != AgentState::Error {
                     agent.state = AgentState::Idle;
                 }
@@ -401,6 +411,7 @@ mod tests {
         store
             .apply(&AgentEvent::TurnStopped {
                 id: id("s"),
+                response: None,
                 at: now,
             })
             .await;
@@ -416,6 +427,65 @@ mod tests {
             store.by_session("s").await.unwrap().state,
             AgentState::Stopped
         );
+    }
+
+    #[tokio::test]
+    async fn turn_stopped_with_response_sets_last_response() {
+        let store = Store::shared();
+        let now = datetime!(2026-04-24 12:00:00 UTC);
+
+        store
+            .apply(&AgentEvent::Started {
+                id: id("s"),
+                at: now,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::TurnStopped {
+                id: id("s"),
+                response: Some("the assistant said hi".into()),
+                at: now,
+            })
+            .await;
+        let agent = store.by_session("s").await.unwrap();
+        assert_eq!(
+            agent.last_response.as_deref(),
+            Some("the assistant said hi")
+        );
+        // Idle transition still happens.
+        assert_eq!(agent.state, AgentState::Idle);
+    }
+
+    #[tokio::test]
+    async fn turn_stopped_without_response_preserves_prior_value() {
+        let store = Store::shared();
+        let now = datetime!(2026-04-24 12:00:00 UTC);
+
+        store
+            .apply(&AgentEvent::Started {
+                id: id("s"),
+                at: now,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::TurnStopped {
+                id: id("s"),
+                response: Some("first answer".into()),
+                at: now,
+            })
+            .await;
+        // A subsequent TurnStopped from an adapter that can't read
+        // transcripts (Codex/Gemini) must not blank the previously
+        // captured response.
+        store
+            .apply(&AgentEvent::TurnStopped {
+                id: id("s"),
+                response: None,
+                at: now,
+            })
+            .await;
+        let agent = store.by_session("s").await.unwrap();
+        assert_eq!(agent.last_response.as_deref(), Some("first answer"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Tail-read the Claude Code session transcript on the `Stop` hook to extract the last assistant turn's text. Claude Code's hook payload includes `transcript_path` (JSONL) but no response body.
- Plumb it through `AgentEvent::TurnStopped { response: Option<String> }` into a new `Agent.last_response` field.
- Sets up at-a-glance UIs (the upcoming `{last_response}` template var in `muxa watch`'s detail row, the dashboard) to show what an agent just said while waiting.

## Notes on compatibility

- The new `response` field on `TurnStopped` is `#[serde(default, skip_serializing_if = "Option::is_none")]`. Existing peers stay wire-compatible: old daemons emit no `response` field and new code reads `None`; new daemons that get `None` (Codex / Gemini adapters, which can't read transcripts today) serialize identically to the old shape.
- `last_response` only updates when `Some` arrives, so a follow-up `TurnStopped { response: None }` from a non-Claude adapter does not blank a previously captured response.

## Implementation

- New `crates/muxa/src/adapters/transcript.rs` — defensive JSONL tail parser, capped at 256 KB read window, returns `None` for any failure mode (missing file, malformed lines, no assistant entry).
- `claude.rs` adapter reads `transcript_path` on `Stop`, runs `last_assistant_text`, truncates to 4 KB (same cap as `PromptSubmitted`).
- `state.rs::apply` `TurnStopped` arm sets `agent.last_response = Some(text)` when `Some`.

## Test plan

- [x] `cargo test --workspace` — 133 tests, all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Unit tests cover: parser happy path / empty file / no assistant entries / multi-text concat / malformed lines / large file tail-seek
- [x] Adapter tests cover: Stop with/without `transcript_path`, unreadable path, 4 KB truncation
- [x] State tests cover: TurnStopped with response sets field, follow-up `None` preserves prior value
- [x] Event tests cover: serde default for missing `response`, omit-on-None on the wire

Once this and #PR-watch-detail-row both merge, a tiny follow-up wires `{last_response}` into `format_detail`'s match in `watch.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)