### PR TITLE
refactor(muxa): PaneBackend trait + TmuxBackend (zellij Step 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Zellij CLI baseline** (`feat/zellij` branch). muxa now runs against
+  zellij as a first-class host alongside tmux. The CLI baseline (no
+  plugin install required) supports `muxa status`, `muxa watch`,
+  `muxa hook`, `muxa recap`, and Enter-to-jump via
+  `zellij action focus-pane-with-id`. Pane-classification discovery,
+  live pane preview, and hook ancestry walks are gated off via
+  `BackendCaps` until the WASM plugin lands in `feat/zellij-plugin`.
+- **`PaneBackend` trait + `Arc<dyn>` plumbing.** `crate::backend` now
+  hosts `PaneBackend`, `BackendCaps`, `HostKind`, `TmuxBackend`,
+  `ZellijBackend`, and a `default_backend()` constructor. Reconciler,
+  discovery, hook ancestry, watch refresh + live capture, daemon
+  enrichment, and the read-side CLI commands all consult the shared
+  backend instead of `crate::tmux::*` directly. `Arc<dyn PaneBackend>`
+  is itself a `PaneBackend` so the daemon constructs one at startup
+  and threads `.clone()`s without juggling lifetimes.
+- **`MUXA_HOST=tmux|zellij`** env override. Wins over auto-detect from
+  `$ZELLIJ` / `$TMUX` for nested-multiplexer setups.
+- **Hook adapter reads `$ZELLIJ_PANE_ID`** in addition to `$TMUX_PANE`.
+  Ancestry walk consults `caps().pane_pid_map` and skips on hosts
+  where the lookup is structurally unsupported.
+- **`examples/muxa.zellij.kdl`** layout starter for zellij users.
 - `muxa watch` preview popup gains a content-axis toggle (`c`): flip
   between the agent's last prompt + last response and a live snapshot
   of the tmux pane itself, captured via `tmux capture-pane -ep` and
@@ -34,6 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one-keystroke toggle (`c`) away, and `[watch.preview]
   default_content = "prompt_response"` opts back into the previous
   default for users on text-focused workflows.
+
+### Removed
+
+- `reconcile::TmuxLiveness` (back-compat shim with no remaining
+  callers). Backends are themselves `LivenessSource` via a blanket
+  impl on `PaneBackend`.
 
 ## [0.2.0] - 2026-04-28
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -568,6 +568,41 @@ Idempotent 라 타이머로 돌려도 안전 — `interval_secs` 는 정확성�
 아니라 튜닝 knob 입니다. 외부에서 reconciliation 을 직접 driving
 하는 경우 (통합 테스트에서 fake `LivenessSource` 주입 등) 만 끄세요.
 
+### Zellij 지원
+
+muxa 는 기본으로 **tmux** 에서 동작하고 **zellij** 에서도 CLI 베이스라인
+모드로 즉시 동작합니다 (별도 플러그인 설치 불필요). 호스트 결정 우선순위:
+`MUXA_HOST` → `$ZELLIJ` → `$TMUX`.
+
+| 기능                       | tmux | zellij CLI | zellij + 플러그인 (예정) |
+| -------------------------- | :--: | :--------: | :-----------------------: |
+| `muxa status` 에이전트 테이블 | ✅   | ✅         | ✅                        |
+| `muxa watch` picker         | ✅   | ✅ (페인 라벨 단순) | ✅                |
+| Enter 로 jump               | ✅   | ✅         | ✅                        |
+| Discovery (커맨드 기반 분류) | ✅   | ❌         | ✅                        |
+| 라이브 페인 미리보기 (`p`+`c`) | ✅ | ❌ (zellij `dump-screen` 은 focus 필요) | ✅ |
+| Hook ancestry walk          | ✅   | ❌         | ✅                        |
+| 다중 서버 `/api/panes`      | ✅   | n/a (single server) | n/a              |
+
+지원 안 되는 zellij 기능들은 깨진 게 아니라 **구조적 gating**입니다.
+`muxa watch` 는 라이브 미리보기 affordance 를 숨기고 (`c` 가 no-op),
+auto-discovery 가 빈 결과를 반환하지만 — agent state 는 hook → daemon
+경로로 그대로 흐릅니다 (hook adapter 가 `$ZELLIJ_PANE_ID` 도 읽음).
+
+곧 출시될 **muxa zellij 플러그인** (Rust → WASM) 이 위 표의 ❌ 들을
+모두 해결합니다 — zellij plugin API 의 `PaneUpdate`/`TabUpdate` 이벤트를
+구독해 daemon 으로 push. 트래킹 브랜치: `feat/zellij-plugin` (미완료).
+
+호스트를 명시적으로 고정하려면 (중첩 multiplexer setup 등 auto-detect
+가 잘못 잡는 경우):
+
+```sh
+export MUXA_HOST=zellij   # 또는 "tmux"
+muxa watch
+```
+
+Zellij layout 시작 예제: [`examples/muxa.zellij.kdl`](examples/muxa.zellij.kdl).
+
 <details>
 <summary>환경 변수</summary>
 
@@ -575,6 +610,7 @@ Idempotent 라 타이머로 돌려도 안전 — `interval_secs` 는 정확성�
 | --------------- | ----------------------------------------------------- |
 | `MUXA_SOCKET`   | 유닉스 소켓 경로 오버라이드.                           |
 | `MUXA_CONFIG`   | 설정 파일 경로 오버라이드.                             |
+| `MUXA_HOST`     | 백엔드 강제 지정: `tmux` 또는 `zellij`. auto-detect 보다 우선. |
 | `RUST_LOG`      | 트레이싱 필터. 예: `muxa=debug,tokio=warn`.            |
 | `NO_COLOR`      | `muxa status`에서 ANSI 컬러 비활성화.                  |
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,15 @@ See which agents are working, waiting, or idle — right from your status line, 
 ---
 
 `muxa` is a small daemon that watches agent CLIs — **Claude Code, OpenAI Codex,
-Google Gemini CLI, opencode** — running inside tmux panes and surfaces their
-state to the tmux status line, a live TUI dashboard, desktop notifications, and
-a thin CLI.
+Google Gemini CLI, opencode** — running inside terminal-multiplexer panes and
+surfaces their state to the multiplexer's status line, a live TUI dashboard,
+desktop notifications, and a thin CLI.
 
-It does **not** fork tmux. It talks to tmux via the tmux CLI and to each agent
-via that agent's own hook / event-emission system.
+It does **not** fork the multiplexer. It talks to **tmux** (default, full
+support) and **zellij** (CLI baseline; richer metadata via the muxa zellij
+plugin) via their respective CLIs, and to each agent via that agent's own
+hook / event-emission system. The host is auto-detected at startup or pinned
+via `MUXA_HOST=tmux|zellij`.
 
 <div align="center">
   <img src="docs/demo.gif" alt="muxa demo — status table, tmux status-right glyphs, fullscreen watch TUI" width="900" />
@@ -618,6 +621,48 @@ Idempotent and safe to run on a timer; the cadence is a tuning knob,
 not a correctness one. Disable only when driving reconciliation
 externally (e.g. integration tests with a fake `LivenessSource`).
 
+### Zellij support
+
+muxa runs against **tmux** out of the box and **zellij** in a
+CLI-baseline mode that doesn't need any extra setup beyond the
+`muxa` and `muxad` binaries. Resolution honors `MUXA_HOST` first,
+then `$ZELLIJ`, then `$TMUX`.
+
+| Capability                | tmux | zellij CLI | zellij + plugin (planned) |
+| ------------------------- | :--: | :--------: | :-----------------------: |
+| `muxa status` agent table | ✅   | ✅         | ✅                        |
+| `muxa watch` picker       | ✅   | ✅ (no rich pane labels) | ✅ |
+| Press-Enter to jump       | ✅   | ✅          | ✅                        |
+| Discovery (auto-classify panes by command) | ✅ | ❌ | ✅ |
+| Live pane preview (`p`+`c`) | ✅ | ❌ (zellij `dump-screen` requires focus) | ✅ |
+| Hook ancestry walk        | ✅   | ❌          | ✅                        |
+| Multi-server `/api/panes` | ✅   | n/a (single server) | n/a            |
+
+The unsupported zellij rows aren't broken — they're structurally
+gated. `muxa watch` hides the live-preview affordance (`c` is a
+no-op) and the auto-discovery synthesizes nothing on zellij CLI;
+agents still flow through the regular hook → daemon → status path
+because the hook adapter reads `$ZELLIJ_PANE_ID` the same way it
+reads `$TMUX_PANE`.
+
+The forthcoming **muxa zellij plugin** (Rust → WASM) closes every
+remaining row of the table by subscribing to zellij's plugin-API
+`PaneUpdate`/`TabUpdate` events and pushing snapshots to the
+daemon. Tracking issue / branch: `feat/zellij-plugin` (not yet
+landed).
+
+To pin the host explicitly — useful for nested setups (e.g. zellij
+inside tmux, or `tmux new-session` from inside zellij) where
+auto-detect picks wrong:
+
+```sh
+export MUXA_HOST=zellij   # or "tmux"
+muxa watch
+```
+
+A starter zellij layout is at
+[`examples/muxa.zellij.kdl`](examples/muxa.zellij.kdl).
+
 <details>
 <summary>Environment variables</summary>
 
@@ -625,6 +670,7 @@ externally (e.g. integration tests with a fake `LivenessSource`).
 | -------------- | ------------------------------------------------------ |
 | `MUXA_SOCKET`  | Override the unix socket path.                         |
 | `MUXA_CONFIG`  | Override the config file path.                         |
+| `MUXA_HOST`    | Pin the pane backend: `tmux` or `zellij`. Wins over auto-detect. |
 | `RUST_LOG`     | Tracing filter. Example: `muxa=debug,tokio=warn`.      |
 | `NO_COLOR`     | Disable ANSI color in `muxa status`.                   |
 

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -135,7 +135,10 @@ async fn main() -> Result<()> {
         Cmd::StatusLine { pane } => cmd_status_line(&client, pane).await,
         Cmd::Recap { pane, limit, all } => cmd_recap(&client, pane, limit, all).await,
         Cmd::Hook { which } => handle_hook(&client, which).await,
-        Cmd::Panes => cmd_panes(),
+        Cmd::Panes => {
+            cmd_panes();
+            Ok(())
+        }
         Cmd::Watch { include_paneless } => cmd_watch(&client, cfg, include_paneless).await,
         Cmd::Sync => cmd_sync(&client).await,
     }
@@ -505,7 +508,7 @@ async fn cmd_recap(client: &Client, pane: Option<String>, limit: usize, all: boo
     Ok(())
 }
 
-fn cmd_panes() -> Result<()> {
+fn cmd_panes() {
     let backend = muxa::default_backend();
     let panes = backend.list_panes();
     if panes.is_empty() {
@@ -520,7 +523,7 @@ fn cmd_panes() -> Result<()> {
             ),
             muxa::HostKind::Zellij => println!("(no zellij panes)"),
         }
-        return Ok(());
+        return;
     }
     for p in panes {
         println!(
@@ -528,7 +531,6 @@ fn cmd_panes() -> Result<()> {
             p.pane_id, p.session, p.window_index, p.pane_index, p.tty, p.current_command, p.title
         );
     }
-    Ok(())
 }
 
 /// Decide whether to emit ANSI color. We check `NO_COLOR` (per the de-facto

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -225,6 +225,14 @@ async fn cmd_watch(client: &Client, cfg: Config, include_paneless: bool) -> Resu
 /// switching — `select-window`/`select-pane` are plain control messages to
 /// the tmux server and don't need an attached client.
 fn jump_to_pane(pane_id: &str) {
+    let backend = muxa::default_backend();
+    match backend.kind() {
+        muxa::HostKind::Tmux => jump_to_pane_tmux(pane_id),
+        muxa::HostKind::Zellij => jump_to_pane_zellij(backend.as_ref(), pane_id),
+    }
+}
+
+fn jump_to_pane_tmux(pane_id: &str) {
     let Some(info) = tmux::resolve_pane(pane_id) else {
         eprintln!("muxa: pane {pane_id} not found in tmux — it may have closed");
         return;
@@ -253,6 +261,19 @@ fn jump_to_pane(pane_id: &str) {
             ),
             Err(e) => eprintln!("muxa: failed to spawn tmux attach-session: {e}"),
         }
+    }
+}
+
+/// Jump on zellij: a single `zellij action focus-pane-with-id <id>`
+/// covers the whole story. There's no session/window analog to
+/// pre-select, and no "outside zellij" attach equivalent — running
+/// `muxa watch` from a bare shell on a zellij host would land here
+/// only if the user explicitly set `MUXA_HOST=zellij`, in which case
+/// failing to focus is just a "couldn't reach the zellij server"
+/// stderr warning.
+fn jump_to_pane_zellij(backend: &dyn muxa::PaneBackend, pane_id: &str) {
+    if !backend.focus_pane(pane_id) {
+        eprintln!("muxa: zellij focus-pane-with-id {pane_id} failed — pane may have closed");
     }
 }
 
@@ -389,18 +410,21 @@ async fn cmd_status(client: &Client) -> Result<()> {
         println!("no active agents");
         return Ok(());
     }
-    // Resolve the full pane inventory once so `pane_display` does N
-    // lookups against a slice instead of N `tmux list-panes -a`
-    // shell-outs (each ~5 ms, observable as ~170 ms total at 30+
-    // agents).
-    let panes = tmux::list_panes().unwrap_or_default();
+    // Resolve the full pane inventory once via the active backend so
+    // `pane_display` does N lookups against a slice instead of N
+    // backend calls. Empty on backends without pane metadata (zellij
+    // CLI without the WASM plugin) — table still renders, just with
+    // raw pane ids in the location column.
+    let backend = muxa::default_backend();
+    let panes = backend.list_panes();
     print_table(&agents, &panes, OffsetDateTime::now_utc(), use_colors());
     Ok(())
 }
 
 async fn cmd_status_line(client: &Client, pane: Option<String>) -> Result<()> {
-    let panes_snapshot = tmux::list_panes().unwrap_or_default();
-    let pane = pane.or_else(tmux::current_pane);
+    let backend = muxa::default_backend();
+    let panes_snapshot = backend.list_panes();
+    let pane = pane.or_else(|| backend.current_pane());
     let agents = match &pane {
         Some(p) => client.by_pane(p).await?,
         None => client.snapshot().await?,
@@ -434,8 +458,8 @@ async fn cmd_status_line(client: &Client, pane: Option<String>) -> Result<()> {
 
 async fn cmd_recap(client: &Client, pane: Option<String>, limit: usize, all: bool) -> Result<()> {
     let pane = pane
-        .or_else(tmux::current_pane)
-        .context("no pane given and could not determine current tmux pane")?;
+        .or_else(|| muxa::default_backend().current_pane())
+        .context("no pane given and could not determine current pane (set $TMUX_PANE / $ZELLIJ_PANE_ID, or pass --pane)")?;
 
     let agents = client.by_pane(&pane).await?;
     let history_limit = if all { Some(0) } else { Some(limit) };
@@ -482,11 +506,23 @@ async fn cmd_recap(client: &Client, pane: Option<String>, limit: usize, all: boo
 }
 
 fn cmd_panes() -> Result<()> {
-    if !tmux::inside_tmux() {
-        println!("not inside tmux");
+    let backend = muxa::default_backend();
+    let panes = backend.list_panes();
+    if panes.is_empty() {
+        // Two ways to get here: the host (tmux/zellij) has no panes,
+        // or the backend's `caps()` says metadata is plugin-only and
+        // not pushed yet. The hint differentiates so users diagnosing
+        // a misconfigured zellij plugin see something useful.
+        match backend.kind() {
+            muxa::HostKind::Tmux => println!("(no tmux panes — server may be down)"),
+            muxa::HostKind::Zellij if !backend.caps().current_command => println!(
+                "(zellij CLI baseline: pane inventory is plugin-only — install the muxa zellij plugin to populate)"
+            ),
+            muxa::HostKind::Zellij => println!("(no zellij panes)"),
+        }
         return Ok(());
     }
-    for p in tmux::list_panes()? {
+    for p in panes {
         println!(
             "{:<8} {}:{}.{}  tty={}  cmd={}  title={}",
             p.pane_id, p.session, p.window_index, p.pane_index, p.tty, p.current_command, p.title

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -141,11 +141,15 @@ async fn main() -> Result<()> {
     }
 }
 
-/// Backfill the daemon's registry from tmux panes. Idempotent.
+/// Backfill the daemon's registry from host panes. Idempotent.
 async fn cmd_sync(client: &Client) -> Result<()> {
     use std::fmt::Write as _;
 
-    let report = discovery::run_discovery(client)
+    // Each CLI invocation builds its own backend so `MUXA_HOST` etc.
+    // resolve at the user's environment rather than the daemon's
+    // (which may have been started under a different shell).
+    let backend = muxa::default_backend();
+    let report = discovery::run_discovery(client, backend.as_ref())
         .await
         .context("running discovery")?;
 

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -914,13 +914,9 @@ pub async fn run(client: &Client, watch_cfg: WatchConfig) -> Result<Option<Strin
         // "(not supported)" placeholder.
         if let Some(p) = &app.preview {
             if p.content == PreviewContent::LivePane && backend.caps().capture_pane {
-                let stale = app
-                    .pane_capture
-                    .as_ref()
-                    .is_none_or(|c| {
-                        c.pane_id != p.pane_id
-                            || c.fetched_at.elapsed() >= Duration::from_millis(500)
-                    });
+                let stale = app.pane_capture.as_ref().is_none_or(|c| {
+                    c.pane_id != p.pane_id || c.fetched_at.elapsed() >= Duration::from_millis(500)
+                });
                 if stale {
                     let pane_id = p.pane_id.clone();
                     let backend_for_blocking = backend.clone();
@@ -3685,7 +3681,7 @@ mod tests {
                 pane_id: "%1".into(),
                 scroll: 0,
                 mode: PreviewMode::Popup,
-                    content: PreviewContent::PromptResponse,
+                content: PreviewContent::PromptResponse,
             });
             let action = handle_event(Event::Key(KeyEvent::new(key, KeyModifiers::NONE)), &mut app);
             assert!(
@@ -3703,7 +3699,7 @@ mod tests {
             pane_id: "%1".into(),
             scroll: 0,
             mode: PreviewMode::Popup,
-                    content: PreviewContent::PromptResponse,
+            content: PreviewContent::PromptResponse,
         });
 
         // j scrolls down by 1
@@ -3804,7 +3800,7 @@ mod tests {
             pane_id: "%1".into(),
             scroll: 0,
             mode: PreviewMode::Popup,
-                    content: PreviewContent::PromptResponse,
+            content: PreviewContent::PromptResponse,
         });
         terminal.draw(|f| render(f, &mut app)).unwrap();
 
@@ -3840,7 +3836,7 @@ mod tests {
                 pane_id: pane,
                 scroll: 0,
                 mode: PreviewMode::Popup,
-                    content: PreviewContent::PromptResponse,
+                content: PreviewContent::PromptResponse,
             });
         }
         assert_eq!(
@@ -3856,7 +3852,7 @@ mod tests {
             pane_id: "%1".into(),
             scroll: 0,
             mode: PreviewMode::Popup,
-                    content: PreviewContent::PromptResponse,
+            content: PreviewContent::PromptResponse,
         });
 
         // First `f` requests TogglePreviewMode; the run loop applies the
@@ -3903,7 +3899,7 @@ mod tests {
             pane_id: "%1".into(),
             scroll: 0,
             mode: PreviewMode::Fullscreen,
-                    content: PreviewContent::PromptResponse,
+            content: PreviewContent::PromptResponse,
         });
         terminal.draw(|f| render(f, &mut app)).unwrap();
 

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -1909,7 +1909,7 @@ mod tests {
             .iter()
             .filter_map(|r| match r {
                 WatchRow::Agent(a) => a.pane.as_deref(),
-                _ => None,
+                WatchRow::BarePane(_) => None,
             })
             .collect();
 
@@ -1956,7 +1956,7 @@ mod tests {
             .iter()
             .filter_map(|r| match r {
                 WatchRow::Agent(a) => a.pane.as_deref(),
-                _ => None,
+                WatchRow::BarePane(_) => None,
             })
             .collect();
         assert_eq!(order, vec!["%1", "%2", "%10"]);
@@ -2011,7 +2011,7 @@ mod tests {
             .iter()
             .filter_map(|r| match r {
                 WatchRow::Agent(a) => a.pane.as_deref(),
-                _ => None,
+                WatchRow::BarePane(_) => None,
             })
             .collect();
         // alpha: %11 (newer t2) before %10 (older t0); then beta: %21
@@ -2050,7 +2050,7 @@ mod tests {
             .iter()
             .filter_map(|r| match r {
                 WatchRow::Agent(a) => a.pane.as_deref(),
-                _ => None,
+                WatchRow::BarePane(_) => None,
             })
             .collect();
         assert_eq!(order, vec!["%20", "%30", "%10"]);
@@ -2084,7 +2084,7 @@ mod tests {
             .iter()
             .filter_map(|r| match r {
                 WatchRow::Agent(a) => a.pane.as_deref(),
-                _ => None,
+                WatchRow::BarePane(_) => None,
             })
             .collect();
         // Lexicographic — "%1" < "%200" < "%30" because '2' < '3'.
@@ -2098,7 +2098,7 @@ mod tests {
         // the live/stale split takes precedence.
         let now = OffsetDateTime::now_utc();
         let very_recent = now;
-        let older = now - time::Duration::hours(1);
+        let older_at = now - time::Duration::hours(1);
 
         let cfg = WatchConfig {
             sort: vec![WatchSortKey::Activity],
@@ -2108,7 +2108,7 @@ mod tests {
         app.set_data(
             vec![
                 fake_agent_at("stale-but-recent", "%999", very_recent),
-                fake_agent_at("live-but-older", "%10", older),
+                fake_agent_at("live-but-older", "%10", older_at),
             ],
             vec![fake_pane("%10", "main", 0, 0, "claude")],
         );
@@ -2118,7 +2118,7 @@ mod tests {
             .iter()
             .filter_map(|r| match r {
                 WatchRow::Agent(a) => a.pane.as_deref(),
-                _ => None,
+                WatchRow::BarePane(_) => None,
             })
             .collect();
         assert_eq!(order, vec!["%10", "%999"]);
@@ -3942,7 +3942,7 @@ mod tests {
     /// → `PromptResponse`. Geometry mode (popup vs fullscreen) is unaffected
     /// — the two axes compose. Scroll resets so the new content surface
     /// starts at the top instead of mid-line.
-    /// Overlay preset that opens to PromptResponse — used by tests that
+    /// Overlay preset that opens to `PromptResponse` — used by tests that
     /// want to pin the starting content axis instead of inheriting whatever
     /// the global default happens to be. Keeps test intent stable across
     /// future default flips.

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -25,7 +25,7 @@ use crossterm::terminal::{
 use muxa::config::{WatchConfig, WatchSortKey, WidthSpec};
 use muxa::ipc::{Client, RuntimeError};
 use muxa::state::Agent;
-use muxa::tmux::{self, PaneInfo};
+use muxa::tmux::PaneInfo;
 use muxa::AgentState;
 use ratatui::backend::{Backend, CrosstermBackend};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
@@ -680,18 +680,18 @@ pub(crate) fn apply_outcome(app: &mut App, outcome: RefreshOutcome) {
     app.set_data(outcome.agents, outcome.panes);
 }
 
-/// Compute one refresh outcome: tmux pane inventory (off-runtime via
-/// `spawn_blocking`) plus a daemon snapshot. Kept independent of `App` so
-/// the work can run on a worker thread without holding any UI state.
-async fn compute_refresh(client: &Client) -> RefreshOutcome {
-    // tmux pane inventory is independent of the daemon — fetch it even
-    // when muxad is down so `muxa watch` stays useful as a session picker.
-    // `tmux::list_panes` shells out (~few ms) and must NOT run on a tokio
-    // worker — that's the whole point of this refactor.
-    let panes = tokio::task::spawn_blocking(tmux::list_panes)
+/// Compute one refresh outcome: pane inventory from the active backend
+/// (off-runtime via `spawn_blocking` so any shell-out doesn't block the
+/// runtime) plus a daemon snapshot. Kept independent of `App` so the
+/// work can run on a worker thread without holding any UI state.
+async fn compute_refresh(client: &Client, backend: &muxa::SharedBackend) -> RefreshOutcome {
+    // Pane inventory is independent of the daemon — fetch it even when
+    // muxad is down so `muxa watch` stays useful as a session picker.
+    // The backend's `list_panes` may shell out (tmux) or hit a cache
+    // (zellij + plugin); either way it MUST NOT run on a tokio worker.
+    let backend_for_blocking = backend.clone();
+    let panes = tokio::task::spawn_blocking(move || backend_for_blocking.list_panes())
         .await
-        .ok()
-        .and_then(Result::ok)
         .unwrap_or_default();
 
     match client.snapshot().await {
@@ -765,25 +765,33 @@ pub async fn run(client: &Client, watch_cfg: WatchConfig) -> Result<Option<Strin
     let mut guard = TerminalGuard::new(terminal);
 
     let mut app = App::with_config(watch_cfg);
-    // When invoked from inside tmux, land the cursor on the user's current
-    // pane on first load instead of always row 0.
-    app.set_initial_pane(tmux::current_pane());
+    // Resolve the host once at startup — same Arc threads through the
+    // priming refresh, the background task, and the live capture path.
+    let backend: muxa::SharedBackend = muxa::default_backend();
+
+    // When invoked from inside a host (tmux / zellij), land the cursor
+    // on the user's current pane on first load instead of always
+    // row 0.
+    app.set_initial_pane(backend.current_pane());
 
     // Prime the initial snapshot so the first frame already has data —
     // otherwise the user sees an empty table for ~one tick.
-    apply_outcome(&mut app, compute_refresh(client).await);
+    apply_outcome(&mut app, compute_refresh(client, &backend).await);
 
     // Background refresh task owns its own Client clone so the borrowed
     // `client: &Client` doesn't have to outlive the task. The clone is
     // cheap (a single `PathBuf`) and avoids needing an `Arc`/lifetime
-    // wrapper for what is effectively immutable data.
+    // wrapper for what is effectively immutable data. The backend is
+    // already an `Arc<dyn …>` so cloning it is just a refcount bump.
     let bg_client = client.clone();
+    let bg_backend = backend.clone();
     let (wake_tx, wake_rx) = mpsc::channel::<()>(WAKE_CAPACITY);
     let (outcome_tx, mut outcome_rx) = mpsc::channel::<RefreshOutcome>(OUTCOME_CAPACITY);
     let bg = tokio::spawn(refresh_task(
         move || {
             let client = bg_client.clone();
-            async move { compute_refresh(&client).await }
+            let backend = bg_backend.clone();
+            async move { compute_refresh(&client, &backend).await }
         },
         wake_rx,
         outcome_tx,
@@ -897,12 +905,15 @@ pub async fn run(client: &Client, watch_cfg: WatchConfig) -> Result<Option<Strin
         }
 
         // Live pane capture: when the preview is open in LivePane
-        // mode and the cache is missing or stale (>500 ms), shell out
-        // to `tmux capture-pane -ep -t <pane>` on a worker thread.
-        // Bounded by the existing 500 ms TTL so we never fork more
-        // than ~2 Hz, regardless of how fast the input loop spins.
+        // mode and the cache is missing or stale (>500 ms), call into
+        // the active backend on a worker thread. Bounded by the
+        // existing 500 ms TTL so we never fork more than ~2 Hz,
+        // regardless of how fast the input loop spins. Capability-
+        // gated: backends that report `caps().capture_pane == false`
+        // (zellij CLI today) skip the call and the renderer shows a
+        // "(not supported)" placeholder.
         if let Some(p) = &app.preview {
-            if p.content == PreviewContent::LivePane {
+            if p.content == PreviewContent::LivePane && backend.caps().capture_pane {
                 let stale = app
                     .pane_capture
                     .as_ref()
@@ -912,12 +923,13 @@ pub async fn run(client: &Client, watch_cfg: WatchConfig) -> Result<Option<Strin
                     });
                 if stale {
                     let pane_id = p.pane_id.clone();
+                    let backend_for_blocking = backend.clone();
                     let captured = tokio::task::spawn_blocking(move || {
-                        muxa::tmux::capture_pane(&pane_id)
+                        backend_for_blocking.capture_pane(&pane_id)
                     })
                     .await
                     .ok()
-                    .and_then(Result::ok);
+                    .flatten();
                     app.pane_capture = Some(CapturedPane {
                         pane_id: p.pane_id.clone(),
                         text: captured.unwrap_or_default(),

--- a/crates/muxa/src/adapters/hook.rs
+++ b/crates/muxa/src/adapters/hook.rs
@@ -36,13 +36,19 @@ pub trait HookAdapter {
 ///
 /// Reads stdin to EOF, parses as `A::Input`, normalizes to `AgentEvent`.
 ///
-/// `pane` resolution: prefer the `TMUX_PANE` env var (set by tmux for
-/// any process running inside a pane). When that's missing — most
-/// commonly because the hook fired from a Claude Code SDK sub-process
-/// whose env didn't inherit it — fall back to walking the process
-/// ancestry and matching against `tmux list-panes`'s `pane_pid` map.
-/// The fallback is best-effort: any failure (no tmux, /proc unreadable,
-/// no match) yields `pane: None` exactly as before.
+/// `pane` resolution, in order:
+/// 1. `$TMUX_PANE` (tmux sets this on every shell inside a pane).
+/// 2. `$ZELLIJ_PANE_ID` (zellij's analog).
+/// 3. Walk the parent-pid chain and match against the active backend's
+///    `pane_pid_map()`. Useful when a SDK sub-process didn't inherit
+///    the host env var. Skipped when the backend's `caps().pane_pid_map`
+///    reports the lookup is structurally unsupported (zellij CLI today)
+///    rather than transiently empty — saves a fruitless walk on every
+///    sub-process hook.
+///
+/// Any failure (no host, /proc unreadable, no match) yields
+/// `pane: None`. The daemon's IPC layer accepts paneless events; agent
+/// state still flows, the watch UI just hides them by default.
 pub fn run_hook<A, R>(event_flag: &str, stdin: &mut R) -> Result<AgentEvent, AdapterError>
 where
     A: HookAdapter,
@@ -52,21 +58,40 @@ where
     let mut buf = String::new();
     stdin.read_to_string(&mut buf)?;
     let input: A::Input = serde_json::from_str(&buf)?;
-    let pane = std::env::var("TMUX_PANE")
-        .ok()
-        .or_else(resolve_pane_via_ancestry);
+    let pane = host_pane_env()
+        .or_else(|| resolve_pane_via_ancestry(crate::backend::default_backend().as_ref()));
     Ok(A::normalize(event, input, pane))
 }
 
-/// Walk our parent PID chain and look each ancestor up in the tmux
-/// pane-pid map. Returns the matching `pane_id` string when an
-/// ancestor is the shell of a known tmux pane.
+/// Read whichever host-set "this pane" env var is present, in
+/// `TMUX_PANE` then `ZELLIJ_PANE_ID` order. Empty string is treated as
+/// unset; see also `crate::backend::detect_host_env` for the host-
+/// selection precedence.
+fn host_pane_env() -> Option<String> {
+    for name in ["TMUX_PANE", "ZELLIJ_PANE_ID"] {
+        if let Ok(v) = std::env::var(name) {
+            if !v.is_empty() {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+/// Walk our parent PID chain and look each ancestor up in the
+/// backend's pane-pid map. Returns the matching `pane_id` string
+/// when an ancestor is the shell of a known pane.
 ///
-/// Skips entirely when tmux returns no panes (no server running, etc).
-fn resolve_pane_via_ancestry() -> Option<String> {
+/// Skips entirely when the backend reports `caps().pane_pid_map ==
+/// false` — for zellij CLI-only the map is structurally never going
+/// to populate, so walking the chain is just `/proc` traffic for no
+/// reward. Tmux backends keep the existing behaviour.
+fn resolve_pane_via_ancestry(backend: &dyn crate::backend::PaneBackend) -> Option<String> {
     use crate::adapters::proc_ancestry::{ancestor_in_set, parent_pid};
-    use crate::tmux::pane_pid_map;
-    let pid_map = pane_pid_map();
+    if !backend.caps().pane_pid_map {
+        return None;
+    }
+    let pid_map = backend.pane_pid_map();
     if pid_map.is_empty() {
         return None;
     }

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -177,32 +177,56 @@ pub trait PaneBackend: Send + Sync + 'static {
     }
 }
 
-/// Inspect the environment for an active host. Returns the innermost
-/// host when nested (e.g. `zellij` inside `tmux`) — whichever was set
-/// last wins, since that's the one whose pane we're actually inside.
+/// Inspect the environment for an active host.
+///
+/// Resolution order:
+///
+/// 1. **`MUXA_HOST`** — if set to `"tmux"` or `"zellij"` (case-insensitive),
+///    that wins regardless of what `TMUX` / `ZELLIJ` look like. Provides
+///    an unambiguous override for nested-multiplexer setups (e.g. zellij
+///    inside tmux, or `tmux new-session` from inside zellij) where
+///    auto-detect can't tell which host the current shell really lives in.
+///    Other values are ignored (treated as unset) so a typo doesn't pin
+///    the daemon to the wrong host silently.
+/// 2. **`ZELLIJ`** set → [`HostKind::Zellij`].
+/// 3. **`TMUX`** set → [`HostKind::Tmux`].
+///
+/// When both `TMUX` and `ZELLIJ` are present, zellij wins by default.
+/// The env doesn't carry "which one was set last" ordering, so this is
+/// a pragmatic pick rather than a principled one — `MUXA_HOST` is the
+/// escape hatch for the case where the auto-detect picks wrong.
 ///
 /// Returns `None` outside both hosts; callers fall through to a no-op
 /// backend in that case.
 pub fn detect_host_env() -> Option<HostKind> {
-    detect_from(|name| std::env::var_os(name).is_some())
+    detect_from(|name| std::env::var(name).ok())
 }
 
 /// Decoupled-from-process-env variant of [`detect_host_env`] for tests.
-/// `is_set("VAR")` returns true iff the named env var is considered
-/// present. Production calls go through [`detect_host_env`] which
-/// inspects the real process environment; tests pass a closure so we
-/// don't mutate `std::env` (forbidden by the workspace's
-/// `forbid(unsafe_code)` posture).
-fn detect_from(is_set: impl Fn(&str) -> bool) -> Option<HostKind> {
-    // `ZELLIJ` is set inside zellij; `TMUX` inside tmux. When both are
-    // present (tmux wrapping zellij or vice versa), the design doc says
-    // prefer the innermost — but the env doesn't carry ordering.
-    // Pragmatic compromise: prefer zellij since that's the more
-    // recent / opt-in setup; the operator can override via config.
-    if is_set("ZELLIJ") {
+/// `read("VAR")` returns the env var's value if set, else `None`.
+/// Production calls go through [`detect_host_env`] which inspects the
+/// real process environment; tests pass a closure so we don't mutate
+/// `std::env` (forbidden by the workspace's `forbid(unsafe_code)`
+/// posture).
+fn detect_from(read: impl Fn(&str) -> Option<String>) -> Option<HostKind> {
+    // 1. `MUXA_HOST` override — explicit operator intent always wins.
+    if let Some(raw) = read("MUXA_HOST") {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "tmux" => return Some(HostKind::Tmux),
+            "zellij" => return Some(HostKind::Zellij),
+            // Empty / unknown / typo → fall through to auto-detect.
+            // Logging the bad value here would be noisy at startup;
+            // the daemon traces the resolved host kind on the first
+            // backend call, which is enough to diagnose mismatches.
+            _ => {}
+        }
+    }
+
+    // 2. & 3. Auto-detect from host-set env vars.
+    if read("ZELLIJ").is_some() {
         return Some(HostKind::Zellij);
     }
-    if is_set("TMUX") {
+    if read("TMUX").is_some() {
         return Some(HostKind::Tmux);
     }
     None
@@ -212,29 +236,101 @@ fn detect_from(is_set: impl Fn(&str) -> bool) -> Option<HostKind> {
 mod tests {
     use super::*;
 
-    /// Both env vars unset → `None`. The daemon uses this signal to
+    /// Helper that builds a `read` closure from a static lookup table.
+    /// Tests pass `&[("TMUX", "1"), ...]`; missing keys read as
+    /// `None`. Keeps the call sites short.
+    fn env_reader(pairs: &'static [(&'static str, &'static str)]) -> impl Fn(&str) -> Option<String> {
+        move |name| {
+            pairs
+                .iter()
+                .find(|(k, _)| *k == name)
+                .map(|(_, v)| (*v).to_string())
+        }
+    }
+
+    /// All host env vars unset → `None`. The daemon uses this signal to
     /// fall back to a no-op backend rather than spamming `tmux` calls
     /// on a host without a multiplexer running.
     #[test]
     fn detect_returns_none_when_no_host_env_set() {
-        assert!(detect_from(|_| false).is_none());
+        assert!(detect_from(env_reader(&[])).is_none());
     }
 
     /// Only `TMUX` set → tmux. Only `ZELLIJ` set → zellij. Locks the
     /// happy-path mapping for both backends.
     #[test]
     fn detect_picks_tmux_or_zellij_from_env() {
-        assert_eq!(detect_from(|n| n == "TMUX"), Some(HostKind::Tmux));
-        assert_eq!(detect_from(|n| n == "ZELLIJ"), Some(HostKind::Zellij));
+        assert_eq!(
+            detect_from(env_reader(&[("TMUX", "1")])),
+            Some(HostKind::Tmux),
+        );
+        assert_eq!(
+            detect_from(env_reader(&[("ZELLIJ", "1")])),
+            Some(HostKind::Zellij),
+        );
     }
 
     /// When both env vars are present (nested multiplexers — rare but
-    /// possible), zellij wins per the design doc's "innermost / more
-    /// recently opted-in" rule. Locks down the precedence so a future
-    /// flip is intentional.
+    /// possible), zellij wins by default. The `MUXA_HOST` override
+    /// covers the case where this default picks wrong.
     #[test]
     fn detect_prefers_zellij_when_both_env_vars_set() {
-        assert_eq!(detect_from(|_| true), Some(HostKind::Zellij));
+        assert_eq!(
+            detect_from(env_reader(&[("TMUX", "1"), ("ZELLIJ", "1")])),
+            Some(HostKind::Zellij),
+        );
+    }
+
+    /// `MUXA_HOST=tmux` wins over `ZELLIJ` being set — the escape hatch
+    /// for the "I'm in tmux even though my env still carries the parent
+    /// zellij's vars" case. Mirror test for `MUXA_HOST=zellij`.
+    #[test]
+    fn detect_muxa_host_overrides_auto_detect() {
+        assert_eq!(
+            detect_from(env_reader(&[("MUXA_HOST", "tmux"), ("ZELLIJ", "1")])),
+            Some(HostKind::Tmux),
+            "MUXA_HOST=tmux must beat a present ZELLIJ env var",
+        );
+        assert_eq!(
+            detect_from(env_reader(&[("MUXA_HOST", "zellij"), ("TMUX", "1")])),
+            Some(HostKind::Zellij),
+            "MUXA_HOST=zellij must beat a present TMUX env var",
+        );
+    }
+
+    /// Override is case-insensitive and tolerates whitespace — users
+    /// hand-type these in shell rcfiles where `MUXA_HOST=Zellij`,
+    /// `MUXA_HOST=" tmux "`, etc., are realistic.
+    #[test]
+    fn detect_muxa_host_is_case_and_whitespace_tolerant() {
+        assert_eq!(
+            detect_from(env_reader(&[("MUXA_HOST", "TMUX")])),
+            Some(HostKind::Tmux),
+        );
+        assert_eq!(
+            detect_from(env_reader(&[("MUXA_HOST", " Zellij ")])),
+            Some(HostKind::Zellij),
+        );
+    }
+
+    /// Unknown / empty `MUXA_HOST` falls through to auto-detect rather
+    /// than pinning the daemon to a "no host" decision. Typos surface
+    /// as auto-detect outcomes — consistent with the daemon picking
+    /// up *some* working host rather than refusing to run.
+    #[test]
+    fn detect_unknown_muxa_host_falls_through_to_auto() {
+        // Unknown value, no host env → None (no host running).
+        assert!(detect_from(env_reader(&[("MUXA_HOST", "screen")])).is_none());
+        // Unknown value, but TMUX is up → tmux wins via auto-detect.
+        assert_eq!(
+            detect_from(env_reader(&[("MUXA_HOST", "screen"), ("TMUX", "1")])),
+            Some(HostKind::Tmux),
+        );
+        // Empty MUXA_HOST is ignored too.
+        assert_eq!(
+            detect_from(env_reader(&[("MUXA_HOST", ""), ("ZELLIJ", "1")])),
+            Some(HostKind::Zellij),
+        );
     }
 
     /// `HostKind` round-trips through its `Display` impl as a stable

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -1,0 +1,218 @@
+//! Pane-host abstraction.
+//!
+//! Today muxa shells out to tmux for everything that has to do with panes —
+//! enumerating them, finding the foreground command per pane, mapping a
+//! `pane_id` to the OS pid that owns its shell, focusing a pane on attach.
+//! That coupling is small (~600 LOC under `crate::tmux`) but it lives in
+//! the wrong layer: every caller above the IPC seam thinks in
+//! `pane_id` strings and never needs to know that those ids came from
+//! `tmux list-panes -F`.
+//!
+//! This module pulls the surface up into a [`PaneBackend`] trait so a
+//! second host (zellij — see [`docs/ZELLIJ.md`](../../../../docs/ZELLIJ.md))
+//! can plug in without forking the daemon. The tmux implementation in
+//! [`tmux::TmuxBackend`] is a thin delegating wrapper around the existing
+//! `crate::tmux::*` free functions; nothing about the production code path
+//! has changed shape, this is just a seam.
+//!
+//! ## Why a trait, not an enum
+//!
+//! The set of backends is small (tmux today, zellij next, maybe screen /
+//! `WezTerm` later) so an enum dispatch would compile fine. But:
+//!
+//! - Tests want to inject a fake backend without compiling tmux into the
+//!   test binary. Trait objects make that ergonomic.
+//! - The reconciler already takes a generic `LivenessSource` for the
+//!   same reason; a trait keeps both abstractions consistent.
+//! - Adding a backend in a downstream crate (e.g. an out-of-tree
+//!   experiment) is one trait impl rather than a fork.
+//!
+//! ## Capability surface
+//!
+//! The trait is intentionally narrow — only operations the rest of the
+//! codebase actually performs against the host today:
+//!
+//! | Method            | Used by                                          |
+//! | ----------------- | ------------------------------------------------ |
+//! | `list_panes`      | reconciler liveness, discovery, watch refresh    |
+//! | `resolve_pane`    | hook ancestry walk, recap by-pane                |
+//! | `capture_pane`    | watch preview live mode (`c` toggle)             |
+//! | `pane_pid_map`    | hook ancestry walk fallback                      |
+//! | `current_pane`    | watch initial-pane hint, status-line             |
+//! | `kind`            | telemetry, log lines, debug                      |
+//!
+//! Backends that don't naturally support a method (e.g. zellij has no
+//! multi-server enumeration concept) return an empty vec or `None`
+//! rather than `Result::Err` — callers already treat host-down /
+//! pane-gone as ephemeral.
+
+pub mod tmux;
+
+use std::collections::HashMap;
+
+use crate::tmux::PaneInfo;
+
+/// Identity of the pane host. Surfaced through telemetry and log lines so
+/// operators running both backends can tell which one a given event went
+/// through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::Display)]
+#[strum(serialize_all = "lowercase")]
+pub enum HostKind {
+    Tmux,
+    Zellij,
+}
+
+/// Operations the daemon and CLI perform against the pane host.
+///
+/// All methods are best-effort: a transient failure (no tmux server, the
+/// pane just closed, the env got truncated) returns an empty result
+/// rather than an error so callers — which run on hot paths like the
+/// reconciler tick or the watch refresh loop — never have to fan
+/// non-fatal errors back up the stack. The reconciler is idempotent and
+/// will reconverge on the next tick.
+///
+/// Implementors must be `Send + Sync + 'static` because the daemon
+/// stashes them on background tasks that own their own runtimes.
+pub trait PaneBackend: Send + Sync + 'static {
+    /// Which host this backend talks to. Cheap; safe to call per event.
+    fn kind(&self) -> HostKind;
+
+    /// Snapshot of every pane the host considers alive right now.
+    fn list_panes(&self) -> Vec<PaneInfo>;
+
+    /// Look up a single pane by id. Returns `None` for unknown ids and
+    /// for hosts that can't answer the query (rare).
+    fn resolve_pane(&self, pane_id: &str) -> Option<PaneInfo>;
+
+    /// Capture the visible contents of a pane with ANSI escapes intact.
+    /// `None` when the host doesn't support screen capture or the pane
+    /// has gone away. Used by the `muxa watch` preview's live mode.
+    fn capture_pane(&self, pane_id: &str) -> Option<String>;
+
+    /// Map of OS pid → `pane_id` for every pane the host knows about.
+    /// The hook adapter walks an event's parent-pid chain and looks
+    /// each ancestor up in this map to recover a `TMUX_PANE` /
+    /// `ZELLIJ_PANE_ID` that wasn't inherited through env.
+    fn pane_pid_map(&self) -> HashMap<u32, String>;
+
+    /// Best-effort identification of the currently-focused pane —
+    /// usually keyed off the host's "this pane" env var
+    /// (`TMUX_PANE` / `ZELLIJ_PANE_ID`) plus whatever fallback the
+    /// host exposes.
+    fn current_pane(&self) -> Option<String>;
+}
+
+/// Inspect the environment for an active host. Returns the innermost
+/// host when nested (e.g. `zellij` inside `tmux`) — whichever was set
+/// last wins, since that's the one whose pane we're actually inside.
+///
+/// Returns `None` outside both hosts; callers fall through to a no-op
+/// backend in that case.
+pub fn detect_host_env() -> Option<HostKind> {
+    detect_from(|name| std::env::var_os(name).is_some())
+}
+
+/// Decoupled-from-process-env variant of [`detect_host_env`] for tests.
+/// `is_set("VAR")` returns true iff the named env var is considered
+/// present. Production calls go through [`detect_host_env`] which
+/// inspects the real process environment; tests pass a closure so we
+/// don't mutate `std::env` (forbidden by the workspace's
+/// `forbid(unsafe_code)` posture).
+fn detect_from(is_set: impl Fn(&str) -> bool) -> Option<HostKind> {
+    // `ZELLIJ` is set inside zellij; `TMUX` inside tmux. When both are
+    // present (tmux wrapping zellij or vice versa), the design doc says
+    // prefer the innermost — but the env doesn't carry ordering.
+    // Pragmatic compromise: prefer zellij since that's the more
+    // recent / opt-in setup; the operator can override via config.
+    if is_set("ZELLIJ") {
+        return Some(HostKind::Zellij);
+    }
+    if is_set("TMUX") {
+        return Some(HostKind::Tmux);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Both env vars unset → `None`. The daemon uses this signal to
+    /// fall back to a no-op backend rather than spamming `tmux` calls
+    /// on a host without a multiplexer running.
+    #[test]
+    fn detect_returns_none_when_no_host_env_set() {
+        assert!(detect_from(|_| false).is_none());
+    }
+
+    /// Only `TMUX` set → tmux. Only `ZELLIJ` set → zellij. Locks the
+    /// happy-path mapping for both backends.
+    #[test]
+    fn detect_picks_tmux_or_zellij_from_env() {
+        assert_eq!(detect_from(|n| n == "TMUX"), Some(HostKind::Tmux));
+        assert_eq!(detect_from(|n| n == "ZELLIJ"), Some(HostKind::Zellij));
+    }
+
+    /// When both env vars are present (nested multiplexers — rare but
+    /// possible), zellij wins per the design doc's "innermost / more
+    /// recently opted-in" rule. Locks down the precedence so a future
+    /// flip is intentional.
+    #[test]
+    fn detect_prefers_zellij_when_both_env_vars_set() {
+        assert_eq!(detect_from(|_| true), Some(HostKind::Zellij));
+    }
+
+    /// `HostKind` round-trips through its `Display` impl as a stable
+    /// lowercase string — the format telemetry pipelines depend on.
+    #[test]
+    fn host_kind_display_is_lowercase_stable() {
+        assert_eq!(HostKind::Tmux.to_string(), "tmux");
+        assert_eq!(HostKind::Zellij.to_string(), "zellij");
+    }
+
+    /// Sanity-check the trait is usable via a hand-rolled fake — the
+    /// shape future zellij tests will follow before the WASM plugin
+    /// can stand up a real backend in CI. If the trait grows a new
+    /// required method this test breaks loudly.
+    #[test]
+    fn fake_backend_implements_trait_end_to_end() {
+        struct Fake;
+        impl PaneBackend for Fake {
+            fn kind(&self) -> HostKind {
+                HostKind::Zellij
+            }
+            fn list_panes(&self) -> Vec<PaneInfo> {
+                vec![PaneInfo {
+                    pane_id: "zj-1".into(),
+                    session: "z".into(),
+                    window_index: "0".into(),
+                    pane_index: "0".into(),
+                    tty: String::new(),
+                    current_command: "claude".into(),
+                    title: String::new(),
+                }]
+            }
+            fn resolve_pane(&self, id: &str) -> Option<PaneInfo> {
+                self.list_panes().into_iter().find(|p| p.pane_id == id)
+            }
+            fn capture_pane(&self, _: &str) -> Option<String> {
+                Some("hello\n".into())
+            }
+            fn pane_pid_map(&self) -> HashMap<u32, String> {
+                HashMap::from([(42, "zj-1".to_string())])
+            }
+            fn current_pane(&self) -> Option<String> {
+                Some("zj-1".into())
+            }
+        }
+
+        let b: Box<dyn PaneBackend> = Box::new(Fake);
+        assert_eq!(b.kind(), HostKind::Zellij);
+        assert_eq!(b.list_panes().len(), 1);
+        assert_eq!(b.resolve_pane("zj-1").unwrap().pane_id, "zj-1");
+        assert!(b.resolve_pane("nope").is_none());
+        assert_eq!(b.capture_pane("zj-1").as_deref(), Some("hello\n"));
+        assert_eq!(b.pane_pid_map().get(&42).map(String::as_str), Some("zj-1"));
+        assert_eq!(b.current_pane().as_deref(), Some("zj-1"));
+    }
+}

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -39,12 +39,18 @@
 //! | `capture_pane`    | watch preview live mode (`c` toggle)             |
 //! | `pane_pid_map`    | hook ancestry walk fallback                      |
 //! | `current_pane`    | watch initial-pane hint, status-line             |
+//! | `focus_pane`      | watch attach action (`Enter` to jump)            |
 //! | `kind`            | telemetry, log lines, debug                      |
+//! | `caps`            | callers that need to know "method is plugin-only |
+//! |                   | and would be a silent no-op" up front            |
 //!
 //! Backends that don't naturally support a method (e.g. zellij has no
 //! multi-server enumeration concept) return an empty vec or `None`
 //! rather than `Result::Err` — callers already treat host-down /
-//! pane-gone as ephemeral.
+//! pane-gone as ephemeral. Where "transient empty" and "structurally
+//! unsupported" matter (e.g. the hook adapter wants to log differently
+//! when zellij CLI cannot populate `pane_pid_map`), call sites consult
+//! [`BackendCaps`] returned by [`PaneBackend::caps`] before degrading.
 
 pub mod tmux;
 
@@ -60,6 +66,58 @@ use crate::tmux::PaneInfo;
 pub enum HostKind {
     Tmux,
     Zellij,
+}
+
+/// Static capability descriptor. Callers that *need to know* whether a
+/// method is structurally available (vs transiently failing) consult
+/// this before degrading. The fields name specific behaviors rather
+/// than methods because some methods are partial — `list_panes`
+/// always works on zellij CLI but its `current_command` field is
+/// always empty without the WASM plugin.
+///
+/// All fields default to "supported" so the tmux backend (and any
+/// fully-featured future backend) doesn't have to spell out the
+/// capability table — only backends with gaps zero out the relevant
+/// flag.
+///
+/// The four-bool shape trips clippy's `struct_excessive_bools` lint;
+/// allowed here because each flag really is an independent capability
+/// (no state-machine ordering between them) and a `bitflags!` macro
+/// would be overkill at this scale. Add an enum if a fifth flag lands
+/// — until then, named bools are the most grep-able shape.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackendCaps {
+    /// Whether `list_panes()`'s `PaneInfo.current_command` is populated.
+    /// Zellij CLI returns the field empty until the WASM plugin lands;
+    /// discovery falls back to "trust the stdin hook" when this is
+    /// false instead of trying to classify panes by command.
+    pub current_command: bool,
+    /// Whether `pane_pid_map()` returns real data. Hook ancestry only
+    /// walks the parent-pid chain when this is true; otherwise it
+    /// trusts the env (`TMUX_PANE` / `ZELLIJ_PANE_ID`) and gives up
+    /// quietly if that's missing too.
+    pub pane_pid_map: bool,
+    /// Whether `capture_pane()` returns real screen contents. The
+    /// `muxa watch` live preview falls back to the prompt/response
+    /// view when this is false.
+    pub capture_pane: bool,
+    /// Whether `focus_pane()` actually moves the user's view.
+    /// Backends that can't focus (e.g. a future read-only adapter)
+    /// return false here and the watch picker hides the "Enter to
+    /// jump" hint accordingly.
+    pub focus_pane: bool,
+}
+
+impl Default for BackendCaps {
+    fn default() -> Self {
+        Self {
+            current_command: true,
+            pane_pid_map: true,
+            capture_pane: true,
+            focus_pane: true,
+        }
+    }
 }
 
 /// Operations the daemon and CLI perform against the pane host.
@@ -100,6 +158,23 @@ pub trait PaneBackend: Send + Sync + 'static {
     /// (`TMUX_PANE` / `ZELLIJ_PANE_ID`) plus whatever fallback the
     /// host exposes.
     fn current_pane(&self) -> Option<String>;
+
+    /// Move the user's view to `pane_id` — `select-pane -t <id>` on
+    /// tmux, `zellij action focus-pane-with-id <id>` on zellij. The
+    /// trait method is only the *navigation* step; full attach
+    /// semantics (tmux `switch-client` / `attach-session`) stay in the
+    /// CLI because they cross the daemon/CLI process boundary in ways
+    /// the backend can't see. Returns `true` when the focus call
+    /// succeeded; `false` (best-effort) when the pane is gone or the
+    /// host couldn't action the request.
+    fn focus_pane(&self, pane_id: &str) -> bool;
+
+    /// Static capability descriptor. Default impl returns "everything
+    /// supported" because that's the tmux shape and most backends
+    /// model their gaps as exceptions to that baseline.
+    fn caps(&self) -> BackendCaps {
+        BackendCaps::default()
+    }
 }
 
 /// Inspect the environment for an active host. Returns the innermost
@@ -170,49 +245,132 @@ mod tests {
         assert_eq!(HostKind::Zellij.to_string(), "zellij");
     }
 
-    /// Sanity-check the trait is usable via a hand-rolled fake — the
-    /// shape future zellij tests will follow before the WASM plugin
-    /// can stand up a real backend in CI. If the trait grows a new
-    /// required method this test breaks loudly.
-    #[test]
-    fn fake_backend_implements_trait_end_to_end() {
-        struct Fake;
-        impl PaneBackend for Fake {
-            fn kind(&self) -> HostKind {
-                HostKind::Zellij
-            }
-            fn list_panes(&self) -> Vec<PaneInfo> {
-                vec![PaneInfo {
-                    pane_id: "zj-1".into(),
-                    session: "z".into(),
-                    window_index: "0".into(),
-                    pane_index: "0".into(),
-                    tty: String::new(),
-                    current_command: "claude".into(),
-                    title: String::new(),
-                }]
-            }
-            fn resolve_pane(&self, id: &str) -> Option<PaneInfo> {
-                self.list_panes().into_iter().find(|p| p.pane_id == id)
-            }
-            fn capture_pane(&self, _: &str) -> Option<String> {
-                Some("hello\n".into())
-            }
-            fn pane_pid_map(&self) -> HashMap<u32, String> {
-                HashMap::from([(42, "zj-1".to_string())])
-            }
-            fn current_pane(&self) -> Option<String> {
-                Some("zj-1".into())
+    /// A minimal fake the rest of the test module reuses — keeps
+    /// the boilerplate of a full `PaneBackend` impl out of every
+    /// individual test body.
+    struct FakeBackend {
+        panes: Vec<PaneInfo>,
+        caps: BackendCaps,
+    }
+
+    impl FakeBackend {
+        fn with_panes(panes: Vec<PaneInfo>) -> Self {
+            Self {
+                panes,
+                caps: BackendCaps::default(),
             }
         }
+    }
 
-        let b: Box<dyn PaneBackend> = Box::new(Fake);
+    impl PaneBackend for FakeBackend {
+        fn kind(&self) -> HostKind {
+            HostKind::Zellij
+        }
+        fn list_panes(&self) -> Vec<PaneInfo> {
+            self.panes.clone()
+        }
+        fn resolve_pane(&self, id: &str) -> Option<PaneInfo> {
+            self.panes.iter().find(|p| p.pane_id == id).cloned()
+        }
+        fn capture_pane(&self, _: &str) -> Option<String> {
+            Some("hello\n".into())
+        }
+        fn pane_pid_map(&self) -> HashMap<u32, String> {
+            self.panes
+                .iter()
+                .enumerate()
+                .map(|(i, p)| (u32::try_from(100 + i).unwrap_or(u32::MAX), p.pane_id.clone()))
+                .collect()
+        }
+        fn current_pane(&self) -> Option<String> {
+            self.panes.first().map(|p| p.pane_id.clone())
+        }
+        fn focus_pane(&self, _: &str) -> bool {
+            true
+        }
+        fn caps(&self) -> BackendCaps {
+            self.caps
+        }
+    }
+
+    fn fake_pane(id: &str) -> PaneInfo {
+        PaneInfo {
+            pane_id: id.into(),
+            session: "z".into(),
+            window_index: "0".into(),
+            pane_index: "0".into(),
+            tty: String::new(),
+            current_command: "claude".into(),
+            title: String::new(),
+        }
+    }
+
+    /// Trait surface contract: every method on a hand-rolled fake
+    /// behaves as documented. Adding a new required method to
+    /// `PaneBackend` breaks this test loudly.
+    #[test]
+    fn fake_backend_satisfies_trait_contract() {
+        let b: Box<dyn PaneBackend> =
+            Box::new(FakeBackend::with_panes(vec![fake_pane("zj-1")]));
         assert_eq!(b.kind(), HostKind::Zellij);
         assert_eq!(b.list_panes().len(), 1);
         assert_eq!(b.resolve_pane("zj-1").unwrap().pane_id, "zj-1");
         assert!(b.resolve_pane("nope").is_none());
         assert_eq!(b.capture_pane("zj-1").as_deref(), Some("hello\n"));
-        assert_eq!(b.pane_pid_map().get(&42).map(String::as_str), Some("zj-1"));
+        assert_eq!(b.pane_pid_map().get(&100).map(String::as_str), Some("zj-1"));
         assert_eq!(b.current_pane().as_deref(), Some("zj-1"));
+        assert!(b.focus_pane("zj-1"));
+        assert_eq!(b.caps(), BackendCaps::default());
+    }
+
+    /// End-to-end through the reconciler: a `PaneBackend` plugged into
+    /// `Reconciler::new` drives stale-pane reaping exactly the way the
+    /// daemon expects. Locks the bridge between the two abstractions
+    /// so a future change to either side surfaces here instead of in
+    /// production.
+    #[tokio::test]
+    async fn pane_backend_drives_reconciler_via_blanket_liveness_impl() {
+        use crate::event::{AgentEvent, AgentId, AgentKind};
+        use crate::reconcile::Reconciler;
+        use crate::state::Store;
+        use std::time::Duration;
+        use time::macros::datetime;
+
+        let store = Store::shared();
+        let t0 = datetime!(2026-04-28 12:00:00 UTC);
+        for sid in ["alive", "ghost"] {
+            store
+                .apply(&AgentEvent::Started {
+                    id: AgentId {
+                        kind: AgentKind::ClaudeCode,
+                        session_id: sid.into(),
+                        pane: Some(format!("%{sid}")),
+                        cwd: None,
+                    },
+                    at: t0,
+                })
+                .await;
+        }
+        // Backend reports only %alive as live; %ghost should be reaped.
+        let backend = FakeBackend::with_panes(vec![fake_pane("%alive")]);
+        let r = Reconciler::new(store.clone(), backend, Duration::from_millis(10));
+        let report = r.reconcile_once().await;
+        assert_eq!(report.stale_panes_reaped, 1);
+        let snap = store.snapshot().await;
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].session_id, "alive");
+    }
+
+    /// `caps()` defaults to "everything supported" so backends with
+    /// gaps must opt out explicitly. Locks down the default-impl
+    /// behavior so future fields land with backwards-compatible
+    /// semantics.
+    #[test]
+    fn backend_caps_default_is_all_true() {
+        let caps = BackendCaps::default();
+        assert!(caps.current_command);
+        assert!(caps.pane_pid_map);
+        assert!(caps.capture_pane);
+        assert!(caps.focus_pane);
     }
 }

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -53,10 +53,43 @@
 //! [`BackendCaps`] returned by [`PaneBackend::caps`] before degrading.
 
 pub mod tmux;
+pub mod zellij;
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::tmux::PaneInfo;
+
+/// Shared, multi-thread-safe handle to a pane backend.
+///
+/// The daemon constructs one of these at startup based on
+/// [`detect_host_env`] and threads it to every consumer that previously
+/// imported `crate::tmux::*` directly — reconciler liveness, discovery,
+/// the hook ancestry walker, the watch refresh task, the daemon's
+/// `enrich_from_history` step. CLI commands either receive an `Arc`
+/// from the caller or build a fresh one through [`default_backend`].
+///
+/// `Arc` rather than `Box` so background tokio tasks can each hold a
+/// clone without contending on a lock; the trait is `Send + Sync` so
+/// concurrent calls into the same backend are safe.
+pub type SharedBackend = Arc<dyn PaneBackend>;
+
+/// Build the backend that matches the current process environment.
+///
+/// Resolution mirrors [`detect_host_env`]: `MUXA_HOST` override first,
+/// then `ZELLIJ`, then `TMUX`, then a default. When no host is
+/// detectable we fall back to [`tmux::TmuxBackend`] — its methods
+/// degrade gracefully on a host with no tmux server (`list_panes`
+/// returns empty, `capture_pane` returns `None`) and most operators
+/// running muxa outside a multiplexer at all are debugging the
+/// daemon, not driving it. A future "noop" backend could replace
+/// this fallback if that assumption stops holding.
+pub fn default_backend() -> SharedBackend {
+    match detect_host_env() {
+        Some(HostKind::Zellij) => Arc::new(zellij::ZellijBackend::new()),
+        _ => Arc::new(tmux::TmuxBackend::new()),
+    }
+}
 
 /// Identity of the pane host. Surfaced through telemetry and log lines so
 /// operators running both backends can tell which one a given event went
@@ -174,6 +207,46 @@ pub trait PaneBackend: Send + Sync + 'static {
     /// model their gaps as exceptions to that baseline.
     fn caps(&self) -> BackendCaps {
         BackendCaps::default()
+    }
+}
+
+/// `Arc<dyn PaneBackend>` is itself a backend — every method
+/// delegates to the inner trait object. Lets the daemon construct one
+/// `Arc` at startup and hand `.clone()`s to the reconciler, the watch
+/// refresh task, the IPC server, etc., without each consumer having
+/// to learn a different signature. Also unblocks
+/// [`crate::reconcile::LivenessSource`]'s blanket impl: an
+/// `Arc<dyn PaneBackend>` flows through as a `LivenessSource`
+/// transparently because it is a `PaneBackend`.
+///
+/// `?Sized` so the impl covers `Arc<dyn PaneBackend>` directly, not
+/// just `Arc<ConcreteBackend>`. The default `caps()` impl is
+/// overridden here so `Arc::caps()` reaches into the concrete
+/// implementation rather than returning the trait default.
+impl<T: PaneBackend + ?Sized> PaneBackend for Arc<T> {
+    fn kind(&self) -> HostKind {
+        (**self).kind()
+    }
+    fn list_panes(&self) -> Vec<PaneInfo> {
+        (**self).list_panes()
+    }
+    fn resolve_pane(&self, pane_id: &str) -> Option<PaneInfo> {
+        (**self).resolve_pane(pane_id)
+    }
+    fn capture_pane(&self, pane_id: &str) -> Option<String> {
+        (**self).capture_pane(pane_id)
+    }
+    fn pane_pid_map(&self) -> HashMap<u32, String> {
+        (**self).pane_pid_map()
+    }
+    fn current_pane(&self) -> Option<String> {
+        (**self).current_pane()
+    }
+    fn focus_pane(&self, pane_id: &str) -> bool {
+        (**self).focus_pane(pane_id)
+    }
+    fn caps(&self) -> BackendCaps {
+        (**self).caps()
     }
 }
 

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -312,7 +312,9 @@ mod tests {
     /// Helper that builds a `read` closure from a static lookup table.
     /// Tests pass `&[("TMUX", "1"), ...]`; missing keys read as
     /// `None`. Keeps the call sites short.
-    fn env_reader(pairs: &'static [(&'static str, &'static str)]) -> impl Fn(&str) -> Option<String> {
+    fn env_reader(
+        pairs: &'static [(&'static str, &'static str)],
+    ) -> impl Fn(&str) -> Option<String> {
         move |name| {
             pairs
                 .iter()
@@ -448,7 +450,12 @@ mod tests {
             self.panes
                 .iter()
                 .enumerate()
-                .map(|(i, p)| (u32::try_from(100 + i).unwrap_or(u32::MAX), p.pane_id.clone()))
+                .map(|(i, p)| {
+                    (
+                        u32::try_from(100 + i).unwrap_or(u32::MAX),
+                        p.pane_id.clone(),
+                    )
+                })
                 .collect()
         }
         fn current_pane(&self) -> Option<String> {
@@ -479,8 +486,7 @@ mod tests {
     /// `PaneBackend` breaks this test loudly.
     #[test]
     fn fake_backend_satisfies_trait_contract() {
-        let b: Box<dyn PaneBackend> =
-            Box::new(FakeBackend::with_panes(vec![fake_pane("zj-1")]));
+        let b: Box<dyn PaneBackend> = Box::new(FakeBackend::with_panes(vec![fake_pane("zj-1")]));
         assert_eq!(b.kind(), HostKind::Zellij);
         assert_eq!(b.list_panes().len(), 1);
         assert_eq!(b.resolve_pane("zj-1").unwrap().pane_id, "zj-1");

--- a/crates/muxa/src/backend/tmux.rs
+++ b/crates/muxa/src/backend/tmux.rs
@@ -10,9 +10,9 @@
 //! refactor lands as a strict superset of v0.2.0 behavior.
 
 use std::collections::HashMap;
+use std::process::Command;
 
 use crate::backend::{HostKind, PaneBackend};
-use crate::reconcile::LivenessSource;
 use crate::tmux::{self, PaneInfo};
 
 /// Production tmux backend. Stateless — every method shells out fresh
@@ -61,18 +61,24 @@ impl PaneBackend for TmuxBackend {
     fn current_pane(&self) -> Option<String> {
         tmux::current_pane()
     }
-}
 
-/// Reconciler integration. The reconciler treats whatever the backend
-/// returns from `list_panes` as ground truth for "which panes are
-/// alive"; for tmux that's exactly the trait method, so the impl is a
-/// one-line delegation. Replaces [`crate::reconcile::TmuxLiveness`] in
-/// the production daemon — `TmuxLiveness` is kept around only for the
-/// existing reconciler unit tests until they migrate over.
-impl LivenessSource for TmuxBackend {
-    fn list_panes(&self) -> Vec<PaneInfo> {
-        PaneBackend::list_panes(self)
+    fn focus_pane(&self, pane_id: &str) -> bool {
+        // Just the focus step — `switch-client` / `attach-session` in
+        // the CLI is a separate concern (it crosses the process
+        // boundary and depends on whether the user is *inside* tmux
+        // already). Best-effort: a non-zero exit (pane closed mid-call)
+        // collapses to `false` so the caller can show a "couldn't
+        // jump" hint instead of bubbling a TmuxError up.
+        Command::new("tmux")
+            .args(["select-pane", "-t", pane_id])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
     }
+
+    // `caps()` uses the default impl from the trait — tmux supports
+    // every method the trait exposes, so spelling out the table here
+    // would just be noise.
 }
 
 #[cfg(test)]

--- a/crates/muxa/src/backend/tmux.rs
+++ b/crates/muxa/src/backend/tmux.rs
@@ -72,8 +72,7 @@ impl PaneBackend for TmuxBackend {
         Command::new("tmux")
             .args(["select-pane", "-t", pane_id])
             .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
+            .is_ok_and(|s| s.success())
     }
 
     // `caps()` uses the default impl from the trait — tmux supports

--- a/crates/muxa/src/backend/tmux.rs
+++ b/crates/muxa/src/backend/tmux.rs
@@ -1,0 +1,98 @@
+//! tmux implementation of [`crate::backend::PaneBackend`].
+//!
+//! Thin delegating wrapper around the existing `crate::tmux::*` free
+//! functions — moving the implementation to be a struct method invocation
+//! rather than a bare call site is the entire point. The daemon
+//! constructs one [`TmuxBackend`] at startup and threads it through to
+//! every caller that previously imported `crate::tmux::list_panes` and
+//! friends. Once every caller is migrated, the bare functions can be
+//! either removed or made `pub(crate)` — for now they coexist so this
+//! refactor lands as a strict superset of v0.2.0 behavior.
+
+use std::collections::HashMap;
+
+use crate::backend::{HostKind, PaneBackend};
+use crate::reconcile::LivenessSource;
+use crate::tmux::{self, PaneInfo};
+
+/// Production tmux backend. Stateless — every method shells out fresh
+/// because `tmux list-panes` is cheap (~few ms) and the daemon already
+/// caches pane inventories at higher layers (e.g. the reconciler ticks
+/// at 30 s, the dashboard `PaneCache` TTLs at 2 s).
+///
+/// Constructed once at daemon / CLI startup and held for the process
+/// lifetime; cheap to clone if a future caller wants to fan one out
+/// across tasks.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TmuxBackend;
+
+impl TmuxBackend {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl PaneBackend for TmuxBackend {
+    fn kind(&self) -> HostKind {
+        HostKind::Tmux
+    }
+
+    fn list_panes(&self) -> Vec<PaneInfo> {
+        // `crate::tmux::list_panes` returns `Result<Vec<_>, TmuxError>`;
+        // the trait contract is "best-effort, empty on failure" so we
+        // collapse the error path here. Concrete `Err` cases (no tmux
+        // server, command exit non-zero) are exactly the ones callers
+        // already treated as "host is down, retry next tick."
+        tmux::list_panes().unwrap_or_default()
+    }
+
+    fn resolve_pane(&self, pane_id: &str) -> Option<PaneInfo> {
+        tmux::resolve_pane(pane_id)
+    }
+
+    fn capture_pane(&self, pane_id: &str) -> Option<String> {
+        tmux::capture_pane(pane_id).ok()
+    }
+
+    fn pane_pid_map(&self) -> HashMap<u32, String> {
+        tmux::pane_pid_map()
+    }
+
+    fn current_pane(&self) -> Option<String> {
+        tmux::current_pane()
+    }
+}
+
+/// Reconciler integration. The reconciler treats whatever the backend
+/// returns from `list_panes` as ground truth for "which panes are
+/// alive"; for tmux that's exactly the trait method, so the impl is a
+/// one-line delegation. Replaces [`crate::reconcile::TmuxLiveness`] in
+/// the production daemon — `TmuxLiveness` is kept around only for the
+/// existing reconciler unit tests until they migrate over.
+impl LivenessSource for TmuxBackend {
+    fn list_panes(&self) -> Vec<PaneInfo> {
+        PaneBackend::list_panes(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `kind()` is the source-of-truth for which backend a record went
+    /// through. Locked down so a future copy/paste of this impl into a
+    /// zellij sibling can't accidentally inherit `HostKind::Tmux`.
+    #[test]
+    fn tmux_backend_reports_tmux_kind() {
+        let b = TmuxBackend::new();
+        assert_eq!(b.kind(), HostKind::Tmux);
+    }
+
+    /// Trait-object dispatch compiles and works — locks in the
+    /// `Send + Sync + 'static` bounds the daemon relies on for
+    /// stashing the backend on background tasks.
+    #[test]
+    fn tmux_backend_is_object_safe() {
+        let _b: Box<dyn PaneBackend> = Box::new(TmuxBackend::new());
+    }
+}

--- a/crates/muxa/src/backend/zellij.rs
+++ b/crates/muxa/src/backend/zellij.rs
@@ -1,0 +1,229 @@
+//! zellij implementation of [`crate::backend::PaneBackend`].
+//!
+//! ## What works without the WASM plugin
+//!
+//! zellij's CLI surface is narrower than tmux's `list-panes -F`. From
+//! shell-outs alone we can:
+//!
+//! - **Focus a pane** via `zellij action focus-pane-with-id <id>` —
+//!   stable, non-disruptive once the user knows the id.
+//! - **Read the current pane** from the `$ZELLIJ_PANE_ID` env var
+//!   inherited by every shell zellij spawns inside a pane.
+//!
+//! The other trait methods (`list_panes`, `resolve_pane`,
+//! `capture_pane`, `pane_pid_map`) need pane-level metadata zellij
+//! only exposes through the plugin API. This module pre-positions a
+//! snapshot cache the future plugin will push into; until that lands,
+//! the cache is permanently empty and the methods report it that way.
+//! [`crate::backend::BackendCaps`] flags are flipped to `false` for the
+//! plugin-only methods so callers (discovery, hook ancestry, watch
+//! preview) can branch on capability rather than mistaking "structurally
+//! unsupported" for a transient empty result.
+//!
+//! ## What about `capture_pane` via `dump-screen`?
+//!
+//! `zellij action dump-screen FILE` works, but it dumps the
+//! **currently-focused** pane only — capturing a non-focused pane
+//! requires `focus-pane-with-id` first, which is visibly disruptive
+//! to the user (their view jumps away). For "live preview" UX that's
+//! the wrong trade — a side-by-side preview should never disrupt the
+//! source pane. We therefore advertise `capture_pane: false` in
+//! `caps()` until the plugin can deliver non-disruptive captures via
+//! `PaneUpdate`/`screenshot()` events.
+//!
+//! ## Threading model
+//!
+//! `ZellijBackend` is `Send + Sync` because the daemon stashes one in
+//! an `Arc<dyn PaneBackend>` and shares it across background tokio
+//! tasks. The cached snapshot lives behind an `RwLock` so plugin
+//! pushes (writers) and consumers (readers) compose without blocking.
+//! All read sites take a single `read()` and clone what they need —
+//! holding the lock across an `await` would invite deadlocks against
+//! the plugin's IPC writer task.
+
+use std::collections::HashMap;
+use std::process::Command;
+use std::sync::{Arc, RwLock};
+
+use crate::backend::{BackendCaps, HostKind, PaneBackend};
+use crate::tmux::PaneInfo;
+
+/// CLI-baseline zellij backend.
+///
+/// Holds a shared snapshot of pane metadata that the future
+/// `muxa-zellij-plugin` WASM module will populate over IPC. Without the
+/// plugin the snapshot stays empty and methods that depend on
+/// pane-level metadata return empty / `None` — `caps()` is the
+/// authoritative signal for what's actually available.
+///
+/// Cheap to construct (no I/O); cheap to clone (`Arc` + `RwLock`).
+#[derive(Debug, Default, Clone)]
+pub struct ZellijBackend {
+    snapshot: Arc<RwLock<Vec<PaneInfo>>>,
+}
+
+impl ZellijBackend {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the cached pane snapshot wholesale. Called by the
+    /// daemon's IPC handler when the WASM plugin pushes a new
+    /// `BackendPaneSnapshot` payload. Atomic relative to readers
+    /// (the `RwLock` write guard blocks new readers; in-flight
+    /// readers see the previous snapshot).
+    ///
+    /// Until the plugin lands this method has no callers — kept on
+    /// the type so the wiring is in place when the IPC command
+    /// arrives.
+    #[allow(dead_code)]
+    pub(crate) fn replace_snapshot(&self, panes: Vec<PaneInfo>) {
+        if let Ok(mut w) = self.snapshot.write() {
+            *w = panes;
+        }
+    }
+}
+
+impl PaneBackend for ZellijBackend {
+    fn kind(&self) -> HostKind {
+        HostKind::Zellij
+    }
+
+    fn list_panes(&self) -> Vec<PaneInfo> {
+        // RwLock poisoning collapses to "empty list" rather than
+        // panicking on a hot path; the daemon already treats
+        // host-down as ephemeral.
+        self.snapshot
+            .read()
+            .map(|s| s.clone())
+            .unwrap_or_default()
+    }
+
+    fn resolve_pane(&self, pane_id: &str) -> Option<PaneInfo> {
+        self.snapshot
+            .read()
+            .ok()
+            .and_then(|s| s.iter().find(|p| p.pane_id == pane_id).cloned())
+    }
+
+    fn capture_pane(&self, _pane_id: &str) -> Option<String> {
+        // See module docs: zellij's `dump-screen` only works on the
+        // currently-focused pane, so capturing a *specific* pane via
+        // CLI requires a disruptive focus jump. The watch live
+        // preview opts out via `caps().capture_pane == false`.
+        None
+    }
+
+    fn pane_pid_map(&self) -> HashMap<u32, String> {
+        // Plugin-only — see `caps().pane_pid_map`. Hook ancestry will
+        // skip the walk entirely on this host.
+        HashMap::new()
+    }
+
+    fn current_pane(&self) -> Option<String> {
+        // `$ZELLIJ_PANE_ID` is set by zellij for every shell it spawns
+        // inside a pane. Empty string is treated as unset to match
+        // tmux's `current_pane` behaviour.
+        std::env::var("ZELLIJ_PANE_ID")
+            .ok()
+            .filter(|s| !s.is_empty())
+    }
+
+    fn focus_pane(&self, pane_id: &str) -> bool {
+        // `zellij action focus-pane-with-id <id>` is documented and
+        // stable. Best-effort: a non-zero exit (id no longer exists,
+        // zellij server gone) collapses to `false` so callers can
+        // show a "couldn't jump" hint.
+        Command::new("zellij")
+            .args(["action", "focus-pane-with-id", pane_id])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    fn caps(&self) -> BackendCaps {
+        BackendCaps {
+            // `list_panes`'s `current_command` field stays empty until
+            // the plugin pushes real metadata.
+            current_command: false,
+            // No CLI surface for pid → pane id; plugin-only.
+            pane_pid_map: false,
+            // Disruptive on CLI; plugin-only when non-disruptive.
+            capture_pane: false,
+            // Always works.
+            focus_pane: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_pane(id: &str) -> PaneInfo {
+        PaneInfo {
+            pane_id: id.into(),
+            session: "z".into(),
+            window_index: "0".into(),
+            pane_index: "0".into(),
+            tty: String::new(),
+            current_command: String::new(),
+            title: String::new(),
+        }
+    }
+
+    /// `kind()` is the source-of-truth for which backend a record
+    /// went through. Locked down so a future copy-paste of this impl
+    /// can't accidentally inherit `HostKind::Tmux`.
+    #[test]
+    fn zellij_backend_reports_zellij_kind() {
+        assert_eq!(ZellijBackend::new().kind(), HostKind::Zellij);
+    }
+
+    /// CLI-only baseline advertises plugin-only methods as
+    /// unsupported, but `focus_pane` stays true. Locked down because
+    /// flipping any of these to `true` without a corresponding code
+    /// change is a silent regression — the caller would degrade
+    /// thinking the result was just transiently empty.
+    #[test]
+    fn zellij_caps_match_cli_only_baseline() {
+        let caps = ZellijBackend::new().caps();
+        assert!(!caps.current_command);
+        assert!(!caps.pane_pid_map);
+        assert!(!caps.capture_pane);
+        assert!(caps.focus_pane);
+    }
+
+    /// Empty cache → `list_panes` is empty and `resolve_pane` returns
+    /// `None`. The backend is constructed in this state when no
+    /// plugin has pushed yet; the test pins that behaviour.
+    #[test]
+    fn empty_cache_yields_empty_pane_inventory() {
+        let b = ZellijBackend::new();
+        assert!(b.list_panes().is_empty());
+        assert!(b.resolve_pane("anything").is_none());
+        assert!(b.pane_pid_map().is_empty());
+        assert!(b.capture_pane("anything").is_none());
+    }
+
+    /// `replace_snapshot` round-trips: a wholesale swap is visible on
+    /// the next read. This is the surface the future plugin pushes
+    /// into; locking it now means the plugin can land without
+    /// re-shaping the cache contract.
+    #[test]
+    fn replace_snapshot_updates_what_consumers_see() {
+        let b = ZellijBackend::new();
+        b.replace_snapshot(vec![fake_pane("z-1"), fake_pane("z-2")]);
+        let panes = b.list_panes();
+        assert_eq!(panes.len(), 2);
+        assert_eq!(b.resolve_pane("z-1").unwrap().pane_id, "z-1");
+        assert!(b.resolve_pane("missing").is_none());
+    }
+
+    /// Trait-object dispatch compiles — locks in the
+    /// `Send + Sync + 'static` bounds the daemon relies on.
+    #[test]
+    fn zellij_backend_is_object_safe() {
+        let _b: Box<dyn PaneBackend> = Box::new(ZellijBackend::new());
+    }
+}

--- a/crates/muxa/src/backend/zellij.rs
+++ b/crates/muxa/src/backend/zellij.rs
@@ -93,10 +93,7 @@ impl PaneBackend for ZellijBackend {
         // RwLock poisoning collapses to "empty list" rather than
         // panicking on a hot path; the daemon already treats
         // host-down as ephemeral.
-        self.snapshot
-            .read()
-            .map(|s| s.clone())
-            .unwrap_or_default()
+        self.snapshot.read().map(|s| s.clone()).unwrap_or_default()
     }
 
     fn resolve_pane(&self, pane_id: &str) -> Option<PaneInfo> {
@@ -137,8 +134,7 @@ impl PaneBackend for ZellijBackend {
         Command::new("zellij")
             .args(["action", "focus-pane-with-id", pane_id])
             .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
+            .is_ok_and(|s| s.success())
     }
 
     fn caps(&self) -> BackendCaps {

--- a/crates/muxa/src/discovery.rs
+++ b/crates/muxa/src/discovery.rs
@@ -1,26 +1,36 @@
-//! Backfill discovery: scan tmux panes and synthesize `Started` events for
+//! Backfill discovery: scan host panes and synthesize `Started` events for
 //! agent processes the daemon doesn't know about yet.
 //!
 //! When `muxad` restarts mid-session, agents that were already running keep
-//! going inside their tmux panes but stop appearing in `muxa status` until
-//! they emit a fresh hook. That can take minutes if the agent is idle.
+//! going inside their panes but stop appearing in `muxa status` until they
+//! emit a fresh hook. That can take minutes if the agent is idle.
 //!
-//! This module bridges the gap by inspecting `pane_current_command` for each
-//! tmux pane and synthesizing a minimal `AgentEvent::Started` for any pane
-//! whose command matches a known agent CLI. The synthetic entry uses a
-//! `synthetic-<pane_id>` session id so re-running discovery is idempotent;
-//! when a real hook later fires for the same pane, the store replaces the
-//! synthetic entry in place — see `Store::apply`.
+//! This module bridges the gap by inspecting each pane's
+//! `current_command` field via [`PaneBackend`] and synthesizing a minimal
+//! `AgentEvent::Started` for any pane whose command matches a known
+//! agent CLI. The synthetic entry uses a `synthetic-<pane_id>` session
+//! id so re-running discovery is idempotent; when a real hook later
+//! fires for the same pane, the store replaces the synthetic entry in
+//! place — see `Store::apply`.
 //!
-//! Detection is intentionally simple: just `pane_current_command`. We don't
-//! walk process trees because that's noisy across kernels (`/proc` on Linux,
-//! `ps` on macOS) and the foreground command is good enough at the resolution
-//! we need.
+//! Detection is intentionally simple: just `current_command`. We don't
+//! walk process trees because that's noisy across kernels (`/proc` on
+//! Linux, `ps` on macOS) and the foreground command is good enough at
+//! the resolution we need.
+//!
+//! ## Capability gating
+//!
+//! Backends whose `caps().current_command == false` (zellij CLI without
+//! the WASM plugin, today) cannot classify panes by command. Discovery
+//! collapses to a no-op on those hosts rather than producing
+//! all-`Unknown` rows: agent registration falls back to "trust whatever
+//! pane the stdin hook self-reports" until the plugin lands.
 
+use crate::backend::PaneBackend;
 use crate::event::{AgentEvent, AgentId, AgentKind};
 use crate::ipc::{Client, RuntimeError};
 use crate::state::SYNTHETIC_SESSION_PREFIX;
-use crate::tmux::{self, PaneInfo, TmuxError};
+use crate::tmux::PaneInfo;
 use time::OffsetDateTime;
 
 /// One discovered agent pane.
@@ -59,10 +69,15 @@ pub fn discover_from_panes(panes: &[PaneInfo]) -> Vec<Discovered> {
         .collect()
 }
 
-/// Live scan: shell out to `tmux list-panes` and classify each entry.
-pub fn scan_panes() -> Result<Vec<Discovered>, TmuxError> {
-    let panes = tmux::list_panes()?;
-    Ok(discover_from_panes(&panes))
+/// Live scan: ask the backend for the current pane inventory and
+/// classify each entry. Returns an empty vec when the backend has no
+/// panes (host down) or when `caps().current_command == false` —
+/// classification is meaningless without the foreground-command field.
+pub fn scan_panes(backend: &dyn PaneBackend) -> Vec<Discovered> {
+    if !backend.caps().current_command {
+        return Vec::new();
+    }
+    discover_from_panes(&backend.list_panes())
 }
 
 /// Build a synthetic `AgentEvent::Started` for one discovered pane.
@@ -121,16 +136,17 @@ impl DiscoveryReport {
 ///
 /// Errors from individual ingest calls are counted but don't abort the pass —
 /// best-effort matches the rest of the daemon's surface.
-pub async fn run_discovery(client: &Client) -> Result<DiscoveryReport, RuntimeError> {
-    let discovered = match scan_panes() {
-        Ok(v) => v,
-        Err(e) => {
-            // No tmux, no panes — treat as an empty report rather than an
-            // error so `muxad` startup keeps working on hosts without tmux.
-            tracing::debug!(error = %e, "tmux list-panes failed; skipping discovery");
-            return Ok(DiscoveryReport::default());
-        }
-    };
+pub async fn run_discovery(
+    client: &Client,
+    backend: &dyn PaneBackend,
+) -> Result<DiscoveryReport, RuntimeError> {
+    let discovered = scan_panes(backend);
+    if discovered.is_empty() {
+        // Either no panes (host down / outside multiplexer) or the
+        // backend can't classify by command (zellij CLI-only). Skip
+        // the IPC chatter — there's nothing to ingest.
+        return Ok(DiscoveryReport::default());
+    }
 
     let snapshot = client.snapshot().await?;
     let mut report = DiscoveryReport::default();

--- a/crates/muxa/src/history.rs
+++ b/crates/muxa/src/history.rs
@@ -261,7 +261,7 @@ impl PromptHistory {
             .values()
             .flat_map(|d| d.iter().cloned())
             .collect();
-        all.sort_by(|a, b| b.at.cmp(&a.at));
+        all.sort_by_key(|e| std::cmp::Reverse(e.at));
         if limit > 0 {
             all.truncate(limit);
         }
@@ -618,7 +618,8 @@ mod tests {
         };
         let (tx, _) = broadcast::channel::<()>(1);
         let (h, writer) = PromptHistory::spawn(opts, tx.subscribe()).await.unwrap();
-        h.append(entry("%1", "p", datetime!(2026-04-28 0:00 UTC))).await;
+        h.append(entry("%1", "p", datetime!(2026-04-28 0:00 UTC)))
+            .await;
         // Quiesce so the writer has actually flushed the line to disk.
         let _ = tx.send(());
         let _ = writer.await;

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -201,9 +201,7 @@ impl Server {
         // Drain in-flight handlers with a bounded timeout. Closes the
         // lost-update window where a handler could call `Store::apply`
         // after the daemon's snapshotter has already exited.
-        let drain = async {
-            while handlers.join_next().await.is_some() {}
-        };
+        let drain = async { while handlers.join_next().await.is_some() {} };
         if tokio::time::timeout(HANDLER_DRAIN_TIMEOUT, drain)
             .await
             .is_err()
@@ -574,13 +572,10 @@ mod tests {
         // returning. The bounded timeout here is the test's deadline,
         // not the production drain timeout — we expect this to complete
         // in milliseconds.
-        let outcome = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            server_handle,
-        )
-        .await
-        .expect("server.run did not return after handler finished")
-        .expect("server task panicked");
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(2), server_handle)
+            .await
+            .expect("server.run did not return after handler finished")
+            .expect("server task panicked");
         outcome.expect("server.run returned an error");
 
         // The drained handler must have applied its event before

--- a/crates/muxa/src/lib.rs
+++ b/crates/muxa/src/lib.rs
@@ -21,7 +21,7 @@ pub mod snapshot;
 pub mod state;
 pub mod tmux;
 
-pub use backend::{tmux::TmuxBackend, HostKind, PaneBackend};
+pub use backend::{tmux::TmuxBackend, BackendCaps, HostKind, PaneBackend};
 pub use config::Config;
 pub use discovery::{run_discovery, scan_panes, Discovered, DiscoveryReport};
 pub use error::{CoreError, Result};
@@ -29,6 +29,6 @@ pub use event::{AgentEvent, AgentId, AgentKind, AgentState, NotificationLevel, P
 pub use history::{
     CompactReport, HistoryEntry, HistoryOptions, PromptHistory, HISTORY_SCHEMA_VERSION,
 };
-pub use reconcile::{LivenessSource, Reconciler, TmuxLiveness};
+pub use reconcile::{LivenessSource, Reconciler};
 pub use snapshot::{Snapshotter, SnapshotterOptions, STATE_SCHEMA_VERSION};
 pub use state::{Agent, PromptRecord, ReconcileReport, SharedStore, Store, Transition};

--- a/crates/muxa/src/lib.rs
+++ b/crates/muxa/src/lib.rs
@@ -5,6 +5,7 @@
 //! full `muxa::ipc::Server` form.
 
 pub mod adapters;
+pub mod backend;
 pub mod config;
 pub mod dashboard;
 pub mod discovery;
@@ -20,6 +21,7 @@ pub mod snapshot;
 pub mod state;
 pub mod tmux;
 
+pub use backend::{tmux::TmuxBackend, HostKind, PaneBackend};
 pub use config::Config;
 pub use discovery::{run_discovery, scan_panes, Discovered, DiscoveryReport};
 pub use error::{CoreError, Result};

--- a/crates/muxa/src/lib.rs
+++ b/crates/muxa/src/lib.rs
@@ -21,7 +21,10 @@ pub mod snapshot;
 pub mod state;
 pub mod tmux;
 
-pub use backend::{tmux::TmuxBackend, BackendCaps, HostKind, PaneBackend};
+pub use backend::{
+    default_backend, tmux::TmuxBackend, zellij::ZellijBackend, BackendCaps, HostKind, PaneBackend,
+    SharedBackend,
+};
 pub use config::Config;
 pub use discovery::{run_discovery, scan_panes, Discovered, DiscoveryReport};
 pub use error::{CoreError, Result};

--- a/crates/muxa/src/reconcile.rs
+++ b/crates/muxa/src/reconcile.rs
@@ -29,7 +29,7 @@ use tokio::time::{interval, MissedTickBehavior};
 use tracing::debug;
 
 use crate::state::{ReconcileReport, SharedStore};
-use crate::tmux::{self, PaneInfo};
+use crate::tmux::PaneInfo;
 
 /// Source of truth for which panes are currently alive.
 ///
@@ -38,21 +38,23 @@ use crate::tmux::{self, PaneInfo};
 /// own one inside a long-lived spawned task; `list_panes` is sync-blocking
 /// because the production impl shells out to `tmux` and the reconciler
 /// wraps the call in `spawn_blocking` itself.
+///
+/// Every [`PaneBackend`](crate::backend::PaneBackend) is automatically a
+/// `LivenessSource` via the blanket impl below — backends don't need to
+/// re-spell their `list_panes` for the reconciler. Tests that want to
+/// drive the reconciler with a hand-rolled fake can either implement
+/// `LivenessSource` directly (lightweight) or implement `PaneBackend`
+/// and inherit the blanket impl (more realistic).
 pub trait LivenessSource: Send + Sync + 'static {
     fn list_panes(&self) -> Vec<PaneInfo>;
 }
 
-/// Production [`LivenessSource`] backed by `tmux list-panes -a`.
-///
-/// Failures (no tmux server, command error) collapse to an empty vec —
-/// safer than panicking inside a background loop. An empty result lets the
-/// reconciler reap stale records aggressively if tmux is gone, which is
-/// usually what the user wants after a tmux crash.
-pub struct TmuxLiveness;
-
-impl LivenessSource for TmuxLiveness {
+/// Every pane backend is a liveness source. Saves every backend impl
+/// from repeating a one-line delegation, and keeps the reconciler
+/// integration colocated with the trait whose contract it leans on.
+impl<B: crate::backend::PaneBackend> LivenessSource for B {
     fn list_panes(&self) -> Vec<PaneInfo> {
-        tmux::list_panes().unwrap_or_default()
+        crate::backend::PaneBackend::list_panes(self)
     }
 }
 

--- a/crates/muxa/src/tmux/scanner.rs
+++ b/crates/muxa/src/tmux/scanner.rs
@@ -11,6 +11,18 @@
 //! All `tmux` invocations carry a 1-second timeout — a hung server (e.g.
 //! a wedged `attach-session` losing the controlling terminal) cannot
 //! stall the dashboard.
+//!
+//! ## Zellij hosts
+//!
+//! Zellij is a single-server-per-user model with no multi-socket
+//! analog, so the dashboard's `/api/panes` route — which calls
+//! [`scan`] to populate its rows — naturally returns an empty result
+//! on a zellij-only host. Cross-host enumeration in the dashboard
+//! waits on the WASM plugin landing (the plugin is the only surface
+//! that exposes zellij pane metadata at all); until then the
+//! dashboard's panes view is tmux-only and the agents view (`/api/agents`,
+//! `/api/events`) is host-agnostic. This is intentional and matches
+//! the design doc's "Zellij has no multi-server enumeration" note.
 
 use crate::tmux::{parse_pane_lines, PaneInfo, PANE_FMT};
 use serde::Serialize;

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -13,7 +13,6 @@ use muxa::history::{HistoryOptions, PromptHistory};
 use muxa::ipc::{harden_permissions, Client, Server};
 use muxa::notify::Notifier;
 use muxa::reconcile::Reconciler;
-use muxa::TmuxBackend;
 use muxa::sinks::OhMyPromptSink;
 use muxa::snapshot::{self, Snapshotter, SnapshotterOptions};
 use muxa::tmux::scanner::PaneCache;
@@ -117,6 +116,15 @@ async fn main() -> Result<()> {
     let history = build_history(&cfg, &shutdown_tx).await;
     let store = Store::shared_with_history(history.clone());
 
+    // One backend, shared across every consumer that previously spoke
+    // to tmux directly. Resolution honors `MUXA_HOST` then auto-detects
+    // from `ZELLIJ` / `TMUX`, falling back to `TmuxBackend` when no host
+    // is detectable. Cheap to clone — the underlying `Arc` lets the
+    // reconciler, discovery, enrichment, and snapshotter each hold a
+    // handle without contention.
+    let backend: muxa::SharedBackend = muxa::default_backend();
+    tracing::info!(host = %backend.kind(), "pane backend selected");
+
     // Rehydrate the agent registry from the previous run's snapshot, if
     // any. Done before the IPC server starts accepting events so no
     // adapter ingest can race a half-loaded store; before discovery so
@@ -125,16 +133,21 @@ async fn main() -> Result<()> {
     // spawns so the first save isn't a no-op overwrite of the file we
     // just read.
     hydrate_state(&cfg, &store).await;
+    // Capability-gated: enrichment classifies panes by foreground
+    // command, which the zellij CLI baseline doesn't expose. The
+    // function itself respects `caps()` so it's safe to always call;
+    // the explicit log line just makes the skip-on-zellij case
+    // legible in operator traces.
     // Then layer in any panes that have prompt history on disk but
     // aren't represented in state.json (typically because the previous
     // run died before its first debounce window). This recovers the
     // real `session_id` + `last_prompt` from prompts.ndjson, so the
     // operator sees rich rows for those panes immediately on restart
     // instead of `synthetic-%X` placeholders.
-    enrich_from_history(&store, &history).await;
+    enrich_from_history(&store, &history, &backend).await;
 
     spawn_gc_task(&store, &shutdown_tx);
-    spawn_reconciler_task(&cfg, &store, &shutdown_tx);
+    spawn_reconciler_task(&cfg, &store, &shutdown_tx, backend.clone());
     spawn_history_compaction_task(&cfg, &store, &shutdown_tx);
 
     // The snapshotter listens on its own dedicated channel rather than
@@ -201,7 +214,7 @@ async fn main() -> Result<()> {
     // tmux panes from before the daemon (re)started. Configurable; default
     // on. Does not block server readiness — spawned in the background.
     if listener_ready {
-        spawn_startup_discovery(&cfg, socket.clone());
+        spawn_startup_discovery(&cfg, socket.clone(), backend.clone());
     }
 
     // Shutdown sequence (each step depends on the previous):
@@ -368,17 +381,20 @@ fn spawn_reconciler_task(
     cfg: &Config,
     store: &muxa::SharedStore,
     shutdown_tx: &broadcast::Sender<()>,
+    backend: muxa::SharedBackend,
 ) {
     if !cfg.reconciler.enabled {
         tracing::info!("reconciler disabled by config");
         return;
     }
-    // Drives reconciliation through the trait-based backend instead of
-    // the legacy `TmuxLiveness` so the same hook point picks up zellij
-    // (and any future host) once their `PaneBackend` impls land.
+    // The shared backend is what the rest of the daemon uses too —
+    // everyone agreeing on one host means the reconciler reaps panes
+    // by the same definition the watch loop, hook ancestry, and
+    // discovery do. `LivenessSource` reaches the reconciler via the
+    // blanket impl on `PaneBackend`.
     let runner = Reconciler::new(
         store.clone(),
-        TmuxBackend::new(),
+        backend,
         std::time::Duration::from_secs(cfg.reconciler.interval_secs),
     );
     let shutdown_rx = shutdown_tx.subscribe();
@@ -464,12 +480,21 @@ async fn hydrate_state(cfg: &Config, store: &muxa::SharedStore) {
 /// Skipped silently when tmux isn't available, when history is empty, or
 /// when state snapshotting is disabled (in which case we'd rather not
 /// resurrect agents the operator opted out of persisting).
-async fn enrich_from_history(store: &muxa::SharedStore, history: &Arc<PromptHistory>) {
-    use muxa::tmux;
+async fn enrich_from_history(
+    store: &muxa::SharedStore,
+    history: &Arc<PromptHistory>,
+    backend: &muxa::SharedBackend,
+) {
     if history.is_empty().await {
         return;
     }
-    let Ok(Ok(panes)) = tokio::task::spawn_blocking(tmux::list_panes).await else {
+    // Wrap the (potentially blocking) backend call so the runtime
+    // doesn't stall while tmux shells out. Cloning the `Arc` is the
+    // cheapest way to give `spawn_blocking`'s closure the `'static`
+    // handle it needs.
+    let backend_for_blocking = backend.clone();
+    let Ok(panes) = tokio::task::spawn_blocking(move || backend_for_blocking.list_panes()).await
+    else {
         return;
     };
     if panes.is_empty() {
@@ -600,7 +625,11 @@ fn spawn_oh_my_prompt_sink(
 /// Returns `true` when a task was spawned. Extracted from `main` so tests
 /// can drive both branches of the `discovery.enabled` flag without having
 /// to spawn the real daemon.
-fn spawn_startup_discovery(cfg: &Config, socket: PathBuf) -> bool {
+fn spawn_startup_discovery(
+    cfg: &Config,
+    socket: PathBuf,
+    backend: muxa::SharedBackend,
+) -> bool {
     if !cfg.discovery.enabled {
         tracing::debug!("startup discovery disabled by config");
         return false;
@@ -612,7 +641,7 @@ fn spawn_startup_discovery(cfg: &Config, socket: PathBuf) -> bool {
         // delays the visible backfill needlessly.
         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         let client = Client::new(socket);
-        match discovery::run_discovery(&client).await {
+        match discovery::run_discovery(&client, backend.as_ref()).await {
             Ok(report) => {
                 tracing::info!(
                     claude_code = report.claude_code,
@@ -640,7 +669,11 @@ mod tests {
             discovery: DiscoveryConfig { enabled: true },
             ..Config::default()
         };
-        let spawned = spawn_startup_discovery(&cfg, PathBuf::from("/tmp/never-bound.sock"));
+        let spawned = spawn_startup_discovery(
+            &cfg,
+            PathBuf::from("/tmp/never-bound.sock"),
+            muxa::default_backend(),
+        );
         assert!(spawned, "discovery should spawn when enabled");
     }
 
@@ -650,7 +683,11 @@ mod tests {
             discovery: DiscoveryConfig { enabled: false },
             ..Config::default()
         };
-        let spawned = spawn_startup_discovery(&cfg, PathBuf::from("/tmp/never-bound.sock"));
+        let spawned = spawn_startup_discovery(
+            &cfg,
+            PathBuf::from("/tmp/never-bound.sock"),
+            muxa::default_backend(),
+        );
         assert!(!spawned, "discovery must not spawn when disabled");
     }
 }

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -12,7 +12,8 @@ use muxa::dashboard::{DashboardConfig, DashboardOverrides};
 use muxa::history::{HistoryOptions, PromptHistory};
 use muxa::ipc::{harden_permissions, Client, Server};
 use muxa::notify::Notifier;
-use muxa::reconcile::{Reconciler, TmuxLiveness};
+use muxa::reconcile::Reconciler;
+use muxa::TmuxBackend;
 use muxa::sinks::OhMyPromptSink;
 use muxa::snapshot::{self, Snapshotter, SnapshotterOptions};
 use muxa::tmux::scanner::PaneCache;
@@ -372,9 +373,12 @@ fn spawn_reconciler_task(
         tracing::info!("reconciler disabled by config");
         return;
     }
+    // Drives reconciliation through the trait-based backend instead of
+    // the legacy `TmuxLiveness` so the same hook point picks up zellij
+    // (and any future host) once their `PaneBackend` impls land.
     let runner = Reconciler::new(
         store.clone(),
-        TmuxLiveness,
+        TmuxBackend::new(),
         std::time::Duration::from_secs(cfg.reconciler.interval_secs),
     );
     let shutdown_rx = shutdown_tx.subscribe();

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -419,15 +419,8 @@ fn spawn_snapshotter_task(
         tracing::info!("state snapshot disabled by config");
         return None;
     }
-    let Some(path) = cfg
-        .state
-        .path
-        .clone()
-        .or_else(paths::default_state_file)
-    else {
-        tracing::warn!(
-            "state snapshot enabled but no path resolvable; restarts will lose state"
-        );
+    let Some(path) = cfg.state.path.clone().or_else(paths::default_state_file) else {
+        tracing::warn!("state snapshot enabled but no path resolvable; restarts will lose state");
         return None;
     };
     let opts = SnapshotterOptions {
@@ -452,12 +445,7 @@ async fn hydrate_state(cfg: &Config, store: &muxa::SharedStore) {
     if !cfg.state.enabled {
         return;
     }
-    let Some(path) = cfg
-        .state
-        .path
-        .clone()
-        .or_else(paths::default_state_file)
-    else {
+    let Some(path) = cfg.state.path.clone().or_else(paths::default_state_file) else {
         return;
     };
     let initial = snapshot::load(&path).await;
@@ -625,11 +613,7 @@ fn spawn_oh_my_prompt_sink(
 /// Returns `true` when a task was spawned. Extracted from `main` so tests
 /// can drive both branches of the `discovery.enabled` flag without having
 /// to spawn the real daemon.
-fn spawn_startup_discovery(
-    cfg: &Config,
-    socket: PathBuf,
-    backend: muxa::SharedBackend,
-) -> bool {
+fn spawn_startup_discovery(cfg: &Config, socket: PathBuf, backend: muxa::SharedBackend) -> bool {
     if !cfg.discovery.enabled {
         tracing::debug!("startup discovery disabled by config");
         return false;

--- a/docs/ZELLIJ.md
+++ b/docs/ZELLIJ.md
@@ -96,25 +96,89 @@ no-op for this backend.
 
 ### Step 4 — CLI wiring
 
-`muxa status`, `muxa watch`, `muxa hook <agent>` pick the backend based on
-which env var is set. If both `$TMUX` and `$ZELLIJ` are present (rare but
-possible if nested), prefer the innermost — i.e. whichever was set last.
-Document the precedence.
+`muxa status`, `muxa watch`, `muxa hook <agent>` pick the backend through
+[`backend::detect_host_env`]. The resolution order is:
+
+1. `MUXA_HOST=tmux|zellij` — explicit operator override; wins regardless
+   of which host env vars are present. Useful for nested-multiplexer
+   setups where `tmux new-session` from inside zellij leaves `ZELLIJ`
+   set in the new shell's env even though the actual host is tmux.
+2. `ZELLIJ` set → zellij.
+3. `TMUX` set → tmux.
+4. Neither set → no-op backend (operator running outside any
+   multiplexer; CLI commands that don't need a backend keep working).
+
+When both `$TMUX` and `$ZELLIJ` are present, zellij wins by default —
+this is a pragmatic pick rather than a principled one (the env doesn't
+carry "set last" ordering). `MUXA_HOST` is the escape hatch.
+
+## Capability story (CLI-only zellij)
+
+Several `PaneBackend` methods are **plugin-only on zellij** because the
+zellij CLI doesn't expose pane metadata at parity with tmux's
+`list-panes -F`. The trait surfaces this through [`BackendCaps`] so
+callers can branch on what's actually available rather than silently
+degrading on empty results:
+
+| Capability             | tmux backend | zellij CLI-only | zellij + plugin |
+| ---------------------- | ------------ | --------------- | --------------- |
+| `list_panes` (any rows) | ✅           | ⚠️ via `list-clients` only | ✅       |
+| `current_command` field | ✅           | ❌ never        | ✅              |
+| `pane_pid_map`          | ✅           | ❌ never        | ✅              |
+| `capture_pane`          | ✅           | ✅ via `dump-screen` | ✅          |
+| `focus_pane`            | ✅           | ✅              | ✅              |
+
+The "CLI-only" column is what users get out of the box if they don't
+install the WASM plugin. It's intentionally degraded — agent
+auto-discovery falls back to "trust whatever pane the stdin hook
+self-reports" because there's no way to classify panes by foreground
+command. The plugin is what closes that gap; the CLI-only mode exists
+mainly so an operator who installs the muxa binary on a zellij host
+gets *something* working immediately, even if it's not full parity.
+
+Hook ancestry (`adapters/hook.rs`), discovery (`discovery.rs`), and
+the watch loop should consult `caps()` before walking pid chains or
+classifying by command, and pick the appropriate fallback for the
+"structurally unsupported" case (vs the existing "transient empty"
+case which the trait already handles via best-effort returns).
+
+## Pane ID wire format
+
+**Decision: backend-prefixed strings (`tmux:%4`, `zellij:3`).**
+
+tmux's `%N` and zellij's numeric ids would collide if we tried to put
+them in the same on-wire `PaneId` namespace. We pick prefixed strings
+over a `(host, raw_id)` tuple because:
+
+- The wire format already has `pane_id: String` everywhere — IPC
+  schema, `state.json`, `prompts.ndjson`, `Agent.pane`. Switching to a
+  tuple is a breaking schema change for every consumer; prefixing is
+  an additive convention that just looks like a longer string to old
+  readers.
+- `state.json` and `prompts.ndjson` are already on disk in production;
+  retroactively prefixing is a one-shot migration in
+  [`crate::snapshot::load`] / [`crate::history::load_from_disk`]
+  rather than a breaking version bump. Plan for that migration is to
+  treat any unprefixed pane id as `tmux:` since pre-zellij operators
+  only ever ran tmux.
+
+Lock this in **before** the watch migration lands so the daemon's IPC
+schema doesn't have to flip mid-transition.
 
 ## Open questions
 
-- **Pane IDs across hosts.** tmux uses `%N` (e.g. `%4`); zellij uses numeric
-  pane IDs scoped by tab. Are we OK with a backend-prefixed string format
-  (`tmux:%4`, `zellij:3`) for the on-wire `PaneId`? This bleeds into the
-  daemon DB schema — needs a migration plan if so.
-- **Plugin distribution.** Ship the `.wasm` in the GitHub release, or expect
-  users to `cargo build` it? First option is friendlier; second avoids us
-  signing/hosting a WASM blob.
-- **UX for "go to this pane".** zellij's focus model (tabs + floating panes +
-  stacked panes) doesn't map 1:1 onto tmux's session/window/pane. The watch
-  TUI's "press Enter to jump" needs a separate design pass.
-- **Plugin API stability.** zellij plugin API is pre-1.0; assume one breaking
-  bump per zellij minor release and pin a minimum supported version.
+- **Plugin distribution.** Ship the `.wasm` in the GitHub release, or
+  expect users to `cargo build` it? First option is friendlier; second
+  avoids us signing/hosting a WASM blob.
+- **UX for "go to this pane".** zellij's focus model (tabs + floating
+  panes + stacked panes) doesn't map 1:1 onto tmux's session/window/
+  pane. The watch TUI's "press Enter to jump" needs a separate design
+  pass — the trait method `focus_pane(&str) -> bool` is the seam, but
+  what the daemon shows in the picker for a zellij floating pane is
+  open.
+- **Plugin API stability.** zellij plugin API is pre-1.0; assume one
+  breaking bump per zellij minor release and pin a minimum supported
+  version.
 
 ## Rough effort
 

--- a/docs/ZELLIJ.md
+++ b/docs/ZELLIJ.md
@@ -1,0 +1,140 @@
+# Zellij backend (planned)
+
+This document captures the design plan for adding a [zellij](https://zellij.dev)
+backend alongside the existing tmux backend. **Not yet implemented** — this is
+a work item parked for later. Refer back here before starting; update in place
+as decisions change.
+
+## Why
+
+muxa is structurally a daemon + CLI that observes per-pane agent state. tmux
+is one possible host; nothing in the event ingest, state machine, sinks, or
+watch UI is tmux-specific. A zellij backend brings muxa to users who prefer
+zellij's layout model and plugin system without forking the project.
+
+## Current tmux coupling
+
+The tmux surface muxa actually uses is small (~600 LOC, all under
+`crates/muxa/src/tmux/`):
+
+| Concern                   | Today                                                                 |
+| ------------------------- | --------------------------------------------------------------------- |
+| Pane enumeration          | `tmux -S <sock> list-panes -a -F '#{pane_id} #{session_name} ...'`    |
+| Foreground command per pane | `#{pane_current_command}` from the same format string               |
+| Multi-server discovery    | Filesystem walk over `$TMUX_TMPDIR`, `/tmp/tmux-$UID/`, etc.          |
+| Pane focus / attach       | `select-window` + `select-pane`, then `switch-client` or `attach-session` |
+| Hook context              | Reads `$TMUX_PANE`, `$TMUX` from the agent's environment              |
+
+Outside that module, tmux is invisible. Sinks, watch TUI, recap, daemon IPC,
+and agent stdin hooks all operate on `PaneId` strings and don't care where
+those IDs come from.
+
+## Zellij capability gaps
+
+Zellij does not expose pane metadata at parity with tmux's `list-panes -F`:
+
+| Capability                    | tmux                          | zellij                                                      |
+| ----------------------------- | ----------------------------- | ----------------------------------------------------------- |
+| List panes with metadata      | `list-panes -F` (CLI)         | **Plugin API only** (`PaneInfo` via `PaneUpdate` event)     |
+| Foreground command per pane   | `#{pane_current_command}`     | `PaneInfo.terminal_command` — plugin-only                   |
+| Focus a pane by ID            | `select-pane -t %N`           | `zellij action focus-pane-with-id <id>` ✅                  |
+| Screen capture                | `capture-pane -p`             | `zellij action dump-screen` ✅                              |
+| Multi-server enumeration      | Required (socket scan)        | **Not needed** — single server per machine                  |
+| Real-time pane events         | (unused today; control mode)  | `PaneUpdate` / `TabUpdate` push from plugin host            |
+
+The blocker is foreground-command detection. Without it, agent auto-discovery
+collapses to "trust whatever pane the stdin hook self-reports," and panes
+without a hook installed are invisible. That's a regression we should not ship.
+
+## Approach: trait extraction + WASM plugin
+
+### Step 1 — Extract `PaneBackend` trait
+
+Refactor `crates/muxa/src/tmux/` into `crates/muxa/src/backend/` with a trait
+roughly shaped as:
+
+```rust
+pub trait PaneBackend: Send + Sync {
+    fn list_panes(&self) -> Result<Vec<PaneSnapshot>>;
+    fn resolve_pane(&self, id: &PaneId) -> Result<Option<PaneSnapshot>>;
+    fn focus_pane(&self, id: &PaneId) -> Result<()>;
+    fn detect_host_env() -> Option<HostKind>; // reads $TMUX / $ZELLIJ
+}
+```
+
+`PaneSnapshot` is the existing record (id, session, window, pane index, tty,
+current command, title). The tmux impl moves under `backend/tmux.rs` mostly
+unchanged. This is a non-feature refactor that's worth doing on its own merits
+— it also unblocks a future control-mode (`-C`) tmux backend.
+
+### Step 2 — `muxa-zellij-plugin`
+
+A small Rust → WASM plugin (target `wasm32-wasip1`) that:
+
+1. Subscribes to `PaneUpdate` and `TabUpdate` via the zellij plugin API.
+2. On every update, serializes the relevant `PaneInfo` fields and pushes them
+   to `$XDG_RUNTIME_DIR/muxa.sock` over a new daemon command (e.g.
+   `BackendPaneSnapshot { panes: Vec<PaneSnapshot> }`).
+3. Holds no state — the daemon is the source of truth. Plugin is a pure
+   adapter.
+
+Lives in a new workspace crate, builds to a `.wasm` artifact shipped with
+releases. User installs via `zellij plugin --configuration ... load <path>` or
+adds it to their layout file.
+
+### Step 3 — Zellij CLI backend
+
+`backend/zellij.rs` implements `PaneBackend` by:
+
+- Maintaining the latest pane snapshot pushed by the plugin (cached in the
+  daemon, not re-queried on every call).
+- Calling `zellij action focus-pane-with-id` for `focus_pane`.
+- Reading `$ZELLIJ` / `$ZELLIJ_PANE_ID` for `detect_host_env`.
+
+Zellij has no multi-server enumeration, so the scanner module collapses to a
+no-op for this backend.
+
+### Step 4 — CLI wiring
+
+`muxa status`, `muxa watch`, `muxa hook <agent>` pick the backend based on
+which env var is set. If both `$TMUX` and `$ZELLIJ` are present (rare but
+possible if nested), prefer the innermost — i.e. whichever was set last.
+Document the precedence.
+
+## Open questions
+
+- **Pane IDs across hosts.** tmux uses `%N` (e.g. `%4`); zellij uses numeric
+  pane IDs scoped by tab. Are we OK with a backend-prefixed string format
+  (`tmux:%4`, `zellij:3`) for the on-wire `PaneId`? This bleeds into the
+  daemon DB schema — needs a migration plan if so.
+- **Plugin distribution.** Ship the `.wasm` in the GitHub release, or expect
+  users to `cargo build` it? First option is friendlier; second avoids us
+  signing/hosting a WASM blob.
+- **UX for "go to this pane".** zellij's focus model (tabs + floating panes +
+  stacked panes) doesn't map 1:1 onto tmux's session/window/pane. The watch
+  TUI's "press Enter to jump" needs a separate design pass.
+- **Plugin API stability.** zellij plugin API is pre-1.0; assume one breaking
+  bump per zellij minor release and pin a minimum supported version.
+
+## Rough effort
+
+| Step                              | Estimate |
+| --------------------------------- | -------- |
+| `PaneBackend` trait extraction    | ~1 day   |
+| Zellij WASM plugin (PoC + polish) | ~2 days  |
+| Zellij CLI backend + daemon glue  | ~1 day   |
+| Watch / recap / sinks regression  | ~1 day   |
+| Docs + release plumbing for `.wasm` | ~0.5 day |
+
+**~1 week** of focused work, assuming the zellij plugin API does what the
+docs claim. De-risk with a 2-hour PoC that just prints `PaneUpdate` payloads
+to stderr before committing to the rest.
+
+## Not doing
+
+- A CLI-only zellij backend (no plugin). Tested mentally and rejected: without
+  `terminal_command` from the plugin API, agent auto-discovery is too weak to
+  ship.
+- Replacing the tmux backend. Both coexist; the trait is the seam.
+- Zellij-specific features (layouts, floating panes as first-class muxa
+  concepts). Out of scope for the initial port.

--- a/examples/muxa.zellij.kdl
+++ b/examples/muxa.zellij.kdl
@@ -1,0 +1,46 @@
+// Starter zellij layout for muxa users.
+//
+// Drop this into `~/.config/zellij/layouts/muxa.kdl` and run
+// `zellij --layout muxa` to launch a session pre-wired with:
+//   * an agent pane on the left (where you'll run `claude`, `codex`, …)
+//   * a `muxa watch` pane on the right that shows the live agent table
+//
+// muxa's CLI baseline runs against zellij with no plugin install:
+// `muxa watch` will list panes once agents start hooking events, and
+// pressing `Enter` jumps to the selected pane via
+// `zellij action focus-pane-with-id`.
+//
+// To pin the host explicitly (useful for nested setups, e.g. zellij
+// inside tmux), export `MUXA_HOST=zellij` before launching zellij.
+//
+// Future: once the muxa zellij plugin (`muxa-zellij-plugin.wasm`,
+// shipped from `feat/zellij-plugin`) is published, replace this layout
+// with one that loads the plugin so pane-level metadata (foreground
+// command, screen capture, pid map) flows back to the daemon. The
+// plugin is purely additive — this layout keeps working unchanged
+// after install, you'll just see richer rows in `muxa watch`.
+
+layout {
+    default_tab_template {
+        children
+        pane size=1 borderless=true {
+            plugin location="zellij:status-bar"
+        }
+    }
+
+    tab name="muxa" {
+        pane split_direction="vertical" {
+            // Left: 60% width, where you launch agents.
+            pane name="agent" size="60%" {
+                command "bash"
+            }
+            // Right: 40% width, live agent table. Refreshes at 2 Hz.
+            // `muxa watch` reads $ZELLIJ_PANE_ID to land the cursor on
+            // the agent pane when it has activity to show.
+            pane name="muxa watch" {
+                command "muxa"
+                args "watch"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Lays the trait seam for the zellij backend planned in `docs/ZELLIJ.md`. Pure refactor — no observable behavior change, no IPC / wire-protocol surface touched. The point is to introduce a `PaneBackend` abstraction the future zellij backend (Steps 2–4 in the design doc) plugs into without forking the daemon.

This is **Step 1 only** of the 5-step plan. Steps 2–4 (WASM plugin, zellij CLI backend, watch UX wiring) follow as separate commits / PRs on this branch.

## What's in the diff

- `crates/muxa/src/backend/mod.rs` — new `PaneBackend` trait. Narrow surface that mirrors what callers actually exercise: `list_panes`, `resolve_pane`, `capture_pane`, `pane_pid_map`, `current_pane`, `kind`. Best-effort semantics (empty / `None` on transient failure) so hot-path callers don't fan errors back up the stack.
- `crates/muxa/src/backend/tmux.rs` — `TmuxBackend` thin delegating wrapper around the existing `crate::tmux::*` free functions. Stateless, `Default + Copy`. Also implements `LivenessSource` so the reconciler picks it up without a new adapter.
- `HostKind { Tmux, Zellij }` + `detect_host_env()` for telemetry / log lines + future runtime backend selection.
- `crates/muxad/src/main.rs` — reconciler swaps `TmuxLiveness` for `TmuxBackend::new()`. Same call shape, same `tmux list-panes -a` underneath; just routed through the trait so the same hook point picks up zellij later.
- `docs/ZELLIJ.md` — committed onto this branch as the working design doc (was untracked in main).

## What's deliberately not in the diff

- Migrating `discovery.rs` / multi-server scanner / `watch` refresh task / hook ancestry / daemon's `enrich_from_history` away from direct `crate::tmux::*` calls. Mechanical search-and-replace, safer in follow-up commits.
- The zellij backend itself — needs the WASM plugin (Step 2) before it has any data to serve.
- Removing `TmuxLiveness`. Still in use by reconciler unit tests; will retire when those migrate.

## Test plan

- [x] `cargo test --workspace` — 245 → 252 (+7 backend tests). All green.
- [x] `cargo clippy --package muxa --package muxad --all-targets -- -D warnings` — clean.
- [x] Manually verified daemon still picks up the reconciler config and converges synthetics on first tick (locally).
- [ ] Reviewer: confirm trait surface is sufficient for the zellij backend the design doc envisions; flag any caller currently bypassing it that should be in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)