### PR TITLE
feat(ipc): BackendPaneSnapshot — daemon sink for zellij plugin pushes

### DIFF
--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -208,6 +208,15 @@ pub trait PaneBackend: Send + Sync + 'static {
     fn caps(&self) -> BackendCaps {
         BackendCaps::default()
     }
+
+    /// Ingest a wholesale pane snapshot pushed by an out-of-process
+    /// source — today the zellij WASM plugin, which forwards zellij
+    /// `PaneUpdate` events to the daemon over the `BackendPaneSnapshot`
+    /// IPC command (see [`docs/ZELLIJ.md`](../../../../docs/ZELLIJ.md)
+    /// Step 2). Default no-op: backends that enumerate panes themselves
+    /// (tmux) ignore external pushes; the zellij backend overrides this
+    /// to replace its cached snapshot.
+    fn ingest_pane_snapshot(&self, _panes: Vec<PaneInfo>) {}
 }
 
 /// `Arc<dyn PaneBackend>` is itself a backend — every method
@@ -247,6 +256,9 @@ impl<T: PaneBackend + ?Sized> PaneBackend for Arc<T> {
     }
     fn caps(&self) -> BackendCaps {
         (**self).caps()
+    }
+    fn ingest_pane_snapshot(&self, panes: Vec<PaneInfo>) {
+        (**self).ingest_pane_snapshot(panes);
     }
 }
 

--- a/crates/muxa/src/backend/zellij.rs
+++ b/crates/muxa/src/backend/zellij.rs
@@ -67,16 +67,12 @@ impl ZellijBackend {
         Self::default()
     }
 
-    /// Replace the cached pane snapshot wholesale. Called by the
-    /// daemon's IPC handler when the WASM plugin pushes a new
-    /// `BackendPaneSnapshot` payload. Atomic relative to readers
-    /// (the `RwLock` write guard blocks new readers; in-flight
-    /// readers see the previous snapshot).
-    ///
-    /// Until the plugin lands this method has no callers — kept on
-    /// the type so the wiring is in place when the IPC command
-    /// arrives.
-    #[allow(dead_code)]
+    /// Replace the cached pane snapshot wholesale. Reached via
+    /// [`PaneBackend::ingest_pane_snapshot`] when the daemon's
+    /// `BackendPaneSnapshot` IPC command delivers a fresh push from the
+    /// WASM plugin. Atomic relative to readers (the `RwLock` write
+    /// guard blocks new readers; in-flight readers see the previous
+    /// snapshot).
     pub(crate) fn replace_snapshot(&self, panes: Vec<PaneInfo>) {
         if let Ok(mut w) = self.snapshot.write() {
             *w = panes;
@@ -135,6 +131,14 @@ impl PaneBackend for ZellijBackend {
             .args(["action", "focus-pane-with-id", pane_id])
             .status()
             .is_ok_and(|s| s.success())
+    }
+
+    fn ingest_pane_snapshot(&self, panes: Vec<PaneInfo>) {
+        // The plugin's `PaneUpdate` push arrives via the daemon's
+        // `BackendPaneSnapshot` IPC command. Replace the cache
+        // wholesale — the plugin is the source of truth and always
+        // sends the full pane set.
+        self.replace_snapshot(panes);
     }
 
     fn caps(&self) -> BackendCaps {
@@ -215,6 +219,20 @@ mod tests {
         assert_eq!(panes.len(), 2);
         assert_eq!(b.resolve_pane("z-1").unwrap().pane_id, "z-1");
         assert!(b.resolve_pane("missing").is_none());
+    }
+
+    /// `ingest_pane_snapshot` through a `dyn PaneBackend` routes to
+    /// `replace_snapshot` for zellij — the exact path the daemon's
+    /// `BackendPaneSnapshot` handler takes (it holds an
+    /// `Arc<dyn PaneBackend>`, never the concrete type). Exercised via a
+    /// trait object so a regression that drops the override — falling
+    /// back to the no-op trait default — fails here.
+    #[test]
+    fn ingest_pane_snapshot_via_trait_updates_cache() {
+        let b: Box<dyn PaneBackend> = Box::new(ZellijBackend::new());
+        b.ingest_pane_snapshot(vec![fake_pane("z-7")]);
+        assert_eq!(b.list_panes().len(), 1);
+        assert_eq!(b.resolve_pane("z-7").unwrap().pane_id, "z-7");
     }
 
     /// Trait-object dispatch compiles — locks in the

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -19,8 +19,10 @@
 //! can call `Store::apply` afterwards, so the daemon's final flush
 //! captures every state change the user actually triggered.
 
+use crate::backend::{default_backend, SharedBackend};
 use crate::event::{AgentEvent, PROTOCOL_VERSION};
 use crate::state::{Agent, SharedStore};
+use crate::tmux::PaneInfo;
 use serde::{Deserialize, Serialize};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -94,6 +96,16 @@ enum RequestBody {
     /// socket. Used by `muxa watch` to switch from 500 ms polling to
     /// push-based updates.
     Subscribe,
+
+    /// Wholesale pane-metadata snapshot pushed by an out-of-process
+    /// backend source — today the zellij WASM plugin forwarding
+    /// `PaneUpdate` events. The daemon hands the panes to its
+    /// `SharedBackend::ingest_pane_snapshot`, which the zellij backend
+    /// caches so `list_panes` / `resolve_pane` answer from real data. A
+    /// no-op on tmux (that backend enumerates panes itself).
+    BackendPaneSnapshot {
+        panes: Vec<PaneInfo>,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -192,11 +204,27 @@ impl Response {
 pub struct Server {
     socket_path: PathBuf,
     store: SharedStore,
+    backend: SharedBackend,
 }
 
 impl Server {
     pub fn new(socket_path: PathBuf, store: SharedStore) -> Self {
-        Self { socket_path, store }
+        Self {
+            socket_path,
+            store,
+            backend: default_backend(),
+        }
+    }
+
+    /// Set the pane backend the server forwards `BackendPaneSnapshot`
+    /// pushes to. The daemon passes the same `SharedBackend` the
+    /// reconciler and discovery hold, so a plugin push updates the
+    /// snapshot every consumer reads. Defaults to [`default_backend`]
+    /// for callers (mostly tests) that never push.
+    #[must_use]
+    pub fn with_backend(mut self, backend: SharedBackend) -> Self {
+        self.backend = backend;
+        self
     }
 
     /// Run until `shutdown` fires or an I/O error occurs.
@@ -219,8 +247,9 @@ impl Server {
                 accept = listener.accept() => {
                     let (stream, _) = accept?;
                     let store = self.store.clone();
+                    let backend = self.backend.clone();
                     handlers.spawn(async move {
-                        if let Err(e) = handle(stream, store).await {
+                        if let Err(e) = handle(stream, store, backend).await {
                             tracing::warn!(error = %e, "connection handler failed");
                         }
                     });
@@ -355,9 +384,13 @@ async fn stream_transitions(
     }
 }
 
-#[tracing::instrument(level = "debug", skip(stream, store))]
+#[tracing::instrument(level = "debug", skip(stream, store, backend))]
 #[allow(clippy::too_many_lines)] // dispatch table — splitting would only spread the match across files
-async fn handle(stream: UnixStream, store: SharedStore) -> Result<(), RuntimeError> {
+async fn handle(
+    stream: UnixStream,
+    store: SharedStore,
+    backend: SharedBackend,
+) -> Result<(), RuntimeError> {
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
     let mut line = String::new();
@@ -469,6 +502,13 @@ async fn handle(stream: UnixStream, store: SharedStore) -> Result<(), RuntimeErr
                     kind = "health";
                     Response::health()
                 }
+                RequestBody::BackendPaneSnapshot { panes } => {
+                    kind = "backend_pane_snapshot";
+                    let count = panes.len();
+                    backend.ingest_pane_snapshot(panes);
+                    tracing::debug!(panes = count, "backend_pane_snapshot");
+                    Response::ok()
+                }
                 RequestBody::Subscribe => {
                     kind = "subscribe";
                     let stream_proto = negotiated.unwrap_or(PROTOCOL_VERSION);
@@ -556,6 +596,19 @@ impl Client {
             "protocol": PROTOCOL_VERSION,
             "kind": "ingest",
             "event": event
+        });
+        let _ = self.call(&req).await?;
+        Ok(())
+    }
+
+    /// Push a wholesale pane snapshot to the daemon. The zellij
+    /// WASM-plugin bridge calls this to forward `PaneUpdate` events; the
+    /// daemon hands the panes to its `SharedBackend::ingest_pane_snapshot`.
+    pub async fn push_pane_snapshot(&self, panes: &[PaneInfo]) -> Result<(), RuntimeError> {
+        let req = serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "backend_pane_snapshot",
+            "panes": panes,
         });
         let _ = self.call(&req).await?;
         Ok(())
@@ -1215,6 +1268,57 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("unsupported protocol"));
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    /// A `backend_pane_snapshot` push reaches the server's
+    /// `SharedBackend`, so the zellij backend's cache — and thus
+    /// `list_panes` / `resolve_pane` — reflects it. The request/response
+    /// is synchronous, so once the client call returns the ingest has
+    /// already run daemon-side; no sleep/poll needed.
+    #[tokio::test]
+    async fn backend_pane_snapshot_push_updates_shared_backend() {
+        use crate::backend::zellij::ZellijBackend;
+        use crate::backend::PaneBackend;
+        use std::sync::Arc;
+
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-backend-snap.sock");
+        let store = Store::shared();
+        let backend = Arc::new(ZellijBackend::new());
+        let server = Server::new(sock.clone(), store).with_backend(backend.clone());
+        let (tx, rx) = broadcast::channel(1);
+        let handle = tokio::spawn(async move { server.run(rx).await.unwrap() });
+        wait_for_socket(&sock).await;
+
+        // No plugin push yet → empty.
+        assert!(backend.list_panes().is_empty());
+
+        let pane = PaneInfo {
+            pane_id: "zellij:3".into(),
+            session: "z".into(),
+            window_index: "0".into(),
+            pane_index: "3".into(),
+            tty: String::new(),
+            current_command: "claude".into(),
+            title: String::new(),
+            pane_pid: 0,
+        };
+        Client::new(sock.clone())
+            .push_pane_snapshot(&[pane])
+            .await
+            .unwrap();
+
+        // The same Arc the test holds now sees the pushed pane.
+        let panes = backend.list_panes();
+        assert_eq!(panes.len(), 1);
+        assert_eq!(panes[0].pane_id, "zellij:3");
+        assert_eq!(
+            backend.resolve_pane("zellij:3").unwrap().current_command,
+            "claude"
+        );
 
         tx.send(()).unwrap();
         handle.await.unwrap();

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -28,6 +28,7 @@ use std::sync::OnceLock;
 /// 2. Known Homebrew install prefixes — Apple Silicon then Intel.
 /// 3. Bare `tmux` as a last-resort sentinel so the eventual error message
 ///    matches the prior behavior.
+///
 /// Build a `Command` for shelling out to tmux with the resolved binary
 /// path and a UTF-8 locale pre-applied.
 ///
@@ -54,8 +55,7 @@ pub fn tmux_binary() -> &'static Path {
         if Command::new("tmux")
             .arg("-V")
             .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+            .is_ok_and(|o| o.status.success())
         {
             return PathBuf::from("tmux");
         }
@@ -76,7 +76,7 @@ pub enum TmuxError {
     BadOutput(String),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PaneInfo {
     pub pane_id: String,
     pub session: String,

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -214,7 +214,7 @@ async fn main() -> Result<()> {
     spawn_oh_my_prompt_sink(&cfg, &store, &shutdown_tx)?;
     spawn_webhook_sink(&cfg, &store, &shutdown_tx)?;
 
-    let server = Server::new(socket.clone(), store);
+    let server = Server::new(socket.clone(), store).with_backend(backend.clone());
     let handle = tokio::spawn(server.run(shutdown_tx.subscribe()));
 
     // Harden socket permissions once the listener exists. We poll briefly


### PR DESCRIPTION
Host-side slice of **ZELLIJ.md Step 2** — the daemon command the future zellij WASM plugin pushes into. Part of #40.

## What & why

The zellij backend is a CLI baseline: `list_panes` / `resolve_pane` / `capture_pane` / `pane_pid_map` are permanently empty because zellij only exposes pane metadata through its WASM plugin API. `ZellijBackend` already pre-positions a snapshot cache (`replace_snapshot`) for the plugin to push into, but **nothing called it** — the daemon had no IPC command to receive a push. This wires that hole shut so the plugin (separate follow-up, #40) has a target.

## Changes

- **`PaneBackend::ingest_pane_snapshot`** — default no-op (tmux enumerates panes itself); zellij overrides it to `replace_snapshot`. Delegated through the `Arc<dyn PaneBackend>` blanket impl so a `SharedBackend` reaches the concrete backend rather than the trait default (same reason the blanket impl already overrides `caps()`).
- **IPC `BackendPaneSnapshot { panes }`** — new `RequestBody` variant. `Server` now holds the `SharedBackend` (`Server::with_backend`); muxad passes the **same `Arc`** the reconciler and discovery hold, so a push updates every consumer's `list_panes()`. `Client::push_pane_snapshot` is the bridge the plugin will call.
- **`PaneInfo`** gains `Serialize`/`Deserialize` for the wire.
- Drive-by: a `clippy 1.92 doc_lazy_continuation` fix in `tmux/mod.rs` — CI runs unpinned `stable` clippy, which flags it (unrelated to the feature, but blocks the clippy job otherwise).

## Out of scope (tracked in #40)

The WASM plugin crate itself (`zellij-tile` → `wasm32-wasip1`, `PaneUpdate` subscription), release plumbing for the `.wasm`, and flipping `BackendCaps` to `true` once real data flows. Those need a running zellij and can't be CI-tested here.

## Testing

- `cargo test -p muxa --lib` — 299 pass, incl. two new: trait routing through a `dyn PaneBackend`, and an IPC round-trip (push a snapshot, read it back off the shared backend).
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Note: 3 `muxa-cli` **e2e** tests fail in my local Docker sandbox (no working host env); they fail identically on unmodified `origin/main`, so they're environmental, not from this change. CI's runners should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
