### PR TITLE
fix(state): tool activity recovers from WaitingInput + Claude AskUserQuestion routes through NeedsInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **STATE column now reads `WaitingInput` while a Claude
+  `AskUserQuestion` menu is open**, not `Working`. The Claude
+  adapter routes `PreToolUse` for known user-blocking tools
+  (`AskUserQuestion`, `ExitPlanMode`) through
+  `NotificationFired { NeedsInput }` instead of `ToolStarted`, so
+  the row turns yellow while the operator is being asked something.
+  The matching `PostToolUse` lands as `ToolCompleted` and the
+  state machine flips back (see below).
+- **Tool activity recovers a row from `WaitingInput`** instead of
+  leaving it stuck. `mutate_for_event` now flips
+  `WaitingInput → Working` on either `ToolStarted` (Codex resuming
+  after a permission grant — the next tool fires) or
+  `ToolCompleted` (the matching post-hook for the
+  `AskUserQuestion` case above). Auto-recovers Codex's
+  permission-grant gap without needing the timeout sweep.
+  `Error` state is preserved through `ToolStarted` so a real
+  failure isn't masked.
+
 - **`muxa watch` paints its first frame instantly** instead of
   blocking on the priming snapshot (~50–100 ms tmux + IPC) and the
   v0.5.0 streaming-subscribe ack (~5 ms). Reordered `run()` to draw

--- a/crates/muxa/src/adapters/claude.rs
+++ b/crates/muxa/src/adapters/claude.rs
@@ -108,11 +108,7 @@ impl HookAdapter for ClaudeAdapter {
                 prompt: truncate(input.prompt.unwrap_or_default(), 4_000),
                 at,
             },
-            Event::PreToolUse => AgentEvent::ToolStarted {
-                id,
-                tool: input.tool_name.unwrap_or_else(|| "unknown".into()),
-                at,
-            },
+            Event::PreToolUse => pre_tool_event(id, input.tool_name, at),
             Event::PostToolUse => AgentEvent::ToolCompleted {
                 id,
                 tool: input.tool_name.unwrap_or_else(|| "unknown".into()),
@@ -211,6 +207,44 @@ impl HookAdapter for ClaudeAdapter {
             Event::SessionEnd => AgentEvent::SessionEnded { id, at },
         }
     }
+}
+
+/// Map a `PreToolUse` hook to the right `AgentEvent`. Most tools
+/// emit `ToolStarted` (state → Working); a small closed-set of
+/// user-blocking tools route through `NotificationFired { NeedsInput }`
+/// so the row reads `WaitingInput` while the menu is up. The
+/// matching `PostToolUse` → `ToolCompleted` recovers the row back
+/// to Working via `state::mutate_for_event`.
+fn pre_tool_event(id: AgentId, tool_name: Option<String>, at: OffsetDateTime) -> AgentEvent {
+    let tool_name = tool_name.unwrap_or_else(|| "unknown".into());
+    if is_user_blocking_tool(&tool_name) {
+        AgentEvent::NotificationFired {
+            id,
+            level: NotificationLevel::NeedsInput,
+            message: format!("waiting on {tool_name}"),
+            at,
+        }
+    } else {
+        AgentEvent::ToolStarted {
+            id,
+            tool: tool_name,
+            at,
+        }
+    }
+}
+
+/// Tools whose `PreToolUse` semantically means "block on the user
+/// for input" rather than "agent is doing work". Routing them
+/// through `NotificationFired { NeedsInput }` flips the row to
+/// `WaitingInput` while the menu is up, so the operator's mental
+/// model ("yellow = needs me") matches reality.
+///
+/// Add new entries here when Claude Code (or upstreams that share
+/// this hook surface) ship more user-blocking tools. The list is
+/// closed-set on purpose: an unknown tool default-routes to the
+/// "agent is working" path so we don't accidentally over-flip.
+fn is_user_blocking_tool(name: &str) -> bool {
+    matches!(name, "AskUserQuestion" | "ExitPlanMode")
 }
 
 // ---------------------------------------------------------------------------
@@ -320,6 +354,59 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    fn pretool_input(tool_name: &str) -> Input {
+        Input {
+            session_id: "s".into(),
+            cwd: None,
+            tool_name: Some(tool_name.into()),
+            notification_type: None,
+            message: None,
+            prompt: None,
+            transcript_path: None,
+            error: None,
+            error_details: None,
+            last_assistant_message: None,
+        }
+    }
+
+    #[test]
+    fn pre_tool_use_for_ask_user_question_emits_needs_input_notification() {
+        // The numbered-menu case the user reported: AskUserQuestion
+        // shouldn't read as Working while the menu is open.
+        let ev =
+            ClaudeAdapter::normalize(Event::PreToolUse, pretool_input("AskUserQuestion"), None);
+        match ev {
+            AgentEvent::NotificationFired { level, .. } => {
+                assert!(matches!(level, NotificationLevel::NeedsInput));
+            }
+            other => panic!("expected NotificationFired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pre_tool_use_for_exit_plan_mode_also_blocks() {
+        let ev = ClaudeAdapter::normalize(Event::PreToolUse, pretool_input("ExitPlanMode"), None);
+        assert!(matches!(
+            ev,
+            AgentEvent::NotificationFired {
+                level: NotificationLevel::NeedsInput,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn pre_tool_use_for_regular_tool_emits_tool_started() {
+        // Sanity: non-blocking tools must still go through the
+        // ToolStarted path — we don't want every pre-tool hook to
+        // read as WaitingInput.
+        let ev = ClaudeAdapter::normalize(Event::PreToolUse, pretool_input("Bash"), None);
+        match ev {
+            AgentEvent::ToolStarted { tool, .. } => assert_eq!(tool, "Bash"),
+            other => panic!("expected ToolStarted, got {other:?}"),
+        }
+    }
 
     fn stop_input(transcript_path: Option<PathBuf>) -> Input {
         Input {

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -369,9 +369,32 @@ fn mutate_for_event(
             }
         }
         AgentEvent::ToolStarted { .. } => {
-            agent.state = AgentState::Working;
+            // ToolStarted always means "agent is actively doing work" —
+            // covers the Idle → Working transition AND the
+            // WaitingInput → Working recovery (e.g. Codex resuming
+            // after a permission grant). Error stays Error so a
+            // legitimate failure isn't silently masked by tool activity
+            // — the next Stop or NotificationFired clears it.
+            if agent.state != AgentState::Error {
+                agent.state = AgentState::Working;
+            }
         }
-        AgentEvent::ToolCompleted { .. } => { /* state unchanged */ }
+        AgentEvent::ToolCompleted { .. } => {
+            // Tool activity proves the agent isn't waiting on the user
+            // any more. Specifically targets two cases:
+            //   - Codex grants permission, runs the tool, the
+            //     completion fires before any TurnStopped does.
+            //   - Claude's `AskUserQuestion` (routed through
+            //     NotificationFired { NeedsInput } in the adapter)
+            //     completes; the user answered.
+            // Other states are left alone — Working stays Working,
+            // Idle stays Idle (a stray ToolCompleted with no
+            // PromptSubmitted before it shouldn't fake activity),
+            // Error is preserved.
+            if agent.state == AgentState::WaitingInput {
+                agent.state = AgentState::Working;
+            }
+        }
         AgentEvent::NotificationFired { level, message, .. } => {
             agent.last_notification = Some(message.clone());
             match level {
@@ -993,6 +1016,159 @@ mod tests {
             pane: Some("%1".into()),
             cwd: None,
         }
+    }
+
+    #[tokio::test]
+    async fn tool_started_recovers_from_waiting_input() {
+        // Codex permission-grant scenario: Notification flips the row
+        // to WaitingInput, user grants, the next tool runs, and
+        // ToolStarted should auto-recover the row to Working without
+        // needing the timeout sweep.
+        let store = Store::shared();
+        let now = datetime!(2026-05-05 12:00:00 UTC);
+        store
+            .apply(&AgentEvent::Started {
+                id: id("c"),
+                at: now,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::NotificationFired {
+                id: id("c"),
+                level: NotificationLevel::NeedsInput,
+                message: "permission".into(),
+                at: now,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("c").await.unwrap().state,
+            AgentState::WaitingInput
+        );
+
+        store
+            .apply(&AgentEvent::ToolStarted {
+                id: id("c"),
+                tool: "Bash".into(),
+                at: now,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("c").await.unwrap().state,
+            AgentState::Working,
+            "ToolStarted should recover WaitingInput → Working"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_completed_recovers_from_waiting_input() {
+        // Claude AskUserQuestion scenario: PreToolUse routes through
+        // NotificationFired so the row reads WaitingInput while the
+        // menu is up; the matching PostToolUse → ToolCompleted lands
+        // when the user answers and should flip the row back to
+        // Working.
+        let store = Store::shared();
+        let now = datetime!(2026-05-05 12:00:00 UTC);
+        store
+            .apply(&AgentEvent::Started {
+                id: id("c"),
+                at: now,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::NotificationFired {
+                id: id("c"),
+                level: NotificationLevel::NeedsInput,
+                message: "ask".into(),
+                at: now,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("c").await.unwrap().state,
+            AgentState::WaitingInput
+        );
+
+        store
+            .apply(&AgentEvent::ToolCompleted {
+                id: id("c"),
+                tool: "AskUserQuestion".into(),
+                success: true,
+                at: now,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("c").await.unwrap().state,
+            AgentState::Working,
+            "ToolCompleted should recover WaitingInput → Working"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_started_preserves_error_state() {
+        // Errors aren't transient activity — a tool firing while a row
+        // is red shouldn't silently mask the failure.
+        let store = Store::shared();
+        let now = datetime!(2026-05-05 12:00:00 UTC);
+        store
+            .apply(&AgentEvent::Started {
+                id: id("e"),
+                at: now,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::NotificationFired {
+                id: id("e"),
+                level: NotificationLevel::Error,
+                message: "boom".into(),
+                at: now,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("e").await.unwrap().state,
+            AgentState::Error
+        );
+
+        store
+            .apply(&AgentEvent::ToolStarted {
+                id: id("e"),
+                tool: "Read".into(),
+                at: now,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("e").await.unwrap().state,
+            AgentState::Error,
+            "ToolStarted must not clobber Error"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_completed_leaves_idle_alone() {
+        // A stray ToolCompleted with no PromptSubmitted before it
+        // shouldn't fake activity — only the WaitingInput → Working
+        // recovery path is special.
+        let store = Store::shared();
+        let now = datetime!(2026-05-05 12:00:00 UTC);
+        store
+            .apply(&AgentEvent::Started {
+                id: id("i"),
+                at: now,
+            })
+            .await;
+        assert_eq!(store.by_session("i").await.unwrap().state, AgentState::Idle);
+
+        store
+            .apply(&AgentEvent::ToolCompleted {
+                id: id("i"),
+                tool: "Read".into(),
+                success: true,
+                at: now,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("i").await.unwrap().state,
+            AgentState::Idle,
+            "ToolCompleted must not flip Idle to Working on its own"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

User-reported: Claude Code's \`AskUserQuestion\` (numbered multi-choice menu) showed STATE = Working while the operator was being asked to pick an option. Should read WaitingInput. Two changes interlock to fix this — and they also self-heal Codex's permission-grant gap.

### 1. Tool activity from WaitingInput → Working

\`state::mutate_for_event\`:

- \`WaitingInput + ToolStarted   → Working\`
- \`WaitingInput + ToolCompleted → Working\`

Error preserved through ToolStarted; Idle preserved through stray ToolCompleted. Other transitions unchanged.

**Bonus**: this fix self-heals Codex's permission-grant gap that v0.5.0's \`stuck_waiting_timeout_secs\` targeted with a timeout. When the user grants permission and Codex runs its next tool, ToolStarted recovers the row to Working immediately. No config needed.

### 2. Claude adapter: AskUserQuestion → NotificationFired

\`PreToolUse\` for a closed-set of user-blocking tools (\`AskUserQuestion\`, \`ExitPlanMode\`) now emits \`NotificationFired { NeedsInput }\` instead of \`ToolStarted\`. The state machine flips to WaitingInput while the menu is up; the matching PostToolUse → ToolCompleted recovers the row to Working when the user has answered (point 1).

Other tools default-route to ToolStarted as before. The list is closed-set on purpose: an unknown tool accidentally appearing yellow is worse than a new user-blocking tool reading as Working until we add it.

## Test plan

- [x] \`cargo test --workspace\` — 388 / 388 pass (was 381 + 7 new)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] Manual smoke: trigger AskUserQuestion in Claude Code, observe row flips to WaitingInput while the menu is open and back to Working after picking an option
- [ ] Codex smoke: trigger permission_request, grant, observe row flips back to Working without waiting for the timeout sweep

## Files

- \`crates/muxa/src/state.rs\` — ToolStarted/Completed transitions + 4 new tests
- \`crates/muxa/src/adapters/claude.rs\` — \`pre_tool_event\` helper, \`is_user_blocking_tool\`, 3 new adapter tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)