### PR TITLE
feat(watch): default detail template to {last_response}

### DIFF
--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -1646,35 +1646,34 @@ mod tests {
     #[test]
     fn selected_row_renders_with_extra_detail_line() {
         // Render to a TestBackend and assert the detail prefix appears in
-        // the buffer for the selected row only.
+        // the buffer for the selected row only. Default template is
+        // `{last_response}`, so the agent must have a captured response
+        // for the detail line to render (otherwise it suppresses).
         let backend = TestBackend::new(140, 12);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
-        app.set_data(
-            vec![
-                fake_agent(
-                    "s1",
-                    Some("%1"),
-                    AgentKind::ClaudeCode,
-                    AgentState::WaitingInput,
-                    Some("waiting prompt that is long enough to be visible in the detail line"),
-                    None,
-                    None,
-                    None,
-                ),
-                fake_agent(
-                    "s2",
-                    Some("%2"),
-                    AgentKind::ClaudeCode,
-                    AgentState::Idle,
-                    Some("another prompt"),
-                    None,
-                    None,
-                    None,
-                ),
-            ],
-            vec![],
+        let mut a1 = fake_agent(
+            "s1",
+            Some("%1"),
+            AgentKind::ClaudeCode,
+            AgentState::WaitingInput,
+            Some("waiting prompt that is long enough to be visible in the detail line"),
+            None,
+            None,
+            None,
         );
+        a1.last_response = Some("the assistant said something".into());
+        let a2 = fake_agent(
+            "s2",
+            Some("%2"),
+            AgentKind::ClaudeCode,
+            AgentState::Idle,
+            Some("another prompt"),
+            None,
+            None,
+            None,
+        );
+        app.set_data(vec![a1, a2], vec![]);
         terminal.draw(|f| render(f, &mut app)).unwrap();
         let buf = terminal.backend().buffer();
         let text: String = buf
@@ -1772,41 +1771,40 @@ mod tests {
             ..Default::default()
         };
         let mut app = App::with_config(cfg);
-        app.set_data(
-            vec![
-                fake_agent(
-                    "s1",
-                    Some("%1"),
-                    AgentKind::ClaudeCode,
-                    AgentState::Working,
-                    Some("ALPHAprompt"),
-                    Some("Opus"),
-                    Some(7.0),
-                    Some(0.05),
-                ),
-                fake_agent(
-                    "s2",
-                    Some("%2"),
-                    AgentKind::ClaudeCode,
-                    AgentState::Idle,
-                    Some("BETAprompt"),
-                    None,
-                    None,
-                    None,
-                ),
-                fake_agent(
-                    "s3",
-                    Some("%3"),
-                    AgentKind::ClaudeCode,
-                    AgentState::Working,
-                    Some("GAMMAprompt"),
-                    None,
-                    None,
-                    None,
-                ),
-            ],
-            vec![],
+        let mut a1 = fake_agent(
+            "s1",
+            Some("%1"),
+            AgentKind::ClaudeCode,
+            AgentState::Working,
+            Some("ALPHAprompt"),
+            Some("Opus"),
+            Some(7.0),
+            Some(0.05),
         );
+        a1.last_response = Some("ALPHAresp".into());
+        let mut a2 = fake_agent(
+            "s2",
+            Some("%2"),
+            AgentKind::ClaudeCode,
+            AgentState::Idle,
+            Some("BETAprompt"),
+            None,
+            None,
+            None,
+        );
+        a2.last_response = Some("BETAresp".into());
+        let mut a3 = fake_agent(
+            "s3",
+            Some("%3"),
+            AgentKind::ClaudeCode,
+            AgentState::Working,
+            Some("GAMMAprompt"),
+            None,
+            None,
+            None,
+        );
+        a3.last_response = Some("GAMMAresp".into());
+        app.set_data(vec![a1, a2, a3], vec![]);
         app
     }
 
@@ -1830,7 +1828,7 @@ mod tests {
         // Rows:
         //   y=5  ALPHAprompt (row 0, not selected)
         //   y=6  BETAprompt  (row 1, selected, 2-line)
-        //   y=7  ↳ BETAprompt (detail line)
+        //   y=7  ↳ BETAresp  (detail line — default template is `{last_response}`)
         //   y=8  GAMMAprompt (row 2, not selected)
         let r0 = row_text(buf, 5);
         let r1 = row_text(buf, 6);
@@ -1848,7 +1846,7 @@ mod tests {
             "selected row's first line must not be the detail line: {r1:?}"
         );
         assert!(
-            r1_detail.contains("↳") && r1_detail.contains("BETAprompt"),
+            r1_detail.contains("↳") && r1_detail.contains("BETAresp"),
             "detail line not on the row directly below the selection: {r1_detail:?}"
         );
         assert!(r2.contains("GAMMAprompt"), "row 2 missing top text: {r2:?}");
@@ -2004,25 +2002,25 @@ mod tests {
     #[test]
     fn very_long_detail_renders_without_panic() {
         // Long enough to exceed any reasonable terminal width plus the
-        // `truncate_chars` ceiling.
+        // `truncate_chars` ceiling. Default template is `{last_response}`,
+        // so the long string lives on the response field.
         let long: String = "x".repeat(2000);
         let cfg = WatchConfig::default();
         let backend = TestBackend::new(80, 12);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::with_config(cfg);
-        app.set_data(
-            vec![fake_agent(
-                "s1",
-                Some("%1"),
-                AgentKind::ClaudeCode,
-                AgentState::Working,
-                Some(&long),
-                None,
-                None,
-                None,
-            )],
-            vec![],
+        let mut a = fake_agent(
+            "s1",
+            Some("%1"),
+            AgentKind::ClaudeCode,
+            AgentState::Working,
+            Some("hi"),
+            None,
+            None,
+            None,
         );
+        a.last_response = Some(long);
+        app.set_data(vec![a], vec![]);
         terminal.draw(|f| render(f, &mut app)).unwrap();
         let buf = terminal.backend().buffer();
         // The detail line is capped at 240 chars + ellipsis; we only

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -208,7 +208,11 @@ impl Default for DetailConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            template: "{last_prompt}".to_string(),
+            // The PROMPT column already shows the user's last prompt, so
+            // the detail row defaults to its complement — the assistant's
+            // last response. Users who want both can override with e.g.
+            // `template = "{last_prompt} → {last_response}"`.
+            template: "{last_response}".to_string(),
         }
     }
 }
@@ -357,10 +361,10 @@ broken = "what"
     }
 
     #[test]
-    fn detail_defaults_to_last_prompt_template() {
+    fn detail_defaults_to_last_response_template() {
         let cfg = WatchConfig::default();
         assert!(cfg.detail.enabled);
-        assert_eq!(cfg.detail.template, "{last_prompt}");
+        assert_eq!(cfg.detail.template, "{last_response}");
     }
 
     #[test]
@@ -376,7 +380,7 @@ template = "{cwd} · {last_prompt}"
     }
 
     /// Missing `[watch.detail]` section -> defaults applied (enabled +
-    /// `{last_prompt}` template). The `default = WatchConfig::default`
+    /// `{last_response}` template). The `default = WatchConfig::default`
     /// machinery on the parent struct must kick in.
     #[test]
     fn missing_watch_detail_section_uses_defaults() {
@@ -386,7 +390,7 @@ columns = ["pane", "prompt"]
 "#;
         let cfg: Config = toml::from_str(toml).unwrap();
         assert!(cfg.watch.detail.enabled);
-        assert_eq!(cfg.watch.detail.template, "{last_prompt}");
+        assert_eq!(cfg.watch.detail.template, "{last_response}");
     }
 
     /// Partial `[watch.detail]` (only `enabled`, no `template`) — the
@@ -400,7 +404,7 @@ enabled = false
 ";
         let cfg: Config = toml::from_str(toml).unwrap();
         assert!(!cfg.watch.detail.enabled);
-        assert_eq!(cfg.watch.detail.template, "{last_prompt}");
+        assert_eq!(cfg.watch.detail.template, "{last_response}");
     }
 
     /// `deny_unknown_fields` is in force on `DetailConfig` — a stray


### PR DESCRIPTION
## Summary

Detail row was just duplicating the PROMPT column — both rendered `last_prompt` (the column truncated to 80 chars; the detail row in full). Wasted real estate.

Switch the default `[watch.detail] template` from `"{last_prompt}"` to `"{last_response}"` so column and detail row are complementary:

- **PROMPT column** — what the user asked
- **Detail row** — what the assistant answered (full text, multiline collapsed to ` · `, capped at ~240 chars)

## Why not show both on one line?

Prompts and responses are typically long. Cramming both into a single detail line means each gets truncated heavily — the whole point of having a separate detail row is to host one long field at a time.

Users who do want a combined view can still set:
```toml
[watch.detail]
template = "{last_prompt} → {last_response}"
```

## Tradeoffs accepted

- Agents in `Starting`/`Working` state (no response yet) show no detail — better than echoing the prompt that's already visible.
- Non-Claude adapters (Codex / Gemini) never populate `last_response` today, so they show no detail by default. Follow-up to wire transcript parsing into those adapters would close the gap.

## Test plan

- [x] `cargo test --workspace` — 157 tests, all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Existing visual tests updated to populate `last_response` on fake agents (the new default behavior is now exercised end-to-end through the renderer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)