### PR TITLE
fix(watch): instant first paint + stuck-WaitingInput sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`muxa watch` paints its first frame instantly** instead of
+  blocking on the priming snapshot (~50–100 ms tmux + IPC) and the
+  v0.5.0 streaming-subscribe ack (~5 ms). Reordered `run()` to draw
+  the empty table scaffold immediately after terminal setup and
+  defer both compute_refresh and `subscribe()` to the background
+  refresh task, with an immediate wake to force the first real
+  refresh. The total time-to-data is unchanged; the perceived popup
+  latency drops from "blank for ~80 ms then content" to "scaffold
+  instant, rows fill in within ~80 ms".
+
+### Added
+
+- **`stuck-WaitingInput` sweep** (Codex permission-grant recovery).
+  New config knob `[reconciler] stuck_waiting_timeout_secs` with
+  the same shape as `stuck_working_timeout_secs`. Specifically
+  fixes Codex's hook-surface gap: `permission_request` flips a row
+  to `WaitingInput`, the user grants permission, Codex resumes —
+  but Codex never fires another hook, so the row stays yellow
+  indefinitely. With `stuck_waiting_timeout_secs = 600` the
+  reconciler recovers it after 10 min of inactivity. Default `0`
+  (disabled).
+- `Store::mark_stuck_idle` was generalized to
+  `mark_stuck_idle_from(state, threshold)` so the reconciler runs
+  one pass for `Working` and another for `WaitingInput`, with
+  independent thresholds. `Reconciler::with_stuck_waiting_timeout()`
+  is the matching builder method.
+
 ## [0.5.0] - 2026-05-04
 
 ### Added

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -739,15 +739,22 @@ async fn compute_refresh(client: &Client, backend: &muxa::SharedBackend) -> Refr
 ///
 /// Generic over the fetcher so unit tests can swap in a closure that
 /// returns a canned `RefreshOutcome` without touching tmux or the daemon.
-async fn refresh_task<F, Fut>(
+async fn refresh_task<F, Fut, S>(
     mut fetch: F,
     mut wake: mpsc::Receiver<()>,
     out: mpsc::Sender<RefreshOutcome>,
-    mut sub: Option<muxa::ipc::TransitionStream>,
+    sub_init: S,
 ) where
     F: FnMut() -> Fut + Send + 'static,
     Fut: Future<Output = RefreshOutcome> + Send,
+    S: Future<Output = Option<muxa::ipc::TransitionStream>> + Send + 'static,
 {
+    // Acquire the streaming subscription as the first thing the
+    // background task does — `run` doesn't await it any more, so the
+    // popup gets to paint its empty frame before we pay this latency.
+    // `None` falls back to historical polling.
+    let mut sub = sub_init.await;
+
     // When we have a streaming subscription, push updates handle the
     // common case in milliseconds — the polling tick only exists for
     // catch-up after `Lagged` drops or reconnect. Without the
@@ -837,9 +844,20 @@ pub async fn run(client: &Client, watch_cfg: WatchConfig) -> Result<Option<Strin
     // row 0.
     app.set_initial_pane(backend.current_pane());
 
-    // Prime the initial snapshot so the first frame already has data —
-    // otherwise the user sees an empty table for ~one tick.
-    apply_outcome(&mut app, compute_refresh(client, &backend).await);
+    // Paint the first frame **before** any IPC. The popup
+    // (`prefix + s` → `display-popup -E muxa watch`) becomes visible
+    // the instant tmux finishes spawning us, so we want the user to
+    // see the table scaffold (header + empty body) immediately
+    // rather than a black rectangle for the ~50-100 ms it takes to
+    // shell out to `tmux list-panes` and round-trip a snapshot.
+    //
+    // The first real refresh fires from the background task right
+    // after this — we send a wake on the channel below so it doesn't
+    // wait for the 5 s fallback tick.
+    guard
+        .terminal_mut()
+        .draw(|f| render(f, &mut app))
+        .map_err(anyhow::Error::from)?;
 
     // Background refresh task owns its own Client clone so the borrowed
     // `client: &Client` doesn't have to outlive the task. The clone is
@@ -848,20 +866,20 @@ pub async fn run(client: &Client, watch_cfg: WatchConfig) -> Result<Option<Strin
     // already an `Arc<dyn …>` so cloning it is just a refcount bump.
     let bg_client = client.clone();
     let bg_backend = backend.clone();
+    let sub_client = client.clone();
     let (wake_tx, wake_rx) = mpsc::channel::<()>(WAKE_CAPACITY);
     let (outcome_tx, mut outcome_rx) = mpsc::channel::<RefreshOutcome>(OUTCOME_CAPACITY);
 
-    // Try to open a streaming subscribe so we get push updates from
-    // the daemon. Falls back gracefully when the daemon is older
-    // (no `subscribe` RPC), the socket is unreachable, or the
-    // connection is denied — in any of those cases we hand `None`
-    // to the refresh task and it stays on the historical 500 ms
-    // polling cadence.
-    let subscription = match client.subscribe().await {
-        Ok(s) => Some(s),
-        Err(e) => {
-            tracing::debug!(error = %e, "subscribe unavailable; falling back to polling");
-            None
+    // Subscribe lazily inside the refresh task so its `await` doesn't
+    // block the first paint. Falls back to polling on any error
+    // (older daemon, socket unreachable, connection refused).
+    let subscription_init = async move {
+        match sub_client.subscribe().await {
+            Ok(s) => Some(s),
+            Err(e) => {
+                tracing::debug!(error = %e, "subscribe unavailable; falling back to polling");
+                None
+            }
         }
     };
 
@@ -873,8 +891,15 @@ pub async fn run(client: &Client, watch_cfg: WatchConfig) -> Result<Option<Strin
         },
         wake_rx,
         outcome_tx,
-        subscription,
+        subscription_init,
     ));
+
+    // Force the priming refresh immediately so the empty frame above
+    // gets replaced by real data within ~50-100 ms instead of waiting
+    // for the next fallback tick. `try_send` is safe here — the
+    // channel is freshly created with capacity > 0, so the send can't
+    // block or fail.
+    let _ = wake_tx.try_send(());
 
     let mut jump_target: Option<String> = None;
 
@@ -3085,7 +3110,7 @@ mod tests {
             },
             wake_rx,
             out_tx,
-            None,
+            async { None },
         ));
 
         // The 500 ms tick is paused; force the wake path.
@@ -3121,7 +3146,7 @@ mod tests {
             },
             wake_rx,
             out_tx,
-            None,
+            async { None },
         ));
 
         // Time is paused; advance past one full POLL_INTERVAL so the

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -225,6 +225,18 @@ pub struct ReconcilerConfig {
     /// routinely run multi-hour tasks.
     #[serde(default = "default_zero")]
     pub stuck_working_timeout_secs: u64,
+    /// Same shape as `stuck_working_timeout_secs` but for the
+    /// `WaitingInput` state. Specifically targets Codex's
+    /// permission-grant gap: `permission_request` flips the row to
+    /// `WaitingInput`, the user grants permission, Codex resumes —
+    /// but Codex never fires another hook, so the row stays yellow
+    /// indefinitely.
+    ///
+    /// Default `0` (disabled). A reasonable opt-in is `600` (10 min)
+    /// — `WaitingInput` legitimately means the user is away from the
+    /// keyboard, so the cutoff should be generous.
+    #[serde(default = "default_zero")]
+    pub stuck_waiting_timeout_secs: u64,
 }
 
 impl Default for ReconcilerConfig {
@@ -233,6 +245,7 @@ impl Default for ReconcilerConfig {
             enabled: true,
             interval_secs: default_reconciler_interval_secs(),
             stuck_working_timeout_secs: 0,
+            stuck_waiting_timeout_secs: 0,
         }
     }
 }

--- a/crates/muxa/src/reconcile.rs
+++ b/crates/muxa/src/reconcile.rs
@@ -83,6 +83,10 @@ pub struct Reconciler<L: LivenessSource> {
     /// (default) disables the sweep so the historical
     /// "state-on-events-only" semantics are preserved.
     stuck_working_timeout: Duration,
+    /// Same shape as `stuck_working_timeout` but for `WaitingInput`.
+    /// Covers Codex's permission-grant case where the row gets
+    /// pinned yellow with no follow-up hook to recover from.
+    stuck_waiting_timeout: Duration,
 }
 
 impl<L: LivenessSource> Reconciler<L> {
@@ -93,6 +97,7 @@ impl<L: LivenessSource> Reconciler<L> {
             interval,
             metrics: None,
             stuck_working_timeout: Duration::ZERO,
+            stuck_waiting_timeout: Duration::ZERO,
         }
     }
 
@@ -112,6 +117,17 @@ impl<L: LivenessSource> Reconciler<L> {
         self
     }
 
+    /// Enable auto-downgrade of stuck `WaitingInput` agents to
+    /// `Idle`. Used to recover Codex rows that get pinned to
+    /// `WaitingInput` after the user grants permission and the
+    /// agent resumes without firing a follow-up hook.
+    /// `Duration::ZERO` (the default) keeps the sweep off.
+    #[must_use]
+    pub fn with_stuck_waiting_timeout(mut self, t: Duration) -> Self {
+        self.stuck_waiting_timeout = t;
+        self
+    }
+
     /// Run a single reconciliation pass on demand. Useful for tests, for
     /// surfacing a "force reconcile" CLI command later, and for triggering
     /// a pass right after startup discovery so the user doesn't wait a full
@@ -125,14 +141,29 @@ impl<L: LivenessSource> Reconciler<L> {
             .await
             .unwrap_or_default();
         let report = self.store.reconcile(&panes).await;
-        let stuck_flipped = self.store.mark_stuck_idle(self.stuck_working_timeout).await;
+        let stuck_w = self
+            .store
+            .mark_stuck_idle_from(
+                crate::event::AgentState::Working,
+                self.stuck_working_timeout,
+            )
+            .await;
+        let stuck_wi = self
+            .store
+            .mark_stuck_idle_from(
+                crate::event::AgentState::WaitingInput,
+                self.stuck_waiting_timeout,
+            )
+            .await;
         if let Some(m) = &self.metrics {
             m.record_reconcile_pass();
         }
-        if stuck_flipped > 0 {
+        if stuck_w + stuck_wi > 0 {
             tracing::info!(
-                count = stuck_flipped,
-                "stuck-working sweep flipped {stuck_flipped} agent(s) to Idle"
+                working = stuck_w,
+                waiting = stuck_wi,
+                "stuck-state sweep flipped {} agent(s) to Idle",
+                stuck_w + stuck_wi
             );
         }
         // Always emit the timing line at debug (cheap, off by default)

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -798,20 +798,29 @@ impl Store {
         removed
     }
 
-    /// Auto-downgrade `Working` agents to `Idle` if they've been
-    /// sitting in `Working` past `threshold` since their
+    /// Auto-downgrade agents in `from` to `Idle` if they've been
+    /// sitting in that state past `threshold` since their
     /// `last_activity_at`. Returns the number of agents flipped.
     ///
-    /// Insurance against missed `Stop`/`TurnStopped` hook firings —
-    /// without this a single dropped event would leave a row glowing
-    /// green forever. Every flip emits a synthetic `Transition` so
-    /// IPC subscribers (`muxa watch`) see the correction live.
+    /// Used by the reconciler to recover rows that a missed hook
+    /// would otherwise leave stuck:
+    /// - `from = Working` covers a missed `Stop`/`TurnStopped`
+    ///   (Claude/Codex/Gemini)
+    /// - `from = WaitingInput` covers Codex's permission-grant gap:
+    ///   `permission_request` flips the row to `WaitingInput`, the
+    ///   user grants permission, Codex resumes — but Codex never
+    ///   fires another hook to flip the state back, so the row
+    ///   stays yellow indefinitely.
     ///
-    /// Off by default (`threshold == Duration::ZERO`) to preserve the
+    /// Every flip emits a synthetic `Transition` so IPC subscribers
+    /// (`muxa watch`) see the correction live.
+    ///
+    /// Off when `threshold == Duration::ZERO` to preserve the
     /// "state changes only on explicit events" guarantee. The
-    /// reconciler turns it on when
-    /// `[reconciler] stuck_working_timeout_secs` is set.
-    pub async fn mark_stuck_idle(&self, threshold: Duration) -> usize {
+    /// reconciler turns each variant on independently via the
+    /// `stuck_working_timeout_secs` / `stuck_waiting_timeout_secs`
+    /// config keys.
+    pub async fn mark_stuck_idle_from(&self, from: AgentState, threshold: Duration) -> usize {
         if threshold.is_zero() {
             return 0;
         }
@@ -819,7 +828,7 @@ impl Store {
         let mut agents = self.agents.write().await;
         let mut flipped = 0_usize;
         for agent in agents.values_mut() {
-            if agent.state != AgentState::Working {
+            if agent.state != from {
                 continue;
             }
             if agent.last_activity_at > cutoff {
@@ -830,8 +839,8 @@ impl Store {
             flipped += 1;
             // Broadcast for IPC subscribers and in-process sinks.
             // Identical shape to the broadcast in `apply` so consumers
-            // can't tell a stuck-working sweep from a real event —
-            // they just see an Idle row.
+            // can't tell a sweep from a real event — they just see an
+            // Idle row.
             let _ = self.transitions.send(Transition {
                 from: prev,
                 to: agent.state,
@@ -1545,7 +1554,9 @@ mod tests {
 
         // Subscribe before the sweep so we can observe the broadcast.
         let mut rx = store.subscribe();
-        let flipped = store.mark_stuck_idle(Duration::from_secs(60)).await;
+        let flipped = store
+            .mark_stuck_idle_from(AgentState::Working, Duration::from_secs(60))
+            .await;
         assert_eq!(flipped, 1);
         assert_eq!(store.by_session("s").await.unwrap().state, AgentState::Idle);
 
@@ -1553,6 +1564,73 @@ mod tests {
         let t = rx.try_recv().expect("transition broadcast");
         assert_eq!(t.from, AgentState::Working);
         assert_eq!(t.to, AgentState::Idle);
+    }
+
+    #[tokio::test]
+    async fn mark_stuck_idle_flips_old_waiting_input_to_idle() {
+        // Codex permission-grant case: row gets pinned to
+        // WaitingInput by `permission_request`, user grants and
+        // Codex resumes without firing another hook. The sweep
+        // recovers the row after `threshold` of inactivity.
+        let store = Store::shared();
+        let stale_at = OffsetDateTime::now_utc() - time::Duration::hours(1);
+        store
+            .apply(&AgentEvent::Started {
+                id: id("c"),
+                at: stale_at,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::NotificationFired {
+                id: id("c"),
+                level: NotificationLevel::NeedsInput,
+                message: "codex permission: shell".into(),
+                at: stale_at,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("c").await.unwrap().state,
+            AgentState::WaitingInput
+        );
+
+        let mut rx = store.subscribe();
+        let flipped = store
+            .mark_stuck_idle_from(AgentState::WaitingInput, Duration::from_secs(60))
+            .await;
+        assert_eq!(flipped, 1);
+        assert_eq!(store.by_session("c").await.unwrap().state, AgentState::Idle);
+        let t = rx.try_recv().expect("transition broadcast");
+        assert_eq!(t.from, AgentState::WaitingInput);
+        assert_eq!(t.to, AgentState::Idle);
+    }
+
+    #[tokio::test]
+    async fn mark_stuck_idle_only_sweeps_target_state() {
+        // Asking for the WaitingInput sweep does not touch a
+        // Working row — the two timeouts must stay independent.
+        let store = Store::shared();
+        let stale_at = OffsetDateTime::now_utc() - time::Duration::hours(1);
+        store
+            .apply(&AgentEvent::Started {
+                id: id("w"),
+                at: stale_at,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::PromptSubmitted {
+                id: id("w"),
+                prompt: "p".into(),
+                at: stale_at,
+            })
+            .await;
+        let flipped = store
+            .mark_stuck_idle_from(AgentState::WaitingInput, Duration::from_secs(60))
+            .await;
+        assert_eq!(flipped, 0);
+        assert_eq!(
+            store.by_session("w").await.unwrap().state,
+            AgentState::Working
+        );
     }
 
     #[tokio::test]
@@ -1576,7 +1654,9 @@ mod tests {
                 at: now,
             })
             .await;
-        let flipped = store.mark_stuck_idle(Duration::from_secs(60)).await;
+        let flipped = store
+            .mark_stuck_idle_from(AgentState::Working, Duration::from_secs(60))
+            .await;
         assert_eq!(flipped, 0);
         assert_eq!(
             store.by_session("s").await.unwrap().state,
@@ -1603,7 +1683,9 @@ mod tests {
             .await;
         // Even a hours-stale agent stays Working when the sweep is
         // disabled (Duration::ZERO).
-        let flipped = store.mark_stuck_idle(Duration::ZERO).await;
+        let flipped = store
+            .mark_stuck_idle_from(AgentState::Working, Duration::ZERO)
+            .await;
         assert_eq!(flipped, 0);
         assert_eq!(
             store.by_session("s").await.unwrap().state,

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -412,12 +412,16 @@ fn spawn_reconciler_task(
     .with_metrics(store.metrics())
     .with_stuck_working_timeout(std::time::Duration::from_secs(
         cfg.reconciler.stuck_working_timeout_secs,
+    ))
+    .with_stuck_waiting_timeout(std::time::Duration::from_secs(
+        cfg.reconciler.stuck_waiting_timeout_secs,
     ));
     let shutdown_rx = shutdown_tx.subscribe();
     tokio::spawn(runner.run(shutdown_rx));
     tracing::info!(
         interval_secs = cfg.reconciler.interval_secs,
         stuck_working_timeout_secs = cfg.reconciler.stuck_working_timeout_secs,
+        stuck_waiting_timeout_secs = cfg.reconciler.stuck_waiting_timeout_secs,
         "reconciler enabled",
     );
 }


### PR DESCRIPTION
## Summary

Two UX fixes from local testing of v0.5.0. No version bump (local-testing scope).

### 1. Instant first paint

Previously \`muxa watch\` awaited \`compute_refresh\` (~50-100 ms) and \`client.subscribe()\` (~5 ms) before drawing the first frame, so the popup showed as a blank rectangle for that whole duration.

Now: draws the empty table scaffold immediately after terminal setup, then defers both the priming refresh and the subscribe to the background task. An immediate wake on the channel forces the first real refresh to land within ~80 ms — total time-to-data unchanged, perceived popup latency drops to ~10 ms.

### 2. Codex stuck-WaitingInput

Codex's \`permission_request\` flips a row to \`WaitingInput\`, the user grants permission, Codex resumes — but Codex doesn't fire a follow-up hook, so the row stays yellow indefinitely. The v0.5.0 stuck-Working sweep didn't catch this because the stuck state is \`WaitingInput\`.

Generalized \`Store::mark_stuck_idle(threshold)\` → \`mark_stuck_idle_from(state, threshold)\`. New config knob \`[reconciler] stuck_waiting_timeout_secs\` mirrors \`stuck_working_timeout_secs\`. Reconciler runs two sweeps per tick now. Default `0` (disabled); recommended `600` (10 min) — \`WaitingInput\` legitimately means the user is AFK so the cutoff should be generous.

## Test plan

- [x] \`cargo test --workspace\` — 381 / 381 pass (was 379 + 2 new)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] Manual smoke (macOS): launch \`muxa watch\` via tmux popup, verify scaffold appears instantly and rows populate within ~100 ms
- [ ] Codex repro: trigger permission_request, grant, observe row stuck on WaitingInput, then verify it flips to Idle after the configured timeout

## Files

| | |
|---|---|
| \`crates/muxa-cli/src/watch.rs\` | \`run()\` reordered; \`refresh_task\` takes subscribe future |
| \`crates/muxa/src/state.rs\` | \`mark_stuck_idle\` → \`mark_stuck_idle_from(state, …)\` + 2 new tests |
| \`crates/muxa/src/reconcile.rs\` | \`Reconciler::with_stuck_waiting_timeout\` builder; tick runs both sweeps |
| \`crates/muxa/src/config.rs\` | new \`stuck_waiting_timeout_secs\` field |
| \`crates/muxad/src/main.rs\` | wire the new field through reconciler builder |

🤖 Generated with [Claude Code](https://claude.com/claude-code)