### PR TITLE
feat(watch): push-based updates via Subscribe + stuck-Working sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-04
+
+### Added
+
+- **`muxa watch` is now push-based** instead of polling. New
+  streaming `Subscribe` IPC RPC: client opens a long-lived unix-
+  socket connection, daemon writes one JSON-encoded `Transition` per
+  state change. The TUI's background refresh task races the
+  subscription stream against a much slower fallback poll
+  (`STREAMING_FALLBACK_INTERVAL = 5s`, was 500 ms unconditionally).
+  State changes now hit the screen in ~milliseconds; idle CPU drops
+  to effectively zero. The fallback poll handles `Lagged` drops on
+  the broadcast and reconnects after daemon restarts. Falls back
+  cleanly to historical 500 ms polling against an old daemon that
+  doesn't speak the streaming variant.
+- **`Reconciler` stuck-Working sweep**: new
+  `[reconciler] stuck_working_timeout_secs = N` config (default `0`,
+  disabled). When non-zero, every reconciler tick auto-flips agents
+  whose `state == Working` and whose `last_activity_at` is older
+  than the threshold to `Idle`. Insurance against missed
+  `Stop`/`TurnStopped` hook firings — without it a single dropped
+  hook would leave a row glowing green forever. Each flip emits a
+  synthetic `Transition` so subscribed `muxa watch` instances see
+  the correction live. Off by default to preserve the historical
+  "state changes only on explicit events" guarantee; opt-in to a
+  reasonable value (`300` for 5 min) for interactive use.
+
+### Changed
+
+- `Transition` (was `Serialize`-only) is now also `Deserialize`. The
+  type is on the IPC wire as a result of the streaming subscribe
+  RPC. In-process consumers (sinks, notifier) are unaffected.
+- `lib::Client::subscribe()` (new method) returns `TransitionStream`,
+  a small async handle whose `recv()` yields the next `Transition`.
+
 ## [0.4.5] - 2026-05-02
 
 ### Fixed

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -39,7 +39,17 @@ use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use tokio::time::MissedTickBehavior;
 
+/// Polling cadence when no streaming `Subscribe` is active. We still
+/// fall back to this if the daemon doesn't speak the streaming
+/// variant or the subscription drops mid-session.
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Slower fallback cadence when streaming `Subscribe` is wired. Push
+/// updates land in ~milliseconds, so the polling tick only exists
+/// to catch up after broadcast `Lagged` drops or transient
+/// connection blips. 5 s gives plenty of headroom while keeping
+/// idle CPU effectively zero.
+const STREAMING_FALLBACK_INTERVAL: Duration = Duration::from_secs(5);
 /// Max time to wait for a single keystroke when the input buffer is
 /// empty. ~60 Hz so a press feels immediate without burning CPU on an
 /// idle terminal. Held keys / fast typing are absorbed by the
@@ -733,11 +743,22 @@ async fn refresh_task<F, Fut>(
     mut fetch: F,
     mut wake: mpsc::Receiver<()>,
     out: mpsc::Sender<RefreshOutcome>,
+    mut sub: Option<muxa::ipc::TransitionStream>,
 ) where
     F: FnMut() -> Fut + Send + 'static,
     Fut: Future<Output = RefreshOutcome> + Send,
 {
-    let mut tick = tokio::time::interval(POLL_INTERVAL);
+    // When we have a streaming subscription, push updates handle the
+    // common case in milliseconds — the polling tick only exists for
+    // catch-up after `Lagged` drops or reconnect. Without the
+    // subscription we fall back to the historical 500 ms cadence so
+    // the watch still updates against an old daemon.
+    let interval_dur = if sub.is_some() {
+        STREAMING_FALLBACK_INTERVAL
+    } else {
+        POLL_INTERVAL
+    };
+    let mut tick = tokio::time::interval(interval_dur);
     // If a refresh runs longer than one tick (slow daemon, slow tmux),
     // don't pile up backlog ticks — skip them.
     tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -746,6 +767,11 @@ async fn refresh_task<F, Fut>(
     tick.tick().await;
 
     loop {
+        // Reduce subscribe-arm noise: the `if sub.is_some()` guard
+        // on the select branch keeps the helper out of the wait set
+        // entirely when we don't have a stream — `pending()` would
+        // never resolve but tokio still polls it once per loop, which
+        // would burn a tiny bit of CPU and obscure traces.
         tokio::select! {
             _ = tick.tick() => {}
             req = wake.recv() => {
@@ -754,12 +780,38 @@ async fn refresh_task<F, Fut>(
                     return;
                 }
             }
+            res = recv_transition(&mut sub), if sub.is_some() => {
+                // `Some(())` → a transition fired → fall through to
+                // `fetch().await` below. `None` → daemon closed the
+                // stream OR a parse/IO error; drop the subscription
+                // and continue with pure polling so the user keeps a
+                // working (if higher-latency) view.
+                if res.is_none() {
+                    sub = None;
+                    // Tighten the tick interval since push is gone.
+                    tick = tokio::time::interval(POLL_INTERVAL);
+                    tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                    tick.tick().await;
+                    continue; // skip the eager refresh — next tick will fetch
+                }
+            }
         }
         let outcome = fetch().await;
         if out.send(outcome).await.is_err() {
             // Main loop dropped its receiver (quit/attach) — go home.
             return;
         }
+    }
+}
+
+/// Helper for the select arm: await the next transition, mapping
+/// every "stream is dead" case (Ok(None) for clean shutdown, Err for
+/// IO/parse) to `None` so the caller can fall back uniformly.
+async fn recv_transition(sub: &mut Option<muxa::ipc::TransitionStream>) -> Option<()> {
+    let stream = sub.as_mut()?;
+    match stream.recv().await {
+        Ok(Some(_)) => Some(()),
+        Ok(None) | Err(_) => None,
     }
 }
 
@@ -798,6 +850,21 @@ pub async fn run(client: &Client, watch_cfg: WatchConfig) -> Result<Option<Strin
     let bg_backend = backend.clone();
     let (wake_tx, wake_rx) = mpsc::channel::<()>(WAKE_CAPACITY);
     let (outcome_tx, mut outcome_rx) = mpsc::channel::<RefreshOutcome>(OUTCOME_CAPACITY);
+
+    // Try to open a streaming subscribe so we get push updates from
+    // the daemon. Falls back gracefully when the daemon is older
+    // (no `subscribe` RPC), the socket is unreachable, or the
+    // connection is denied — in any of those cases we hand `None`
+    // to the refresh task and it stays on the historical 500 ms
+    // polling cadence.
+    let subscription = match client.subscribe().await {
+        Ok(s) => Some(s),
+        Err(e) => {
+            tracing::debug!(error = %e, "subscribe unavailable; falling back to polling");
+            None
+        }
+    };
+
     let bg = tokio::spawn(refresh_task(
         move || {
             let client = bg_client.clone();
@@ -806,6 +873,7 @@ pub async fn run(client: &Client, watch_cfg: WatchConfig) -> Result<Option<Strin
         },
         wake_rx,
         outcome_tx,
+        subscription,
     ));
 
     let mut jump_target: Option<String> = None;
@@ -3017,6 +3085,7 @@ mod tests {
             },
             wake_rx,
             out_tx,
+            None,
         ));
 
         // The 500 ms tick is paused; force the wake path.
@@ -3052,6 +3121,7 @@ mod tests {
             },
             wake_rx,
             out_tx,
+            None,
         ));
 
         // Time is paused; advance past one full POLL_INTERVAL so the

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -214,6 +214,17 @@ pub struct ReconcilerConfig {
     /// enough that the cost of shelling out to tmux is negligible.
     #[serde(default = "default_reconciler_interval_secs")]
     pub interval_secs: u64,
+    /// If non-zero, agents stuck in `Working` for longer than this many
+    /// seconds get auto-downgraded to `Idle`. Insurance against missed
+    /// `Stop`/`TurnStopped` hook firings — without it a single dropped
+    /// hook leaves the row glowing green forever.
+    ///
+    /// Default `0` (disabled) preserves the historical "state changes
+    /// only on explicit events" guarantee. A reasonable opt-in value
+    /// is `300` (5 min) for interactive use; longer if your agents
+    /// routinely run multi-hour tasks.
+    #[serde(default = "default_zero")]
+    pub stuck_working_timeout_secs: u64,
 }
 
 impl Default for ReconcilerConfig {
@@ -221,12 +232,17 @@ impl Default for ReconcilerConfig {
         Self {
             enabled: true,
             interval_secs: default_reconciler_interval_secs(),
+            stuck_working_timeout_secs: 0,
         }
     }
 }
 
 fn default_reconciler_interval_secs() -> u64 {
     30
+}
+
+fn default_zero() -> u64 {
+    0
 }
 
 /// `[history]` config — controls the disk-backed prompt audit log.

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -79,6 +79,12 @@ enum RequestBody {
         limit: Option<usize>,
     },
     Health,
+    /// Long-lived streaming subscribe. Server replies with a one-shot
+    /// `ok` ack, then writes one JSON-encoded `Transition` per
+    /// state change (newline-delimited) until the client closes the
+    /// socket. Used by `muxa watch` to switch from 500 ms polling to
+    /// push-based updates.
+    Subscribe,
 }
 
 #[derive(Debug, Deserialize)]
@@ -243,6 +249,44 @@ impl Server {
     }
 }
 
+/// Pump every state transition from `store` to `writer` as a JSON
+/// line. Runs until the broadcast channel closes (daemon shutting
+/// down) or the client closes its half of the socket — the first
+/// failed write returns Ok(()) so the per-connection task wraps
+/// cleanly.
+///
+/// `Lagged` errors are logged but do not terminate the stream:
+/// dropping a few transitions on a slow consumer is preferable to
+/// disconnecting them. The next snapshot the client takes (via the
+/// fallback polling tick) will reconcile any holes.
+async fn stream_transitions(
+    mut writer: tokio::net::unix::OwnedWriteHalf,
+    store: SharedStore,
+) -> Result<(), RuntimeError> {
+    let mut rx = store.subscribe();
+    loop {
+        match rx.recv().await {
+            Ok(t) => {
+                let mut bytes = serde_json::to_vec(&t)?;
+                bytes.push(b'\n');
+                if writer.write_all(&bytes).await.is_err() {
+                    return Ok(());
+                }
+                if writer.flush().await.is_err() {
+                    return Ok(());
+                }
+            }
+            Err(broadcast::error::RecvError::Closed) => return Ok(()),
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                tracing::warn!(
+                    dropped = n,
+                    "subscribe lagged; client will reconcile via fallback poll"
+                );
+            }
+        }
+    }
+}
+
 #[tracing::instrument(level = "debug", skip(stream, store))]
 async fn handle(stream: UnixStream, store: SharedStore) -> Result<(), RuntimeError> {
     let (reader, mut writer) = stream.into_split();
@@ -316,6 +360,25 @@ async fn handle(stream: UnixStream, store: SharedStore) -> Result<(), RuntimeErr
                     kind = "health";
                     Response::health()
                 }
+                RequestBody::Subscribe => {
+                    kind = "subscribe";
+                    // Stream takeover. Send ack, then write transitions
+                    // until the client disconnects or muxad shuts down.
+                    // We deliberately do NOT return to the request loop
+                    // — this connection is now owned by the streaming
+                    // pump.
+                    let ack_bytes = serde_json::to_vec(&Response::ok())?;
+                    writer.write_all(&ack_bytes).await?;
+                    writer.write_all(b"\n").await?;
+                    writer.flush().await?;
+                    tracing::debug!(
+                        elapsed_us =
+                            u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX),
+                        kind,
+                        "ipc.handle (stream takeover)",
+                    );
+                    return stream_transitions(writer, store).await;
+                }
             },
             Err(e) => {
                 kind = "parse_error";
@@ -350,6 +413,29 @@ pub fn harden_permissions(socket_path: &Path) -> std::io::Result<()> {
 #[derive(Clone)]
 pub struct Client {
     socket_path: PathBuf,
+}
+
+/// Long-lived handle returned by [`Client::subscribe`]. Calls to
+/// [`Self::recv`] yield successive `Transition`s as they happen on
+/// the daemon. Returns `Ok(None)` when the daemon closes the
+/// connection (shutdown) or `Err(_)` on a parse / IO failure that
+/// the caller will probably want to handle by reconnecting.
+pub struct TransitionStream {
+    reader: BufReader<tokio::net::unix::OwnedReadHalf>,
+    line: String,
+}
+
+impl TransitionStream {
+    /// Wait for and return the next streamed `Transition`.
+    pub async fn recv(&mut self) -> Result<Option<crate::state::Transition>, RuntimeError> {
+        self.line.clear();
+        let n = self.reader.read_line(&mut self.line).await?;
+        if n == 0 {
+            return Ok(None);
+        }
+        let t: crate::state::Transition = serde_json::from_str(self.line.trim())?;
+        Ok(Some(t))
+    }
 }
 
 impl Client {
@@ -417,6 +503,55 @@ impl Client {
             .unwrap_or_default())
     }
 
+    /// Open a long-lived subscription to state transitions. Returns
+    /// a stream-like handle whose `recv()` yields the next
+    /// `Transition` from the daemon, or `None` when the daemon
+    /// closes the connection (shutdown).
+    ///
+    /// Designed for `muxa watch` to drop polling latency from 500 ms
+    /// to ~1 ms while keeping a slower fallback poll for catch-up
+    /// after reconnects or `Lagged` drops on the server side.
+    pub async fn subscribe(&self) -> Result<TransitionStream, RuntimeError> {
+        let stream = UnixStream::connect(&self.socket_path)
+            .await
+            .map_err(|e| match e.kind() {
+                std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound => {
+                    RuntimeError::NotConnected(self.socket_path.clone())
+                }
+                _ => RuntimeError::Io(e),
+            })?;
+        let (reader, mut writer) = stream.into_split();
+        let mut req = serde_json::to_vec(&serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "subscribe",
+        }))?;
+        req.push(b'\n');
+        writer.write_all(&req).await?;
+        writer.flush().await?;
+
+        // Server replies with a one-shot ack before the streaming
+        // pump takes over.
+        let mut reader = BufReader::new(reader);
+        let mut ack = String::new();
+        reader.read_line(&mut ack).await?;
+        let ack: serde_json::Value = serde_json::from_str(ack.trim())?;
+        if !ack["ok"].as_bool().unwrap_or(false) {
+            return Err(RuntimeError::Json(serde::de::Error::custom(format!(
+                "subscribe rejected: {}",
+                ack["error"].as_str().unwrap_or("(no error message)")
+            ))));
+        }
+
+        // Drop the writer immediately — we never send another byte
+        // on this connection. The server detects our close-when-done
+        // via EOF on its read half.
+        drop(writer);
+        Ok(TransitionStream {
+            reader,
+            line: String::new(),
+        })
+    }
+
     pub async fn call(&self, req: &serde_json::Value) -> Result<serde_json::Value, RuntimeError> {
         // Connect-time ECONNREFUSED/ENOENT mean the daemon socket isn't there
         // or nothing is listening — surface a friendly message that names the
@@ -446,7 +581,7 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::{AgentEvent, AgentId, AgentKind};
+    use crate::event::{AgentEvent, AgentId, AgentKind, AgentState};
     use crate::state::Store;
     use tempfile::tempdir;
     use time::OffsetDateTime;
@@ -493,6 +628,71 @@ mod tests {
 
         tx.send(()).unwrap();
         handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn subscribe_streams_transitions_to_client() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-sub.sock");
+        let store = Store::shared();
+        let server = Server::new(sock.clone(), store.clone());
+        let (tx, rx) = broadcast::channel(1);
+        let handle = tokio::spawn(async move { server.run(rx).await.unwrap() });
+        for _ in 0..50 {
+            if sock.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        // Open subscription before any events fire.
+        let client = Client::new(sock.clone());
+        let mut stream = client.subscribe().await.expect("subscribe");
+
+        // Drive a state transition: Started → Idle (initial).
+        let id = AgentId {
+            kind: AgentKind::ClaudeCode,
+            session_id: "sub-test".into(),
+            pane: Some("%9".into()),
+            cwd: None,
+        };
+        store
+            .apply(&AgentEvent::Started {
+                id: id.clone(),
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+
+        // Then Idle → Working via PromptSubmitted.
+        store
+            .apply(&AgentEvent::PromptSubmitted {
+                id: id.clone(),
+                prompt: "hi".into(),
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+
+        // Stream should deliver both transitions in order.
+        let t1 = tokio::time::timeout(std::time::Duration::from_secs(2), stream.recv())
+            .await
+            .expect("first transition arrives within timeout")
+            .expect("recv ok")
+            .expect("transition present");
+        assert_eq!(t1.from, AgentState::Starting);
+        assert_eq!(t1.to, AgentState::Idle);
+
+        let t2 = tokio::time::timeout(std::time::Duration::from_secs(2), stream.recv())
+            .await
+            .expect("second transition arrives within timeout")
+            .expect("recv ok")
+            .expect("transition present");
+        assert_eq!(t2.from, AgentState::Idle);
+        assert_eq!(t2.to, AgentState::Working);
+
+        // Drop the stream to close the connection, then shut down.
+        drop(stream);
+        tx.send(()).unwrap();
+        let _ = handle.await;
     }
 
     #[tokio::test]

--- a/crates/muxa/src/reconcile.rs
+++ b/crates/muxa/src/reconcile.rs
@@ -78,6 +78,11 @@ pub struct Reconciler<L: LivenessSource> {
     /// [`Self::with_metrics`]; tests can leave it `None` to avoid
     /// plumbing through a `Metrics` they never inspect.
     metrics: Option<Metrics>,
+    /// If non-zero, agents stuck in `Working` for this long get
+    /// auto-flipped to `Idle` on every tick. `Duration::ZERO`
+    /// (default) disables the sweep so the historical
+    /// "state-on-events-only" semantics are preserved.
+    stuck_working_timeout: Duration,
 }
 
 impl<L: LivenessSource> Reconciler<L> {
@@ -87,6 +92,7 @@ impl<L: LivenessSource> Reconciler<L> {
             source: Arc::new(source),
             interval,
             metrics: None,
+            stuck_working_timeout: Duration::ZERO,
         }
     }
 
@@ -95,6 +101,14 @@ impl<L: LivenessSource> Reconciler<L> {
     #[must_use]
     pub fn with_metrics(mut self, metrics: Metrics) -> Self {
         self.metrics = Some(metrics);
+        self
+    }
+
+    /// Enable auto-downgrade of stuck `Working` agents to `Idle`.
+    /// `Duration::ZERO` (the default) keeps the sweep off.
+    #[must_use]
+    pub fn with_stuck_working_timeout(mut self, t: Duration) -> Self {
+        self.stuck_working_timeout = t;
         self
     }
 
@@ -111,8 +125,15 @@ impl<L: LivenessSource> Reconciler<L> {
             .await
             .unwrap_or_default();
         let report = self.store.reconcile(&panes).await;
+        let stuck_flipped = self.store.mark_stuck_idle(self.stuck_working_timeout).await;
         if let Some(m) = &self.metrics {
             m.record_reconcile_pass();
+        }
+        if stuck_flipped > 0 {
+            tracing::info!(
+                count = stuck_flipped,
+                "stuck-working sweep flipped {stuck_flipped} agent(s) to Idle"
+            );
         }
         // Always emit the timing line at debug (cheap, off by default)
         // even on no-op passes — operators want to see the loop is alive

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use time::OffsetDateTime;
 use tokio::sync::{broadcast, Notify, RwLock};
 
@@ -163,11 +163,15 @@ impl Agent {
 
 /// In-process notification emitted when an agent's `state` field changes.
 ///
-/// Not part of the IPC protocol — consumers must live in the daemon
-/// process. `agent` is the post-transition snapshot, suitable for rendering
-/// UI (desktop notification body, log line, etc.) without racing further
-/// mutations.
-#[derive(Debug, Clone, Serialize)]
+/// `agent` is the post-transition snapshot, suitable for rendering
+/// UI (desktop notification body, log line, status row) without
+/// racing further mutations.
+///
+/// Both in-process consumers (sinks, notifier) and IPC subscribers
+/// (`muxa watch`) receive the same payload — the type is
+/// `Serialize + Deserialize` so the daemon can stream it as
+/// newline-delimited JSON over the unix socket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Transition {
     pub from: AgentState,
     pub to: AgentState,
@@ -792,6 +796,49 @@ impl Store {
             self.dirty.notify_one();
         }
         removed
+    }
+
+    /// Auto-downgrade `Working` agents to `Idle` if they've been
+    /// sitting in `Working` past `threshold` since their
+    /// `last_activity_at`. Returns the number of agents flipped.
+    ///
+    /// Insurance against missed `Stop`/`TurnStopped` hook firings —
+    /// without this a single dropped event would leave a row glowing
+    /// green forever. Every flip emits a synthetic `Transition` so
+    /// IPC subscribers (`muxa watch`) see the correction live.
+    ///
+    /// Off by default (`threshold == Duration::ZERO`) to preserve the
+    /// "state changes only on explicit events" guarantee. The
+    /// reconciler turns it on when
+    /// `[reconciler] stuck_working_timeout_secs` is set.
+    pub async fn mark_stuck_idle(&self, threshold: Duration) -> usize {
+        if threshold.is_zero() {
+            return 0;
+        }
+        let cutoff = OffsetDateTime::now_utc() - threshold;
+        let mut agents = self.agents.write().await;
+        let mut flipped = 0_usize;
+        for agent in agents.values_mut() {
+            if agent.state != AgentState::Working {
+                continue;
+            }
+            if agent.last_activity_at > cutoff {
+                continue;
+            }
+            let prev = agent.state;
+            agent.state = AgentState::Idle;
+            flipped += 1;
+            // Broadcast for IPC subscribers and in-process sinks.
+            // Identical shape to the broadcast in `apply` so consumers
+            // can't tell a stuck-working sweep from a real event —
+            // they just see an Idle row.
+            let _ = self.transitions.send(Transition {
+                from: prev,
+                to: agent.state,
+                agent: agent.clone(),
+            });
+        }
+        flipped
     }
 
     /// Converge the registry against ground truth from tmux.
@@ -1470,6 +1517,98 @@ mod tests {
             .await;
         let agent = store.by_session("s").await.unwrap();
         assert_eq!(agent.last_response.as_deref(), Some("first answer"));
+    }
+
+    #[tokio::test]
+    async fn mark_stuck_idle_flips_old_working_to_idle() {
+        let store = Store::shared();
+        // Drive an agent into Working with a stale last_activity_at
+        // so it crosses the timeout cutoff.
+        let stale_at = OffsetDateTime::now_utc() - time::Duration::hours(1);
+        store
+            .apply(&AgentEvent::Started {
+                id: id("s"),
+                at: stale_at,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::PromptSubmitted {
+                id: id("s"),
+                prompt: "long-running".into(),
+                at: stale_at,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("s").await.unwrap().state,
+            AgentState::Working
+        );
+
+        // Subscribe before the sweep so we can observe the broadcast.
+        let mut rx = store.subscribe();
+        let flipped = store.mark_stuck_idle(Duration::from_secs(60)).await;
+        assert_eq!(flipped, 1);
+        assert_eq!(store.by_session("s").await.unwrap().state, AgentState::Idle);
+
+        // Sweep emits a Transition matching the synthesized flip.
+        let t = rx.try_recv().expect("transition broadcast");
+        assert_eq!(t.from, AgentState::Working);
+        assert_eq!(t.to, AgentState::Idle);
+    }
+
+    #[tokio::test]
+    async fn mark_stuck_idle_skips_recent_working() {
+        // An agent that just transitioned to Working should NOT be
+        // flipped: real long-running tasks would be falsely marked
+        // idle. The cutoff is `now - threshold`; recent activity
+        // beats the cutoff and survives.
+        let store = Store::shared();
+        let now = OffsetDateTime::now_utc();
+        store
+            .apply(&AgentEvent::Started {
+                id: id("s"),
+                at: now,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::PromptSubmitted {
+                id: id("s"),
+                prompt: "fresh".into(),
+                at: now,
+            })
+            .await;
+        let flipped = store.mark_stuck_idle(Duration::from_secs(60)).await;
+        assert_eq!(flipped, 0);
+        assert_eq!(
+            store.by_session("s").await.unwrap().state,
+            AgentState::Working
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_stuck_idle_zero_threshold_is_noop() {
+        let store = Store::shared();
+        let stale_at = OffsetDateTime::now_utc() - time::Duration::hours(2);
+        store
+            .apply(&AgentEvent::Started {
+                id: id("s"),
+                at: stale_at,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::PromptSubmitted {
+                id: id("s"),
+                prompt: "ancient".into(),
+                at: stale_at,
+            })
+            .await;
+        // Even a hours-stale agent stays Working when the sweep is
+        // disabled (Duration::ZERO).
+        let flipped = store.mark_stuck_idle(Duration::ZERO).await;
+        assert_eq!(flipped, 0);
+        assert_eq!(
+            store.by_session("s").await.unwrap().state,
+            AgentState::Working
+        );
     }
 
     #[tokio::test]

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -409,11 +409,15 @@ fn spawn_reconciler_task(
         backend,
         std::time::Duration::from_secs(cfg.reconciler.interval_secs),
     )
-    .with_metrics(store.metrics());
+    .with_metrics(store.metrics())
+    .with_stuck_working_timeout(std::time::Duration::from_secs(
+        cfg.reconciler.stuck_working_timeout_secs,
+    ));
     let shutdown_rx = shutdown_tx.subscribe();
     tokio::spawn(runner.run(shutdown_rx));
     tracing::info!(
         interval_secs = cfg.reconciler.interval_secs,
+        stuck_working_timeout_secs = cfg.reconciler.stuck_working_timeout_secs,
         "reconciler enabled",
     );
 }


### PR DESCRIPTION
## Summary

User reported: `muxa watch` STATE column sometimes lags or shows stale values. Investigation surfaced two independent root causes; both addressed in one PR (option E + C from the design discussion).

### E — Push-based updates close the polling gap

`muxa watch` was polling on a hard `tokio::time::interval(500ms)` regardless of whether anything had changed. State updates that landed mid-tick took up to 500 ms to surface — structural lag at 2 Hz.

New IPC \`Subscribe\` RPC: client opens a long-lived socket, daemon ack's once, then writes one JSON-encoded \`Transition\` per state change until either side closes. Watch's background refresh task races the stream against a much slower fallback poll (5 s).

Effect:
- **hot path**: state hits the screen in ~ms (was up to 500 ms)
- **idle path**: CPU drops to ~0 (was constant 2 Hz polling)
- **fallback path**: \`Lagged\` drops or a dead stream cleanly degrade to 500 ms polling
- **back-compat**: older daemons without \`subscribe\` → silent fallback to historical polling

### C — Stuck-Working sweep covers missed-event cases

Push doesn't help when the agent never fires the event. Claude Code's \`Stop\` hook can drop on context-limit hits, mid-turn crashes, etc. The state machine had no time-based fallback, so a single missed \`TurnStopped\` left the row green forever.

New \`[reconciler] stuck_working_timeout_secs\` config: every reconciler tick scans agents with \`state == Working\` and \`last_activity_at\` older than threshold, flips them to \`Idle\`, broadcasts a synthetic \`Transition\` so subscribers (the new push path above) see the correction live. Default \`0\` (disabled) preserves the historical invariant.

## Files

| | |
|---|---|
| \`state.rs\` | \`Transition\` gains \`Deserialize\`; new \`Store::mark_stuck_idle()\` |
| \`ipc.rs\` | \`RequestBody::Subscribe\` variant; \`stream_transitions\` pump; \`Client::subscribe() -> TransitionStream\` |
| \`reconcile.rs\` | \`Reconciler::with_stuck_working_timeout()\` builder |
| \`config.rs\` | \`ReconcilerConfig::stuck_working_timeout_secs\` field |
| \`muxad/main.rs\` | wires the timeout from config into the reconciler |
| \`watch.rs\` | \`refresh_task\` takes \`Option<TransitionStream>\`; select arm \`recv_transition\` gated on \`sub.is_some()\` |

## Performance — net win, not a hit

- agent CLIs (hook latency): **zero change**
- daemon CPU: +1 broadcast subscriber per watch instance + O(n_agents) cmp ops on the reconciler sweep
- watch CPU: **lower** in idle (5 s tick vs 500 ms polls)
- IPC traffic: **lower** in idle (no per-tick snapshot RPC)

## Test plan

- [x] \`cargo test --workspace\` — 379 / 379 pass (was 375 + 4 new)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] End-to-end subscribe test: spin up server, drive transitions, assert delivery within 2 s
- [x] Stuck-Working sweep tests: flips stale agent, skips fresh agent, no-ops at threshold=0
- [ ] Live test: \`RUST_LOG=muxa=debug muxad\` in one pane, \`muxa watch\` in another, drive a Claude Code prompt; STATE column should update within ~50 ms instead of waiting for the next 500 ms tick.

## Release

Ship as **v0.5.0** (minor — additive new RPC + behavior change in watch's refresh cadence; both backwards-compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)