### PR TITLE
fix(init): defer to service manager + clearer preflight label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-05-02
+
+### Fixed
+
+- **`muxa init` no longer races the service manager's spawn** — the
+  `--start-daemon` action is now suppressed when `muxad-systemd` or
+  `muxad-launchd` is in the plan. Previously both fired on every
+  install and the wizard's direct `nohup muxad &` won the socket-bind
+  race against the manager's child, producing an orphan muxad that
+  *worked* immediately but wasn't supervised — `pkill -9 muxad` left
+  it gone with no auto-restart, and `launchctl print` showed
+  `active count = 0 / state = spawn scheduled`. The shellrc-only path
+  (where no real manager owns the lifecycle) still gets the
+  start-daemon action so `muxa init` leaves muxad responsive in the
+  same session.
+- **Pre-flight label** — `muxad already running` rendered with a `·`
+  bullet even when muxad was *not* running, which read as a
+  contradiction. Replaced with state-dependent text:
+  `✔ muxad responding` vs `· muxad not running (will be started on apply)`.
+
 ## [0.4.3] - 2026-04-30
 
 ### Fixed

--- a/crates/muxa-cli/src/init/mod.rs
+++ b/crates/muxa-cli/src/init/mod.rs
@@ -101,10 +101,19 @@ pub async fn run(args: Args, socket: PathBuf) -> Result<()> {
         Direction::Install
     };
     let mut plan = plan::build(direction, &chosen, &detect)?;
-    if matches!(direction, Direction::Install) && args.start_daemon {
+    if matches!(direction, Direction::Install) && args.start_daemon && !manages_daemon(&chosen) {
         // Append last so disk edits + service enablement happen first;
         // by the time we try to start muxad the file/socket layout it
         // expects is fully in place.
+        //
+        // Suppressed when a real service manager (systemd / launchd)
+        // was selected: those components own the spawn lifecycle, and
+        // a parallel `nohup muxad &` here races their startup. The
+        // orphan we'd spawn wins the socket bind, the manager's child
+        // exits with EADDRINUSE, and `KeepAlive` / `Restart=on-failure`
+        // is dead-on-arrival. Reported by a user on macOS — `muxa
+        // status` worked but `pkill -9 muxad` left muxad gone with no
+        // auto-restart.
         plan.actions.push(plan::Action::StartDaemonIfNeeded);
     }
     for w in &plan.warnings {
@@ -263,6 +272,17 @@ fn pick(uninstall: bool, args: &Args, detect: &Detection, mode: Mode) -> Result<
             Ok(filter_excluded(detect.default_selection(), &args.no))
         }
     }
+}
+
+/// True iff one of the components owns the muxad spawn lifecycle.
+/// `MuxadShellrc` *does* start muxad lazily on the next interactive
+/// shell, but it doesn't run during `muxa init` itself — we still
+/// want `--start-daemon` to fire so the user has a working muxad in
+/// the same session.
+fn manages_daemon(components: &[Component]) -> bool {
+    components
+        .iter()
+        .any(|c| matches!(c, Component::MuxadSystemd | Component::MuxadLaunchd))
 }
 
 fn filter_excluded(components: Vec<Component>, no: &[String]) -> Vec<Component> {

--- a/crates/muxa-cli/src/init/ui.rs
+++ b/crates/muxa-cli/src/init/ui.rs
@@ -115,10 +115,14 @@ pub fn render_detection(mode: Mode, d: &Detection) {
             "—"
         }
     ));
-    lines.push(format!(
-        "{} muxad already running",
-        if d.muxad_running { "✔" } else { "·" }
-    ));
+    // Distinct text per state — the previous "muxad already running"
+    // string was shown with a `·` glyph even when muxad was NOT
+    // running, which read as a contradiction at first glance.
+    lines.push(if d.muxad_running {
+        "✔ muxad responding".into()
+    } else {
+        "· muxad not running (will be started on apply)".into()
+    });
     note(mode, "Pre-flight", &lines.join("\n"));
 }
 


### PR DESCRIPTION
## Summary

Reported on macOS during v0.4.3 testing. Install succeeded, `muxa status` worked, but `pkill -9 muxad` left muxad gone with no auto-restart — `launchctl print` revealed muxad was never under launchd supervision (`active count = 0`, `state = spawn scheduled`). Two distinct fixes.

### 1. `--start-daemon` raced the service manager

The orchestrator unconditionally appended `StartDaemonIfNeeded` after `EnableLaunchdUnit` / `EnableSystemdUnit`. Both fired during apply:

1. launchd's `bootstrap` with `RunAtLoad=true` scheduled a spawn.
2. our `nohup muxad >/tmp/muxad.log 2>&1 &` shell-out fired.
3. the shell-out won the socket-bind race.
4. launchd's child exited with `EADDRINUSE`; launchd entered throttle backoff.
5. the orphan muxad responded to `muxa status` but was never launchd-supervised. `KeepAlive` was dead-on-arrival.

**Fix**: only append `StartDaemonIfNeeded` when the plan does *not* include a real manager component (`muxad-systemd` / `muxad-launchd`). `muxad-shellrc` keeps the action since its rc hook only fires on the next interactive shell, not in the current `muxa init` session.

### 2. Pre-flight label was a contradiction

`· muxad already running` was emitted even when muxad was NOT running — only the leading `✔` glyph flipped to `·`. Read as "muxad already running" with a strikethrough-ish bullet, which wasted ~5 min of user debugging. Now state-dependent:

- `✔ muxad responding`
- `· muxad not running (will be started on apply)`

## Test plan

- [x] `cargo test --workspace` — 375 / 375 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Linux dry-run with `--preset standard`: plan no longer includes `start muxad if not running` (manager owns the lifecycle).
- [x] Linux dry-run with `--component muxad-shellrc`: plan still includes `start muxad if not running` (no manager owns it).
- [ ] macOS smoke: `muxa init --component muxad-launchd --yes` then `pkill -9 muxad ; sleep 12 ; muxa status` — auto-restart should fire from launchd.

## Release

Ship as **v0.4.4** (patch — bugfix only, no API changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)