### PR TITLE
Default `muxa watch` to session view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`muxa watch` now defaults to session view** (`[watch] view`'s default
+  flipped `pane` → `session`). One row per tmux session — collapsing the
+  panes in a session onto its most-recently-active agent — is the
+  fleet-at-a-glance shape for operators juggling many sessions, and surfaces
+  the `DUR` (session foreground-time) column by default. The finer-grained
+  one-row-per-agent view is still a flag/config away: `muxa watch --view
+  pane` or `[watch] view = "pane"`. No wire/protocol change — purely the
+  default value of a CLI-side setting; configs that pin `view` explicitly
+  are unaffected.
 - **`PROTOCOL_VERSION` bumped 1 → 2.** Adding new variants to wire-visible
   enums (`AgentState`, `NotificationLevel`) is breaking because serde
   rejects unknown variant values on deserialize — an old client receiving

--- a/README.ko.md
+++ b/README.ko.md
@@ -327,12 +327,14 @@ fallback 합니다. 자세한 설정은 [설정 > 디테일 행](#watch-detail-r
 에이전트가 위로 올라옵니다. 정렬 기준은 `[watch] sort` 로 변경 가능
 (`session`, `activity`, `pane`, `pane_id` — [설정 > 정렬](#watch-sort) 참고).
 
-세션당 한 줄로 보고 싶으면 `muxa watch --view session`을 쓰거나
-`[watch] view = "session"`을 설정하세요. 같은 tmux 세션의 모든 페인이
-하나의 행으로 합쳐지고, 해당 세션에서 가장 최근 활동한 에이전트가 대표
-행이 됩니다. 세션 뷰에서 `Enter`는 대표 페인으로 이동하며, `DUR`
-컬럼은 그 tmux 세션이 interactive tmux client에서 foreground였던 누적
-시간을 보여줍니다.
+`muxa watch`는 기본적으로 **세션 뷰**로 열립니다. 같은 tmux 세션의 모든
+페인이 하나의 행으로 합쳐지고, 해당 세션에서 가장 최근 활동한 에이전트가
+대표 행이 됩니다 — 여러 세션을 동시에 굴리는 운영자를 위한 한눈에 보기
+형태죠. `Enter`는 대표 페인으로 이동하며, `DUR` 컬럼은 그 tmux 세션이
+interactive tmux client에서 foreground였던 누적 시간을 보여줍니다.
+
+에이전트/페인별로 한 줄씩 보고 싶으면 `muxa watch --view pane`을 쓰거나
+`[watch] view = "pane"`을 설정하세요.
 
 detail 라인 한 줄로 부족할 때 — 긴 prompt, 여러 단락의 응답 — 선택된
 행에서 **`p`** 키를 누르면 가운데 정렬된 preview 팝업이 뜹니다. 전체
@@ -463,7 +465,7 @@ backend = "libnotify"
 
 ```toml
 [watch]
-view = "pane" # 또는 "session"
+view = "session" # 기본값; 에이전트별 한 줄은 "pane"
 # 표시 순서. 빠진 키는 숨겨집니다.
 columns = ["pane", "state", "prompt", "activity"]
 
@@ -604,7 +606,7 @@ wedge 시키지 않습니다.
 `muxad`는 tmux 세션별 누적 foreground 시간을 추적합니다. interactive
 tmux client가 해당 세션을 foreground로 보고 있는 동안을 active 시간으로
 계산합니다(`tmux list-clients`의 `client_session` 기준이며 control-mode
-client는 제외). 이 값은 `muxa watch --view session`의 `DUR` 컬럼에
+client는 제외). 이 값은 `muxa watch` 세션 뷰(기본값)의 `DUR` 컬럼에
 표시됩니다.
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -420,12 +420,15 @@ floated to the top of each group. Reorder via `[watch] sort` (see
 [Configuration](#watch-sort)) — useful sort keys: `session`, `activity`,
 `pane`, `pane_id`.
 
-Prefer one row per tmux session? Run `muxa watch --view session` (or set
-`[watch] view = "session"`). All panes in the same tmux session collapse
-into one row, represented by the most recently active agent in that
-session. In session view, `Enter` jumps to that representative pane and
-the `DUR` column shows the cumulative time the session has been foregrounded
-by an interactive tmux client.
+By default `muxa watch` opens in **session view**: all panes in the same
+tmux session collapse into one row, represented by the most recently
+active agent in that session — the fleet-at-a-glance shape for operators
+juggling many sessions. `Enter` jumps to that representative pane, and the
+`DUR` column shows the cumulative time the session has been foregrounded by
+an interactive tmux client.
+
+Want one row per agent/pane instead? Run `muxa watch --view pane` (or set
+`[watch] view = "pane"`).
 
 When the detail line isn't enough — long prompt, multi-paragraph
 assistant response — press **`p`** on the selected row to pop open a
@@ -587,7 +590,7 @@ the last prompt — `model` / `ctx` / `cost` are opt-in:
 
 ```toml
 [watch]
-view = "pane" # or "session"
+view = "session" # default; or "pane" for one row per agent
 # Display order. Omitted keys are hidden.
 columns = ["pane", "state", "prompt", "activity"]
 
@@ -734,8 +737,8 @@ than wedging the daemon.
 `muxad` also tracks cumulative tmux foreground time per session. A tmux
 session counts as active while an interactive tmux client has that
 session foregrounded (`tmux list-clients`, grouped by `client_session`;
-control-mode clients are ignored). This is shown by `muxa watch --view
-session` in the `DUR` column.
+control-mode clients are ignored). This is shown in the `DUR` column of
+`muxa watch`'s session view (the default).
 
 ```toml
 [session_activity]

--- a/config.example.toml
+++ b/config.example.toml
@@ -49,8 +49,8 @@
 # debounce_ms = 200                  # coalesce window between dirty signal and write
 
 # tmux session foreground-time tracker. A session counts as active while an
-# interactive tmux client has that session foregrounded. `muxa watch --view
-# session` shows the cumulative total in its DUR column.
+# interactive tmux client has that session foregrounded. `muxa watch`
+# (session view — the default) shows the cumulative total in its DUR column.
 [session_activity]
 # enabled       = true
 # path          = "/home/$USER/.local/share/muxa/session-activity.json"
@@ -67,8 +67,8 @@
 # activity, session_time.
 # Omit a key to hide the column. Unknown keys log a warning and are skipped.
 [watch]
-# view = "pane"       # one row per agent/pane (default)
-# view = "session"    # one row per tmux session; panes merge by latest activity
+# view = "session"    # one row per tmux session; panes merge by latest activity (default)
+# view = "pane"       # one row per agent/pane
 # columns = ["pane", "state", "model", "ctx", "cost", "prompt", "activity"]
 # Hide agents that aren't bound to a tmux pane (Claude SDK sub-processes,
 # agents launched outside tmux). Default true because Enter on the picker

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -85,7 +85,7 @@ enum Cmd {
         /// detached SDK session.
         #[arg(long)]
         include_paneless: bool,
-        /// Row granularity: pane (default) or tmux session.
+        /// Row granularity: tmux session (default) or pane.
         #[arg(long, value_enum)]
         view: Option<WatchViewArg>,
     },

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -860,7 +860,16 @@ pub struct CapturedPane {
 impl App {
     #[cfg(test)]
     pub(crate) fn new() -> Self {
-        Self::with_config(WatchConfig::default())
+        // Pin pane view for the pane-level tests built around this helper
+        // (sorting, grouping, per-row actions, single-agent updates). The
+        // *production* default is `session` (see `WatchConfig::default`);
+        // session-view behavior is covered separately by config-crate tests
+        // and the explicit `view: Session` cases below. Pinning here keeps
+        // those pane-mechanics assertions stable regardless of the default.
+        Self::with_config(WatchConfig {
+            view: WatchView::Pane,
+            ..WatchConfig::default()
+        })
     }
 
     pub(crate) fn with_config(cfg: WatchConfig) -> Self {
@@ -3647,6 +3656,7 @@ mod tests {
         // independent of `last_activity_at` jitter from `fake_agent`. The
         // default `[Session, Activity]` is exercised by separate tests.
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             sort: vec![WatchSortKey::Session, WatchSortKey::Pane],
             ..WatchConfig::default()
         };
@@ -3701,6 +3711,7 @@ mod tests {
         // would invert that. Regression guard for the parse::<u32>() path.
         // Uses explicit `Pane` sort so activity-jitter doesn't matter.
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             sort: vec![WatchSortKey::Session, WatchSortKey::Pane],
             ..WatchConfig::default()
         };
@@ -3909,6 +3920,7 @@ mod tests {
         let t2 = time::macros::datetime!(2026-04-28 11:00:00 UTC);
 
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             sort: vec![WatchSortKey::Activity],
             ..WatchConfig::default()
         };
@@ -3943,6 +3955,7 @@ mod tests {
         // alphabetic order is preferred over recency.
         let now = OffsetDateTime::now_utc();
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             sort: vec![WatchSortKey::PaneId],
             ..WatchConfig::default()
         };
@@ -3982,6 +3995,7 @@ mod tests {
         let older_at = now - time::Duration::hours(1);
 
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             sort: vec![WatchSortKey::Activity],
             ..WatchConfig::default()
         };
@@ -4047,6 +4061,7 @@ mod tests {
         // selected_pane() contract — not on the default sort behaviour
         // covered by other tests.
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             sort: vec![WatchSortKey::PaneId],
             ..WatchConfig::default()
         };
@@ -4156,6 +4171,7 @@ mod tests {
         // Lock to PaneId sort: this test cares about which row matches
         // `set_initial_pane`, not the default sort interleaving.
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             sort: vec![WatchSortKey::PaneId],
             ..WatchConfig::default()
         };
@@ -4333,6 +4349,7 @@ mod tests {
     #[test]
     fn custom_columns_resolve_in_config_order() {
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             columns: vec!["prompt".into(), "pane".into(), "kind".into()],
             widths: HashMap::new(),
             ..Default::default()
@@ -4347,6 +4364,7 @@ mod tests {
     #[test]
     fn unknown_column_keys_are_skipped() {
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             columns: vec!["pane".into(), "bogus".into(), "prompt".into()],
             widths: HashMap::new(),
             ..Default::default()
@@ -4364,6 +4382,7 @@ mod tests {
         widths.insert("kind".into(), WidthSpec::Percentage(20));
         widths.insert("state".into(), WidthSpec::Invalid("nope".into()));
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             columns: vec![
                 "pane".into(),
                 "prompt".into(),
@@ -4645,6 +4664,7 @@ mod tests {
         // others — we verify the BarePane row is built without panic and
         // that the prompt column carries the summary.
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             columns: vec!["pane".into(), "prompt".into()],
             widths: HashMap::new(),
             ..Default::default()
@@ -4977,6 +4997,7 @@ mod tests {
     #[test]
     fn detail_disabled_skips_expansion() {
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             detail: muxa::config::DetailConfig {
                 enabled: false,
                 template: "{last_prompt}".into(),
@@ -5099,6 +5120,7 @@ mod tests {
         let backend = TestBackend::new(140, 12);
         let mut terminal = Terminal::new(backend).unwrap();
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             hide_paneless: false,
             ..WatchConfig::default()
         };
@@ -5170,6 +5192,7 @@ mod tests {
     fn selected_pane_returns_none_for_no_pane_agent() {
         // include the paneless row under test
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             hide_paneless: false,
             ..WatchConfig::default()
         };
@@ -5235,6 +5258,7 @@ mod tests {
     #[test]
     fn include_paneless_keeps_every_agent() {
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             hide_paneless: false,
             ..WatchConfig::default()
         };
@@ -5806,6 +5830,7 @@ mod tests {
         // which index don't drift with the default [Session, Activity]
         // sort once `fake_agent` timestamps differ across runs.
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             detail,
             sort: vec![WatchSortKey::PaneId],
             ..Default::default()
@@ -6495,6 +6520,7 @@ mod tests {
     /// future default flips.
     fn cfg_with_prompt_default() -> WatchConfig {
         WatchConfig {
+            view: WatchView::Pane,
             preview: muxa::config::PreviewConfig {
                 default_content: PreviewContent::PromptResponse,
             },
@@ -6773,6 +6799,7 @@ mod tests {
     /// shapes without re-doing the fixture each time.
     fn app_with_paneless_and_pane() -> App {
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             // Disable hide_paneless so the row stays in the table
             // — the picker default would filter it out and the test
             // would have to look elsewhere.
@@ -7333,8 +7360,11 @@ mod tests {
     fn snapshot_app() -> App {
         // Pin sort to PaneId so row order doesn't drift on activity jitter
         // and disable hide_paneless so the paneless row stays visible in
-        // the mixed-list snapshot.
+        // the mixed-list snapshot. Pin pane view too so these row-rendering
+        // snapshots stay focused on per-row visuals (state glyphs, columns,
+        // selection) independent of the production default (`session`).
         let cfg = WatchConfig {
+            view: WatchView::Pane,
             sort: vec![WatchSortKey::PaneId],
             hide_paneless: false,
             ..WatchConfig::default()

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -658,11 +658,13 @@ pub struct WatchConfig {
     /// a TOML integer (fixed length) or a string of the form `min:N` /
     /// `pct:N`. Missing keys fall back to the column's built-in default.
     pub widths: HashMap<String, WidthSpec>,
-    /// Row granularity for `muxa watch`.
+    /// Row granularity for `muxa watch`. Defaults to `session`.
     ///
-    /// `pane` is the historical view: one row per tracked agent / bare pane.
-    /// `session` collapses all panes in the same tmux session into one row,
-    /// using the most recently active agent as that session's representative.
+    /// `session` (default) collapses all panes in the same tmux session into
+    /// one row, using the most recently active agent as that session's
+    /// representative — the fleet-at-a-glance view for operators juggling
+    /// many sessions. `pane` is the finer-grained view: one row per tracked
+    /// agent / bare pane.
     pub view: WatchView,
     /// Expanded detail line shown under the currently-selected row.
     pub detail: DetailConfig,
@@ -724,8 +726,8 @@ pub enum PreviewContent {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WatchView {
-    #[default]
     Pane,
+    #[default]
     Session,
 }
 
@@ -778,7 +780,7 @@ impl Default for WatchConfig {
         Self {
             columns,
             widths,
-            view: WatchView::Pane,
+            view: WatchView::Session,
             detail: DetailConfig::default(),
             // Group by session, then bring the most recently active agent
             // in each group to the top — covers both "what's moving" and
@@ -1010,6 +1012,25 @@ sort = ["activity"]
     fn parses_watch_session_view() {
         let cfg: Config = toml::from_str("[watch]\nview = \"session\"\n").unwrap();
         assert_eq!(cfg.watch.view, WatchView::Session);
+    }
+
+    /// The default view is `session` — the fleet-at-a-glance row granularity.
+    /// Both the struct default and a config that omits `view` resolve to it,
+    /// so an empty `~/.config/muxa/config.toml` lands on session view.
+    #[test]
+    fn default_watch_view_is_session() {
+        assert_eq!(WatchConfig::default().view, WatchView::Session);
+        assert_eq!(WatchView::default(), WatchView::Session);
+        let cfg: Config = toml::from_str("[watch]\n").unwrap();
+        assert_eq!(cfg.watch.view, WatchView::Session);
+    }
+
+    /// `pane` is now the opt-in (non-default) granularity; setting it
+    /// explicitly still parses.
+    #[test]
+    fn parses_watch_pane_view() {
+        let cfg: Config = toml::from_str("[watch]\nview = \"pane\"\n").unwrap();
+        assert_eq!(cfg.watch.view, WatchView::Pane);
     }
 
     #[test]


### PR DESCRIPTION
## What

Flip `[watch] view`'s default from `pane` → **`session`**. One row per tmux session — collapsing a session's panes onto its most-recently-active agent — is the fleet-at-a-glance shape for operators juggling many sessions, and surfaces the `DUR` (session foreground-time) column by default. This matches how muxa is actually run day-to-day.

The finer-grained one-row-per-agent view stays one flag/config away: `muxa watch --view pane` or `[watch] view = "pane"`.

## How

- Production change is two spots: `WatchConfig::default().view` and the `WatchView` `#[default]`.
- The watch test suite predates this and assumes a pane-view default. The two **test-only** helpers it funnels through (`App::new`, `snapshot_app`) now pin `view: Pane` explicitly, and the custom-config test sites do the same — so pane-mechanics assertions and the existing snapshots stay stable without regeneration.
- The new default is locked by config-crate tests (`default_watch_view_is_session`, `parses_watch_pane_view`).
- Docs updated: `config.example.toml`, `README.md`, `README.ko.md`, `CHANGELOG.md`.

**No wire/protocol change** — purely a CLI-side default value; configs that pin `view` explicitly are unaffected.

## Verification

- `cargo fmt --all -- --check` ✅ · `cargo clippy --workspace --all-targets -- -D warnings` ✅
- Full workspace tests green: **286 lib + 232 cli + 8 e2e + 7 sink + 2 muxad**, including the watch suite (121) and the 3 new config tests.

## Note for the reviewer / merge ordering

There is in-flight parallel work on `main` (an `activity.ndjson` duration ledger touching `config.rs`/`stats.rs`/watch columns). This PR was built in an isolated worktree off `origin/main` to avoid disturbing it, but the two will likely touch `config.rs` and `CHANGELOG.md` in nearby spots — recommend merging after the activity-ledger work lands (or resolving the trivial textual conflicts at merge time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)