### PR TITLE
fix(watch): copy backend cascade + tmux load-buffer + env pre-flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`muxa watch`'s `c` (copy prompt) action now works in headless
+  / remote / tmux sessions.** Previously the priority list
+  (`pbcopy` → `wl-copy` → `xclip`) treated `xclip` as viable
+  whenever the binary was on PATH — which surfaced
+  `xclip exited with 1` on SSH hosts where `$DISPLAY` is unset.
+  Two changes:
+  - **Priority list now leads with `tmux load-buffer`** when
+    `$TMUX` is set. Lands the prompt in tmux's paste buffer
+    (`prefix + ]`); on tmux 3.2+ with `set -g set-clipboard on`
+    it also forwards via OSC 52 to the host terminal's clipboard
+    — single backend covers most of the "remote dev over SSH"
+    case.
+  - **Pre-flight env checks + cascade on failure**: `wl-copy`
+    requires `$WAYLAND_DISPLAY`, `xclip` / `xsel` require
+    `$DISPLAY`. If any backend fails (NotFound or Failed) we move
+    to the next one instead of surfacing the failure. The
+    `/tmp/muxa-clip-<ts>.txt` fallback at the bottom is the
+    safety net.
+  - Added `xsel` as another X11 candidate for users who don't
+    install xclip.
 - **`muxa watch` no longer redraws every row on every transition.**
   v0.5.0's push-based subscribe was only used as a "wake" signal:
   each Transition triggered a fresh `client.snapshot()` call and the

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -394,30 +394,79 @@ impl Effects for RealEffects {
     }
 
     fn copy_to_clipboard(&mut self, text: &str) -> std::result::Result<String, String> {
-        // Try the platform-native helper first, then fall back. Order
-        // matters: macOS ships pbcopy unconditionally; on Linux we
-        // prefer wl-copy when WAYLAND_DISPLAY is set, else xclip.
-        let candidates: &[(&str, &[&str])] = if std::env::var_os("WAYLAND_DISPLAY").is_some() {
-            &[
-                ("pbcopy", &[]),
-                ("wl-copy", &[]),
-                ("xclip", &["-selection", "clipboard"]),
-            ]
-        } else {
-            &[
-                ("pbcopy", &[]),
-                ("xclip", &["-selection", "clipboard"]),
-                ("wl-copy", &[]),
-            ]
-        };
-        for (bin, args) in candidates {
-            match pipe_to_command(bin, args, text) {
-                Ok(()) => return Ok((*bin).to_string()),
-                // ENOENT (binary missing) is expected — try the next one.
-                // Other errors propagate so the user sees `xclip: ...`
-                // rather than a silent "wrote to /tmp" surprise.
-                Err(PipeErr::NotFound) => {}
-                Err(PipeErr::Failed(msg)) => return Err(msg),
+        // Backend priority — first one that's *applicable* and
+        // succeeds wins. We cascade past Failed (not just
+        // NotFound) so an installed-but-broken backend (e.g.
+        // `xclip` present without an X server) doesn't strand the
+        // user; the /tmp fallback at the bottom is the safety
+        // net.
+        //
+        //   1. tmux load-buffer when $TMUX is set — works in pure
+        //      SSH/headless because tmux owns its own paste buffer
+        //      (`prefix + ]`) and on tmux 3.2+ with
+        //      `set -g set-clipboard on` it transparently forwards
+        //      to the host terminal's clipboard via OSC 52. Single
+        //      backend that covers most of the "remote dev" case.
+        //   2. pbcopy on macOS (unconditional — pbcopy is always
+        //      present on Apple shells).
+        //   3. wl-copy when $WAYLAND_DISPLAY is set.
+        //   4. xclip / xsel when $DISPLAY is set. Pre-flight env
+        //      check skips them entirely on headless hosts so we
+        //      don't even produce the misleading "exit 1" the user
+        //      hit before this fix.
+        //   5. /tmp/muxa-clip-<ts>.txt as the last resort.
+        struct Cand<'a> {
+            label: &'a str,
+            bin: &'a str,
+            args: &'a [&'a str],
+            applicable: bool,
+        }
+
+        let in_tmux = std::env::var_os("TMUX").is_some();
+        let in_wayland = std::env::var_os("WAYLAND_DISPLAY").is_some();
+        let in_x11 = std::env::var_os("DISPLAY").is_some();
+        let candidates: &[Cand] = &[
+            Cand {
+                label: "tmux",
+                bin: "tmux",
+                args: &["load-buffer", "-"],
+                applicable: in_tmux,
+            },
+            Cand {
+                label: "pbcopy",
+                bin: "pbcopy",
+                args: &[],
+                applicable: cfg!(target_os = "macos"),
+            },
+            Cand {
+                label: "wl-copy",
+                bin: "wl-copy",
+                args: &[],
+                applicable: in_wayland,
+            },
+            Cand {
+                label: "xclip",
+                bin: "xclip",
+                args: &["-selection", "clipboard"],
+                applicable: in_x11,
+            },
+            Cand {
+                label: "xsel",
+                bin: "xsel",
+                args: &["--clipboard", "--input"],
+                applicable: in_x11,
+            },
+        ];
+        for c in candidates {
+            if !c.applicable {
+                continue;
+            }
+            // Cascade past Failed AND NotFound — the user never saw
+            // a successful copy, so trying the next backend is
+            // strictly more useful than surfacing one backend's
+            // error.
+            if pipe_to_command(c.bin, c.args, text).is_ok() {
+                return Ok(c.label.to_string());
             }
         }
         // Last-resort fallback: dump to /tmp so the user can `cat` it.
@@ -435,7 +484,11 @@ enum PipeErr {
     /// The binary itself wasn't on PATH — caller should try the next.
     NotFound,
     /// The binary ran but returned non-zero, or stdin write failed.
-    /// Caller bubbles this up rather than silently fallback.
+    /// The String describes the failure for ad-hoc logging; current
+    /// callers cascade past `Failed` to the next backend so the
+    /// payload isn't surfaced anywhere user-visible — but it stays
+    /// for debug traces and future use.
+    #[allow(dead_code)]
     Failed(String),
 }
 


### PR DESCRIPTION
## Summary

User on a headless SSH dev box hit \`copy failed: xclip exited with 1\` when pressing \`c\` in \`muxa watch\`. \`xclip\` was on PATH so the priority list tried it; without \`\$DISPLAY\` set the binary exits 1, and the dispatch surfaced that failure to the user instead of cascading.

## Three improvements

1. **Lead with \`tmux load-buffer\` when \`\$TMUX\` is set.** Loads the prompt into tmux's paste buffer (\`prefix + ]\`); on tmux 3.2+ with \`set -g set-clipboard on\` it also forwards to the host terminal's clipboard via OSC 52. Single backend covers most of the "remote dev over SSH" case.
2. **Pre-flight env check** before each X11/Wayland backend: skip \`wl-copy\` if \`\$WAYLAND_DISPLAY\` is unset, skip \`xclip\` / \`xsel\` if \`\$DISPLAY\` is unset. Prevents the misleading "xclip exit 1" surface entirely on headless hosts.
3. **Cascade past \`Failed\`, not just \`NotFound\`.** Combined with (2), the chain now only contains plausibly-working backends, so any failure cleanly falls through to the next.

\`xsel\` added as another X11 candidate.

## Test plan

- [x] \`cargo test --workspace\` — 477 / 477 (existing recorder-based tests don't shell out)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] Manual: this dev box (SSH, no \$DISPLAY, in tmux) reproduces the original bug pre-fix; with this fix \`c\` should land in tmux's paste buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)