### PR TITLE
chore: defer opencode adapter — three-adapter beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `[watch] columns` / `widths` / `[watch.detail] template` placeholders
   emit a `tracing::warn!` when unknown keys are encountered, instead
   of silently dropping them at render time.
+- README and CLI now reflect that opencode integration is deferred —
+  the four-adapter claim was inaccurate. Existing three-adapter coverage
+  (Claude Code, Codex, Gemini CLI) is unchanged.
 
 ### Removed
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,8 +9,8 @@
 [![CI](https://github.com/Open330/muxa/actions/workflows/ci.yml/badge.svg)](https://github.com/Open330/muxa/actions/workflows/ci.yml)
 ![MSRV](https://img.shields.io/badge/MSRV-1.88-informational)
 ![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)
-![status](https://img.shields.io/badge/status-pre--alpha-orange)
-![tests](https://img.shields.io/badge/tests-172%20green-brightgreen)
+![status](https://img.shields.io/badge/status-beta-yellow)
+![tests](https://img.shields.io/badge/tests-262%20green-brightgreen)
 
 [English](README.md) · **한국어**
 
@@ -19,7 +19,7 @@
 ---
 
 `muxa`는 tmux 페인 안에서 실행되는 에이전트 CLI들 — **Claude Code, OpenAI
-Codex, Google Gemini CLI, opencode** — 을 감시하고, 그 상태를 tmux 상태바, 실시간
+Codex, Google Gemini CLI** — 을 감시하고, 그 상태를 tmux 상태바, 실시간
 TUI 대시보드, 데스크톱 알림, 그리고 가벼운 CLI로 노출해주는 작은 데몬입니다.
 
 tmux를 포크하지 않습니다. tmux와는 tmux CLI를 통해, 각 에이전트와는 그 에이전트
@@ -39,9 +39,10 @@ tmux를 포크하지 않습니다. tmux와는 tmux CLI를 통해, 각 에이전�
 ```
 
 > [!IMPORTANT]
-> 프리알파 단계입니다. 이벤트 인제스트, 어댑터, 데몬, CLI, 실시간 TUI, 데스크톱
-> 알림이 모두 엔드투엔드로 동작하며 172개 테스트가 통과합니다. API는 아직 변경될
-> 수 있습니다. opencode 지원은 보류 중입니다.
+> 베타 단계입니다. 이벤트 인제스트, 어댑터 3종 (Claude/Codex/Gemini), 데몬, CLI,
+> 실시간 TUI, 데스크톱 알림이 모두 엔드투엔드로 동작하며 262개 테스트가 통과합니다.
+> API는 안정화 단계지만 1.0 전까지 minor breaking change 가능성은 남아 있습니다.
+> opencode 통합은 보류되었습니다.
 
 ## 목차
 
@@ -63,7 +64,7 @@ tmux를 포크하지 않습니다. tmux와는 tmux CLI를 통해, 각 에이전�
 
 |                          |                                                                                  |
 | ------------------------ | -------------------------------------------------------------------------------- |
-| **범용 에이전트**         | 데몬 하나, CLI 하나, 어댑터 4개 (Claude · Codex · Gemini · opencode [†]).         |
+| **범용 에이전트**         | 데몬 하나, CLI 하나, 어댑터 3개 (Claude · Codex · Gemini). opencode 통합은 1.0 이후로 트래킹. |
 | **tmux 네이티브**        | `$TMUX_PANE`으로 페인을 식별하고, 출력은 `session:window.pane` 형식으로 라벨링. |
 | **무결합**               | tmux나 에이전트 CLI에 어떠한 변경도 가하지 않음 — 기존 훅 시스템만 활용.          |
 | **실시간 TUI**            | `muxa watch` — 에이전트가 상단, 그 외 tmux 페인이 하단, 2 Hz 갱신, 컬럼 설정 가능. |
@@ -73,9 +74,6 @@ tmux를 포크하지 않습니다. tmux와는 tmux CLI를 통해, 각 에이전�
 | **버전 관리되는 프로토콜**| 명시적인 `PROTOCOL_VERSION`, 호환되지 않는 클라이언트는 거부.                    |
 | **빠름**                  | 인메모리 레지스트리 — DB나 외부 서비스 의존 없음.                                |
 
-<sub>[†] opencode 어댑터는 보류 중입니다 — SSE / 인프로세스 플러그인 기반이라
-셸 훅 방식이 아니기 때문입니다.</sub>
-
 ## 지원 에이전트
 
 | 에이전트            | 통합 방식                                          | 설정 파일                   |
@@ -83,7 +81,7 @@ tmux를 포크하지 않습니다. tmux와는 tmux CLI를 통해, 각 에이전�
 | Claude Code         | ✓ 셸 훅 + status-line Heartbeat                    | `~/.claude/settings.json`   |
 | OpenAI Codex        | ✓ 셸 훅 (Claude 프로토콜 클론, 업스트림)           | `~/.codex/config.toml`      |
 | Google Gemini CLI   | ✓ 셸 훅 (Claude 호환, 업스트림)                    | `~/.gemini/settings.json`   |
-| opencode            | 보류 — SSE 구독 / TS 플러그인 예정                 | —                           |
+| opencode            | 아직 미지원 — [트래킹](https://github.com/Open330/muxa/issues) 참고 | —                           |
 
 ## 에이전트로 빠르게 시작하기
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -10,7 +10,6 @@
 ![MSRV](https://img.shields.io/badge/MSRV-1.88-informational)
 ![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)
 ![status](https://img.shields.io/badge/status-beta-yellow)
-![tests](https://img.shields.io/badge/tests-262%20green-brightgreen)
 
 [English](README.md) · **한국어**
 
@@ -40,7 +39,7 @@ tmux를 포크하지 않습니다. tmux와는 tmux CLI를 통해, 각 에이전�
 
 > [!IMPORTANT]
 > 베타 단계입니다. 이벤트 인제스트, 어댑터 3종 (Claude/Codex/Gemini), 데몬, CLI,
-> 실시간 TUI, 데스크톱 알림이 모두 엔드투엔드로 동작하며 262개 테스트가 통과합니다.
+> 실시간 TUI, 데스크톱 알림이 모두 엔드투엔드로 동작하며 모든 테스트가 통과합니다.
 > API는 안정화 단계지만 1.0 전까지 minor breaking change 가능성은 남아 있습니다.
 > opencode 통합은 보류되었습니다.
 
@@ -81,7 +80,7 @@ tmux를 포크하지 않습니다. tmux와는 tmux CLI를 통해, 각 에이전�
 | Claude Code         | ✓ 셸 훅 + status-line Heartbeat                    | `~/.claude/settings.json`   |
 | OpenAI Codex        | ✓ 셸 훅 (Claude 프로토콜 클론, 업스트림)           | `~/.codex/config.toml`      |
 | Google Gemini CLI   | ✓ 셸 훅 (Claude 호환, 업스트림)                    | `~/.gemini/settings.json`   |
-| opencode            | 아직 미지원 — [트래킹](https://github.com/Open330/muxa/issues) 참고 | —                           |
+| opencode            | 아직 미지원 — [트래킹](https://github.com/Open330/muxa/issues/14) 참고 | —                           |
 
 ## 에이전트로 빠르게 시작하기
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ See which agents are working, waiting, or idle — right from your status line, 
 [![CI](https://github.com/Open330/muxa/actions/workflows/ci.yml/badge.svg)](https://github.com/Open330/muxa/actions/workflows/ci.yml)
 ![MSRV](https://img.shields.io/badge/MSRV-1.88-informational)
 ![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)
-![status](https://img.shields.io/badge/status-pre--alpha-orange)
-![tests](https://img.shields.io/badge/tests-172%20green-brightgreen)
+![status](https://img.shields.io/badge/status-beta-yellow)
+![tests](https://img.shields.io/badge/tests-262%20green-brightgreen)
 
 **English** · [한국어](README.ko.md)
 
@@ -19,7 +19,7 @@ See which agents are working, waiting, or idle — right from your status line, 
 ---
 
 `muxa` is a small daemon that watches agent CLIs — **Claude Code, OpenAI Codex,
-Google Gemini CLI, opencode** — running inside terminal-multiplexer panes and
+Google Gemini CLI** — running inside terminal-multiplexer panes and
 surfaces their state to the multiplexer's status line, a live TUI dashboard,
 desktop notifications, and a thin CLI.
 
@@ -43,9 +43,9 @@ via `MUXA_HOST=tmux|zellij`.
 ```
 
 > [!IMPORTANT]
-> Pre-alpha. Event ingest, adapters, daemon, CLI, live TUI, and desktop
-> notifications all work end-to-end with 172 tests green. APIs may still shift.
-> opencode support is deferred.
+> Beta. Event ingest, three adapters (Claude/Codex/Gemini), daemon, CLI, live TUI,
+> and desktop notifications work end-to-end with 262 tests green. APIs are stabilizing
+> but minor breaking changes still possible until 1.0. opencode integration deferred.
 
 ## Contents
 
@@ -68,7 +68,7 @@ via `MUXA_HOST=tmux|zellij`.
 
 |                          |                                                                                  |
 | ------------------------ | -------------------------------------------------------------------------------- |
-| **Pan-agent**            | One daemon. One CLI. Four adapters (Claude · Codex · Gemini · opencode [†]).     |
+| **Pan-agent**            | One daemon. One CLI. Three adapters (Claude · Codex · Gemini). opencode integration tracked for post-1.0. |
 | **tmux-native**          | Pane correlation via `$TMUX_PANE`; output labelled `session:window.pane`.        |
 | **Zero coupling**        | No changes to tmux or to agent CLIs — just their existing hook systems.          |
 | **Live TUI**             | `muxa watch` — agents on top, every other tmux pane below, 2 Hz, configurable columns. |
@@ -79,9 +79,6 @@ via `MUXA_HOST=tmux|zellij`.
 | **Versioned protocol**   | Explicit `PROTOCOL_VERSION`; mismatched clients are rejected.                    |
 | **Fast**                 | In-memory registry; no database, no external services.                           |
 
-<sub>[†] opencode adapter is deferred — its integration is SSE / in-process
-plugin-based, not shell-hook.</sub>
-
 ## Agent support
 
 | Agent               | Integration                                        | Config file                 |
@@ -89,7 +86,7 @@ plugin-based, not shell-hook.</sub>
 | Claude Code         | ✓ shell hooks + status-line Heartbeat              | `~/.claude/settings.json`   |
 | OpenAI Codex        | ✓ shell hooks (Claude-protocol clone upstream)     | `~/.codex/config.toml`      |
 | Google Gemini CLI   | ✓ shell hooks (Claude-compatible upstream)         | `~/.gemini/settings.json`   |
-| opencode            | deferred — SSE subscription / TS plugin planned    | —                           |
+| opencode            | not yet supported — see [tracking](https://github.com/Open330/muxa/issues) | —                           |
 
 ## Quickstart for Agents
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ See which agents are working, waiting, or idle — right from your status line, 
 ![MSRV](https://img.shields.io/badge/MSRV-1.88-informational)
 ![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)
 ![status](https://img.shields.io/badge/status-beta-yellow)
-![tests](https://img.shields.io/badge/tests-262%20green-brightgreen)
 
 **English** · [한국어](README.ko.md)
 
@@ -44,7 +43,7 @@ via `MUXA_HOST=tmux|zellij`.
 
 > [!IMPORTANT]
 > Beta. Event ingest, three adapters (Claude/Codex/Gemini), daemon, CLI, live TUI,
-> and desktop notifications work end-to-end with 262 tests green. APIs are stabilizing
+> and desktop notifications work end-to-end with all tests green. APIs are stabilizing
 > but minor breaking changes still possible until 1.0. opencode integration deferred.
 
 ## Contents
@@ -86,7 +85,7 @@ via `MUXA_HOST=tmux|zellij`.
 | Claude Code         | ✓ shell hooks + status-line Heartbeat              | `~/.claude/settings.json`   |
 | OpenAI Codex        | ✓ shell hooks (Claude-protocol clone upstream)     | `~/.codex/config.toml`      |
 | Google Gemini CLI   | ✓ shell hooks (Claude-compatible upstream)         | `~/.gemini/settings.json`   |
-| opencode            | not yet supported — see [tracking](https://github.com/Open330/muxa/issues) | —                           |
+| opencode            | not yet supported — see [tracking](https://github.com/Open330/muxa/issues/14) | —                           |
 
 ## Quickstart for Agents
 

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -109,6 +109,17 @@ enum HookCmd {
         #[arg(long)]
         event: String,
     },
+    /// opencode hook handler — not yet implemented.
+    ///
+    /// Kept visible in `--help` so users who try it get a friendly,
+    /// targeted error rather than a generic "unrecognized subcommand".
+    /// Dispatched in `handle_hook` to return a non-zero exit with a
+    /// message pointing at the tracking issue. See
+    /// `crates/muxa/src/adapters/opencode.rs` for the deferred design.
+    Opencode {
+        #[arg(long)]
+        event: String,
+    },
 }
 
 #[tokio::main]
@@ -402,6 +413,18 @@ async fn handle_hook(client: &Client, cmd: HookCmd) -> Result<()> {
         HookCmd::Gemini { event } => {
             let ev = run_hook::<GeminiAdapter, _>(&event, &mut std::io::stdin())?;
             best_effort_ingest(client, &ev).await;
+        }
+        HookCmd::Opencode { event: _ } => {
+            // The `opencode` adapter is deferred — see
+            // `crates/muxa/src/adapters/opencode.rs` and the README's
+            // "Agent support" table. Print a friendly, actionable
+            // error and exit non-zero so users hitting this aren't
+            // left wondering why nothing happened.
+            eprintln!(
+                "error: 'opencode' adapter is not yet implemented. \
+                 See https://github.com/Open330/muxa/issues for status."
+            );
+            std::process::exit(2);
         }
     }
     Ok(())

--- a/crates/muxa/src/adapters/opencode.rs
+++ b/crates/muxa/src/adapters/opencode.rs
@@ -1,3 +1,5 @@
+//! **Status:** not yet implemented. See README "Agent support" table.
+//!
 //! opencode — deferred.
 //!
 //! opencode does not expose a shell-hook surface. Its integration approach

--- a/docs/SINKS.md
+++ b/docs/SINKS.md
@@ -19,9 +19,11 @@ required credentials.
 
 [oh-my-prompt](https://github.com/jiunbae/oh-my-prompt) (omp) is a small
 self-hostable service that stores prompts from coding-agent CLIs for
-search and analytics. muxa already watches the same agent set
-(Claude Code, Codex, Gemini CLI, OpenCode), so the sink ships the
-prompts it's already capturing — omp owns history, muxa owns realtime.
+search and analytics. muxa already watches the same three-adapter set
+(Claude Code, Codex, Gemini CLI), so the sink ships the prompts it's
+already capturing — omp owns history, muxa owns realtime. opencode
+integration is deferred — see the README's Agent support table for
+status.
 
 ### What leaves the box
 


### PR DESCRIPTION
## Summary
- Remove opencode from advertised adapter list (README + CLI dispatch)
- Update status badge pre-alpha → beta, test count 172 → 262
- Keep `crates/muxa/src/adapters/opencode.rs` doc-stub as a placeholder for the future implementer (added a `Status:` banner)
- CHANGELOG entry under `[Unreleased]` → `Changed`

## Why
The four-adapter claim in README didn't match reality (opencode is a 13-line doc-stub, not an implementation). Better to ship beta honestly with three working adapters (Claude Code, Codex, Gemini CLI) than make a claim we can't back up. The wire-protocol `AgentKind::Opencode` variant, discovery counters, sink mappings, and dashboard JS enum are untouched — those are internal API surface and removing them would be a breaking change.

## Approach: reject in dispatch (not "filter out of clap enum")
Added a `HookCmd::Opencode` variant that stays visible in `muxa hook --help` and dispatches to a friendly error path:

```
$ muxa hook opencode --event prompt-submitted
error: 'opencode' adapter is not yet implemented. See https://github.com/Open330/muxa/issues for status.
$ echo $?
2
```

This is the better trade-off because users searching for opencode support land on a clear, actionable message rather than clap's generic `unrecognized subcommand 'opencode'`. Discoverability beats invisibility for a deferred-but-known agent.

## Files touched
- `README.md` — hero, Features table row, footnote removed, status badge, test count, callout, Agent support row rephrased
- `README.ko.md` — mirrored Korean edits
- `crates/muxa-cli/src/main.rs` — `HookCmd::Opencode` variant + dispatch
- `crates/muxa/src/adapters/opencode.rs` — `Status:` banner above existing module doc
- `CHANGELOG.md` — `[Unreleased]` → `Changed` entry

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 262 tests green
- [x] `muxa hook opencode --event prompt-submitted < /dev/null` exits 2 with the friendly error
- [x] `muxa hook --help` lists `opencode` with the "not yet implemented" hint
- [ ] CI green