### PR TITLE
fix(init): remove tmux verify that killed user sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Critical: `muxa init` no longer kills running tmux sessions.** The
+  v0.4.0 post-apply verification step shelled out to
+  `tmux -f <conf> start-server \; kill-server` to syntax-check the
+  edited `~/.tmux.conf`. The `-f` flag only scopes the config file —
+  the command still attached to the user's *default* tmux socket and
+  the trailing `kill-server` killed every running session on the box.
+  The check has been removed entirely; the modest upside (parse
+  validation after a write we control end-to-end) was not worth the
+  catastrophic blast radius. Users see the diff in the review step
+  before apply, and `tmux source-file` surfaces any error when it
+  runs. The "tmux config syntax check" line in the final summary is
+  gone too.
+
 ## [0.4.0] - 2026-04-30
 
 ### Added

--- a/crates/muxa-cli/src/init/mod.rs
+++ b/crates/muxa-cli/src/init/mod.rs
@@ -192,9 +192,6 @@ fn summarize_verify(v: &verify::VerifyReport) -> Vec<String> {
     if v.current_pane_seen == Some(true) {
         extra.push("✔ current pane registered with muxad".into());
     }
-    if v.tmux_status_ok == Some(false) {
-        extra.push("⚠ tmux config syntax check failed — review the diff".into());
-    }
     for n in &v.notes {
         extra.push(n.clone());
     }

--- a/crates/muxa-cli/src/init/verify.rs
+++ b/crates/muxa-cli/src/init/verify.rs
@@ -17,7 +17,6 @@ use tokio::time::timeout;
 pub struct VerifyReport {
     pub muxad_responsive: Option<bool>,
     pub current_pane_seen: Option<bool>,
-    pub tmux_status_ok: Option<bool>,
     pub notes: Vec<String>,
 }
 
@@ -25,7 +24,6 @@ pub async fn run(plan: &Plan, socket: PathBuf) -> Result<VerifyReport> {
     let mut report = VerifyReport {
         muxad_responsive: None,
         current_pane_seen: None,
-        tmux_status_ok: None,
         notes: Vec::new(),
     };
 
@@ -38,14 +36,6 @@ pub async fn run(plan: &Plan, socket: PathBuf) -> Result<VerifyReport> {
         if report.muxad_responsive == Some(true) {
             report.current_pane_seen = Some(check_current_pane(socket.as_path()).await);
         }
-    }
-
-    let want_tmux = plan
-        .components
-        .iter()
-        .any(|c| matches!(c, Component::TmuxPopup | Component::TmuxStatusLine));
-    if want_tmux {
-        report.tmux_status_ok = Some(check_tmux_config_parses());
     }
 
     Ok(report)
@@ -81,32 +71,17 @@ async fn check_current_pane(socket: &Path) -> bool {
     )
 }
 
-/// Cheap parse-only check: `tmux start-server \; source-file -q ~/.tmux.conf`
-/// would actually evaluate it, but we just want to know syntax is OK.
-fn check_tmux_config_parses() -> bool {
-    use std::process::Command;
-    let Some(home) = dirs::home_dir() else {
-        return false;
-    };
-    let path = home.join(".tmux.conf");
-    if !path.is_file() {
-        return false;
-    }
-    // `is_ok_and` would default to `false` on Err, but here we want
-    // the opposite — a missing tmux is "not our problem" and should
-    // not flag a config-syntax error. Explicit `match` keeps the
-    // intent obvious to a future reader.
-    match Command::new("tmux")
-        .args([
-            "-f",
-            path.to_str().unwrap_or(""),
-            "start-server",
-            ";",
-            "kill-server",
-        ])
-        .output()
-    {
-        Ok(o) => o.status.success(),
-        Err(_) => true,
-    }
-}
+// NOTE — `check_tmux_config_parses()` was removed in v0.4.1 after a
+// reported incident: the previous implementation shelled out to
+// `tmux -f <conf> start-server \; kill-server` which kills the
+// running tmux server on the *default* socket — i.e. the user's
+// real sessions. The `-f` flag scopes the config but NOT the
+// socket; isolating it would have required `-L <name>` / `-S <path>`.
+//
+// Given the catastrophic failure mode (silently wiping every session)
+// vs. the modest upside (a syntax check after a write we already
+// control end-to-end), we removed the check entirely instead of
+// trying to harden it. Users see the diff in the review step before
+// apply, our marker-block content is fixed, and `tmux source-file`
+// will surface any error itself when it runs. The "tmux config
+// syntax check" line in the final summary is gone too.


### PR DESCRIPTION
## Summary

**Critical bug in v0.4.0** — the post-apply verification step in `muxa init` killed every running tmux session on the host. Reported by a user on macOS (tmux 3.6a) whose live sessions were all wiped during a `muxa init` run.

## Root cause

`crates/muxa-cli/src/init/verify.rs::check_tmux_config_parses()` shelled out to:

\`\`\`
tmux -f ~/.tmux.conf start-server \; kill-server
\`\`\`

intending to spin up a throwaway tmux server, parse the conf, then tear it down. The \`-f\` flag scopes the **config file** but NOT the **socket** — \`start-server\` attached to the user's *default* socket (\`/private/tmp/tmux-<uid>/default\` on macOS), and the trailing \`kill-server\` killed everything on it. Catastrophic blast radius from a nice-to-have check.

## Fix

Remove the check entirely. Hardening with \`-L muxa-init-verify\` would patch the immediate bug, but the value/risk math doesn't justify keeping it:

- The check runs *after* we write the conf — can't prevent bad output, only post-hoc confirm
- Marker-block content is fixed inside the binary; we control it
- User already approves the diff in the "Review changes" step before apply
- \`tmux source-file ~/.tmux.conf\` (which apply.rs runs) surfaces any real syntax error itself

Drops \`tmux_status_ok\` from \`VerifyReport\` and the matching summary line. Test and clippy clean.

## Test plan

- [x] \`cargo test --workspace\` — 361 / 361 pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [ ] Manual smoke on a host with active tmux sessions: run \`muxa init\` and confirm \`tmux ls\` still lists them afterward

## Release

Ship as **v0.4.1** (patch) immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)