### PR TITLE
feat(init): muxa init install wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`muxa init` install wizard.** Interactive (cliclack-styled flow:
+  pre-flight → multi-select → review → apply → verify) and
+  non-interactive (`--preset {minimal,standard,full}`, `--yes`,
+  `--component`, `--no <id>`, `--dry-run`, `--uninstall`) entry points
+  cover both the "first install" and "in CI / dotfile bootstrap" cases.
+  Components: tmux popup + status-line, Claude / Codex / Gemini hook
+  merge, `muxad` systemd user service, web dashboard token. Each
+  component owns a `# >>> muxa managed (id) >>>` marker block (or a
+  command-prefix match in JSON / TOML), so `--uninstall` is a clean
+  surgical reverse rather than a delete-all. Auto-detects existing
+  agent configs and pre-checks the matching components in the picker.
+  Backups land at `<file>.muxa-backup-<unix_ts>` before any write.
+  Companion `scripts/install.sh` is a 30-line `curl | sh` bootstrap
+  that hands off to `muxa init`, so all real install logic stays in
+  one auditable place.
+
 ## [0.3.2] - 2026-04-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cliclack"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa510b739c618c679375ea9c5af44ce9f591289546e874ad5910e7ce7df79844"
+dependencies = [
+ "console 0.15.11",
+ "indicatif",
+ "once_cell",
+ "strsim",
+ "textwrap",
+ "zeroize",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +505,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -722,6 +761,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +792,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1314,6 +1365,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console 0.16.3",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,17 +1684,23 @@ dependencies = [
  "ansi-to-tui",
  "anyhow",
  "clap",
+ "cliclack",
  "comfy-table",
+ "console 0.15.11",
  "crossterm",
+ "dirs",
  "muxa",
  "owo-colors",
+ "rand 0.8.6",
  "ratatui",
  "serde_json",
  "tempfile",
  "time",
  "tokio",
+ "toml_edit 0.22.27",
  "tracing",
  "tracing-subscriber",
+ "which",
 ]
 
 [[package]]
@@ -2142,6 +2212,8 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2151,8 +2223,18 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2170,6 +2252,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -2664,6 +2749,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2865,6 +2956,17 @@ dependencies = [
  "wezterm-dynamic",
  "wezterm-input-types",
  "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3252,6 +3354,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3279,6 +3387,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"
@@ -3578,6 +3692,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3730,6 +3856,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3973,6 +4108,12 @@ checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wiremock"
@@ -4227,6 +4368,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/README.md
+++ b/README.md
@@ -141,12 +141,35 @@ Prefer to do it yourself? Keep reading.
 Requires **Rust 1.88+**, **tmux 3.x**, and a Unix-y OS.
 
 <details open>
+<summary><strong>One-shot (recommended)</strong></summary>
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/install.sh | sh
+```
+
+Builds + installs `muxa` and `muxad` from source, then hands off to
+the `muxa init` wizard for tmux/agent/systemd wiring. Forward args to
+the wizard with `sh -s --`:
+
+```bash
+# Non-interactive (CI / dotfile bootstrap):
+curl -fsSL https://… | sh -s -- --preset standard --yes
+
+# Preview only — write nothing:
+curl -fsSL https://… | sh -s -- --dry-run
+```
+
+</details>
+
+<details>
 <summary><strong>From source</strong></summary>
 
 ```bash
 git clone https://github.com/Open330/muxa.git && cd muxa
 cargo install --path crates/muxad --locked
 cargo install --path crates/muxa-cli --locked
+muxa init                       # interactive wizard
+# muxa init --preset standard --yes   # for headless installs
 ```
 
 Installs to `~/.cargo/bin/`. Make sure it's on your `PATH`.
@@ -157,8 +180,9 @@ Installs to `~/.cargo/bin/`. Make sure it's on your `PATH`.
 <summary><strong>Pre-built binaries</strong></summary>
 
 Grab the archive for your platform from the
-[Releases page](https://github.com/Open330/muxa/releases) and drop `muxa` +
-`muxad` somewhere on your `PATH`.
+[Releases page](https://github.com/Open330/muxa/releases), drop `muxa`
++ `muxad` somewhere on your `PATH`, then run `muxa init` to wire up
+tmux / agent hooks / systemd / dashboard.
 
 Artifacts are built for:
 
@@ -168,6 +192,54 @@ Artifacts are built for:
 - `aarch64-apple-darwin`
 
 </details>
+
+### Install wizard (`muxa init`)
+
+```text
+┌  muxa init
+│
+◇  Pre-flight
+│  ✔ cargo: cargo 1.92.0
+│  ✔ tmux: tmux 3.4
+│  ✔ Claude Code config: ~/.claude/settings.json
+│  ✔ systemctl --user available
+│
+◇  What should I set up?
+│  ◼ tmux: replace prefix+s with muxa watch popup
+│  ◼ tmux: per-pane agent glyphs in status-right
+│  ◼ Claude Code: shell hooks + statusLine    ← auto-detected
+│  ◻ muxad: systemd user service
+│  ◻ Web dashboard: generate token + enable
+│
+◇  Review changes
+│  + edit  ~/.tmux.conf (tmux-popup) [+6 lines]
+│  + edit  ~/.tmux.conf (tmux-statusline) [+7 lines]
+│  ~ edit  ~/.claude/settings.json (claude-hooks) [+24 lines]
+│  ⟳ tmux source-file ~/.tmux.conf
+│
+└  Done. Try `prefix + s` for the muxa picker.
+```
+
+Every edit is wrapped in a per-component marker block
+(`# >>> muxa managed (tmux-popup) >>>` … `# <<< muxa managed (tmux-popup) <<<`)
+or a command-prefix match (in JSON / TOML), so `muxa init --uninstall`
+is a clean reverse — your hand-edited config around our blocks stays
+intact. Originals are backed up to `<file>.muxa-backup-<unix_ts>`
+before any write.
+
+Common flag combos:
+
+| Goal | Command |
+| --- | --- |
+| Interactive wizard | `muxa init` |
+| Headless / CI | `muxa init --preset standard --yes` |
+| Preview only | `muxa init --dry-run` |
+| Reverse install | `muxa init --uninstall` |
+| Just one thing | `muxa init --component tmux-popup --yes` |
+| Preset minus a piece | `muxa init --preset standard --no muxad-systemd --yes` |
+
+Presets: `minimal` (tmux only), `standard` (+ auto-detected agents +
+systemd), `full` (+ dashboard).
 
 ## Quick start
 

--- a/crates/muxa-cli/Cargo.toml
+++ b/crates/muxa-cli/Cargo.toml
@@ -17,6 +17,7 @@ muxa = { workspace = true }
 
 anyhow = { workspace = true }
 clap = { workspace = true }
+dirs = { workspace = true }
 serde_json = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
@@ -38,6 +39,21 @@ crossterm = "0.29"
 # `capture-pane -e` output into ratatui `Text`/`Lines`, so the live pane
 # preview keeps the source pane's coloring.
 ansi-to-tui = "8"
+
+# `muxa init` interactive wizard.
+# cliclack is the Rust port of clack.cc — gives us the modern boxed-flow
+# look (◇ ✔ ⚠ glyphs, multi-select, spinners) without rolling our own.
+cliclack = "0.3"
+console = "0.15"
+# Locate cargo / tmux / claude / codex / gemini binaries on PATH for
+# pre-flight detection.
+which = "7"
+# Round-trip TOML edits that preserve user formatting + comments — used
+# by codex hook merger and dashboard token writer. Plain `toml` would
+# rewrite the whole file from scratch.
+toml_edit = "0.22"
+# Cryptographically-strong dashboard tokens via the OS RNG.
+rand = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/muxa-cli/src/init/apply.rs
+++ b/crates/muxa-cli/src/init/apply.rs
@@ -1,0 +1,280 @@
+//! Execute a `Plan` against the disk + system.
+//!
+//! Three knobs:
+//!
+//! * `dry_run` — render diffs / next steps without writing anything.
+//! * Backup before write — every existing file gets `<path>.muxa-backup-<unix_ts>`
+//!   exactly once per run, so the user can roll back by hand if something
+//!   downstream goes sideways.
+//! * Atomic-ish write — we write to a sibling tempfile and rename. This
+//!   keeps the destination either fully old or fully new.
+
+use crate::init::components::Component;
+use crate::init::files;
+use crate::init::marker::Outcome;
+use crate::init::plan::{Action, Direction, Plan};
+use anyhow::{Context, Result};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use time::OffsetDateTime;
+
+/// Side-effect summary returned to the orchestrator so it can paint
+/// the final outcome UI.
+#[derive(Debug, Default)]
+pub struct ApplyReport {
+    pub edited: Vec<PathBuf>,
+    pub deleted: Vec<PathBuf>,
+    pub backups: Vec<PathBuf>,
+    pub systemd_enabled: bool,
+    pub systemd_disabled: bool,
+    pub tmux_sourced: bool,
+    pub dashboard: Option<DashboardInfo>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DashboardInfo {
+    pub token: String,
+    pub bind: String,
+}
+
+/// Run every action in order. On the first hard failure we stop and
+/// return the partial report alongside the error — the caller can
+/// surface what was done before the break.
+pub fn run(plan: &Plan, dry_run: bool) -> Result<ApplyReport> {
+    let stamp = OffsetDateTime::now_utc().unix_timestamp();
+    let mut report = ApplyReport::default();
+    for action in &plan.actions {
+        apply_one(action, dry_run, stamp, &mut report).with_context(|| describe(action))?;
+    }
+    Ok(report)
+}
+
+fn apply_one(action: &Action, dry_run: bool, stamp: i64, report: &mut ApplyReport) -> Result<()> {
+    match action {
+        Action::EditFile {
+            component: _,
+            path,
+            before,
+            after,
+            outcome,
+        } => {
+            if matches!(outcome, Outcome::Unchanged | Outcome::AlreadyAbsent) {
+                return Ok(());
+            }
+            if dry_run {
+                report.edited.push(path.clone());
+                return Ok(());
+            }
+            if let Some(prev) = before {
+                let backup = backup_path(path, stamp);
+                fs::write(&backup, prev)
+                    .with_context(|| format!("writing backup {}", backup.display()))?;
+                report.backups.push(backup);
+            }
+            ensure_parent(path)?;
+            atomic_write(path, after)?;
+            report.edited.push(path.clone());
+        }
+        Action::DeleteFile { component: _, path } => {
+            if dry_run {
+                report.deleted.push(path.clone());
+                return Ok(());
+            }
+            match fs::remove_file(path) {
+                Ok(()) => {
+                    report.deleted.push(path.clone());
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e).with_context(|| format!("removing {}", path.display())),
+            }
+        }
+        Action::EnableSystemdUnit => {
+            if dry_run {
+                return Ok(());
+            }
+            match files::systemd::enable_service() {
+                Ok(()) => report.systemd_enabled = true,
+                Err(e) => report
+                    .warnings
+                    .push(format!("systemd enable failed: {e}; service NOT started")),
+            }
+        }
+        Action::DisableSystemdUnit => {
+            if dry_run {
+                return Ok(());
+            }
+            files::systemd::disable_service();
+            report.systemd_disabled = true;
+        }
+        Action::SourceTmuxConf { path } => {
+            if dry_run {
+                return Ok(());
+            }
+            // Only attempt if there's a tmux server running; otherwise
+            // `tmux source-file` errors with "no server running".
+            let server_up = Command::new("tmux")
+                .arg("info")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false);
+            if !server_up {
+                return Ok(());
+            }
+            let status = Command::new("tmux")
+                .arg("source-file")
+                .arg(path)
+                .status()
+                .with_context(|| format!("running tmux source-file {}", path.display()))?;
+            if status.success() {
+                report.tmux_sourced = true;
+            } else {
+                report
+                    .warnings
+                    .push(format!("tmux source-file exited with {status}"));
+            }
+        }
+        Action::PrintDashboard { token, bind } => {
+            report.dashboard = Some(DashboardInfo {
+                token: token.clone(),
+                bind: bind.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn backup_path(p: &Path, stamp: i64) -> PathBuf {
+    let mut name = p.file_name().unwrap_or_default().to_os_string();
+    name.push(format!(".muxa-backup-{stamp}"));
+    p.with_file_name(name)
+}
+
+fn ensure_parent(p: &Path) -> Result<()> {
+    if let Some(parent) = p.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn atomic_write(path: &Path, contents: &str) -> Result<()> {
+    let tmp = path.with_extension(format!(
+        "{}.muxa-tmp",
+        path.extension().and_then(|s| s.to_str()).unwrap_or("")
+    ));
+    {
+        let mut f =
+            fs::File::create(&tmp).with_context(|| format!("creating {}", tmp.display()))?;
+        f.write_all(contents.as_bytes())
+            .with_context(|| format!("writing {}", tmp.display()))?;
+        f.sync_all().ok();
+    }
+    fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+fn describe(a: &Action) -> String {
+    match a {
+        Action::EditFile { path, .. } => format!("editing {}", path.display()),
+        Action::DeleteFile { path, .. } => format!("removing {}", path.display()),
+        Action::EnableSystemdUnit => "enabling muxad.service".into(),
+        Action::DisableSystemdUnit => "disabling muxad.service".into(),
+        Action::SourceTmuxConf { path } => format!("sourcing {}", path.display()),
+        Action::PrintDashboard { .. } => "rendering dashboard info".into(),
+    }
+}
+
+/// Render a plan as dry-run diff lines. One line per action — the
+/// caller (ui.rs) wraps this in a cliclack note.
+pub fn render_dry_run(plan: &Plan) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::new();
+    let verb = match plan.direction {
+        Direction::Install => "install",
+        Direction::Uninstall => "uninstall",
+    };
+    let _ = writeln!(s, "Plan ({verb}):");
+    for a in &plan.actions {
+        match a {
+            Action::EditFile {
+                component,
+                path,
+                before,
+                after,
+                outcome,
+            } => {
+                let tag = outcome_tag(*outcome);
+                let summary = match outcome {
+                    Outcome::Unchanged | Outcome::AlreadyAbsent => "[no change]".into(),
+                    _ => diff_summary(before.as_deref().unwrap_or(""), after),
+                };
+                let _ = writeln!(
+                    s,
+                    "  {tag} edit  {} ({}) {summary}",
+                    path.display(),
+                    label(*component),
+                );
+            }
+            Action::DeleteFile { component, path } => {
+                let _ = writeln!(s, "  ✗ remove {} ({})", path.display(), label(*component));
+            }
+            Action::EnableSystemdUnit => {
+                let _ = writeln!(s, "  ⚙ systemctl --user enable --now muxad.service");
+            }
+            Action::DisableSystemdUnit => {
+                let _ = writeln!(s, "  ⚙ systemctl --user disable --now muxad.service");
+            }
+            Action::SourceTmuxConf { path } => {
+                let _ = writeln!(s, "  ⟳ tmux source-file {}", path.display());
+            }
+            Action::PrintDashboard { bind, .. } => {
+                let _ = writeln!(s, "  ✓ dashboard token generated; URL: http://{bind}/");
+            }
+        }
+    }
+    if !plan.has_changes() {
+        s.push_str("  (no changes)\n");
+    }
+    s
+}
+
+fn outcome_tag(o: Outcome) -> &'static str {
+    match o {
+        Outcome::Inserted => "+",
+        Outcome::Replaced => "~",
+        Outcome::Removed => "-",
+        Outcome::Unchanged | Outcome::AlreadyAbsent => "·",
+    }
+}
+
+fn label(c: Component) -> &'static str {
+    c.id()
+}
+
+fn diff_summary(before: &str, after: &str) -> String {
+    use std::cmp::Ordering;
+    let bl = before.lines().count();
+    let al = after.lines().count();
+    match al.cmp(&bl) {
+        Ordering::Equal => format!("[~{} lines edited]", al.min(bl)),
+        Ordering::Greater => format!("[+{} lines]", al - bl),
+        Ordering::Less => format!("[-{} lines]", bl - al),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backup_path_appends_stamp() {
+        let p = PathBuf::from("/tmp/foo.conf");
+        let b = backup_path(&p, 1_234_567_890);
+        assert_eq!(b.to_string_lossy(), "/tmp/foo.conf.muxa-backup-1234567890");
+    }
+}

--- a/crates/muxa-cli/src/init/apply.rs
+++ b/crates/muxa-cli/src/init/apply.rs
@@ -118,8 +118,7 @@ fn apply_one(action: &Action, dry_run: bool, stamp: i64, report: &mut ApplyRepor
             let server_up = Command::new("tmux")
                 .arg("info")
                 .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false);
+                .is_ok_and(|o| o.status.success());
             if !server_up {
                 return Ok(());
             }

--- a/crates/muxa-cli/src/init/components.rs
+++ b/crates/muxa-cli/src/init/components.rs
@@ -1,0 +1,164 @@
+//! The catalog of installable components.
+//!
+//! Each variant is one user-selectable item in the wizard. A component
+//! is the unit of: marker-block id, default selection, file-edit
+//! target, and uninstall scope. Adding a new component means adding a
+//! variant here and a matching arm in `apply.rs` / `uninstall.rs`.
+
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Component {
+    /// `prefix + s` → `display-popup -E muxa watch`
+    TmuxPopup,
+    /// per-pane glyph in `status-right`
+    TmuxStatusLine,
+    /// Claude Code shell hooks + statusLine
+    ClaudeHooks,
+    /// Codex shell hooks
+    CodexHooks,
+    /// Gemini CLI shell hooks
+    GeminiHooks,
+    /// `muxad` user-level systemd service
+    MuxadSystemd,
+    /// Web dashboard: generate token, enable in config
+    Dashboard,
+}
+
+impl Component {
+    pub const ALL: &'static [Component] = &[
+        Component::TmuxPopup,
+        Component::TmuxStatusLine,
+        Component::ClaudeHooks,
+        Component::CodexHooks,
+        Component::GeminiHooks,
+        Component::MuxadSystemd,
+        Component::Dashboard,
+    ];
+
+    /// Stable kebab-case id used in CLI flags and marker blocks.
+    pub fn id(self) -> &'static str {
+        match self {
+            Component::TmuxPopup => "tmux-popup",
+            Component::TmuxStatusLine => "tmux-statusline",
+            Component::ClaudeHooks => "claude-hooks",
+            Component::CodexHooks => "codex-hooks",
+            Component::GeminiHooks => "gemini-hooks",
+            Component::MuxadSystemd => "muxad-systemd",
+            Component::Dashboard => "dashboard",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Component> {
+        Component::ALL.iter().copied().find(|c| c.id() == s)
+    }
+
+    /// One-line label shown in the multi-select.
+    pub fn label(self) -> &'static str {
+        match self {
+            Component::TmuxPopup => "tmux: replace prefix+s with muxa watch popup",
+            Component::TmuxStatusLine => "tmux: per-pane agent glyphs in status-right",
+            Component::ClaudeHooks => "Claude Code: shell hooks + statusLine",
+            Component::CodexHooks => "OpenAI Codex: shell hooks",
+            Component::GeminiHooks => "Gemini CLI: shell hooks",
+            Component::MuxadSystemd => "muxad: systemd user service (auto-start on login)",
+            Component::Dashboard => "Web dashboard: generate token + enable",
+        }
+    }
+
+    /// Longer help text shown next to the label.
+    pub fn hint(self) -> &'static str {
+        match self {
+            Component::TmuxPopup => "drop-in replacement for tmux's choose-tree",
+            Component::TmuxStatusLine => "⚙ / · / ! per pane, refreshed every 2s",
+            Component::ClaudeHooks => "auto-detect when ~/.claude/settings.json exists",
+            Component::CodexHooks => "auto-detect when ~/.codex/config.toml exists",
+            Component::GeminiHooks => "auto-detect when ~/.gemini/settings.json exists",
+            Component::MuxadSystemd => "Linux only — skipped on macOS",
+            Component::Dashboard => "loopback :7878 by default; token in config",
+        }
+    }
+
+    /// Components shipped by each preset.
+    pub fn preset(p: Preset) -> Vec<Component> {
+        match p {
+            Preset::Minimal => vec![Component::TmuxPopup, Component::TmuxStatusLine],
+            Preset::Standard => vec![
+                Component::TmuxPopup,
+                Component::TmuxStatusLine,
+                Component::ClaudeHooks,
+                Component::CodexHooks,
+                Component::GeminiHooks,
+                Component::MuxadSystemd,
+            ],
+            Preset::Full => Component::ALL.to_vec(),
+        }
+    }
+}
+
+impl fmt::Display for Component {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.id())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Preset {
+    Minimal,
+    Standard,
+    Full,
+}
+
+impl Preset {
+    pub fn parse(s: &str) -> Option<Preset> {
+        match s {
+            "minimal" => Some(Preset::Minimal),
+            "standard" => Some(Preset::Standard),
+            "full" => Some(Preset::Full),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Preset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Preset::Minimal => "minimal",
+            Preset::Standard => "standard",
+            Preset::Full => "full",
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_round_trip() {
+        for c in Component::ALL {
+            assert_eq!(Component::parse(c.id()), Some(*c));
+        }
+    }
+
+    #[test]
+    fn preset_parses() {
+        assert_eq!(Preset::parse("minimal"), Some(Preset::Minimal));
+        assert_eq!(Preset::parse("standard"), Some(Preset::Standard));
+        assert_eq!(Preset::parse("full"), Some(Preset::Full));
+        assert_eq!(Preset::parse("bogus"), None);
+    }
+
+    #[test]
+    fn presets_grow_monotonically() {
+        let m = Component::preset(Preset::Minimal);
+        let s = Component::preset(Preset::Standard);
+        let f = Component::preset(Preset::Full);
+        for c in &m {
+            assert!(s.contains(c), "standard should include all of minimal");
+        }
+        for c in &s {
+            assert!(f.contains(c), "full should include all of standard");
+        }
+    }
+}

--- a/crates/muxa-cli/src/init/detect.rs
+++ b/crates/muxa-cli/src/init/detect.rs
@@ -120,8 +120,7 @@ fn muxad_is_running() -> bool {
     Command::new("pgrep")
         .args(["-u", &uid_string(), "-x", "muxad"])
         .output()
-        .map(|o| o.status.success() && !o.stdout.is_empty())
-        .unwrap_or(false)
+        .is_ok_and(|o| o.status.success() && !o.stdout.is_empty())
 }
 
 fn uid_string() -> String {

--- a/crates/muxa-cli/src/init/detect.rs
+++ b/crates/muxa-cli/src/init/detect.rs
@@ -1,0 +1,161 @@
+//! Pre-flight environment probing.
+//!
+//! Used for two things:
+//!
+//! 1. **Hard gates.** Cargo missing or no tmux + zellij anywhere on
+//!    PATH means the wizard exits early with a friendly message —
+//!    there's nothing to wire.
+//! 2. **Smart defaults.** When a user runs `muxa init` interactively,
+//!    components are pre-checked based on what we found: Claude config
+//!    file present → `claude-hooks` ✓; macOS → `muxad-systemd` greyed
+//!    out; etc. The user can still toggle.
+
+use crate::init::components::Component;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[derive(Debug, Default)]
+pub struct Detection {
+    pub tmux: Option<String>,
+    pub zellij: Option<String>,
+    pub cargo: Option<String>,
+    pub claude_settings: Option<PathBuf>,
+    pub codex_config: Option<PathBuf>,
+    pub gemini_settings: Option<PathBuf>,
+    pub muxad_running: bool,
+    pub systemd_user_available: bool,
+}
+
+impl Detection {
+    pub fn run() -> Detection {
+        Detection {
+            tmux: tool_version("tmux", &["-V"]),
+            zellij: tool_version("zellij", &["--version"]),
+            cargo: tool_version("cargo", &["--version"]),
+            claude_settings: existing_file(home_join(".claude/settings.json")),
+            codex_config: existing_file(home_join(".codex/config.toml")),
+            gemini_settings: existing_file(home_join(".gemini/settings.json")),
+            muxad_running: muxad_is_running(),
+            systemd_user_available: super::files::systemd::systemd_available(),
+        }
+    }
+
+    /// Components that should be pre-checked by default given this
+    /// detection result.
+    pub fn default_selection(&self) -> Vec<Component> {
+        let mut out = Vec::new();
+        if self.tmux.is_some() {
+            out.push(Component::TmuxPopup);
+            out.push(Component::TmuxStatusLine);
+        }
+        if self.claude_settings.is_some() {
+            out.push(Component::ClaudeHooks);
+        }
+        if self.codex_config.is_some() {
+            out.push(Component::CodexHooks);
+        }
+        if self.gemini_settings.is_some() {
+            out.push(Component::GeminiHooks);
+        }
+        // Don't pre-check systemd / dashboard — they're opt-in.
+        out
+    }
+
+    /// Hard-gate the wizard. Empty Vec means "go ahead".
+    pub fn blockers(&self) -> Vec<&'static str> {
+        let mut blockers = Vec::new();
+        if self.cargo.is_none() {
+            blockers.push("`cargo` not found on PATH (we need it to install muxa)");
+        }
+        if self.tmux.is_none() && self.zellij.is_none() {
+            blockers.push("neither tmux nor zellij found on PATH — install one first");
+        }
+        blockers
+    }
+
+    /// Soft warnings — render but don't block.
+    pub fn warnings(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
+        if !self.systemd_user_available {
+            warnings.push(
+                "systemctl --user unavailable — `muxad-systemd` component will be skipped if selected".into(),
+            );
+        }
+        if self.tmux.is_none() && self.zellij.is_some() {
+            warnings.push("tmux not found — only zellij components will be considered".into());
+        }
+        warnings
+    }
+}
+
+fn tool_version(name: &str, args: &[&str]) -> Option<String> {
+    if which::which(name).is_err() {
+        return None;
+    }
+    let out = Command::new(name).args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    Some(if s.is_empty() { name.to_string() } else { s })
+}
+
+fn existing_file(p: PathBuf) -> Option<PathBuf> {
+    if p.is_file() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+fn home_join(rel: &str) -> PathBuf {
+    dirs::home_dir().unwrap_or_default().join(rel)
+}
+
+/// Best-effort check for a running muxad. We just look for any
+/// `muxad` process owned by the current uid via `pgrep`. False on
+/// systems without `pgrep` (e.g. minimal containers); the verify
+/// stage will retry against the daemon's IPC socket anyway.
+fn muxad_is_running() -> bool {
+    Command::new("pgrep")
+        .args(["-u", &uid_string(), "-x", "muxad"])
+        .output()
+        .map(|o| o.status.success() && !o.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+fn uid_string() -> String {
+    Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map_or_else(|| "0".into(), |s| s.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detection_runs_without_panicking() {
+        // Just confirm the call shape — environment-dependent assertions
+        // would be flaky in CI. We require `cargo` because cargo built us.
+        let d = Detection::run();
+        assert!(d.cargo.is_some());
+    }
+
+    #[test]
+    fn default_selection_is_empty_when_nothing_detected() {
+        let d = Detection::default();
+        assert!(d.default_selection().is_empty());
+    }
+
+    #[test]
+    fn blockers_fire_when_no_multiplexer() {
+        let d = Detection::default();
+        let blockers = d.blockers();
+        assert!(blockers.iter().any(|m| m.contains("cargo")));
+        assert!(blockers.iter().any(|m| m.contains("tmux")));
+    }
+}

--- a/crates/muxa-cli/src/init/files/claude.rs
+++ b/crates/muxa-cli/src/init/files/claude.rs
@@ -1,0 +1,347 @@
+//! `~/.claude/settings.json` content layer.
+//!
+//! Strategy:
+//!
+//! - **Hooks**: for each event we care about, ensure there is at least
+//!   one entry whose `hooks[].command` matches `muxa hook claude
+//!   --event <e>`. Other entries (user's own hooks, other tools) are
+//!   preserved verbatim. Adding ours twice is impossible — we dedupe
+//!   by command-prefix match.
+//! - **statusLine**: only set when absent or already ours. If the user
+//!   already has a custom `statusLine` (e.g. ccstatusline), we leave
+//!   it alone and surface that fact to the caller.
+//! - **Uninstall**: strip every hook entry whose command starts with
+//!   `muxa hook claude`, plus the statusLine if we own it. Empty
+//!   arrays / objects are pruned to keep the file tidy.
+//!
+//! Returns `(new_text, Outcome)` so the caller (apply.rs) handles I/O,
+//! backups, and diffing.
+
+use crate::init::marker::Outcome;
+use anyhow::{Context, Result};
+use serde_json::{json, Map, Value};
+
+/// (Claude event name in settings.json, hook flag passed to muxa)
+const HOOK_EVENTS: &[(&str, &str)] = &[
+    ("SessionStart", "session_start"),
+    ("UserPromptSubmit", "user_prompt_submit"),
+    ("PreToolUse", "pre_tool_use"),
+    ("PostToolUse", "post_tool_use"),
+    ("Notification", "notification"),
+    ("Stop", "stop"),
+    ("SessionEnd", "session_end"),
+];
+
+const STATUSLINE_CMD: &str = "muxa hook claude-statusline";
+const HOOK_CMD_PREFIX: &str = "muxa hook claude";
+
+/// Result of an upsert telling the caller whether we touched
+/// `statusLine` or skipped it because the user owns it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusLineDecision {
+    /// We wrote our statusLine into the file.
+    Ours,
+    /// File already had ours — no-op.
+    AlreadyOurs,
+    /// Some other tool's statusLine was present; we left it alone.
+    SkippedUserOwned,
+}
+
+#[derive(Debug)]
+pub struct UpsertReport {
+    pub outcome: Outcome,
+    pub statusline: StatusLineDecision,
+}
+
+/// Default path: `~/.claude/settings.json`.
+pub fn default_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(".claude").join("settings.json"))
+}
+
+/// Insert muxa hooks + statusLine into the JSON text. An empty input
+/// (file missing) is treated as `{}`.
+pub fn upsert(original: &str) -> Result<(String, UpsertReport)> {
+    let mut root = parse_or_empty(original)?;
+    let root_obj = ensure_object(&mut root);
+
+    let hooks_changed = upsert_hooks(root_obj);
+    let statusline = upsert_statusline(root_obj);
+
+    let new_text = pretty_print(&root)?;
+    let changed = hooks_changed
+        || matches!(statusline, StatusLineDecision::Ours)
+        || new_text.trim() != original.trim();
+    let outcome = if original.is_empty() {
+        Outcome::Inserted
+    } else if changed {
+        Outcome::Replaced
+    } else {
+        Outcome::Unchanged
+    };
+    Ok((
+        new_text,
+        UpsertReport {
+            outcome,
+            statusline,
+        },
+    ))
+}
+
+/// Strip every hook + statusLine that we own. Leaves the file intact
+/// if it was empty, so a later install can recreate cleanly.
+pub fn remove(original: &str) -> Result<(String, Outcome)> {
+    if original.trim().is_empty() {
+        return Ok((original.to_string(), Outcome::AlreadyAbsent));
+    }
+    let mut root = parse_or_empty(original)?;
+    let root_obj = ensure_object(&mut root);
+
+    let mut changed = false;
+    if let Some(Value::Object(hooks)) = root_obj.get_mut("hooks") {
+        let event_keys: Vec<String> = hooks.keys().cloned().collect();
+        for ev in event_keys {
+            let Some(Value::Array(arr)) = hooks.get_mut(&ev) else {
+                continue;
+            };
+            let before = arr.len();
+            arr.retain(|entry| !entry_owned_by_us(entry));
+            if arr.len() != before {
+                changed = true;
+            }
+            if arr.is_empty() {
+                hooks.remove(&ev);
+                changed = true;
+            }
+        }
+        if hooks.is_empty() {
+            root_obj.remove("hooks");
+        }
+    }
+    if let Some(Value::Object(sl)) = root_obj.get("statusLine") {
+        if statusline_is_ours(sl) {
+            root_obj.remove("statusLine");
+            changed = true;
+        }
+    }
+
+    let new_text = pretty_print(&root)?;
+    Ok((
+        new_text,
+        if changed {
+            Outcome::Removed
+        } else {
+            Outcome::AlreadyAbsent
+        },
+    ))
+}
+
+fn parse_or_empty(text: &str) -> Result<Value> {
+    if text.trim().is_empty() {
+        Ok(Value::Object(Map::new()))
+    } else {
+        serde_json::from_str(text).context("parsing claude settings.json")
+    }
+}
+
+fn ensure_object(v: &mut Value) -> &mut Map<String, Value> {
+    if !v.is_object() {
+        *v = Value::Object(Map::new());
+    }
+    v.as_object_mut().expect("just ensured object")
+}
+
+fn upsert_hooks(root: &mut Map<String, Value>) -> bool {
+    let hooks = root
+        .entry("hooks".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let Value::Object(hooks_obj) = hooks else {
+        // Replace non-object hooks field — that's malformed.
+        *hooks = Value::Object(Map::new());
+        return upsert_hooks(root);
+    };
+
+    let mut changed = false;
+    for (event_name, flag) in HOOK_EVENTS {
+        let arr = hooks_obj
+            .entry((*event_name).to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        if !arr.is_array() {
+            *arr = Value::Array(Vec::new());
+            changed = true;
+        }
+        let arr = arr.as_array_mut().expect("just ensured array");
+        let want_cmd = format!("muxa hook claude --event {flag}");
+        if arr.iter().any(|e| entry_command_eq(e, &want_cmd)) {
+            continue;
+        }
+        arr.push(json!({
+            "hooks": [{ "type": "command", "command": want_cmd }]
+        }));
+        changed = true;
+    }
+    changed
+}
+
+fn upsert_statusline(root: &mut Map<String, Value>) -> StatusLineDecision {
+    match root.get("statusLine") {
+        Some(Value::Object(sl)) if statusline_is_ours(sl) => StatusLineDecision::AlreadyOurs,
+        Some(_) => StatusLineDecision::SkippedUserOwned,
+        None => {
+            root.insert(
+                "statusLine".to_string(),
+                json!({
+                    "type": "command",
+                    "command": STATUSLINE_CMD,
+                    "refreshInterval": 5,
+                }),
+            );
+            StatusLineDecision::Ours
+        }
+    }
+}
+
+fn statusline_is_ours(sl: &Map<String, Value>) -> bool {
+    sl.get("command")
+        .and_then(Value::as_str)
+        .is_some_and(|c| c.trim_start().starts_with(STATUSLINE_CMD))
+}
+
+/// True iff the entry is one of muxa's hook entries (any event).
+fn entry_owned_by_us(entry: &Value) -> bool {
+    let Some(arr) = entry.get("hooks").and_then(Value::as_array) else {
+        return false;
+    };
+    arr.iter().any(|h| {
+        h.get("command")
+            .and_then(Value::as_str)
+            .is_some_and(|c| c.trim_start().starts_with(HOOK_CMD_PREFIX))
+    })
+}
+
+fn entry_command_eq(entry: &Value, want_cmd: &str) -> bool {
+    let Some(arr) = entry.get("hooks").and_then(Value::as_array) else {
+        return false;
+    };
+    arr.iter().any(|h| {
+        h.get("command")
+            .and_then(Value::as_str)
+            .is_some_and(|c| c.trim() == want_cmd)
+    })
+}
+
+fn pretty_print(v: &Value) -> Result<String> {
+    let mut s = serde_json::to_string_pretty(v)?;
+    s.push('\n');
+    Ok(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_into_empty_file_creates_full_config() {
+        let (out, report) = upsert("").unwrap();
+        assert_eq!(report.outcome, Outcome::Inserted);
+        assert_eq!(report.statusline, StatusLineDecision::Ours);
+        let v: Value = serde_json::from_str(&out).unwrap();
+        // Every hook event has at least one entry.
+        for (event, _) in HOOK_EVENTS {
+            assert!(
+                v["hooks"][event].as_array().is_some_and(|a| !a.is_empty()),
+                "missing event {event}"
+            );
+        }
+        assert_eq!(v["statusLine"]["command"], STATUSLINE_CMD);
+    }
+
+    #[test]
+    fn upsert_is_idempotent() {
+        let (first, _) = upsert("").unwrap();
+        let (second, report) = upsert(&first).unwrap();
+        assert_eq!(report.outcome, Outcome::Unchanged);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn upsert_preserves_user_hooks() {
+        let user_settings = r#"{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "echo hi from the user" }
+        ]
+      }
+    ]
+  }
+}"#;
+        let (out, _) = upsert(user_settings).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        let arr = v["hooks"]["SessionStart"].as_array().unwrap();
+        assert_eq!(arr.len(), 2, "user entry + muxa entry");
+        // User's entry survived.
+        assert!(arr.iter().any(|e| e["hooks"][0]["command"]
+            .as_str()
+            .unwrap()
+            .contains("echo hi")));
+        // Ours is present.
+        assert!(arr.iter().any(|e| e["hooks"][0]["command"]
+            .as_str()
+            .unwrap()
+            .starts_with("muxa hook claude")));
+    }
+
+    #[test]
+    fn upsert_skips_user_owned_statusline() {
+        let user = r#"{ "statusLine": { "type": "command", "command": "npx ccstatusline" } }"#;
+        let (out, report) = upsert(user).unwrap();
+        assert_eq!(report.statusline, StatusLineDecision::SkippedUserOwned);
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["statusLine"]["command"], "npx ccstatusline");
+    }
+
+    #[test]
+    fn remove_strips_only_our_entries() {
+        let user_settings = r#"{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "echo user" }] }
+    ]
+  }
+}"#;
+        let (with, _) = upsert(user_settings).unwrap();
+        let (after, o) = remove(&with).unwrap();
+        assert_eq!(o, Outcome::Removed);
+        let v: Value = serde_json::from_str(&after).unwrap();
+        let arr = v["hooks"]["SessionStart"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert!(arr[0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap()
+            .contains("echo user"));
+        // Other events were ours-only — they should be pruned away.
+        assert!(v["hooks"].get("PreToolUse").is_none());
+        // Our statusLine is gone.
+        assert!(v.get("statusLine").is_none());
+    }
+
+    #[test]
+    fn remove_on_clean_file_is_noop() {
+        let user = r#"{ "hooks": { "SessionStart": [{ "hooks": [{ "type":"command", "command":"echo user" }] }] } }"#;
+        let (out, o) = remove(user).unwrap();
+        assert_eq!(o, Outcome::AlreadyAbsent);
+        // Roundtrip-equivalent JSON (whitespace may differ).
+        let before: Value = serde_json::from_str(user).unwrap();
+        let after: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn remove_does_not_drop_user_statusline() {
+        let user = r#"{ "statusLine": { "type": "command", "command": "npx ccstatusline" } }"#;
+        let (out, _) = remove(user).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["statusLine"]["command"], "npx ccstatusline");
+    }
+}

--- a/crates/muxa-cli/src/init/files/codex.rs
+++ b/crates/muxa-cli/src/init/files/codex.rs
@@ -1,0 +1,256 @@
+//! `~/.codex/config.toml` content layer.
+//!
+//! Codex's hook engine is a verbatim port of Claude Code's, so the
+//! semantic shape is identical to `claude.rs` — different file format.
+//! We use `toml_edit` to round-trip user comments and existing
+//! formatting verbatim, only mutating the `hooks.<Event>` arrays.
+//!
+//! Returns `(new_text, Outcome)` so the caller (apply.rs) handles I/O,
+//! backups, and diffing.
+
+use crate::init::marker::Outcome;
+use anyhow::{Context, Result};
+use toml_edit::{Array, ArrayOfTables, DocumentMut, Item, Table, Value};
+
+const HOOK_EVENTS: &[(&str, &str)] = &[
+    ("SessionStart", "session_start"),
+    ("UserPromptSubmit", "user_prompt_submit"),
+    ("PreToolUse", "pre_tool_use"),
+    ("PostToolUse", "post_tool_use"),
+    ("PermissionRequest", "permission_request"),
+    ("Stop", "stop"),
+];
+
+const HOOK_CMD_PREFIX: &str = "muxa hook codex";
+
+pub fn default_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(".codex").join("config.toml"))
+}
+
+pub fn upsert(original: &str) -> Result<(String, Outcome)> {
+    let mut doc = parse_or_empty(original)?;
+    let changed = upsert_hooks(&mut doc);
+    let new_text = doc.to_string();
+
+    let outcome = if original.is_empty() {
+        Outcome::Inserted
+    } else if changed || new_text != original {
+        Outcome::Replaced
+    } else {
+        Outcome::Unchanged
+    };
+    Ok((new_text, outcome))
+}
+
+pub fn remove(original: &str) -> Result<(String, Outcome)> {
+    if original.trim().is_empty() {
+        return Ok((original.to_string(), Outcome::AlreadyAbsent));
+    }
+    let mut doc = parse_or_empty(original)?;
+    let changed = strip_our_hooks(&mut doc);
+    Ok((
+        doc.to_string(),
+        if changed {
+            Outcome::Removed
+        } else {
+            Outcome::AlreadyAbsent
+        },
+    ))
+}
+
+fn parse_or_empty(text: &str) -> Result<DocumentMut> {
+    if text.trim().is_empty() {
+        Ok(DocumentMut::new())
+    } else {
+        text.parse::<DocumentMut>()
+            .context("parsing codex config.toml")
+    }
+}
+
+fn upsert_hooks(doc: &mut DocumentMut) -> bool {
+    let mut changed = false;
+
+    // Make sure `hooks` is a table.
+    if !doc.contains_table("hooks") {
+        doc["hooks"] = Item::Table(Table::new());
+        changed = true;
+    }
+    let hooks_tbl = doc["hooks"]
+        .as_table_mut()
+        .expect("hooks is a table by construction");
+    hooks_tbl.set_implicit(true); // render as `[[hooks.X]]`, not `[hooks]\n[[hooks.X]]`
+
+    for (event, flag) in HOOK_EVENTS {
+        let want_cmd = format!("muxa hook codex --event {flag}");
+        // hooks.<Event> is an array of tables — each table has a
+        // nested `hooks = [{ type, command }, ...]`.
+        if !hooks_tbl.contains_array_of_tables(event) {
+            hooks_tbl.insert(event, Item::ArrayOfTables(ArrayOfTables::new()));
+            changed = true;
+        }
+        let outer = hooks_tbl
+            .get_mut(event)
+            .and_then(Item::as_array_of_tables_mut)
+            .expect("array of tables by construction");
+
+        if outer.iter().any(|t| outer_table_has_command(t, &want_cmd)) {
+            continue;
+        }
+
+        let mut entry = Table::new();
+        let mut inner_arr = Array::new();
+        let mut inner = toml_edit::InlineTable::new();
+        inner.insert("type", Value::from("command"));
+        inner.insert("command", Value::from(want_cmd));
+        inner_arr.push(Value::InlineTable(inner));
+        entry.insert("hooks", Item::Value(Value::Array(inner_arr)));
+        outer.push(entry);
+        changed = true;
+    }
+    changed
+}
+
+fn strip_our_hooks(doc: &mut DocumentMut) -> bool {
+    let Some(hooks_tbl) = doc.get_mut("hooks").and_then(Item::as_table_mut) else {
+        return false;
+    };
+
+    let mut changed = false;
+    let event_keys: Vec<String> = hooks_tbl.iter().map(|(k, _)| k.to_string()).collect();
+    for ev in event_keys {
+        if let Some(outer) = hooks_tbl
+            .get_mut(&ev)
+            .and_then(Item::as_array_of_tables_mut)
+        {
+            let before = outer.len();
+            outer.retain(|t| !outer_table_owned_by_us(t));
+            if outer.len() != before {
+                changed = true;
+            }
+            if outer.is_empty() {
+                hooks_tbl.remove(&ev);
+                changed = true;
+            }
+        }
+    }
+    if hooks_tbl.is_empty() {
+        doc.remove("hooks");
+    }
+    changed
+}
+
+/// Does this outer-array entry contain an inner hook with the exact
+/// expected command string?
+fn outer_table_has_command(t: &Table, want_cmd: &str) -> bool {
+    inner_hooks_iter(t).any(|cmd| cmd.trim() == want_cmd)
+}
+
+/// Does this outer-array entry contain *any* inner hook owned by us?
+fn outer_table_owned_by_us(t: &Table) -> bool {
+    inner_hooks_iter(t).any(|cmd| cmd.trim_start().starts_with(HOOK_CMD_PREFIX))
+}
+
+/// Iterate every `command` string inside a single outer table's
+/// `hooks` array, regardless of whether the entries are inline tables
+/// or normal tables.
+fn inner_hooks_iter(t: &Table) -> impl Iterator<Item = &str> {
+    let inner = t.get("hooks");
+    inner
+        .into_iter()
+        .flat_map(|item| match item {
+            Item::Value(Value::Array(arr)) => arr
+                .iter()
+                .filter_map(|v| match v {
+                    Value::InlineTable(it) => it.get("command").and_then(Value::as_str),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+            Item::ArrayOfTables(aot) => aot
+                .iter()
+                .filter_map(|inner| inner.get("command").and_then(Item::as_str))
+                .collect::<Vec<_>>(),
+            _ => Vec::new(),
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_into_empty_emits_all_events() {
+        let (out, o) = upsert("").unwrap();
+        assert_eq!(o, Outcome::Inserted);
+        let doc: DocumentMut = out.parse().unwrap();
+        for (event, flag) in HOOK_EVENTS {
+            let aot = doc["hooks"][event].as_array_of_tables().unwrap();
+            assert_eq!(aot.len(), 1, "expected one entry for {event}");
+            let cmd = inner_hooks_iter(aot.get(0).unwrap())
+                .next()
+                .expect("command string");
+            assert!(
+                cmd.contains(&format!("--event {flag}")),
+                "{cmd} should mention {flag}"
+            );
+        }
+    }
+
+    #[test]
+    fn upsert_is_idempotent() {
+        let (first, _) = upsert("").unwrap();
+        let (second, o) = upsert(&first).unwrap();
+        assert_eq!(o, Outcome::Unchanged);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn upsert_preserves_user_table() {
+        let user = r#"# my notes
+[model]
+name = "gpt-x"
+
+[[hooks.SessionStart]]
+  [[hooks.SessionStart.hooks]]
+  type = "command"
+  command = "echo user"
+"#;
+        let (out, _) = upsert(user).unwrap();
+        assert!(out.contains("# my notes"));
+        assert!(out.contains("echo user"));
+        assert!(out.contains(r#"name = "gpt-x""#));
+        assert!(out.contains("muxa hook codex --event session_start"));
+    }
+
+    #[test]
+    fn remove_drops_only_our_entries() {
+        let user = r#"
+[[hooks.SessionStart]]
+  [[hooks.SessionStart.hooks]]
+  type = "command"
+  command = "echo user"
+"#;
+        let (with_ours, _) = upsert(user).unwrap();
+        let (after, o) = remove(&with_ours).unwrap();
+        assert_eq!(o, Outcome::Removed);
+        let doc: DocumentMut = after.parse().unwrap();
+        let aot = doc["hooks"]["SessionStart"].as_array_of_tables().unwrap();
+        assert_eq!(aot.len(), 1);
+        let cmd = inner_hooks_iter(aot.get(0).unwrap()).next().unwrap();
+        assert_eq!(cmd, "echo user");
+        // Other events were ours-only — pruned.
+        assert!(doc["hooks"].get("PreToolUse").is_none());
+    }
+
+    #[test]
+    fn remove_on_clean_file_is_noop() {
+        let user = r#"[model]
+name = "gpt"
+"#;
+        let (out, o) = remove(user).unwrap();
+        assert_eq!(o, Outcome::AlreadyAbsent);
+        // toml_edit may add a trailing newline but content equivalent.
+        assert!(out.contains(r#"name = "gpt""#));
+    }
+}

--- a/crates/muxa-cli/src/init/files/dashboard.rs
+++ b/crates/muxa-cli/src/init/files/dashboard.rs
@@ -1,0 +1,173 @@
+//! `$XDG_CONFIG_HOME/muxa/config.toml` dashboard block.
+//!
+//! Adds a `[dashboard]` table with `enabled = true`, a freshly-
+//! generated 32-byte hex token, and `bind = "127.0.0.1:7878"`. We use
+//! `toml_edit` so the rest of the config (potentially user-managed) is
+//! preserved verbatim.
+//!
+//! Token policy: if a token is already present we keep it (rotating
+//! invalidates any browser sessions the user has open). Only on first
+//! install do we generate one.
+
+use crate::init::marker::Outcome;
+use anyhow::{Context, Result};
+use rand::RngCore;
+use std::path::PathBuf;
+use toml_edit::{value, DocumentMut, Item, Table};
+
+pub fn default_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("muxa").join("config.toml"))
+}
+
+/// Ensure `[dashboard]` is present with `enabled = true` and a token.
+/// Returns the new file text + the token we ended up with (so the
+/// orchestrator can print the URL at the end of the run).
+pub fn upsert(original: &str) -> Result<(String, Outcome, String)> {
+    let mut doc = parse_or_empty(original)?;
+    let (changed, token) = upsert_dashboard(&mut doc);
+    let new_text = doc.to_string();
+    let outcome = if original.is_empty() {
+        Outcome::Inserted
+    } else if changed || new_text != original {
+        Outcome::Replaced
+    } else {
+        Outcome::Unchanged
+    };
+    Ok((new_text, outcome, token))
+}
+
+/// Remove the `[dashboard]` table entirely. We also drop a
+/// best-effort scrub of the token to keep the file from leaking it
+/// after uninstall.
+pub fn remove(original: &str) -> Result<(String, Outcome)> {
+    if original.trim().is_empty() {
+        return Ok((original.to_string(), Outcome::AlreadyAbsent));
+    }
+    let mut doc = parse_or_empty(original)?;
+    let had = doc.remove("dashboard").is_some();
+    Ok((
+        doc.to_string(),
+        if had {
+            Outcome::Removed
+        } else {
+            Outcome::AlreadyAbsent
+        },
+    ))
+}
+
+fn parse_or_empty(text: &str) -> Result<DocumentMut> {
+    if text.trim().is_empty() {
+        Ok(DocumentMut::new())
+    } else {
+        text.parse::<DocumentMut>().context("parsing config.toml")
+    }
+}
+
+/// Returns `(changed, token)`. If a token already exists we reuse it.
+fn upsert_dashboard(doc: &mut DocumentMut) -> (bool, String) {
+    let mut changed = false;
+
+    if !doc.contains_table("dashboard") {
+        doc["dashboard"] = Item::Table(Table::new());
+        changed = true;
+    }
+    let tbl = doc["dashboard"]
+        .as_table_mut()
+        .expect("table by construction");
+
+    if !matches!(tbl.get("enabled"), Some(Item::Value(v)) if v.as_bool() == Some(true)) {
+        tbl["enabled"] = value(true);
+        changed = true;
+    }
+    if tbl.get("bind").is_none() {
+        tbl["bind"] = value("127.0.0.1:7878");
+        changed = true;
+    }
+
+    let token = match tbl.get("token").and_then(Item::as_str) {
+        Some(t) if !t.trim().is_empty() => t.to_string(),
+        _ => {
+            let t = generate_token();
+            tbl["token"] = value(t.clone());
+            changed = true;
+            t
+        }
+    };
+    (changed, token)
+}
+
+fn generate_token() -> String {
+    let mut buf = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut buf);
+    let mut s = String::with_capacity(buf.len() * 2);
+    for b in buf {
+        use std::fmt::Write as _;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_into_empty_writes_full_block() {
+        let (out, o, token) = upsert("").unwrap();
+        assert_eq!(o, Outcome::Inserted);
+        assert_eq!(token.len(), 64); // 32 bytes hex-encoded
+        let doc: DocumentMut = out.parse().unwrap();
+        assert_eq!(doc["dashboard"]["enabled"].as_bool(), Some(true));
+        assert_eq!(doc["dashboard"]["bind"].as_str(), Some("127.0.0.1:7878"));
+        assert_eq!(doc["dashboard"]["token"].as_str().unwrap().len(), 64);
+    }
+
+    #[test]
+    fn upsert_preserves_existing_token() {
+        let (first, _, token1) = upsert("").unwrap();
+        let (second, _, token2) = upsert(&first).unwrap();
+        assert_eq!(token1, token2);
+        // No content change beyond whitespace tolerance.
+        let d1: DocumentMut = first.parse().unwrap();
+        let d2: DocumentMut = second.parse().unwrap();
+        assert_eq!(d1.to_string(), d2.to_string());
+    }
+
+    #[test]
+    fn upsert_keeps_user_sections_intact() {
+        let user = r#"# user comment
+[history]
+enabled = false
+
+[notifier]
+backend = "libnotify"
+"#;
+        let (out, _, _) = upsert(user).unwrap();
+        assert!(out.contains("# user comment"));
+        assert!(out.contains("[history]"));
+        assert!(out.contains("backend = \"libnotify\""));
+        assert!(out.contains("[dashboard]"));
+    }
+
+    #[test]
+    fn remove_drops_dashboard_only() {
+        let user = r"[history]
+enabled = false
+";
+        let (with, _, _) = upsert(user).unwrap();
+        let (after, o) = remove(&with).unwrap();
+        assert_eq!(o, Outcome::Removed);
+        assert!(after.contains("[history]"));
+        assert!(!after.contains("[dashboard]"));
+    }
+
+    #[test]
+    fn token_is_random_per_install() {
+        let (_, _, t1) = upsert("").unwrap();
+        let (_, _, t2) = upsert("").unwrap();
+        assert_ne!(
+            t1, t2,
+            "RNG should produce distinct tokens across invocations"
+        );
+    }
+}

--- a/crates/muxa-cli/src/init/files/gemini.rs
+++ b/crates/muxa-cli/src/init/files/gemini.rs
@@ -1,0 +1,219 @@
+//! `~/.gemini/settings.json` content layer.
+//!
+//! Same shape as `claude.rs` (JSON, hooks dict, append-with-dedupe),
+//! different event names and no `statusLine`. The duplication is
+//! intentional: each adapter's event list is small but specific, and
+//! a generic "JSON hooks merger" would obscure the per-agent contract.
+
+use crate::init::marker::Outcome;
+use anyhow::{Context, Result};
+use serde_json::{json, Map, Value};
+
+const HOOK_EVENTS: &[(&str, &str)] = &[
+    ("SessionStart", "session_start"),
+    ("BeforeAgent", "before_agent"),
+    ("AfterAgent", "after_agent"),
+    ("BeforeTool", "before_tool"),
+    ("AfterTool", "after_tool"),
+    ("Notification", "notification"),
+    ("SessionEnd", "session_end"),
+];
+
+const HOOK_CMD_PREFIX: &str = "muxa hook gemini";
+
+pub fn default_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(".gemini").join("settings.json"))
+}
+
+pub fn upsert(original: &str) -> Result<(String, Outcome)> {
+    let mut root = parse_or_empty(original)?;
+    let root_obj = ensure_object(&mut root);
+    let changed = upsert_hooks(root_obj);
+    let new_text = pretty_print(&root)?;
+    let outcome = if original.is_empty() {
+        Outcome::Inserted
+    } else if changed || new_text.trim() != original.trim() {
+        Outcome::Replaced
+    } else {
+        Outcome::Unchanged
+    };
+    Ok((new_text, outcome))
+}
+
+pub fn remove(original: &str) -> Result<(String, Outcome)> {
+    if original.trim().is_empty() {
+        return Ok((original.to_string(), Outcome::AlreadyAbsent));
+    }
+    let mut root = parse_or_empty(original)?;
+    let root_obj = ensure_object(&mut root);
+
+    let mut changed = false;
+    if let Some(Value::Object(hooks)) = root_obj.get_mut("hooks") {
+        let event_keys: Vec<String> = hooks.keys().cloned().collect();
+        for ev in event_keys {
+            let Some(Value::Array(arr)) = hooks.get_mut(&ev) else {
+                continue;
+            };
+            let before = arr.len();
+            arr.retain(|entry| !entry_owned_by_us(entry));
+            if arr.len() != before {
+                changed = true;
+            }
+            if arr.is_empty() {
+                hooks.remove(&ev);
+                changed = true;
+            }
+        }
+        if hooks.is_empty() {
+            root_obj.remove("hooks");
+        }
+    }
+
+    let new_text = pretty_print(&root)?;
+    Ok((
+        new_text,
+        if changed {
+            Outcome::Removed
+        } else {
+            Outcome::AlreadyAbsent
+        },
+    ))
+}
+
+fn parse_or_empty(text: &str) -> Result<Value> {
+    if text.trim().is_empty() {
+        Ok(Value::Object(Map::new()))
+    } else {
+        serde_json::from_str(text).context("parsing gemini settings.json")
+    }
+}
+
+fn ensure_object(v: &mut Value) -> &mut Map<String, Value> {
+    if !v.is_object() {
+        *v = Value::Object(Map::new());
+    }
+    v.as_object_mut().expect("just ensured object")
+}
+
+fn upsert_hooks(root: &mut Map<String, Value>) -> bool {
+    let hooks = root
+        .entry("hooks".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !hooks.is_object() {
+        *hooks = Value::Object(Map::new());
+    }
+    let hooks_obj = hooks.as_object_mut().expect("just ensured object");
+
+    let mut changed = false;
+    for (event_name, flag) in HOOK_EVENTS {
+        let arr = hooks_obj
+            .entry((*event_name).to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        if !arr.is_array() {
+            *arr = Value::Array(Vec::new());
+            changed = true;
+        }
+        let arr = arr.as_array_mut().expect("just ensured array");
+        let want_cmd = format!("muxa hook gemini --event {flag}");
+        if arr.iter().any(|e| entry_command_eq(e, &want_cmd)) {
+            continue;
+        }
+        arr.push(json!({
+            "hooks": [{ "type": "command", "command": want_cmd }]
+        }));
+        changed = true;
+    }
+    changed
+}
+
+fn entry_owned_by_us(entry: &Value) -> bool {
+    let Some(arr) = entry.get("hooks").and_then(Value::as_array) else {
+        return false;
+    };
+    arr.iter().any(|h| {
+        h.get("command")
+            .and_then(Value::as_str)
+            .is_some_and(|c| c.trim_start().starts_with(HOOK_CMD_PREFIX))
+    })
+}
+
+fn entry_command_eq(entry: &Value, want_cmd: &str) -> bool {
+    let Some(arr) = entry.get("hooks").and_then(Value::as_array) else {
+        return false;
+    };
+    arr.iter().any(|h| {
+        h.get("command")
+            .and_then(Value::as_str)
+            .is_some_and(|c| c.trim() == want_cmd)
+    })
+}
+
+fn pretty_print(v: &Value) -> Result<String> {
+    let mut s = serde_json::to_string_pretty(v)?;
+    s.push('\n');
+    Ok(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_into_empty_creates_all_events() {
+        let (out, o) = upsert("").unwrap();
+        assert_eq!(o, Outcome::Inserted);
+        let v: Value = serde_json::from_str(&out).unwrap();
+        for (event, _) in HOOK_EVENTS {
+            assert!(
+                v["hooks"][event].as_array().is_some_and(|a| !a.is_empty()),
+                "missing {event}"
+            );
+        }
+    }
+
+    #[test]
+    fn upsert_is_idempotent() {
+        let (first, _) = upsert("").unwrap();
+        let (second, o) = upsert(&first).unwrap();
+        assert_eq!(o, Outcome::Unchanged);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn upsert_preserves_user_hooks_and_extra_keys() {
+        let user = r#"{
+  "theme": "dark",
+  "hooks": {
+    "BeforeAgent": [
+      { "hooks": [{ "type": "command", "command": "echo user" }] }
+    ]
+  }
+}"#;
+        let (out, _) = upsert(user).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["theme"], "dark");
+        let arr = v["hooks"]["BeforeAgent"].as_array().unwrap();
+        assert_eq!(arr.len(), 2, "user entry + muxa entry");
+    }
+
+    #[test]
+    fn remove_strips_only_our_entries() {
+        let user = r#"{
+  "hooks": {
+    "BeforeAgent": [
+      { "hooks": [{ "type": "command", "command": "echo user" }] }
+    ]
+  }
+}"#;
+        let (with, _) = upsert(user).unwrap();
+        let (after, o) = remove(&with).unwrap();
+        assert_eq!(o, Outcome::Removed);
+        let v: Value = serde_json::from_str(&after).unwrap();
+        let arr = v["hooks"]["BeforeAgent"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert!(arr[0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap()
+            .contains("echo user"));
+    }
+}

--- a/crates/muxa-cli/src/init/files/mod.rs
+++ b/crates/muxa-cli/src/init/files/mod.rs
@@ -1,0 +1,13 @@
+//! Per-target file editors.
+//!
+//! Each submodule is a pure-string content layer for one external
+//! file. They produce `(new_content, Outcome)` pairs and never touch
+//! the disk — `apply.rs` owns I/O so the same edits can be unit-tested
+//! and dry-run-rendered.
+
+pub mod claude;
+pub mod codex;
+pub mod dashboard;
+pub mod gemini;
+pub mod systemd;
+pub mod tmux;

--- a/crates/muxa-cli/src/init/files/systemd.rs
+++ b/crates/muxa-cli/src/init/files/systemd.rs
@@ -1,0 +1,105 @@
+//! `~/.config/systemd/user/muxad.service` installer.
+//!
+//! Two pieces:
+//!   1. Render the unit file (matches `examples/muxad.service`).
+//!   2. Drive `systemctl --user daemon-reload && enable --now`.
+//!
+//! Step (1) is content-only and unit-tested. Step (2) shells out to
+//! `systemctl` and is invoked from `apply.rs`. We deliberately keep
+//! the unit file content layer pure so dry-run can show its diff
+//! without touching the system.
+
+use crate::init::marker::Outcome;
+use anyhow::{anyhow, Context, Result};
+use std::path::PathBuf;
+use std::process::Command;
+
+pub const UNIT_FILENAME: &str = "muxad.service";
+const UNIT_BODY: &str = include_str!("../../../../../examples/muxad.service");
+
+pub fn default_unit_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("systemd").join("user").join(UNIT_FILENAME))
+}
+
+/// Compute the install outcome for the unit file given its current
+/// on-disk content (or `None` if the file doesn't exist). Pure.
+pub fn upsert(existing: Option<&str>) -> (String, Outcome) {
+    let want = UNIT_BODY.to_string();
+    match existing {
+        None => (want, Outcome::Inserted),
+        Some(prev) if prev == UNIT_BODY => (want, Outcome::Unchanged),
+        Some(_) => (want, Outcome::Replaced),
+    }
+}
+
+/// Is `systemctl --user` even usable on this host? On macOS, in
+/// containers, or in CI without a session bus the whole component is
+/// a non-starter. We check by running `systemctl --user is-system-running
+/// --quiet || systemctl --user --version` — the `--version` path always
+/// succeeds when systemctl exists at all.
+pub fn systemd_available() -> bool {
+    Command::new("systemctl")
+        .args(["--user", "--version"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Run `systemctl --user daemon-reload && enable --now muxad.service`.
+pub fn enable_service() -> Result<()> {
+    run_systemctl(&["--user", "daemon-reload"]).context("systemctl daemon-reload")?;
+    run_systemctl(&["--user", "enable", "--now", UNIT_FILENAME])
+        .context("systemctl enable --now muxad.service")?;
+    Ok(())
+}
+
+/// Reverse: `disable --now`. Best-effort — `disable` returns
+/// non-zero when the unit wasn't enabled, and uninstall has to be
+/// idempotent, so we deliberately swallow exit codes.
+pub fn disable_service() {
+    let _ = Command::new("systemctl")
+        .args(["--user", "disable", "--now", UNIT_FILENAME])
+        .status();
+    let _ = Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .status();
+}
+
+fn run_systemctl(args: &[&str]) -> Result<()> {
+    let status = Command::new("systemctl")
+        .args(args)
+        .status()
+        .with_context(|| format!("spawning systemctl {}", args.join(" ")))?;
+    if !status.success() {
+        return Err(anyhow!(
+            "systemctl {} exited with {}",
+            args.join(" "),
+            status
+                .code()
+                .map_or_else(|| "signal".into(), |c| c.to_string())
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_body_has_expected_shape() {
+        // Sanity: the bundled unit file still describes muxad.
+        assert!(UNIT_BODY.contains("ExecStart=%h/.cargo/bin/muxad"));
+        assert!(UNIT_BODY.contains("[Install]"));
+    }
+
+    #[test]
+    fn upsert_decides_outcome_correctly() {
+        assert!(matches!(upsert(None).1, Outcome::Inserted));
+        assert!(matches!(upsert(Some(UNIT_BODY)).1, Outcome::Unchanged));
+        assert!(matches!(
+            upsert(Some("[Unit]\nstale=1\n")).1,
+            Outcome::Replaced
+        ));
+    }
+}

--- a/crates/muxa-cli/src/init/files/systemd.rs
+++ b/crates/muxa-cli/src/init/files/systemd.rs
@@ -41,8 +41,7 @@ pub fn systemd_available() -> bool {
     Command::new("systemctl")
         .args(["--user", "--version"])
         .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+        .is_ok_and(|o| o.status.success())
 }
 
 /// Run `systemctl --user daemon-reload && enable --now muxad.service`.

--- a/crates/muxa-cli/src/init/files/tmux.rs
+++ b/crates/muxa-cli/src/init/files/tmux.rs
@@ -1,0 +1,97 @@
+//! `~/.tmux.conf` content layer.
+//!
+//! Pure functions: take the existing file content + which components
+//! are selected, return the new content. All I/O (read, backup, write,
+//! `tmux source-file`) is handled by `apply.rs`.
+
+use crate::init::components::Component;
+use crate::init::marker::{self, Outcome};
+
+/// The body that goes inside the `tmux-popup` marker block.
+pub const POPUP_BODY: &str = r#"# Replace tmux's stock prefix+s (choose-tree) with muxa watch in a popup.
+# Enter on a row attaches to that pane and closes the popup.
+bind-key s display-popup -E -w 90% -h 85% "muxa watch""#;
+
+/// The body that goes inside the `tmux-statusline` marker block.
+pub const STATUSLINE_BODY: &str = r##"# Per-pane agent glyph (⚙ working / · idle / ! waiting / ✗ error)
+set -g status-interval 2
+set -g status-right-length 140
+set -g status-right "#(muxa status-line --pane #{pane_id}) | #[fg=white]%H:%M""##;
+
+/// Apply (insert or replace) the given component to the supplied tmux
+/// config text. Other components' blocks are left untouched. Components
+/// that don't write to tmux.conf return `Outcome::Unchanged`.
+pub fn upsert(original: &str, component: Component) -> (String, Outcome) {
+    match component {
+        Component::TmuxPopup => marker::upsert(original, component.id(), POPUP_BODY),
+        Component::TmuxStatusLine => marker::upsert(original, component.id(), STATUSLINE_BODY),
+        _ => (original.to_string(), Outcome::Unchanged),
+    }
+}
+
+/// Reverse a previous `upsert`. No-op if the block is already absent.
+pub fn remove(original: &str, component: Component) -> (String, Outcome) {
+    match component {
+        Component::TmuxPopup | Component::TmuxStatusLine => {
+            marker::remove(original, component.id())
+        }
+        _ => (original.to_string(), Outcome::Unchanged),
+    }
+}
+
+/// Default path for `~/.tmux.conf`. Returns `None` only if `$HOME` is
+/// unset, which is exotic enough that we let the caller decide how to
+/// surface the error.
+pub fn default_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(".tmux.conf"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn popup_round_trip() {
+        let (after, o1) = upsert("", Component::TmuxPopup);
+        assert_eq!(o1, Outcome::Inserted);
+        assert!(after.contains("display-popup"));
+        assert!(after.contains("muxa watch"));
+
+        let (after2, o2) = upsert(&after, Component::TmuxPopup);
+        assert_eq!(o2, Outcome::Unchanged);
+        assert_eq!(after, after2);
+
+        let (after3, o3) = remove(&after2, Component::TmuxPopup);
+        assert_eq!(o3, Outcome::Removed);
+        assert!(!after3.contains("display-popup"));
+    }
+
+    #[test]
+    fn statusline_and_popup_coexist() {
+        let (s, _) = upsert("", Component::TmuxPopup);
+        let (s, _) = upsert(&s, Component::TmuxStatusLine);
+        assert!(s.contains("display-popup"));
+        assert!(s.contains("status-right"));
+
+        // Removing one should leave the other alone.
+        let (s, _) = remove(&s, Component::TmuxPopup);
+        assert!(!s.contains("display-popup"));
+        assert!(s.contains("status-right"));
+    }
+
+    #[test]
+    fn upsert_preserves_user_config_around_block() {
+        let user = "set -g mouse on\nbind r source-file ~/.tmux.conf\n";
+        let (after, _) = upsert(user, Component::TmuxPopup);
+        assert!(after.contains("set -g mouse on"));
+        assert!(after.contains("bind r source-file ~/.tmux.conf"));
+        assert!(after.contains("display-popup"));
+    }
+
+    #[test]
+    fn unrelated_component_is_noop() {
+        let (out, o) = upsert("set -g a 1\n", Component::ClaudeHooks);
+        assert_eq!(o, Outcome::Unchanged);
+        assert_eq!(out, "set -g a 1\n");
+    }
+}

--- a/crates/muxa-cli/src/init/marker.rs
+++ b/crates/muxa-cli/src/init/marker.rs
@@ -1,0 +1,230 @@
+//! Reusable comment-fenced "managed block" editor.
+//!
+//! Used by any config file that takes shell-style `#`-prefix comments —
+//! `~/.tmux.conf` today, potentially others later. The format is:
+//!
+//! ```text
+//! # >>> muxa managed (<id>) >>>
+//! <body lines>
+//! # <<< muxa managed (<id>) <<<
+//! ```
+//!
+//! Each component owns its own block keyed by `id`, which means
+//! `--uninstall` can surgically remove just the block we own without
+//! touching anything the user added by hand.
+
+use std::fmt::Write as _;
+
+const OPEN_PREFIX: &str = "# >>> muxa managed (";
+const OPEN_SUFFIX: &str = ") >>>";
+const CLOSE_PREFIX: &str = "# <<< muxa managed (";
+const CLOSE_SUFFIX: &str = ") <<<";
+
+/// Result of a marker-block edit on a file's content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// File didn't have the block; appended one.
+    Inserted,
+    /// File had the block with different content; rewrote in place.
+    Replaced,
+    /// File had the block already with identical content; no-op.
+    Unchanged,
+    /// Asked to remove a block that wasn't there.
+    AlreadyAbsent,
+    /// Removed an existing block.
+    Removed,
+}
+
+impl Outcome {
+    /// Did this operation actually mutate the file content?
+    pub fn changed(self) -> bool {
+        matches!(
+            self,
+            Outcome::Inserted | Outcome::Replaced | Outcome::Removed
+        )
+    }
+}
+
+/// Insert or replace the block keyed by `id` with `body` in `original`.
+/// Returns the new file content + an `Outcome` describing what happened.
+///
+/// `body` should be the inner lines without the fence comments. A
+/// trailing newline on `body` is normalized away — the renderer adds
+/// exactly one between body and close fence.
+pub fn upsert(original: &str, id: &str, body: &str) -> (String, Outcome) {
+    let body = body.trim_end_matches('\n');
+    let rendered = render(id, body);
+    match find_block(original, id) {
+        Some((start, end)) => {
+            let existing = &original[start..end];
+            if existing == rendered {
+                (original.to_string(), Outcome::Unchanged)
+            } else {
+                let mut out = String::with_capacity(original.len() + rendered.len());
+                out.push_str(&original[..start]);
+                out.push_str(&rendered);
+                out.push_str(&original[end..]);
+                (out, Outcome::Replaced)
+            }
+        }
+        None => (append_block(original, &rendered), Outcome::Inserted),
+    }
+}
+
+/// Remove the block keyed by `id` from `original`, if present.
+pub fn remove(original: &str, id: &str) -> (String, Outcome) {
+    let Some((start, end)) = find_block(original, id) else {
+        return (original.to_string(), Outcome::AlreadyAbsent);
+    };
+    // Also eat one leading newline if there is one — keeps the file from
+    // accumulating blank lines after repeated install/uninstall cycles.
+    let cut_start = if start > 0 && original.as_bytes()[start - 1] == b'\n' {
+        start - 1
+    } else {
+        start
+    };
+    let mut out = String::with_capacity(original.len());
+    out.push_str(&original[..cut_start]);
+    out.push_str(&original[end..]);
+    (out, Outcome::Removed)
+}
+
+fn render(id: &str, body: &str) -> String {
+    let mut s = String::with_capacity(body.len() + 80);
+    let _ = writeln!(s, "{OPEN_PREFIX}{id}{OPEN_SUFFIX}");
+    s.push_str(body);
+    s.push('\n');
+    let _ = writeln!(s, "{CLOSE_PREFIX}{id}{CLOSE_SUFFIX}");
+    s
+}
+
+fn append_block(original: &str, rendered: &str) -> String {
+    let mut out = String::with_capacity(original.len() + rendered.len() + 2);
+    out.push_str(original);
+    if !original.is_empty() && !original.ends_with('\n') {
+        out.push('\n');
+    }
+    if !original.is_empty() && !original.ends_with("\n\n") {
+        out.push('\n');
+    }
+    out.push_str(rendered);
+    out
+}
+
+/// Locate the byte range `[start, end)` of the block for `id`,
+/// inclusive of the fence lines and trailing newline. Returns `None`
+/// when the block is absent or malformed (open without matching close).
+fn find_block(haystack: &str, id: &str) -> Option<(usize, usize)> {
+    let open = format!("{OPEN_PREFIX}{id}{OPEN_SUFFIX}");
+    let close = format!("{CLOSE_PREFIX}{id}{CLOSE_SUFFIX}");
+    let open_idx = line_start_of(haystack, &open)?;
+    // Search for the matching close *after* the open fence, scoped to
+    // the same id — this gracefully tolerates other components' blocks
+    // appearing between them in arbitrary order. The close must also be
+    // at a line start; otherwise a literal close-fence string inside a
+    // quoted body line would be misinterpreted as the real terminator.
+    let after_open = open_idx + open.len();
+    let close_line_start = line_start_of(&haystack[after_open..], &close)? + after_open;
+    // Include the trailing newline after the close fence so removal
+    // doesn't leave a dangling blank line.
+    let line_end = haystack[close_line_start..]
+        .find('\n')
+        .map_or(haystack.len(), |off| close_line_start + off + 1);
+    Some((open_idx, line_end))
+}
+
+/// Find `needle` in `haystack` only at line starts (begin-of-string or
+/// just after a `\n`). Prevents matching a literal that happens to
+/// appear inside a quoted string somewhere mid-line.
+fn line_start_of(haystack: &str, needle: &str) -> Option<usize> {
+    let mut search_from = 0;
+    while let Some(rel) = haystack[search_from..].find(needle) {
+        let abs = search_from + rel;
+        if abs == 0 || haystack.as_bytes()[abs - 1] == b'\n' {
+            return Some(abs);
+        }
+        search_from = abs + 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_into_empty() {
+        let (out, o) = upsert("", "x", "set -g foo bar");
+        assert_eq!(o, Outcome::Inserted);
+        assert!(out.contains("# >>> muxa managed (x) >>>"));
+        assert!(out.contains("set -g foo bar"));
+        assert!(out.contains("# <<< muxa managed (x) <<<"));
+    }
+
+    #[test]
+    fn insert_appends_with_blank_separator() {
+        let (out, _) = upsert("set -g status on\n", "x", "y");
+        assert!(out.contains("set -g status on\n\n# >>> muxa managed (x) >>>"));
+    }
+
+    #[test]
+    fn idempotent_same_content() {
+        let (first, _) = upsert("", "x", "body");
+        let (second, o) = upsert(&first, "x", "body");
+        assert_eq!(o, Outcome::Unchanged);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn replace_in_place_keeps_surrounding_lines() {
+        let (with, _) = upsert("before\n", "x", "old");
+        let after = format!("{with}after\n");
+        let (replaced, o) = upsert(&after, "x", "new");
+        assert_eq!(o, Outcome::Replaced);
+        assert!(replaced.starts_with("before\n"));
+        assert!(replaced.ends_with("after\n"));
+        assert!(replaced.contains("new"));
+        assert!(!replaced.contains("old"));
+    }
+
+    #[test]
+    fn remove_strips_block_and_preserves_neighbors() {
+        let original = "set -g a 1\n";
+        let (with, _) = upsert(original, "x", "managed line");
+        let suffix = format!("{with}set -g b 2\n");
+        let (removed, o) = remove(&suffix, "x");
+        assert_eq!(o, Outcome::Removed);
+        assert!(removed.contains("set -g a 1"));
+        assert!(removed.contains("set -g b 2"));
+        assert!(!removed.contains("muxa managed"));
+    }
+
+    #[test]
+    fn remove_when_absent_is_noop() {
+        let (out, o) = remove("just config\n", "x");
+        assert_eq!(o, Outcome::AlreadyAbsent);
+        assert_eq!(out, "just config\n");
+    }
+
+    #[test]
+    fn multiple_components_coexist_in_any_order() {
+        let s = String::new();
+        let (s, _) = upsert(&s, "a", "AAA");
+        let (s, _) = upsert(&s, "b", "BBB");
+        // Removing the inner block must not corrupt the outer one.
+        let (s, o) = remove(&s, "a");
+        assert_eq!(o, Outcome::Removed);
+        assert!(s.contains("BBB"));
+        assert!(!s.contains("AAA"));
+        assert!(find_block(&s, "b").is_some());
+        assert!(find_block(&s, "a").is_none());
+    }
+
+    #[test]
+    fn does_not_match_substring_inside_a_quoted_line() {
+        // Defensive: a status-right that quotes the literal must not
+        // be confused for a fence line.
+        let s = "set -g status-right \"# >>> muxa managed (x) >>> not a fence\"\n";
+        assert!(find_block(s, "x").is_none());
+    }
+}

--- a/crates/muxa-cli/src/init/mod.rs
+++ b/crates/muxa-cli/src/init/mod.rs
@@ -1,0 +1,253 @@
+//! `muxa init` — interactive install wizard.
+//!
+//! Modular layout:
+//!
+//! - `components`  — the catalog of selectable items + presets
+//! - `marker`      — generic comment-fenced "managed block" editor
+//! - `files/*`     — per-target content layers (tmux, claude, codex, …)
+//! - `detect`      — pre-flight environment probing
+//! - `plan`/`apply`/`verify` — three phases of the install pipeline
+//! - `ui`          — cliclack wrappers + non-interactive printer
+
+pub mod apply;
+pub mod components;
+pub mod detect;
+pub mod files;
+pub mod marker;
+pub mod plan;
+pub mod ui;
+pub mod verify;
+
+use crate::init::components::{Component, Preset};
+use crate::init::detect::Detection;
+use crate::init::plan::Direction;
+use crate::init::ui::Mode;
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Debug, Parser, Default)]
+// Each bool is a distinct, well-known CLI flag. Collapsing them into a
+// state-machine enum (clippy's suggestion) would be substantially less
+// usable than the documented flag surface.
+#[allow(clippy::struct_excessive_bools)]
+pub struct Args {
+    /// Apply a named preset instead of opening the wizard.
+    #[arg(long, value_parser = parse_preset)]
+    pub preset: Option<Preset>,
+
+    /// Auto-confirm every prompt. CI environments (CI=true) imply this.
+    #[arg(long, short = 'y', env = "MUXA_INIT_YES")]
+    pub yes: bool,
+
+    /// Compute and render the plan, but do not write or run anything.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Reverse a previous install — strip every muxa-managed block.
+    #[arg(long)]
+    pub uninstall: bool,
+
+    /// Force the wizard to re-prompt even if the components look already
+    /// configured.
+    #[arg(long)]
+    pub reconfigure: bool,
+
+    /// Comma-separated component ids (`tmux-popup,claude-hooks,…`).
+    /// When set, `--preset` and the wizard are bypassed.
+    #[arg(long, value_delimiter = ',')]
+    pub component: Vec<String>,
+
+    /// Skip every component whose id starts with the given prefix.
+    /// Repeatable (`--no tmux-popup --no claude-hooks`). Useful for
+    /// preset+exclusion combos like `--preset standard --no muxad-systemd`.
+    #[arg(long = "no", value_name = "ID")]
+    pub no: Vec<String>,
+}
+
+fn parse_preset(s: &str) -> Result<Preset, String> {
+    Preset::parse(s).ok_or_else(|| format!("unknown preset '{s}' (try minimal | standard | full)"))
+}
+
+pub async fn run(args: Args, socket: PathBuf) -> Result<()> {
+    let mode = Mode::detect(args.yes);
+    ui::intro(mode);
+
+    let detect = Detection::run();
+    if !preflight_ok(mode, &detect, args.uninstall) {
+        anyhow::bail!("pre-flight blockers");
+    }
+
+    let chosen = pick(args.uninstall, &args, &detect, mode)?;
+    if chosen.is_empty() {
+        ui::outro(mode, "Nothing to do.");
+        return Ok(());
+    }
+
+    let direction = if args.uninstall {
+        Direction::Uninstall
+    } else {
+        Direction::Install
+    };
+    let plan = plan::build(direction, &chosen, &detect)?;
+    for w in &plan.warnings {
+        ui::warn_line(mode, w);
+    }
+
+    // Always render the plan — interactive users see the diff before
+    // confirm, --yes / dry-run see it as logged context.
+    let dry = apply::render_dry_run(&plan);
+    ui::note(mode, "Review changes", dry.trim_end());
+
+    if args.dry_run {
+        ui::outro(mode, "Dry run — no changes written.");
+        return Ok(());
+    }
+
+    if !plan.has_changes() {
+        ui::outro(mode, "Already in the desired state.");
+        return Ok(());
+    }
+
+    if !ui::confirm_apply(mode, plan.actions.len())? {
+        ui::outro(mode, "Cancelled.");
+        return Ok(());
+    }
+
+    let report = apply::run(&plan, false).context("applying plan")?;
+    render_apply_steps(mode, &report);
+
+    let v = verify::run(&plan, socket).await?;
+    let extra = summarize_verify(&v);
+    let dashboard = report
+        .dashboard
+        .as_ref()
+        .map(|d| (d.bind.as_str(), d.token.as_str()));
+    ui::final_summary(
+        mode,
+        report.edited.len(),
+        report.backups.len(),
+        dashboard,
+        &extra,
+    );
+
+    let outro_msg = if args.uninstall {
+        "Uninstalled."
+    } else {
+        "Done. Try `prefix + s` for the muxa picker."
+    };
+    ui::outro(mode, outro_msg);
+    Ok(())
+}
+
+/// Render pre-flight, surface warnings, and signal whether we should
+/// proceed. `false` means a hard blocker fired (caller bails).
+fn preflight_ok(mode: Mode, detect: &Detection, uninstall: bool) -> bool {
+    let blockers = detect.blockers();
+    if !blockers.is_empty() && !uninstall {
+        for b in &blockers {
+            ui::error_line(mode, b);
+        }
+        ui::outro(mode, "Aborting — install the missing tools and try again.");
+        return false;
+    }
+    ui::render_detection(mode, detect);
+    for w in detect.warnings() {
+        ui::warn_line(mode, &w);
+    }
+    true
+}
+
+fn render_apply_steps(mode: Mode, report: &apply::ApplyReport) {
+    for path in &report.edited {
+        ui::step(mode, &format!("wrote {}", path.display()));
+    }
+    for path in &report.deleted {
+        ui::step(mode, &format!("removed {}", path.display()));
+    }
+    for backup in &report.backups {
+        ui::step(mode, &format!("backup → {}", backup.display()));
+    }
+    if report.systemd_enabled {
+        ui::step(mode, "systemctl --user enable --now muxad.service");
+    }
+    if report.systemd_disabled {
+        ui::step(mode, "systemctl --user disable --now muxad.service");
+    }
+    if report.tmux_sourced {
+        ui::step(mode, "tmux source-file (config reloaded live)");
+    }
+    for w in &report.warnings {
+        ui::warn_line(mode, w);
+    }
+}
+
+fn summarize_verify(v: &verify::VerifyReport) -> Vec<String> {
+    let mut extra = Vec::new();
+    match v.muxad_responsive {
+        Some(true) => extra.push("✔ muxad responding".into()),
+        Some(false) => extra.push("⚠ muxad not responding (try `muxad &`)".into()),
+        None => {}
+    }
+    if v.current_pane_seen == Some(true) {
+        extra.push("✔ current pane registered with muxad".into());
+    }
+    if v.tmux_status_ok == Some(false) {
+        extra.push("⚠ tmux config syntax check failed — review the diff".into());
+    }
+    for n in &v.notes {
+        extra.push(n.clone());
+    }
+    extra
+}
+
+/// Resolve which components to install/uninstall. Precedence:
+///
+/// 1. `--component` (explicit list — wins over everything)
+/// 2. `--preset`
+/// 3. Interactive multi-select (only on `Mode::Interactive`)
+/// 4. Detection's default selection (in non-interactive mode without preset)
+fn pick(uninstall: bool, args: &Args, detect: &Detection, mode: Mode) -> Result<Vec<Component>> {
+    if !args.component.is_empty() {
+        let mut picked = Vec::new();
+        for id in &args.component {
+            let id = id.trim();
+            if id.is_empty() {
+                continue;
+            }
+            let c = Component::parse(id).with_context(|| format!("unknown component: {id}"))?;
+            picked.push(c);
+        }
+        return Ok(filter_excluded(picked, &args.no));
+    }
+
+    if let Some(p) = args.preset {
+        let picked = Component::preset(p);
+        return Ok(filter_excluded(picked, &args.no));
+    }
+
+    // Uninstall without a preset means "remove everything we can detect"
+    // — but only blocks/edits we actually own (the file editors are
+    // idempotent on already-clean files, so this is safe).
+    if uninstall {
+        return Ok(Component::ALL.to_vec());
+    }
+
+    match mode {
+        Mode::Interactive => Ok(filter_excluded(ui::pick_components(detect)?, &args.no)),
+        Mode::NonInteractive => {
+            // No preset, no flags, can't prompt → use detection defaults.
+            Ok(filter_excluded(detect.default_selection(), &args.no))
+        }
+    }
+}
+
+fn filter_excluded(components: Vec<Component>, no: &[String]) -> Vec<Component> {
+    if no.is_empty() {
+        return components;
+    }
+    components
+        .into_iter()
+        .filter(|c| !no.iter().any(|n| n == c.id()))
+        .collect()
+}

--- a/crates/muxa-cli/src/init/plan.rs
+++ b/crates/muxa-cli/src/init/plan.rs
@@ -1,0 +1,329 @@
+//! Build an `Plan` (`Vec<Action>`) from a set of components.
+//!
+//! The plan is computed eagerly: each `Action::EditFile` already
+//! carries the new file content. This means dry-run rendering and
+//! the apply step share exactly the same bytes, and the network of
+//! per-file editors is decoupled from the I/O layer.
+
+use crate::init::components::Component;
+use crate::init::detect::Detection;
+use crate::init::files;
+use crate::init::marker::Outcome;
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+/// Direction of a plan: install (upsert) or uninstall (remove).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    Install,
+    Uninstall,
+}
+
+#[derive(Debug)]
+pub enum Action {
+    /// Write `new_content` to `path`, backing up any existing file.
+    /// `outcome` is precomputed so apply.rs can short-circuit
+    /// `Outcome::Unchanged` without touching the disk.
+    EditFile {
+        component: Component,
+        path: PathBuf,
+        before: Option<String>,
+        after: String,
+        outcome: Outcome,
+    },
+    /// Delete a file (currently only the systemd unit on uninstall).
+    DeleteFile { component: Component, path: PathBuf },
+    /// Run `systemctl --user enable --now muxad.service`.
+    EnableSystemdUnit,
+    /// Run `systemctl --user disable --now muxad.service`.
+    DisableSystemdUnit,
+    /// Reload the user's tmux config in place if a tmux server is up.
+    /// No-op when not inside tmux + no live server.
+    SourceTmuxConf { path: PathBuf },
+    /// Print the dashboard URL + token at the end. Captured here so
+    /// apply.rs can render it as a final "info" line.
+    PrintDashboard { token: String, bind: String },
+}
+
+#[derive(Debug)]
+pub struct Plan {
+    pub direction: Direction,
+    pub components: Vec<Component>,
+    pub actions: Vec<Action>,
+    /// Plan-time warnings — surfaced to the user before they confirm
+    /// (e.g. "you have a custom Claude statusLine, leaving it alone").
+    pub warnings: Vec<String>,
+}
+
+impl Plan {
+    /// True if any action would actually mutate the disk.
+    pub fn has_changes(&self) -> bool {
+        self.actions.iter().any(|a| match a {
+            Action::EditFile { outcome, .. } => outcome.changed(),
+            Action::DeleteFile { .. } | Action::EnableSystemdUnit | Action::DisableSystemdUnit => {
+                true
+            }
+            Action::SourceTmuxConf { .. } | Action::PrintDashboard { .. } => false,
+        })
+    }
+}
+
+pub fn build(direction: Direction, components: &[Component], detect: &Detection) -> Result<Plan> {
+    let mut actions = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+    let comps = components.to_vec();
+
+    let tmux_path = files::tmux::default_path();
+    let mut tmux_touched = false;
+
+    for c in &comps {
+        match c {
+            Component::TmuxPopup | Component::TmuxStatusLine => {
+                if plan_tmux(direction, *c, tmux_path.as_ref(), &mut actions)? {
+                    tmux_touched = true;
+                }
+            }
+            Component::ClaudeHooks => plan_claude(direction, *c, &mut actions, &mut warnings)?,
+            Component::CodexHooks => plan_codex(direction, *c, &mut actions)?,
+            Component::GeminiHooks => plan_gemini(direction, *c, &mut actions)?,
+            Component::MuxadSystemd => {
+                let Some(path) = files::systemd::default_unit_path() else {
+                    continue;
+                };
+                match direction {
+                    Direction::Install => {
+                        if !detect.systemd_user_available {
+                            continue;
+                        }
+                        let before = read_to_string_opt(&path)?;
+                        let (after, outcome) = files::systemd::upsert(before.as_deref());
+                        actions.push(Action::EditFile {
+                            component: *c,
+                            path,
+                            before,
+                            after,
+                            outcome,
+                        });
+                        actions.push(Action::EnableSystemdUnit);
+                    }
+                    Direction::Uninstall => {
+                        actions.push(Action::DisableSystemdUnit);
+                        if path.is_file() {
+                            actions.push(Action::DeleteFile {
+                                component: *c,
+                                path,
+                            });
+                        }
+                    }
+                }
+            }
+            Component::Dashboard => {
+                let Some(path) = files::dashboard::default_path() else {
+                    continue;
+                };
+                let before = read_to_string_opt(&path)?;
+                let original = before.clone().unwrap_or_default();
+                match direction {
+                    Direction::Install => {
+                        let (after, outcome, token) = files::dashboard::upsert(&original)
+                            .context("writing dashboard token to config.toml")?;
+                        actions.push(Action::EditFile {
+                            component: *c,
+                            path,
+                            before,
+                            after,
+                            outcome,
+                        });
+                        actions.push(Action::PrintDashboard {
+                            token,
+                            bind: "127.0.0.1:7878".into(),
+                        });
+                    }
+                    Direction::Uninstall => {
+                        let (after, outcome) = files::dashboard::remove(&original)
+                            .context("scrubbing dashboard config")?;
+                        actions.push(Action::EditFile {
+                            component: *c,
+                            path,
+                            before,
+                            after,
+                            outcome,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Re-source tmux config if we changed it and a tmux server is reachable.
+    if tmux_touched {
+        if let Some(path) = tmux_path {
+            actions.push(Action::SourceTmuxConf { path });
+        }
+    }
+
+    Ok(Plan {
+        direction,
+        components: comps,
+        actions,
+        warnings,
+    })
+}
+
+/// Returns `true` if the tmux config was changed (caller appends a
+/// `SourceTmuxConf` action).
+fn plan_tmux(
+    direction: Direction,
+    c: Component,
+    tmux_path: Option<&PathBuf>,
+    actions: &mut Vec<Action>,
+) -> Result<bool> {
+    let Some(path) = tmux_path.cloned() else {
+        return Ok(false);
+    };
+    let before = read_to_string_opt(&path)?;
+    let original = before.clone().unwrap_or_default();
+    let (after, outcome) = match direction {
+        Direction::Install => files::tmux::upsert(&original, c),
+        Direction::Uninstall => files::tmux::remove(&original, c),
+    };
+    let changed = outcome.changed();
+    actions.push(Action::EditFile {
+        component: c,
+        path,
+        before,
+        after,
+        outcome,
+    });
+    Ok(changed)
+}
+
+fn plan_claude(
+    direction: Direction,
+    c: Component,
+    actions: &mut Vec<Action>,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    let Some(path) = files::claude::default_path() else {
+        return Ok(());
+    };
+    let before = read_to_string_opt(&path)?;
+    let original = before.clone().unwrap_or_default();
+    let (after, outcome) = match direction {
+        Direction::Install => {
+            let (text, report) =
+                files::claude::upsert(&original).context("merging claude settings.json")?;
+            if matches!(
+                report.statusline,
+                files::claude::StatusLineDecision::SkippedUserOwned
+            ) {
+                warnings.push(
+                    "Claude Code already has a custom statusLine — leaving it alone. \
+                     To layer muxa over it, see `muxa hook claude-statusline --forward`."
+                        .into(),
+                );
+            }
+            (text, report.outcome)
+        }
+        Direction::Uninstall => {
+            files::claude::remove(&original).context("scrubbing claude settings.json")?
+        }
+    };
+    actions.push(Action::EditFile {
+        component: c,
+        path,
+        before,
+        after,
+        outcome,
+    });
+    Ok(())
+}
+
+fn plan_codex(direction: Direction, c: Component, actions: &mut Vec<Action>) -> Result<()> {
+    let Some(path) = files::codex::default_path() else {
+        return Ok(());
+    };
+    let before = read_to_string_opt(&path)?;
+    let original = before.clone().unwrap_or_default();
+    let (after, outcome) = match direction {
+        Direction::Install => {
+            files::codex::upsert(&original).context("merging codex config.toml")?
+        }
+        Direction::Uninstall => {
+            files::codex::remove(&original).context("scrubbing codex config.toml")?
+        }
+    };
+    actions.push(Action::EditFile {
+        component: c,
+        path,
+        before,
+        after,
+        outcome,
+    });
+    Ok(())
+}
+
+fn plan_gemini(direction: Direction, c: Component, actions: &mut Vec<Action>) -> Result<()> {
+    let Some(path) = files::gemini::default_path() else {
+        return Ok(());
+    };
+    let before = read_to_string_opt(&path)?;
+    let original = before.clone().unwrap_or_default();
+    let (after, outcome) = match direction {
+        Direction::Install => {
+            files::gemini::upsert(&original).context("merging gemini settings.json")?
+        }
+        Direction::Uninstall => {
+            files::gemini::remove(&original).context("scrubbing gemini settings.json")?
+        }
+    };
+    actions.push(Action::EditFile {
+        component: c,
+        path,
+        before,
+        after,
+        outcome,
+    });
+    Ok(())
+}
+
+fn read_to_string_opt(p: &PathBuf) -> Result<Option<String>> {
+    match std::fs::read_to_string(p) {
+        Ok(s) => Ok(Some(s)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).with_context(|| format!("reading {}", p.display())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::init::components::Component;
+
+    #[test]
+    fn empty_components_yields_empty_plan() {
+        let d = Detection::default();
+        let plan = build(Direction::Install, &[], &d).unwrap();
+        assert!(plan.actions.is_empty());
+        assert!(!plan.has_changes());
+    }
+
+    #[test]
+    fn tmux_install_produces_edit_then_source() {
+        // Detection irrelevant for tmux components — they don't gate on it.
+        let d = Detection::default();
+        let plan = build(Direction::Install, &[Component::TmuxPopup], &d).unwrap();
+        // First action is EditFile; if it produced changes, last is SourceTmuxConf.
+        assert!(matches!(
+            plan.actions.first(),
+            Some(Action::EditFile { .. })
+        ));
+        let last = plan.actions.last().unwrap();
+        // SourceTmuxConf appears only if the edit actually changed
+        // something. On systems without ~/.tmux.conf it always does
+        // (file is created).
+        let saw_source = matches!(last, Action::SourceTmuxConf { .. })
+            || matches!(plan.actions.last(), Some(Action::EditFile { .. }));
+        assert!(saw_source);
+    }
+}

--- a/crates/muxa-cli/src/init/ui.rs
+++ b/crates/muxa-cli/src/init/ui.rs
@@ -1,0 +1,203 @@
+//! UI layer — cliclack wrappers + non-interactive fallback.
+//!
+//! The interactive path is straightforward (cliclack does the heavy
+//! lifting); the trick is that `--yes` / CI environments must produce
+//! the same visible structure without ever blocking on a TTY. We
+//! achieve that by routing every "ask" through a tiny trait that has
+//! both an interactive and a print-only impl. Non-interactive runs
+//! still emit `◇`-prefixed lines so log output is useful in CI.
+
+use crate::init::components::Component;
+use crate::init::detect::Detection;
+use anyhow::Result;
+use std::io::{self, IsTerminal, Write};
+
+/// How user prompts should be sourced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Live wizard via cliclack.
+    Interactive,
+    /// Auto-confirm everything; emit progress lines only.
+    NonInteractive,
+}
+
+impl Mode {
+    pub fn detect(yes_flag: bool) -> Mode {
+        if yes_flag
+            || std::env::var_os("CI").is_some()
+            || !io::stdout().is_terminal()
+            || !io::stdin().is_terminal()
+        {
+            Mode::NonInteractive
+        } else {
+            Mode::Interactive
+        }
+    }
+}
+
+pub fn intro(mode: Mode) {
+    match mode {
+        Mode::Interactive => {
+            let _ = cliclack::intro("muxa init");
+        }
+        Mode::NonInteractive => {
+            println!("┌  muxa init");
+            println!("│");
+        }
+    }
+}
+
+pub fn outro(mode: Mode, msg: &str) {
+    match mode {
+        Mode::Interactive => {
+            let _ = cliclack::outro(msg);
+        }
+        Mode::NonInteractive => {
+            println!("│");
+            println!("└  {msg}");
+        }
+    }
+}
+
+pub fn note(mode: Mode, title: &str, body: &str) {
+    match mode {
+        Mode::Interactive => {
+            let _ = cliclack::note(title, body);
+        }
+        Mode::NonInteractive => {
+            println!("◇  {title}");
+            for line in body.lines() {
+                println!("│  {line}");
+            }
+            println!("│");
+        }
+    }
+}
+
+pub fn warn_line(mode: Mode, msg: &str) {
+    match mode {
+        Mode::Interactive => {
+            let _ = cliclack::log::warning(msg);
+        }
+        Mode::NonInteractive => {
+            println!("⚠  {msg}");
+        }
+    }
+}
+
+pub fn error_line(mode: Mode, msg: &str) {
+    match mode {
+        Mode::Interactive => {
+            let _ = cliclack::log::error(msg);
+        }
+        Mode::NonInteractive => {
+            eprintln!("✗  {msg}");
+        }
+    }
+}
+
+/// Render the pre-flight detection block.
+pub fn render_detection(mode: Mode, d: &Detection) {
+    let mut lines = Vec::new();
+    lines.push(check("cargo", d.cargo.as_deref()));
+    lines.push(check("tmux", d.tmux.as_deref()));
+    if d.zellij.is_some() {
+        lines.push(check("zellij", d.zellij.as_deref()));
+    }
+    lines.push(check_path("Claude Code config", d.claude_settings.as_ref()));
+    lines.push(check_path("Codex config", d.codex_config.as_ref()));
+    lines.push(check_path("Gemini CLI config", d.gemini_settings.as_ref()));
+    lines.push(format!(
+        "{} systemctl --user",
+        if d.systemd_user_available {
+            "✔"
+        } else {
+            "—"
+        }
+    ));
+    lines.push(format!(
+        "{} muxad already running",
+        if d.muxad_running { "✔" } else { "·" }
+    ));
+    note(mode, "Pre-flight", &lines.join("\n"));
+}
+
+fn check(label: &str, version: Option<&str>) -> String {
+    match version {
+        Some(v) => format!("✔ {label}: {v}"),
+        None => format!("✗ {label}: not found"),
+    }
+}
+
+fn check_path(label: &str, p: Option<&std::path::PathBuf>) -> String {
+    match p {
+        Some(path) => format!("✔ {label}: {}", path.display()),
+        None => format!("· {label}: not detected"),
+    }
+}
+
+/// Multi-select component picker with auto-detected defaults. In
+/// non-interactive mode this is bypassed (caller picks via preset).
+pub fn pick_components(detect: &Detection) -> Result<Vec<Component>> {
+    let defaults = detect.default_selection();
+    let mut ms = cliclack::multiselect("What should I set up?").required(false);
+    for c in Component::ALL {
+        ms = ms.item(*c, c.label(), c.hint());
+    }
+    let chosen = ms.initial_values(defaults).interact()?;
+    Ok(chosen)
+}
+
+pub fn confirm_apply(mode: Mode, count: usize) -> Result<bool> {
+    if count == 0 {
+        return Ok(false);
+    }
+    match mode {
+        Mode::NonInteractive => Ok(true),
+        Mode::Interactive => {
+            let prompt = if count == 1 {
+                "Apply 1 change?".to_string()
+            } else {
+                format!("Apply {count} changes?")
+            };
+            Ok(cliclack::confirm(prompt).initial_value(true).interact()?)
+        }
+    }
+}
+
+/// Print a tagged line right under the most recent step. Used by
+/// apply.rs's running output.
+pub fn step(mode: Mode, msg: &str) {
+    match mode {
+        Mode::Interactive => {
+            let _ = cliclack::log::step(msg);
+        }
+        Mode::NonInteractive => {
+            println!("│  → {msg}");
+            let _ = io::stdout().flush();
+        }
+    }
+}
+
+/// Render the next-step box after a successful run. Mirrors clack's
+/// outro shape so we get a consistent landing screen.
+pub fn final_summary(
+    mode: Mode,
+    edited: usize,
+    backups: usize,
+    dashboard: Option<(&str, &str)>,
+    extra_lines: &[String],
+) {
+    let mut body = Vec::new();
+    body.push(format!("{edited} files updated, {backups} backups written"));
+    for l in extra_lines {
+        body.push(l.clone());
+    }
+    if let Some((bind, token)) = dashboard {
+        body.push(format!("Dashboard: http://{bind}/?token={token}"));
+        body.push("Token also stored in your config.toml.".into());
+    }
+    body.push("Try `prefix + s` for the muxa picker.".into());
+    body.push("Roll back with `muxa init --uninstall`.".into());
+    note(mode, "Done", &body.join("\n"));
+}

--- a/crates/muxa-cli/src/init/verify.rs
+++ b/crates/muxa-cli/src/init/verify.rs
@@ -1,0 +1,106 @@
+//! Post-apply smoke tests.
+//!
+//! Each check is independent so a partial failure still gives the
+//! user useful information. We deliberately do *not* wedge the whole
+//! run on these — they're verifications, not gates. The orchestrator
+//! decides whether failures bubble up as warnings or errors.
+
+use crate::init::components::Component;
+use crate::init::plan::Plan;
+use anyhow::Result;
+use muxa::ipc::Client;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tokio::time::timeout;
+
+#[derive(Debug)]
+pub struct VerifyReport {
+    pub muxad_responsive: Option<bool>,
+    pub current_pane_seen: Option<bool>,
+    pub tmux_status_ok: Option<bool>,
+    pub notes: Vec<String>,
+}
+
+pub async fn run(plan: &Plan, socket: PathBuf) -> Result<VerifyReport> {
+    let mut report = VerifyReport {
+        muxad_responsive: None,
+        current_pane_seen: None,
+        tmux_status_ok: None,
+        notes: Vec::new(),
+    };
+
+    let want_daemon = plan
+        .components
+        .iter()
+        .any(|c| matches!(c, Component::MuxadSystemd) || agent_component(*c));
+    if want_daemon {
+        report.muxad_responsive = Some(check_muxad(socket.as_path()).await);
+        if report.muxad_responsive == Some(true) {
+            report.current_pane_seen = Some(check_current_pane(socket.as_path()).await);
+        }
+    }
+
+    let want_tmux = plan
+        .components
+        .iter()
+        .any(|c| matches!(c, Component::TmuxPopup | Component::TmuxStatusLine));
+    if want_tmux {
+        report.tmux_status_ok = Some(check_tmux_config_parses());
+    }
+
+    Ok(report)
+}
+
+fn agent_component(c: Component) -> bool {
+    matches!(
+        c,
+        Component::ClaudeHooks | Component::CodexHooks | Component::GeminiHooks
+    )
+}
+
+async fn check_muxad(socket: &Path) -> bool {
+    let client = Client::new(socket.to_path_buf());
+    // 1.5 s is plenty; cold-started muxad answers a snapshot in <50 ms.
+    matches!(
+        timeout(Duration::from_millis(1500), client.snapshot()).await,
+        Ok(Ok(_))
+    )
+}
+
+async fn check_current_pane(socket: &Path) -> bool {
+    let Some(pane) = std::env::var("TMUX_PANE")
+        .ok()
+        .or_else(|| std::env::var("ZELLIJ_PANE_ID").ok())
+    else {
+        return false;
+    };
+    let client = Client::new(socket.to_path_buf());
+    matches!(
+        timeout(Duration::from_millis(1500), client.by_pane(&pane)).await,
+        Ok(Ok(v)) if !v.is_empty()
+    )
+}
+
+/// Cheap parse-only check: `tmux start-server \; source-file -q ~/.tmux.conf`
+/// would actually evaluate it, but we just want to know syntax is OK.
+fn check_tmux_config_parses() -> bool {
+    use std::process::Command;
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    let path = home.join(".tmux.conf");
+    if !path.is_file() {
+        return false;
+    }
+    Command::new("tmux")
+        .args([
+            "-f",
+            path.to_str().unwrap_or(""),
+            "start-server",
+            ";",
+            "kill-server",
+        ])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(true) // tmux missing → don't claim a problem
+}

--- a/crates/muxa-cli/src/init/verify.rs
+++ b/crates/muxa-cli/src/init/verify.rs
@@ -92,7 +92,11 @@ fn check_tmux_config_parses() -> bool {
     if !path.is_file() {
         return false;
     }
-    Command::new("tmux")
+    // `is_ok_and` would default to `false` on Err, but here we want
+    // the opposite — a missing tmux is "not our problem" and should
+    // not flag a config-syntax error. Explicit `match` keeps the
+    // intent obvious to a future reader.
+    match Command::new("tmux")
         .args([
             "-f",
             path.to_str().unwrap_or(""),
@@ -101,6 +105,8 @@ fn check_tmux_config_parses() -> bool {
             "kill-server",
         ])
         .output()
-        .map(|o| o.status.success())
-        .unwrap_or(true) // tmux missing → don't claim a problem
+    {
+        Ok(o) => o.status.success(),
+        Err(_) => true,
+    }
 }

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -1,5 +1,6 @@
 //! muxa CLI — user-facing entry point.
 
+mod init;
 mod watch;
 
 use anyhow::{Context, Result};
@@ -78,6 +79,10 @@ enum Cmd {
     },
     /// Backfill the registry by scanning tmux panes for agent processes.
     Sync,
+    /// Interactive install wizard — wires tmux, agent hooks, systemd,
+    /// and the dashboard. Use `--preset standard --yes` for one-shot
+    /// non-interactive installs.
+    Init(init::Args),
 }
 
 #[derive(Debug, Subcommand)]
@@ -139,7 +144,7 @@ async fn main() -> Result<()> {
         .socket
         .or_else(|| cfg.socket.clone())
         .unwrap_or_else(paths::default_socket);
-    let client = Client::new(socket);
+    let client = Client::new(socket.clone());
 
     match args.cmd {
         Cmd::Status => cmd_status(&client).await,
@@ -152,6 +157,7 @@ async fn main() -> Result<()> {
         }
         Cmd::Watch { include_paneless } => cmd_watch(&client, cfg, include_paneless).await,
         Cmd::Sync => cmd_sync(&client).await,
+        Cmd::Init(init_args) => init::run(init_args, socket).await,
     }
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# muxa one-shot installer.
+#
+#   curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/install.sh | sh
+#
+# Or with arguments forwarded to `muxa init`:
+#
+#   curl -fsSL https://… | sh -s -- --preset standard --yes
+#   curl -fsSL https://… | sh -s -- --dry-run
+#
+# Tier 1 of muxa's three-tier install model:
+#   - Tier 1 (this script): builds + installs binaries, then hands off
+#     to `muxa init` which does the actual wiring.
+#   - Tier 2 (interactive):  cargo install + `muxa init`.
+#   - Tier 3 (automation):   the underlying `muxa init` flags
+#     (--preset, --yes, --component, --dry-run).
+#
+# All installation logic — backups, marker blocks, hook merging — lives
+# in `muxa init`, not here. Keeps this script short, auditable, and
+# safe to pipe into `sh`.
+
+set -euo pipefail
+
+REPO_URL="${MUXA_REPO_URL:-https://github.com/Open330/muxa.git}"
+REPO_REF="${MUXA_REPO_REF:-main}"
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "muxa-install: missing dependency: $1" >&2
+    case "$1" in
+      cargo) echo "  install rustup: https://rustup.rs" >&2 ;;
+      git)   echo "  install git via your package manager" >&2 ;;
+    esac
+    exit 1
+  }
+}
+
+need cargo
+need git
+
+echo "muxa-install: cloning $REPO_URL ($REPO_REF)..."
+TMPDIR="$(mktemp -d -t muxa-install.XXXXXX)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+git clone --depth 1 --branch "$REPO_REF" "$REPO_URL" "$TMPDIR" >/dev/null 2>&1 || {
+  # Fallback for forks where the default branch isn't named REPO_REF.
+  git clone --depth 1 "$REPO_URL" "$TMPDIR"
+}
+
+echo "muxa-install: building muxad..."
+cargo install --quiet --path "$TMPDIR/crates/muxad" --locked
+
+echo "muxa-install: building muxa CLI..."
+cargo install --quiet --path "$TMPDIR/crates/muxa-cli" --locked
+
+# Make sure muxa is on PATH for the exec below — fresh `cargo install`
+# adds it but a brand-new shell may not have rebuilt PATH yet.
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+
+if ! command -v muxa >/dev/null 2>&1; then
+  echo "muxa-install: muxa was built but is not on PATH." >&2
+  echo "  Add ${CARGO_HOME:-$HOME/.cargo}/bin to your PATH, then run \`muxa init\`." >&2
+  exit 0
+fi
+
+# Hand off to the wizard. All the file-edit, hook-merge, systemd, and
+# verify logic lives there. Forward any extra args the user piped in.
+exec muxa init "$@"


### PR DESCRIPTION
## Summary

- New `muxa init` subcommand replaces the 5-step manual install (cargo install + hand-edit `~/.tmux.conf` + jq-merge `~/.claude/settings.json` + `~/.codex/config.toml` + `~/.gemini/settings.json` + systemd unit) with one command.
- Three-tier install model sharing one core: `curl | sh` bootstrap (`scripts/install.sh`) → cliclack-styled interactive wizard (`muxa init`) → automation flags (`--preset {minimal,standard,full}`, `--yes`, `--component`, `--no <id>`, `--dry-run`, `--uninstall`, `MUXA_INIT_*` / `CI=true`).
- Seven components, each owning a `# >>> muxa managed (id) >>>` marker block (line-based files) or a command-prefix match (JSON / TOML), so `--uninstall` is a surgical reverse — user config around our blocks stays intact.
- Best-practice baseline: auto-detected smart defaults, atomic backup-then-rename writes (`<file>.muxa-backup-<unix_ts>`), idempotent round-trip, final verify step (muxad IPC ping, pane registration, tmux.conf syntax), custom Claude statusLine detected → warning instead of clobber.

## What it looks like

```text
┌  muxa init
◇  Pre-flight
│  ✔ tmux 3.4
│  ✔ Claude Code config: ~/.claude/settings.json
│  ✔ systemctl --user available
◇  What should I set up?
│  ◼ tmux: replace prefix+s with muxa watch popup
│  ◼ tmux: per-pane agent glyphs
│  ◼ Claude Code: shell hooks + statusLine    ← auto-checked
│  ◻ muxad: systemd user service
│  ◻ Web dashboard
◇  Review changes
│  + edit ~/.tmux.conf (tmux-popup) [+6 lines]
│  ~ edit ~/.claude/settings.json (claude-hooks) [+24 lines]
│  ⟳ tmux source-file ~/.tmux.conf
◇  Apply 3 changes? › yes
◇  Verify
│  ✔ muxad responding
│  ✔ current pane registered with muxad
└  Done. Try `prefix + s` for the muxa picker.
```

CI mode (`--yes`) emits the same visual structure with no prompts, so logs stay readable.

## Module layout (`crates/muxa-cli/src/init/`)

| File | Role |
| --- | --- |
| `mod.rs` | Orchestrator + clap `Args` |
| `components.rs` | 7-variant catalog + 3 presets |
| `detect.rs` | Pre-flight (tmux/cargo/agents/host/systemd) |
| `marker.rs` | Generic comment-fenced "managed block" editor (idempotent insert / replace / remove) |
| `plan.rs` | Build a `Vec<Action>` ahead of time so dry-run renders the same bytes apply will write |
| `apply.rs` | Backup → atomic write → diff render |
| `verify.rs` | Post-apply smoke tests |
| `ui.rs` | cliclack wrappers + matching non-interactive printer |
| `files/{tmux,claude,codex,gemini,systemd,dashboard}.rs` | Pure content-layer editors per target |

## Numbers

- 15 new files, ~3.0 kLOC
- **+146 unit tests** (workspace 215 → 361, all green)
- Clippy clean with `-D warnings`, rustfmt clean
- `scripts/install.sh` is 68 lines — all install logic lives in `muxa init`, the bootstrap just builds binaries and `exec`s the wizard

## Versioning

Per repo convention (`chore: release vX.Y.Z` is a separate commit), no version bump in this PR. CHANGELOG entry sits under `[Unreleased]`. A follow-up release commit + `v0.4.0` tag should land after merge — minor bump because this is a new feature with no breaking changes (still beta until 1.0).

## Test plan

- [x] `cargo test --workspace` — 361 / 361 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `muxa init --help` renders all flags
- [x] `muxa init --dry-run --preset minimal --yes` — tmux blocks only
- [x] `muxa init --dry-run --preset standard --yes` — + agent hooks + systemd
- [x] `muxa init --dry-run --preset full --yes` — + dashboard token
- [x] `muxa init --dry-run --preset standard --yes --no muxad-systemd` — exclusion path
- [x] `muxa init --dry-run --uninstall --yes` — surgical reverse render
- [ ] End-to-end live install on a fresh container/VM (manual)
- [ ] macOS path: muxad-systemd should be silently skipped (no `systemctl --user`)
- [ ] Existing user with custom `statusLine` → wizard warns, leaves config alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)