### PR TITLE
feat(watch): add `latest` sort preset + persist runtime sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`muxa watch` latest sort** — `latest` is now the user-facing name for
+  newest-activity-first sorting. Use `l` in the TUI or `--sort latest`;
+  existing `a`, `activity`, and `act` aliases remain supported.
+
 ### Fixed
 
 - **`muxad` only self-heals the tmux global `MUXA_SOCKET` for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`muxa watch` latest sort** — `latest` is now the user-facing name for
   newest-activity-first sorting. Use `l` in the TUI or `--sort latest`;
-  existing `a`, `activity`, and `act` aliases remain supported.
+  existing `a`, `activity`, and `act` aliases remain supported. Runtime sort
+  changes are saved back to `[watch].sort`.
 
 ### Fixed
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -101,20 +101,21 @@
 # `pane_id` as a final stable tiebreaker. Stale agents (pane closed)
 # always sink to the bottom regardless of what's listed here.
 #
-# Default: ["session", "activity"] — groups by tmux session, floats
+# Default: ["session", "latest"] — groups by tmux session, floats
 # the most recently active agent inside each group to the top.
 #
 # Available keys:
 #   session   — tmux session name asc (groups same-session panes)
-#   activity  — last_activity_at desc (most recently updated first)
+#   latest    — last_activity_at desc (most recently updated first)
+#   activity  — alias for latest
 #   pane      — window then pane index, parsed numerically
 #   pane_id   — raw pane id lex asc (predictable; useful for screenshots)
 #
 # Examples:
-#   sort = ["activity"]              # global newest-first, no grouping
+#   sort = ["latest"]                # global newest-first, no grouping
 #   sort = ["session", "pane"]       # tmux-native order within session
-#   sort = ["session", "activity"]   # default — grouping + recency
-# sort = ["session", "activity"]
+#   sort = ["session", "latest"]     # default — grouping + recency
+# sort = ["session", "latest"]
 
 # Per-column widths. Three accepted forms:
 #   integer  -> fixed length      (Constraint::Length)

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -108,7 +108,7 @@ enum Cmd {
         /// Row granularity: tmux session (default) or pane.
         #[arg(long, value_enum)]
         view: Option<WatchViewArg>,
-        /// One-shot sort override: session, act/activity, dur/duration, st/state, pane, pane-id.
+        /// One-shot sort override: session, latest/activity/act, dur/duration, st/state, pane, pane-id.
         #[arg(long, value_enum)]
         sort: Option<WatchSortArg>,
         /// One-shot visual theme override.
@@ -199,8 +199,8 @@ impl From<WatchViewArg> for muxa::config::WatchView {
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum WatchSortArg {
     Session,
-    #[value(alias = "act")]
-    Activity,
+    #[value(alias = "activity", alias = "act")]
+    Latest,
     #[value(alias = "dur", alias = "duration")]
     SessionTime,
     #[value(alias = "st")]
@@ -214,7 +214,7 @@ impl WatchSortArg {
     fn keys(self) -> Vec<WatchSortKey> {
         match self {
             Self::Session => vec![WatchSortKey::Session, WatchSortKey::Activity],
-            Self::Activity => vec![WatchSortKey::Activity],
+            Self::Latest => vec![WatchSortKey::Activity],
             Self::SessionTime => vec![WatchSortKey::SessionTime],
             Self::State => vec![WatchSortKey::State, WatchSortKey::Activity],
             Self::Pane => vec![WatchSortKey::Session, WatchSortKey::Pane],

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -259,7 +259,18 @@ async fn main() -> Result<()> {
             view,
             sort,
             theme,
-        } => cmd_watch(&client, cfg, include_paneless, view, sort, theme).await,
+        } => {
+            cmd_watch(
+                &client,
+                cfg,
+                config_path.clone(),
+                include_paneless,
+                view,
+                sort,
+                theme,
+            )
+            .await
+        }
         Cmd::Attend(attend_args) => cmd_attend(&client, attend_args).await,
         Cmd::Sync => cmd_sync(&client).await,
         Cmd::Init(init_args) => init::run(init_args, socket).await,
@@ -335,6 +346,7 @@ async fn cmd_sync(client: &Client) -> Result<()> {
 async fn cmd_watch(
     client: &Client,
     cfg: Config,
+    config_path: Option<PathBuf>,
     include_paneless: bool,
     view: Option<WatchViewArg>,
     sort: Option<WatchSortArg>,
@@ -387,6 +399,7 @@ async fn cmd_watch(
         watch_cfg,
         session_activity_path,
         activity_path.clone(),
+        config_path,
     )
     .await?
     {

--- a/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_confirm_popup.snap
+++ b/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_confirm_popup.snap
@@ -25,4 +25,4 @@ expression: "snapshot_helpers::buffer_string(&terminal)"
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/a/d/t  sort   ?  help   q  quit
+ ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/l/d/t  sort   ?  help   q  quit

--- a/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_empty_state.snap
+++ b/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_empty_state.snap
@@ -13,4 +13,4 @@ expression: "snapshot_helpers::buffer_string(&terminal)"
 │                                                                                                  │
 │                                                                                                  │
 └──────────────────────────────────────────────────────────────────────────────────────────────────┘
- ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/a/d/t  sort   ?  help   q  quit
+ ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/l/d/t  sort   ?  help   q  quit

--- a/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_help_overlay.snap
+++ b/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_help_overlay.snap
@@ -26,7 +26,7 @@ expression: "snapshot_helpers::buffer_string(&terminal)"
 │                           │                                                                                  │                           │
 │                           │Sorting                                                                           │                           │
 │                           │  s              sort by session name                                             │                           │
-│                           │  a              sort by activity (ACT)                                           │                           │
+│                           │  l / a          sort by latest activity                                          │                           │
 │                           │  d              sort by duration (DUR)                                           │                           │
 │                           │  t              sort by state (ST)                                               │                           │
 │                           │                                                                                  │                           │
@@ -41,4 +41,4 @@ expression: "snapshot_helpers::buffer_string(&terminal)"
 │                           └──────────────────────────────────────────────────────────────────────────────────┘                           │
 │                                                                                                                                          │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/a/d/t  sort   ?  help   q  quit
+ ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/l/d/t  sort   ?  help   q  quit

--- a/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_mixed_list_with_selection.snap
+++ b/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_mixed_list_with_selection.snap
@@ -17,4 +17,4 @@ expression: "snapshot_helpers::buffer_string(&terminal)"
 │                                                                                                            │
 │                                                                                                            │
 └────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/a/d/t  sort   ?  help   q  quit
+ ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/l/d/t  sort   ?  help   q  quit

--- a/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_row_error.snap
+++ b/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_row_error.snap
@@ -13,4 +13,4 @@ expression: "snapshot_helpers::buffer_string(&terminal)"
 │                                                                                                  │
 │                                                                                                  │
 └──────────────────────────────────────────────────────────────────────────────────────────────────┘
- ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/a/d/t  sort   ?  help   q  quit
+ ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/l/d/t  sort   ?  help   q  quit

--- a/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_row_waiting_choice.snap
+++ b/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_row_waiting_choice.snap
@@ -13,4 +13,4 @@ expression: "snapshot_helpers::buffer_string(&terminal)"
 │                                                                                                  │
 │                                                                                                  │
 └──────────────────────────────────────────────────────────────────────────────────────────────────┘
- ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/a/d/t  sort   ?  help   q  quit
+ ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/l/d/t  sort   ?  help   q  quit

--- a/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_row_waiting_input.snap
+++ b/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_row_waiting_input.snap
@@ -13,4 +13,4 @@ expression: "snapshot_helpers::buffer_string(&terminal)"
 │                                                                                                  │
 │                                                                                                  │
 └──────────────────────────────────────────────────────────────────────────────────────────────────┘
- ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/a/d/t  sort   ?  help   q  quit
+ ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/l/d/t  sort   ?  help   q  quit

--- a/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_row_working.snap
+++ b/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_row_working.snap
@@ -13,4 +13,4 @@ expression: "snapshot_helpers::buffer_string(&terminal)"
 │                                                                                                  │
 │                                                                                                  │
 └──────────────────────────────────────────────────────────────────────────────────────────────────┘
- ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/a/d/t  sort   ?  help   q  quit
+ ↑/↓  move   ⏎  prompt   ⏎⏎  attach   p  preview   r  refresh   s/l/d/t  sort   ?  help   q  quit

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -650,7 +650,7 @@ pub(crate) struct SessionRow {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WatchSortPreset {
     Session,
-    Activity,
+    Latest,
     Duration,
     State,
 }
@@ -659,7 +659,7 @@ impl WatchSortPreset {
     fn keys(self) -> Vec<WatchSortKey> {
         match self {
             Self::Session => vec![WatchSortKey::Session, WatchSortKey::Activity],
-            Self::Activity => vec![WatchSortKey::Activity],
+            Self::Latest => vec![WatchSortKey::Activity],
             Self::Duration => vec![WatchSortKey::SessionTime],
             Self::State => vec![WatchSortKey::State, WatchSortKey::Activity],
         }
@@ -668,7 +668,7 @@ impl WatchSortPreset {
     fn label(self) -> &'static str {
         match self {
             Self::Session => "SESSION",
-            Self::Activity => "ACT",
+            Self::Latest => "LATEST",
             Self::Duration => "DUR",
             Self::State => "ST",
         }
@@ -678,7 +678,7 @@ impl WatchSortPreset {
 fn sort_label(keys: &[WatchSortKey]) -> &'static str {
     match keys.first().copied() {
         Some(WatchSortKey::Session) | None => "SESSION",
-        Some(WatchSortKey::Activity) => "ACT",
+        Some(WatchSortKey::Activity) => "LATEST",
         Some(WatchSortKey::SessionTime) => "DUR",
         Some(WatchSortKey::State) => "ST",
         Some(WatchSortKey::Pane) => "PANE",
@@ -1029,7 +1029,7 @@ pub(crate) fn help_overlay_text() -> Vec<&'static str> {
         "",
         "Sorting",
         "  s              sort by session name",
-        "  a              sort by activity (ACT)",
+        "  l / a          sort by latest activity",
         "  d              sort by duration (DUR)",
         "  t              sort by state (ST)",
         "",
@@ -3020,7 +3020,7 @@ fn handle_event(ev: Event, app: &mut App) -> Action {
         KeyCode::Char('p') => Action::OpenPreview,
         KeyCode::Char('?') => Action::Quick(QuickAction::ShowHelp),
         KeyCode::Char('s') => Action::SetSort(WatchSortPreset::Session),
-        KeyCode::Char('a') => Action::SetSort(WatchSortPreset::Activity),
+        KeyCode::Char('l' | 'a') => Action::SetSort(WatchSortPreset::Latest),
         KeyCode::Char('d') => Action::SetSort(WatchSortPreset::Duration),
         KeyCode::Char('t') => Action::SetSort(WatchSortPreset::State),
         // Capital-K / Capital-R require Shift in the spec — crossterm
@@ -4254,7 +4254,7 @@ fn render_footer(f: &mut Frame, area: Rect, app: &App) {
         Span::raw(" preview  "),
         Span::styled(" r ", theme.key_badge()),
         Span::raw(" refresh  "),
-        Span::styled(" s/a/d/t ", theme.key_badge()),
+        Span::styled(" s/l/d/t ", theme.key_badge()),
         Span::raw(" sort  "),
         Span::styled(" ? ", theme.key_badge()),
         Span::raw(" help  "),
@@ -4895,7 +4895,7 @@ mod tests {
         );
         app.table_state.select(Some(0));
 
-        app.apply_sort_preset(WatchSortPreset::Activity);
+        app.apply_sort_preset(WatchSortPreset::Latest);
 
         let order: Vec<&str> = app
             .rows
@@ -4914,7 +4914,8 @@ mod tests {
         let mut app = App::new();
         for (key, preset) in [
             ('s', WatchSortPreset::Session),
-            ('a', WatchSortPreset::Activity),
+            ('l', WatchSortPreset::Latest),
+            ('a', WatchSortPreset::Latest),
             ('d', WatchSortPreset::Duration),
             ('t', WatchSortPreset::State),
         ] {
@@ -8197,7 +8198,7 @@ mod tests {
                         \n\
                         Sorting\n\
                         \x20\x20s              sort by session name\n\
-                        \x20\x20a              sort by activity (ACT)\n\
+                        \x20\x20l / a          sort by latest activity\n\
                         \x20\x20d              sort by duration (DUR)\n\
                         \x20\x20t              sort by state (ST)\n\
                         \n\

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -686,6 +686,55 @@ fn sort_label(keys: &[WatchSortKey]) -> &'static str {
     }
 }
 
+fn sort_key_toml_name(key: WatchSortKey) -> &'static str {
+    match key {
+        WatchSortKey::Session => "session",
+        WatchSortKey::Activity => "latest",
+        WatchSortKey::SessionTime => "session_time",
+        WatchSortKey::State => "state",
+        WatchSortKey::Pane => "pane",
+        WatchSortKey::PaneId => "pane_id",
+    }
+}
+
+fn persist_watch_sort(path: &Path, keys: &[WatchSortKey]) -> std::result::Result<(), String> {
+    let original = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(format!("read {}: {e}", path.display())),
+    };
+
+    let mut doc = if original.trim().is_empty() {
+        toml_edit::DocumentMut::new()
+    } else {
+        original
+            .parse::<toml_edit::DocumentMut>()
+            .map_err(|e| format!("parse {}: {e}", path.display()))?
+    };
+
+    match doc.get("watch") {
+        Some(toml_edit::Item::Table(_)) | None => {}
+        Some(_) => return Err("[watch] is not a table".to_string()),
+    }
+    if doc.get("watch").is_none() {
+        doc["watch"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+
+    let watch = doc["watch"]
+        .as_table_mut()
+        .ok_or_else(|| "[watch] is not a table".to_string())?;
+    let mut sort = toml_edit::Array::new();
+    for key in keys {
+        sort.push(sort_key_toml_name(*key));
+    }
+    watch["sort"] = toml_edit::Item::Value(toml_edit::Value::Array(sort));
+
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    std::fs::write(path, doc.to_string()).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
 impl WatchRow {
     fn pane_id(&self) -> Option<&str> {
         match self {
@@ -2502,6 +2551,7 @@ pub async fn run(
     watch_cfg: WatchConfig,
     session_activity_path: Option<PathBuf>,
     activity_path: Option<PathBuf>,
+    sort_persist_path: Option<PathBuf>,
 ) -> Result<Option<String>> {
     let terminal = setup_terminal()?;
     let mut guard = TerminalGuard::new(terminal);
@@ -2693,7 +2743,25 @@ pub async fn run(
                 }
                 Action::SetSort(preset) => {
                     app.apply_sort_preset(preset);
-                    app.set_hint(format!("sorted by {}", preset.label()), HintLevel::Ok);
+                    match sort_persist_path.as_deref() {
+                        Some(path) => match persist_watch_sort(path, &app.watch_cfg.sort) {
+                            Ok(()) => {
+                                app.set_hint(
+                                    format!("sorted by {} (saved)", preset.label()),
+                                    HintLevel::Ok,
+                                );
+                            }
+                            Err(e) => {
+                                app.set_hint(
+                                    format!("sorted by {} (save failed: {e})", preset.label()),
+                                    HintLevel::Warn,
+                                );
+                            }
+                        },
+                        None => {
+                            app.set_hint(format!("sorted by {}", preset.label()), HintLevel::Ok);
+                        }
+                    }
                 }
                 Action::AskConfirm(popup) => {
                     app.confirm = Some(popup);
@@ -4925,6 +4993,51 @@ mod tests {
             );
             assert!(matches!(action, Action::SetSort(p) if p == preset));
         }
+    }
+
+    #[test]
+    fn persist_watch_sort_creates_config_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested/config.toml");
+
+        persist_watch_sort(&path, &[WatchSortKey::Activity]).unwrap();
+
+        let saved = std::fs::read_to_string(&path).unwrap();
+        assert!(saved.contains("[watch]"), "{saved}");
+        assert!(saved.contains("sort = [\"latest\"]"), "{saved}");
+        let cfg = muxa::config::Config::load_or_default(Some(&path)).unwrap();
+        assert_eq!(cfg.watch.sort, vec![WatchSortKey::Activity]);
+    }
+
+    #[test]
+    fn persist_watch_sort_updates_sort_without_rewriting_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"# user config
+[ui]
+theme = "focus"
+
+[watch]
+columns = ["pane", "state"]
+sort = ["state"]
+"#,
+        )
+        .unwrap();
+
+        persist_watch_sort(&path, &[WatchSortKey::State, WatchSortKey::Activity]).unwrap();
+
+        let saved = std::fs::read_to_string(&path).unwrap();
+        assert!(saved.contains("# user config"), "{saved}");
+        assert!(saved.contains("theme = \"focus\""), "{saved}");
+        assert!(saved.contains("columns = [\"pane\", \"state\"]"), "{saved}");
+        assert!(saved.contains("sort = [\"state\", \"latest\"]"), "{saved}");
+        let cfg = muxa::config::Config::load_or_default(Some(&path)).unwrap();
+        assert_eq!(
+            cfg.watch.sort,
+            vec![WatchSortKey::State, WatchSortKey::Activity]
+        );
     }
 
     #[test]

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -731,7 +731,7 @@ pub struct WatchConfig {
     /// Stale agents (pane closed) always bucket at the end, regardless of
     /// what's listed here.
     ///
-    /// Default: `["session", "activity"]` — groups by tmux session, then
+    /// Default: `["session", "latest"]` — groups by tmux session, then
     /// floats the most-recently-active agent inside each group to the top.
     pub sort: Vec<WatchSortKey>,
     /// Hide agents that aren't bound to a tmux pane.
@@ -837,7 +837,7 @@ pub enum WatchSortKey {
     /// `last_activity_at` descending — most recently updated first. The
     /// useful default to surface "what's moving right now" without
     /// scrolling.
-    #[serde(alias = "act")]
+    #[serde(rename = "latest", alias = "activity", alias = "act")]
     Activity,
     /// Semantic agent state priority: error/input/choice rows first, then
     /// working/starting/idle/stopped. This is deliberately operational,
@@ -1118,7 +1118,7 @@ broken = "what"
     fn parses_watch_sort_section() {
         let toml = r#"
 [watch]
-sort = ["activity"]
+sort = ["latest"]
 "#;
         let cfg: Config = toml::from_str(toml).unwrap();
         assert_eq!(cfg.watch.sort, vec![WatchSortKey::Activity]);
@@ -1128,18 +1128,33 @@ sort = ["activity"]
     fn parses_watch_sort_aliases_for_cli_column_names() {
         let toml = r#"
 [watch]
-sort = ["act", "st", "dur", "duration"]
+sort = ["activity", "act", "st", "dur", "duration"]
 "#;
         let cfg: Config = toml::from_str(toml).unwrap();
         assert_eq!(
             cfg.watch.sort,
             vec![
                 WatchSortKey::Activity,
+                WatchSortKey::Activity,
                 WatchSortKey::State,
                 WatchSortKey::SessionTime,
                 WatchSortKey::SessionTime,
             ]
         );
+    }
+
+    #[test]
+    fn serializes_activity_sort_as_latest() {
+        #[derive(Serialize)]
+        struct SortOnly {
+            sort: Vec<WatchSortKey>,
+        }
+
+        let rendered = toml::to_string(&SortOnly {
+            sort: vec![WatchSortKey::Session, WatchSortKey::Activity],
+        })
+        .unwrap();
+        assert_eq!(rendered.trim(), "sort = [\"session\", \"latest\"]");
     }
 
     #[test]

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -55,7 +55,7 @@ compatibility source이자 stats fallback으로 사용됩니다.
 [watch]
 view = "session"
 columns = ["pane", "state", "model", "ctx", "cost", "prompt", "activity"]
-sort = ["session", "activity"]
+sort = ["session", "latest"]
 hide_paneless = true
 
 [watch.widths]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -56,7 +56,7 @@ stats while newer activity ledger intervals are accumulating.
 [watch]
 view = "session"
 columns = ["pane", "state", "model", "ctx", "cost", "prompt", "activity"]
-sort = ["session", "activity"]
+sort = ["session", "latest"]
 hide_paneless = true
 
 [watch.widths]

--- a/docs/WATCH.ko.md
+++ b/docs/WATCH.ko.md
@@ -25,7 +25,7 @@ muxa watch --include-paneless
 | `c` | preview content toggle. |
 | `f` | popup/fullscreen preview toggle. |
 | `?` | 도움말. |
-| `a` | activity 기준 정렬. |
+| `l` / `a` | 최신 activity 기준 정렬. |
 | `d` | session duration 기준 정렬. |
 | `s` | session grouping 정렬. |
 | `t` | attention state 우선 정렬. |
@@ -67,16 +67,16 @@ activity = 5
 
 ```toml
 [watch]
-sort = ["session", "activity"]
-# sort = ["activity"]
+sort = ["session", "latest"]
+# sort = ["latest"]
 # sort = ["session_time"]
-# sort = ["state", "activity"]
+# sort = ["state", "latest"]
 # sort = ["session", "pane"]
 # sort = ["pane_id"]
 ```
 
 기본값은 tmux session으로 묶고, 각 group 안에서 가장 최근 activity가 있는
-agent를 위로 올립니다.
+agent를 위로 올립니다. `activity`와 `act`는 `latest` alias로 계속 동작합니다.
 
 ## Detail Row
 

--- a/docs/WATCH.ko.md
+++ b/docs/WATCH.ko.md
@@ -75,8 +75,11 @@ sort = ["session", "latest"]
 # sort = ["pane_id"]
 ```
 
-기본값은 tmux session으로 묶고, 각 group 안에서 가장 최근 activity가 있는
-agent를 위로 올립니다. `activity`와 `act`는 `latest` alias로 계속 동작합니다.
+런타임 정렬 키는 위 preset과 대응하며, 선택한 preset을 `[watch].sort`에 다시
+저장합니다. `--sort` flag는 런타임 정렬 키를 누르기 전까지 현재 실행에만 적용되는
+override입니다. 기본값은 tmux session으로 묶고, 각 group 안에서 가장 최근
+activity가 있는 agent를 위로 올립니다. `activity`와 `act`는 `latest` alias로
+계속 동작합니다.
 
 ## Detail Row
 

--- a/docs/WATCH.md
+++ b/docs/WATCH.md
@@ -26,7 +26,7 @@ row per pane.
 | `c` | Toggle preview content. |
 | `f` | Toggle popup/fullscreen preview. |
 | `?` | Help. |
-| `a` | Sort by activity. |
+| `l` / `a` | Sort by latest activity. |
 | `d` | Sort by session duration. |
 | `s` | Sort by session grouping. |
 | `t` | Sort attention states first. |
@@ -68,16 +68,17 @@ Available column keys include `pane`, `pane_id`, `state`, `kind`, `model`,
 
 ```toml
 [watch]
-sort = ["session", "activity"]
-# sort = ["activity"]
+sort = ["session", "latest"]
+# sort = ["latest"]
 # sort = ["session_time"]
-# sort = ["state", "activity"]
+# sort = ["state", "latest"]
 # sort = ["session", "pane"]
 # sort = ["pane_id"]
 ```
 
 Runtime sort keys mirror these presets. The default groups by tmux session
-and floats the most recently active agent in each group.
+and floats the most recently active agent in each group. `activity` and `act`
+remain accepted aliases for `latest`.
 
 ## Detail Row
 

--- a/docs/WATCH.md
+++ b/docs/WATCH.md
@@ -76,9 +76,11 @@ sort = ["session", "latest"]
 # sort = ["pane_id"]
 ```
 
-Runtime sort keys mirror these presets. The default groups by tmux session
-and floats the most recently active agent in each group. `activity` and `act`
-remain accepted aliases for `latest`.
+Runtime sort keys mirror these presets and save the selected preset back to
+`[watch].sort`. The `--sort` flag remains a one-shot launch override until
+you press a runtime sort key. The default groups by tmux session and floats
+the most recently active agent in each group. `activity` and `act` remain
+accepted aliases for `latest`.
 
 ## Detail Row
 


### PR DESCRIPTION
Restores the `latest` watch sort preset so `[watch] sort = ["latest"]` configs parse again on the main build.

## Why

`muxad`/`muxa` built from `main` reject `[watch] sort = ["latest"]` with `unknown variant 'latest'` — the preset only exists on the unmerged `change/default-watch-view-session` branch. This lands the two watch-sort commits from that branch onto `main`.

## What

Cherry-picks (off `main`):
- `feat(watch): add latest sort preset` — `latest` is the user-facing name for newest-activity-first sorting (TUI `l`, `--sort latest`; `a`/`activity`/`act` aliases retained). Config: `[watch].sort` accepts `latest` (`#[serde(rename = "latest", alias = "activity", alias = "act")]`).
- `fix(watch): persist runtime sort preset` — runtime sort changes save back to `[watch].sort`.

## Deliberately **not** included

The source branch's third commit, `feat(stats): add row sort option` (a separate `StatsSort` enum for `muxa stats`), is a **parallel duplicate of the already-merged #38** (`muxa stats --sort/--reverse` + TOTAL footer). Pulling it would re-collide the stats-sort API for no gain, so it's dropped — only the watch-sort work is landed here. (`change/default-watch-view-session`'s 4th commit was already merged via #39.)

## Testing

- `cargo test -p muxa-cli -p muxa` — all unit tests pass (incl. every watch snapshot test, unchanged — the cherry-pick layered the `sort` label diff cleanly over `main`'s tightened columns).
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean (rustc 1.96).
- The 8 `tests/e2e.rs` failures in my local sandbox are environmental (no host muxad/tmux); they fail identically on `main` and pass on CI runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
