### PR TITLE
fix(muxad): only heal tmux MUXA_SOCKET from the canonical daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`muxad` only self-heals the tmux global `MUXA_SOCKET` for the
+  canonical daemon.** At startup `muxad` writes its socket into the tmux
+  server's global env so panes spawned before it can still reach it — but
+  it now does so only when running on the default (XDG / `/tmp`) socket or
+  the one named in config. An ephemeral instance started with an explicit
+  `--socket` / `MUXA_SOCKET` override (a dashboard demo, an e2e test) no
+  longer clobbers the global env that the primary daemon and `muxa init`'s
+  `tmux.conf` pin own; previously such an instance, on exit, stranded every
+  pane spawned in the meantime on a now-dead socket
+  (`daemon not reachable at …`). Note: a *non-default primary* daemon
+  should set its socket via config (or the `MUXA_SOCKET` pin) rather than a
+  bare `--socket` flag if it needs pre-existing panes auto-healed.
+
 - **`muxa watch` prompt composer** — delay the submit key briefly after
   injecting prompt text into a tmux pane, so Codex treats `Enter` as a
   distinct submit key instead of folding it into a fast paste/input burst.

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -28,6 +28,7 @@ use std::sync::OnceLock;
 /// 2. Known Homebrew install prefixes — Apple Silicon then Intel.
 /// 3. Bare `tmux` as a last-resort sentinel so the eventual error message
 ///    matches the prior behavior.
+///
 /// Build a `Command` for shelling out to tmux with the resolved binary
 /// path and a UTF-8 locale pre-applied.
 ///
@@ -54,8 +55,7 @@ pub fn tmux_binary() -> &'static Path {
         if Command::new("tmux")
             .arg("-V")
             .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+            .is_ok_and(|o| o.status.success())
         {
             return PathBuf::from("tmux");
         }

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -22,7 +22,7 @@ use muxa::tmux::scanner::PaneCache;
 use muxa::{discovery, paths, Config, Store};
 use std::collections::HashMap;
 use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::broadcast;
@@ -239,7 +239,7 @@ async fn main() -> Result<()> {
     // warm-restart scenarios without requiring the user to re-run
     // `muxa init` after every daemon or tmux server restart.
     if listener_ready {
-        heal_tmux_socket_env(&socket);
+        maybe_heal_tmux_socket_env(&socket, cfg.socket.as_deref());
         spawn_startup_discovery(&cfg, socket.clone(), backend.clone());
     }
 
@@ -948,6 +948,43 @@ fn heal_tmux_socket_env(socket: &std::path::Path) {
     }
 }
 
+/// Heal the tmux global `MUXA_SOCKET` — but only for the canonical
+/// daemon (see [`should_heal_tmux_socket_env`]). A non-canonical instance
+/// (an explicit `--socket`/`MUXA_SOCKET` override matching neither the
+/// default nor the configured socket — a dashboard demo, an e2e test, a
+/// throwaway `muxad --socket /tmp/…`) logs and returns without touching
+/// the global env, so its short-lived socket can't strand later panes
+/// once it exits.
+fn maybe_heal_tmux_socket_env(socket: &Path, cfg_socket: Option<&Path>) {
+    if should_heal_tmux_socket_env(socket, &paths::default_socket(), cfg_socket) {
+        heal_tmux_socket_env(socket);
+    } else {
+        tracing::debug!(
+            socket = %socket.display(),
+            "non-canonical socket override — skipping tmux env heal to avoid clobbering the primary daemon's global pin"
+        );
+    }
+}
+
+/// Whether this muxad instance may write its socket into the tmux
+/// server's global `MUXA_SOCKET` (see [`heal_tmux_socket_env`]).
+///
+/// Only the *canonical* daemon heals: one on the XDG/default socket, or
+/// on the socket named in config. An instance started with an explicit
+/// `--socket` / `MUXA_SOCKET` override matching neither — a dashboard
+/// demo, an e2e test, a throwaway `muxad --socket /tmp/…` — must NOT
+/// touch the global env. That env (and `muxa init`'s tmux.conf pin)
+/// belong to the primary daemon; when the ephemeral instance exits its
+/// socket is unlinked, and every pane spawned while the global pointed at
+/// it can no longer reach any daemon until the global is re-pinned.
+fn should_heal_tmux_socket_env(
+    socket: &Path,
+    default_socket: &Path,
+    cfg_socket: Option<&Path>,
+) -> bool {
+    socket == default_socket || cfg_socket == Some(socket)
+}
+
 /// Decide whether to fire the one-shot discovery pass and, if so, spawn it
 /// onto the current tokio runtime.
 ///
@@ -987,6 +1024,38 @@ fn spawn_startup_discovery(cfg: &Config, socket: PathBuf, backend: muxa::SharedB
 mod tests {
     use super::*;
     use muxa::config::DiscoveryConfig;
+
+    #[test]
+    fn heals_canonical_default_or_configured_socket() {
+        let default = Path::new("/run/user/1000/muxa.sock");
+        let configured = Path::new("/custom/primary.sock");
+        // Default socket → the primary daemon, may heal.
+        assert!(should_heal_tmux_socket_env(default, default, None));
+        // Socket named in config → also the primary, may heal even when
+        // it differs from the XDG/default path.
+        assert!(should_heal_tmux_socket_env(
+            configured,
+            default,
+            Some(configured)
+        ));
+    }
+
+    #[test]
+    fn skips_ephemeral_override_socket() {
+        // A dashboard demo / e2e daemon on a throwaway socket matching
+        // neither the default nor the configured one must NOT clobber the
+        // tmux global env the primary daemon owns — that poisoning is
+        // exactly what strands later panes on a dead `muxa-dash.sock`.
+        let default = Path::new("/run/user/1000/muxa.sock");
+        let configured = Path::new("/custom/primary.sock");
+        let ephemeral = Path::new("/tmp/.tmpXYZ/muxa-dash.sock");
+        assert!(!should_heal_tmux_socket_env(ephemeral, default, None));
+        assert!(!should_heal_tmux_socket_env(
+            ephemeral,
+            default,
+            Some(configured)
+        ));
+    }
 
     #[tokio::test]
     async fn startup_discovery_runs_when_enabled() {


### PR DESCRIPTION
## Problem

muxad runs `tmux set-environment -g MUXA_SOCKET <socket>` at startup (`heal_tmux_socket_env`) so panes spawned before the daemon can still reach it. But it did this **unconditionally** — for *any* muxad instance, including ephemeral ones started on a throwaway socket:

- a dashboard demo,
- an **e2e test** (the fixtures literally use `muxa-dash.sock`),
- a manual `muxad --socket /tmp/.../muxa-dash.sock`.

Such an instance clobbers the tmux **server-global** `MUXA_SOCKET`. When it exits, its socket file is unlinked, and **every pane spawned while the global pointed at it** inherits a dead socket → `daemon not reachable at /tmp/.../muxa-dash.sock`. The user's primary daemon is fine; new panes just look at the wrong socket. Seen **twice** in one session.

## Fix

Gate the heal behind `should_heal_tmux_socket_env(socket, default, cfg_socket)`:

```rust
socket == default_socket || cfg_socket == Some(socket)
```

Only the **canonical** daemon — running on the XDG/default socket, or the socket named in config — writes the tmux global env. An instance on an explicit `--socket` / `MUXA_SOCKET` override that matches neither leaves the global (and `muxa init`'s `tmux.conf` pin, both owned by the primary) untouched and logs a debug line.

- Pure decision function with unit tests (`heals_canonical_default_or_configured_socket`, `skips_ephemeral_override_socket`); the tmux shell-out (`heal_tmux_socket_env`) is unchanged.
- `maybe_heal_tmux_socket_env` wraps decision + heal/log so `main` keeps a single call (and stays under clippy's `too_many_lines`).

## Note on the tmux/mod.rs hunk

The 2-line `tmux/mod.rs` change (doc_lazy_continuation blank line + `is_ok_and`) is **not** part of this fix — it's the same clippy-stable (rustc 1.96) fix `main` is currently red on. CI runs unpinned `stable` clippy, so without it the clippy job fails on pre-existing code. It's identical to the hunk in #41; whichever merges first makes the other a no-op.

## Testing

- `cargo test -p muxad` — 4 pass incl. the 2 new guard tests.
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean (rustc 1.96, matching CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
