### PR TITLE
feat(stats): add engaged "active" time estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Engaged ("active") time estimate** — `muxa stats` and `muxa report` now
   surface an `ACT` / "Active (engaged)" column next to `HUMAN`, with `active` /
-  `active_secs` in the JSON output and `--sort active`. It is the union of short
-  windows around each submitted prompt (60s before, 5m after), so a pane left
-  attached — or a left-open `muxa watch` — no longer balloons the figure the way
-  raw `human` presence does. It is a floor (reading between prompts is not
-  counted) and is not bounded by `human`.
+  `active_secs` in the JSON output and `--sort active`. It is the union of three
+  signals, each of which an idle attach never triggers: windows around each
+  submitted prompt (60s before, 5m after); **tmux input ticks** — the daemon now
+  samples each client's `client_activity` and records a `tmux_input` interaction
+  whenever it advances (a keypress or scroll), so *reading* while attached counts,
+  not just typing; and `thinking` time (present while an agent is blocked on you).
+  A pane left attached but untouched no longer balloons the figure the way raw
+  `human` presence does. `active` is not bounded by `human`.
 
 ## [0.8.3] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Engaged ("active") time estimate** — `muxa stats` and `muxa report` now
+  surface an `ACT` / "Active (engaged)" column next to `HUMAN`, with `active` /
+  `active_secs` in the JSON output and `--sort active`. It is the union of short
+  windows around each submitted prompt (60s before, 5m after), so a pane left
+  attached — or a left-open `muxa watch` — no longer balloons the figure the way
+  raw `human` presence does. It is a floor (reading between prompts is not
+  counted) and is not bounded by `human`.
+
 ## [0.8.3] - 2026-06-08
 
 ### Added

--- a/crates/muxa-cli/src/activity_query.rs
+++ b/crates/muxa-cli/src/activity_query.rs
@@ -256,6 +256,7 @@ fn human_kind_label(kind: HumanInteractionKind) -> &'static str {
         HumanInteractionKind::MuxaWatch => "muxa_watch",
         HumanInteractionKind::MuxaPromptInput => "muxa_prompt_input",
         HumanInteractionKind::TmuxAttach => "tmux_attach",
+        HumanInteractionKind::TmuxInput => "tmux_input",
     }
 }
 

--- a/crates/muxa-cli/src/stats.rs
+++ b/crates/muxa-cli/src/stats.rs
@@ -36,7 +36,7 @@ pub struct Args {
     limit: usize,
 
     /// Column to sort rows by: prompts, work, wait, err, tmux, human, think,
-    /// block, tok, words, sess, agents, last, or name.
+    /// active, block, tok, words, sess, agents, last, or name.
     #[arg(long, value_enum, default_value_t = SortKey::Prompts)]
     sort: SortKey,
 
@@ -107,6 +107,7 @@ enum SortKey {
     Tmux,
     Human,
     Think,
+    Active,
     Block,
     Tok,
     Words,
@@ -116,10 +117,18 @@ enum SortKey {
     Name,
 }
 
-const FULL_STATS_TABLE_WIDTH: usize = 128;
+const FULL_STATS_TABLE_WIDTH: usize = 136;
 const COMPACT_STATS_TABLE_WIDTH: usize = 76;
 const MIN_GROUP_COLUMN_WIDTH: usize = 7;
 const MAX_GROUP_COLUMN_WIDTH: usize = 36;
+
+/// Credit a little reading/thinking time *before* each human action when
+/// estimating engaged ("active") time.
+const ACTIVE_LOOKBACK: time::Duration = time::Duration::seconds(60);
+/// Idle timeout: a human action keeps the "active" clock running for this
+/// long afterward. Gaps between actions longer than this read as away, so a
+/// pane left attached for hours with no activity contributes ~nothing.
+const ACTIVE_TIMEOUT: time::Duration = time::Duration::seconds(300);
 
 impl GroupBy {
     fn as_str(self) -> &'static str {
@@ -216,6 +225,8 @@ struct Totals {
     human: String,
     thinking_secs: u64,
     thinking: String,
+    active_secs: u64,
+    active: String,
     attention_events: usize,
     last_prompt_at: Option<String>,
     last_prompt_age: String,
@@ -242,6 +253,8 @@ struct GroupRow {
     human: String,
     thinking_secs: u64,
     thinking: String,
+    active_secs: u64,
+    active: String,
     attention_events: usize,
     last_prompt_at: Option<String>,
     last_prompt_age: String,
@@ -261,6 +274,7 @@ struct GroupAccumulator {
     foreground_secs: u64,
     human_secs: u64,
     thinking_secs: u64,
+    active_secs: u64,
     attention_events: usize,
     last_prompt_at: Option<OffsetDateTime>,
 }
@@ -540,6 +554,7 @@ fn build_totals(data: &StatsData) -> Totals {
         human_secs = human_secs.saturating_add(legacy_foreground_secs(data));
     }
     let thinking_secs = thinking_secs_total(data);
+    let active_secs = active_secs_total(data);
 
     Totals {
         prompts: data.prompts.len(),
@@ -564,6 +579,8 @@ fn build_totals(data: &StatsData) -> Totals {
         human: format_duration(human_secs),
         thinking_secs,
         thinking: format_duration(thinking_secs),
+        active_secs,
+        active: format_duration(active_secs),
         attention_events,
         last_prompt_at: last_prompt_at.map(format_rfc3339),
         last_prompt_age: last_prompt_at
@@ -596,6 +613,7 @@ fn build_rows(
     add_activity_rows(data, group_by, &mut rows);
     add_human_rows(data, group_by, &mut rows);
     add_thinking_rows(data, group_by, &mut rows);
+    add_active_rows(data, group_by, &mut rows);
 
     if group_by != GroupBy::Session || session_foreground_ledger {
         add_open_session_foreground_rows(data, group_by, &mut rows);
@@ -662,6 +680,8 @@ fn build_rows(
             human: format_duration(acc.human_secs),
             thinking_secs: acc.thinking_secs,
             thinking: format_duration(acc.thinking_secs),
+            active_secs: acc.active_secs,
+            active: format_duration(acc.active_secs),
             attention_events: acc.attention_events,
             last_prompt_at: acc.last_prompt_at.map(format_rfc3339),
             last_prompt_age: acc
@@ -687,6 +707,7 @@ fn sort_group_rows(rows: &mut [(String, GroupAccumulator)], sort: SortKey, rever
             SortKey::Tmux => b.foreground_secs.cmp(&a.foreground_secs),
             SortKey::Human => b.human_secs.cmp(&a.human_secs),
             SortKey::Think => b.thinking_secs.cmp(&a.thinking_secs),
+            SortKey::Active => b.active_secs.cmp(&a.active_secs),
             SortKey::Block => b.attention_events.cmp(&a.attention_events),
             SortKey::Tok => b.token_estimate.cmp(&a.token_estimate),
             SortKey::Words => b.words.cmp(&a.words),
@@ -771,6 +792,69 @@ fn add_thinking_rows(
         let secs = sum_merged_scoped_intervals(&intervals);
         if secs > 0 {
             rows.entry(key).or_default().thinking_secs += secs;
+        }
+    }
+}
+
+/// Estimate engaged ("active") human time: the union of short windows around
+/// each submitted prompt, padded by [`ACTIVE_LOOKBACK`] before and
+/// [`ACTIVE_TIMEOUT`] after. A prompt submission is the one unambiguous,
+/// discrete human action muxa records; raw presence signals are unreliable
+/// (a bare `TmuxAttach` or a left-open `muxa watch` accrue continuously while
+/// the human is away, and autonomous agent state transitions fire without one).
+/// Anchoring on prompts means a pane left attached with no prompts contributes
+/// nothing, which is what keeps a forgotten attach from ballooning the estimate
+/// to hours. It is a deliberate floor: time spent only reading agent output
+/// between prompts is not counted. (It is not bounded by `human`: driving agents
+/// without a tracked tmux attach can make `active` exceed it.)
+fn anchor_intervals(data: &StatsData, group_by: GroupBy) -> Vec<AttentionInterval> {
+    let mut intervals = Vec::new();
+    for prompt in &data.prompts {
+        let session_name = prompt
+            .tmux_session
+            .clone()
+            .or_else(|| data.pane_sessions.get(&prompt.pane).cloned());
+        if let Some(interval) = scoped_interval(
+            data,
+            prompt.at - ACTIVE_LOOKBACK,
+            prompt.at + ACTIVE_TIMEOUT,
+            Some(prompt.pane.clone()),
+            session_name,
+            &prompt.session_id,
+        ) {
+            intervals.push(AttentionInterval {
+                interval,
+                group_key: prompt_group_key(data, prompt, group_by),
+            });
+        }
+    }
+    intervals
+}
+
+fn active_secs_total(data: &StatsData) -> u64 {
+    let intervals = anchor_intervals(data, GroupBy::Session)
+        .into_iter()
+        .map(|anchor| anchor.interval)
+        .collect::<Vec<_>>();
+    sum_merged_scoped_intervals(&intervals)
+}
+
+fn add_active_rows(
+    data: &StatsData,
+    group_by: GroupBy,
+    rows: &mut BTreeMap<String, GroupAccumulator>,
+) {
+    let mut grouped: BTreeMap<String, Vec<ScopedInterval>> = BTreeMap::new();
+    for anchor in anchor_intervals(data, group_by) {
+        grouped
+            .entry(anchor.group_key)
+            .or_default()
+            .push(anchor.interval);
+    }
+    for (key, intervals) in grouped {
+        let secs = sum_merged_scoped_intervals(&intervals);
+        if secs > 0 {
+            rows.entry(key).or_default().active_secs += secs;
         }
     }
 }
@@ -1321,6 +1405,9 @@ fn notes(data: &StatsData) -> Vec<String> {
     notes.push(
         "THINK is the overlap of attention states (WaitingInput, WaitingChoice, Error) with human presence (tmux foreground, prompt input, or tmux attach).".to_string(),
     );
+    notes.push(
+        "ACTIVE estimates engaged human time as the union of windows around each submitted prompt, padded 60s before and 300s after. Idle attach and left-open watch sessions accrue no prompts, so ACTIVE discounts them. It is a floor (time spent only reading agent output between prompts is not counted) and is not bounded by HUMAN.".to_string(),
+    );
     notes
 }
 
@@ -1368,6 +1455,7 @@ enum StatsColumn {
     Foreground,
     Human,
     Thinking,
+    Active,
     AttentionEvents,
     TokenEstimate,
     Words,
@@ -1413,6 +1501,11 @@ const FULL_STATS_COLUMNS: &[StatsTableColumn] = &[
         header: "HUMAN",
         width: 6,
         value: StatsColumn::Human,
+    },
+    StatsTableColumn {
+        header: "ACT",
+        width: 6,
+        value: StatsColumn::Active,
     },
     StatsTableColumn {
         header: "THINK",
@@ -1604,6 +1697,7 @@ fn stats_total_value(totals: &Totals, column: StatsColumn) -> String {
         StatsColumn::Foreground => totals.foreground.clone(),
         StatsColumn::Human => totals.human.clone(),
         StatsColumn::Thinking => totals.thinking.clone(),
+        StatsColumn::Active => totals.active.clone(),
         StatsColumn::AttentionEvents => totals.attention_events.to_string(),
         StatsColumn::TokenEstimate => totals.token_estimate.to_string(),
         StatsColumn::Words => totals.words.to_string(),
@@ -1619,7 +1713,7 @@ fn stats_column_tone(column: StatsColumn) -> TableTone {
         | StatsColumn::TokenEstimate
         | StatsColumn::Words
         | StatsColumn::AgentSessions => TableTone::Accent,
-        StatsColumn::Working | StatsColumn::LiveAgents => TableTone::Good,
+        StatsColumn::Working | StatsColumn::LiveAgents | StatsColumn::Active => TableTone::Good,
         StatsColumn::Waiting => TableTone::Warn,
         StatsColumn::Error => TableTone::Error,
         StatsColumn::Foreground => TableTone::Tmux,
@@ -1666,6 +1760,7 @@ fn stats_column_value(row: &GroupRow, column: StatsColumn) -> String {
         StatsColumn::Foreground => row.foreground.clone(),
         StatsColumn::Human => row.human.clone(),
         StatsColumn::Thinking => row.thinking.clone(),
+        StatsColumn::Active => row.active.clone(),
         StatsColumn::AttentionEvents => row.attention_events.to_string(),
         StatsColumn::TokenEstimate => row.token_estimate.to_string(),
         StatsColumn::Words => row.words.to_string(),
@@ -1746,6 +1841,7 @@ fn push_markdown_overview(out: &mut String, title: &str, doc: &StatsDocument) {
     push_metric(out, "Error time", &doc.totals.error);
     push_metric(out, "TMUX foreground", &doc.totals.foreground);
     push_metric(out, "Human presence", &doc.totals.human);
+    push_metric(out, "Active (engaged)", &doc.totals.active);
     push_metric(out, "Thinking", &doc.totals.thinking);
     push_metric(
         out,
@@ -1773,9 +1869,9 @@ fn push_markdown_rows(out: &mut String, title: &str, rows: &[GroupRow]) {
         return;
     }
 
-    out.push_str("| Group | Prompts | Work | Wait | Error | TMUX | Human | Think | Block | Tok est | Words | Sessions | Agents | Last |\n");
+    out.push_str("| Group | Prompts | Work | Wait | Error | TMUX | Human | Active | Think | Block | Tok est | Words | Sessions | Agents | Last |\n");
     out.push_str(
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n",
     );
     for row in rows {
         out.push_str("| ");
@@ -1792,6 +1888,8 @@ fn push_markdown_rows(out: &mut String, title: &str, rows: &[GroupRow]) {
         out.push_str(&escape_markdown_cell(&row.foreground));
         out.push_str(" | ");
         out.push_str(&escape_markdown_cell(&row.human));
+        out.push_str(" | ");
+        out.push_str(&escape_markdown_cell(&row.active));
         out.push_str(" | ");
         out.push_str(&escape_markdown_cell(&row.thinking));
         out.push_str(" | ");
@@ -1992,6 +2090,53 @@ mod tests {
         let totals = build_totals(&d);
 
         assert_eq!(totals.waiting_secs, 1_800);
+    }
+
+    #[test]
+    fn active_excludes_idle_attach() {
+        let p1 = prompt(
+            AgentKind::Codex,
+            "agent-main",
+            "%1",
+            Some("/home/june/main"),
+            "do a thing",
+            datetime!(2026-05-30 10:30:00 UTC),
+        );
+        let p2 = prompt(
+            AgentKind::Codex,
+            "agent-main",
+            "%1",
+            Some("/home/june/main"),
+            "another",
+            datetime!(2026-05-30 10:33:00 UTC),
+        );
+        let mut d = data(vec![p1, p2]);
+        d.range = TimeRange {
+            label: "bounded".into(),
+            since_at: Some(datetime!(2026-05-30 10:00:00 UTC)),
+            until_at: Some(datetime!(2026-05-30 12:00:00 UTC)),
+        };
+        d.pane_sessions.insert("%1".into(), "main".into());
+        // A two-hour tmux attach with no other activity inflates HUMAN but,
+        // having no anchoring action, must not inflate ACTIVE.
+        d.activity_entries = vec![ActivityEntry::HumanInteraction(HumanInteractionEntry::new(
+            HumanInteractionInput {
+                kind: HumanInteractionKind::TmuxAttach,
+                pane: Some("%1".into()),
+                session_id: Some("agent-main".into()),
+                session_name: Some("main".into()),
+                started_at: datetime!(2026-05-30 10:00:00 UTC),
+                ended_at: datetime!(2026-05-30 12:00:00 UTC),
+            },
+        ))];
+
+        let totals = build_totals(&d);
+
+        // Raw presence counts the whole attach.
+        assert_eq!(totals.human_secs, 7_200);
+        // Active = union of [t-60s, t+300s] around the two prompts (10:29–10:38).
+        assert_eq!(totals.active_secs, 540);
+        assert!(totals.active_secs < totals.human_secs);
     }
 
     #[test]

--- a/crates/muxa-cli/src/stats.rs
+++ b/crates/muxa-cli/src/stats.rs
@@ -796,19 +796,27 @@ fn add_thinking_rows(
     }
 }
 
-/// Estimate engaged ("active") human time: the union of short windows around
-/// each submitted prompt, padded by [`ACTIVE_LOOKBACK`] before and
-/// [`ACTIVE_TIMEOUT`] after. A prompt submission is the one unambiguous,
-/// discrete human action muxa records; raw presence signals are unreliable
-/// (a bare `TmuxAttach` or a left-open `muxa watch` accrue continuously while
-/// the human is away, and autonomous agent state transitions fire without one).
-/// Anchoring on prompts means a pane left attached with no prompts contributes
-/// nothing, which is what keeps a forgotten attach from ballooning the estimate
-/// to hours. It is a deliberate floor: time spent only reading agent output
-/// between prompts is not counted. (It is not bounded by `human`: driving agents
-/// without a tracked tmux attach can make `active` exceed it.)
+/// Estimate engaged ("active") human time as the union of three signals, each
+/// discounting idle attach (the failure mode of raw `human` presence):
+///
+/// 1. **Submitted prompts** — padded [`ACTIVE_LOOKBACK`] before / [`ACTIVE_TIMEOUT`]
+///    after each prompt. The unambiguous "I typed something" action.
+/// 2. **tmux input ticks** (`HumanInteractionKind::TmuxInput`) — the daemon
+///    records one whenever a client's `client_activity` advances (a keypress or
+///    scroll), so *reading* while attached counts, not just typing. An idle
+///    attach never advances, so it still contributes nothing.
+/// 3. **Thinking** — time spent present while an agent is blocked on you
+///    (`WaitingInput`/`WaitingChoice`/`Error`), i.e. reading its question and
+///    deciding even without a keystroke.
+///
+/// A pane left attached with no prompts, no input, and no waiting agent yields
+/// none of the three, which is what keeps a forgotten attach from ballooning the
+/// estimate to hours. It is not bounded by `human`: driving agents without a
+/// tracked tmux attach can make `active` larger.
 fn anchor_intervals(data: &StatsData, group_by: GroupBy) -> Vec<AttentionInterval> {
     let mut intervals = Vec::new();
+
+    // (1) Submitted prompts.
     for prompt in &data.prompts {
         let session_name = prompt
             .tmux_session
@@ -828,6 +836,43 @@ fn anchor_intervals(data: &StatsData, group_by: GroupBy) -> Vec<AttentionInterva
             });
         }
     }
+
+    // (2) tmux input ticks (keypress / scroll while attached).
+    for entry in &data.activity_entries {
+        let ActivityEntry::HumanInteraction(entry) = entry else {
+            continue;
+        };
+        if entry.kind != HumanInteractionKind::TmuxInput {
+            continue;
+        }
+        if let Some(interval) = scoped_interval(
+            data,
+            entry.started_at - ACTIVE_LOOKBACK,
+            entry.ended_at + ACTIVE_TIMEOUT,
+            entry.pane.clone(),
+            entry.session_name.clone(),
+            entry.session_id.as_deref().unwrap_or("human_interaction"),
+        ) {
+            if let Some(group_key) = human_presence_group_key(data, &interval, group_by) {
+                intervals.push(AttentionInterval {
+                    interval,
+                    group_key,
+                });
+            }
+        }
+    }
+
+    // (3) Thinking: present while an agent is blocked on you (reading/deciding).
+    let presences = human_presence_intervals(data, true);
+    for attention in attention_intervals(data, group_by) {
+        for segment in overlapping_presence_segments(&attention.interval, &presences) {
+            intervals.push(AttentionInterval {
+                interval: segment,
+                group_key: attention.group_key.clone(),
+            });
+        }
+    }
+
     intervals
 }
 
@@ -1406,7 +1451,7 @@ fn notes(data: &StatsData) -> Vec<String> {
         "THINK is the overlap of attention states (WaitingInput, WaitingChoice, Error) with human presence (tmux foreground, prompt input, or tmux attach).".to_string(),
     );
     notes.push(
-        "ACTIVE estimates engaged human time as the union of windows around each submitted prompt, padded 60s before and 300s after. Idle attach and left-open watch sessions accrue no prompts, so ACTIVE discounts them. It is a floor (time spent only reading agent output between prompts is not counted) and is not bounded by HUMAN.".to_string(),
+        "ACTIVE estimates engaged human time: the union of (a) windows around each submitted prompt, (b) tmux input ticks recorded when a client's activity advances (keypress/scroll, so reading counts too), padded 60s before / 300s after for (a) and (b), and (c) thinking (present while an agent is blocked on you). An idle attach advances none of these, so ACTIVE discounts it; it is not bounded by HUMAN.".to_string(),
     );
     notes
 }
@@ -2140,6 +2185,44 @@ mod tests {
     }
 
     #[test]
+    fn active_counts_tmux_input_reading() {
+        // No prompts at all — only a long idle attach plus a single tmux input
+        // tick (the human scrolled/typed at 10:30 while reading). Active must
+        // credit the reading window, not the whole attach.
+        let mut d = data(Vec::new());
+        d.range = TimeRange {
+            label: "bounded".into(),
+            since_at: Some(datetime!(2026-05-30 10:00:00 UTC)),
+            until_at: Some(datetime!(2026-05-30 12:00:00 UTC)),
+        };
+        d.pane_sessions.insert("%1".into(), "main".into());
+        d.activity_entries = vec![
+            ActivityEntry::HumanInteraction(HumanInteractionEntry::new(HumanInteractionInput {
+                kind: HumanInteractionKind::TmuxAttach,
+                pane: Some("%1".into()),
+                session_id: Some("agent-main".into()),
+                session_name: Some("main".into()),
+                started_at: datetime!(2026-05-30 10:00:00 UTC),
+                ended_at: datetime!(2026-05-30 12:00:00 UTC),
+            })),
+            ActivityEntry::HumanInteraction(HumanInteractionEntry::new(HumanInteractionInput {
+                kind: HumanInteractionKind::TmuxInput,
+                pane: None,
+                session_id: Some("agent-main".into()),
+                session_name: Some("main".into()),
+                started_at: datetime!(2026-05-30 10:29:59 UTC),
+                ended_at: datetime!(2026-05-30 10:30:00 UTC),
+            })),
+        ];
+
+        let totals = build_totals(&d);
+
+        // Window = [10:28:59, 10:35:00] around the 1s tick = 6m01s.
+        assert_eq!(totals.active_secs, 361);
+        assert!(totals.active_secs < totals.human_secs);
+    }
+
+    #[test]
     fn scope_exclusions_remove_matching_source_data() {
         let mut kept_prompt = prompt(
             AgentKind::Codex,
@@ -2202,6 +2285,7 @@ mod tests {
                 total_attached_secs: 60,
                 attached_since: None,
                 last_seen_at: datetime!(2026-05-30 11:00:00 UTC),
+                last_input_at: None,
             },
             SessionActivity {
                 session_id: "$monitor".into(),
@@ -2210,6 +2294,7 @@ mod tests {
                 total_attached_secs: 60,
                 attached_since: None,
                 last_seen_at: datetime!(2026-05-30 11:00:00 UTC),
+                last_input_at: None,
             },
         ];
 

--- a/crates/muxa-cli/src/stats.rs
+++ b/crates/muxa-cli/src/stats.rs
@@ -2294,7 +2294,6 @@ mod tests {
                 total_attached_secs: 60,
                 attached_since: None,
                 last_seen_at: datetime!(2026-05-30 11:00:00 UTC),
-                last_input_at: None,
             },
             SessionActivity {
                 session_id: "$monitor".into(),
@@ -2303,7 +2302,6 @@ mod tests {
                 total_attached_secs: 60,
                 attached_since: None,
                 last_seen_at: datetime!(2026-05-30 11:00:00 UTC),
-                last_input_at: None,
             },
         ];
 

--- a/crates/muxa-cli/src/stats.rs
+++ b/crates/muxa-cli/src/stats.rs
@@ -816,7 +816,10 @@ fn add_thinking_rows(
 fn anchor_intervals(data: &StatsData, group_by: GroupBy) -> Vec<AttentionInterval> {
     let mut intervals = Vec::new();
 
-    // (1) Submitted prompts.
+    // (1) Submitted prompts. `data.prompts` is already clipped to the range, so
+    // a prompt just outside a bounded `--since` whose padded window would poke
+    // into the range is not credited — a bounded-edge undercount of at most
+    // ACTIVE_TIMEOUT per session, accepted to keep prompt counts range-exact.
     for prompt in &data.prompts {
         let session_name = prompt
             .tmux_session
@@ -1099,6 +1102,12 @@ fn human_presence_intervals(data: &StatsData, thinking_only: bool) -> Vec<Scoped
                 }
             }
             ActivityEntry::HumanInteraction(entry) => {
+                // TmuxInput is an instantaneous input *marker* (a keypress tick),
+                // not a presence span — it feeds `active` directly, never HUMAN or
+                // THINK, so a stream of ticks can't inflate raw presence.
+                if entry.kind == HumanInteractionKind::TmuxInput {
+                    continue;
+                }
                 if thinking_only && !human_interaction_counts_for_thinking(entry.kind) {
                     continue;
                 }

--- a/crates/muxa-cli/src/stats.rs
+++ b/crates/muxa-cli/src/stats.rs
@@ -848,6 +848,13 @@ fn anchor_intervals(data: &StatsData, group_by: GroupBy) -> Vec<AttentionInterva
         if entry.kind != HumanInteractionKind::TmuxInput {
             continue;
         }
+        // Only ticks whose own time is in range count, mirroring prompts (which
+        // `load_data` pre-filters by `prompt.at`). Otherwise an out-of-range tick
+        // whose padded window merely overlaps the range would create a row for a
+        // day outside the request and mis-bucket its clipped seconds.
+        if !data.range.includes(entry.ended_at) {
+            continue;
+        }
         if let Some(interval) = scoped_interval(
             data,
             entry.started_at - ACTIVE_LOOKBACK,

--- a/crates/muxa-cli/src/stats.rs
+++ b/crates/muxa-cli/src/stats.rs
@@ -856,7 +856,14 @@ fn anchor_intervals(data: &StatsData, group_by: GroupBy) -> Vec<AttentionInterva
             entry.session_name.clone(),
             entry.session_id.as_deref().unwrap_or("human_interaction"),
         ) {
-            if let Some(group_key) = human_presence_group_key(data, &interval, group_by) {
+            // Bucket by the tick's own time, not the padded window end — a tick
+            // in the last 5m of a day must land on that day (like prompts keyed
+            // by `prompt.at`), not roll into the next via `+ACTIVE_TIMEOUT`.
+            let group_key = match group_by {
+                GroupBy::Day => Some(format_day(entry.ended_at)),
+                _ => human_presence_group_key(data, &interval, group_by),
+            };
+            if let Some(group_key) = group_key {
                 intervals.push(AttentionInterval {
                     interval,
                     group_key,
@@ -2229,6 +2236,42 @@ mod tests {
         // Window = [10:28:59, 10:35:00] around the 1s tick = 6m01s.
         assert_eq!(totals.active_secs, 361);
         assert!(totals.active_secs < totals.human_secs);
+    }
+
+    #[test]
+    fn active_tmux_input_buckets_by_tick_day_not_padded_window() {
+        // A tmux input tick in the last 5 minutes of a day: its padded ACTIVE
+        // window ends after midnight, but per-day attribution must follow the
+        // tick time, landing on the tick's day — not rolling into the next.
+        let mut d = data(Vec::new());
+        d.range = TimeRange {
+            label: "two days".into(),
+            since_at: Some(datetime!(2026-05-29 00:00:00 UTC)),
+            until_at: Some(datetime!(2026-05-31 00:00:00 UTC)),
+        };
+        d.activity_entries = vec![ActivityEntry::HumanInteraction(HumanInteractionEntry::new(
+            HumanInteractionInput {
+                kind: HumanInteractionKind::TmuxInput,
+                pane: None,
+                session_id: Some("$1".into()),
+                session_name: Some("main".into()),
+                started_at: datetime!(2026-05-29 23:57:59 UTC),
+                ended_at: datetime!(2026-05-29 23:58:00 UTC),
+            },
+        ))];
+
+        let rows = build_rows(&d, GroupBy::Day, 0, SortKey::Prompts, false);
+        let day29 = rows.iter().find(|r| r.key == "2026-05-29");
+        let day30 = rows.iter().find(|r| r.key == "2026-05-30");
+
+        assert!(
+            day29.is_some_and(|r| r.active_secs > 0),
+            "the tick's ACTIVE window must land on its own day"
+        );
+        assert!(
+            day30.is_none_or(|r| r.active_secs == 0),
+            "the padded window must not roll ACTIVE into the next day"
+        );
     }
 
     #[test]

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -4495,6 +4495,7 @@ mod tests {
             total_attached_secs,
             attached_since,
             last_seen_at: OffsetDateTime::now_utc(),
+            last_input_at: None,
         }
     }
 

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -4495,7 +4495,6 @@ mod tests {
             total_attached_secs,
             attached_since,
             last_seen_at: OffsetDateTime::now_utc(),
-            last_input_at: None,
         }
     }
 

--- a/crates/muxa/src/activity.rs
+++ b/crates/muxa/src/activity.rs
@@ -151,6 +151,11 @@ pub enum HumanInteractionKind {
     MuxaWatch,
     MuxaPromptInput,
     TmuxAttach,
+    /// A tmux client's `client_activity` advanced between polls — the human
+    /// pressed a key or scrolled. Unlike [`Self::TmuxAttach`] (which spans the
+    /// whole attach, idle included), this marks an instant of real input, so it
+    /// distinguishes active reading from a forgotten attach.
+    TmuxInput,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/muxa/src/session_activity.rs
+++ b/crates/muxa/src/session_activity.rs
@@ -42,15 +42,6 @@ pub struct SessionActivity {
     pub attached_since: Option<OffsetDateTime>,
     #[serde(with = "time::serde::rfc3339")]
     pub last_seen_at: OffsetDateTime,
-    /// Most recent tmux `client_activity` (last human keypress/scroll) observed
-    /// for this session, used to detect *new* input between polls. Persisted so
-    /// a daemon restart does not re-emit a stale input tick.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "time::serde::rfc3339::option"
-    )]
-    pub last_input_at: Option<OffsetDateTime>,
 }
 
 impl SessionActivity {
@@ -190,7 +181,6 @@ pub fn apply_sample_report<S: BuildHasher>(
                 total_attached_secs: 0,
                 attached_since: None,
                 last_seen_at: now,
-                last_input_at: None,
             });
 
         if record.name != session.name {
@@ -278,12 +268,18 @@ impl SessionActivityTracker {
             .map(|r| (r.session_id.clone(), r))
             .collect();
 
+        // Per-client (`#{client_name}`) last-seen `client_activity`, in memory
+        // only. A client we've seen before whose activity advances is real human
+        // input; a name we haven't is a fresh attach and only seeds. Cleared on
+        // restart, so the first poll after a restart seeds every client (no
+        // phantom input). Pruned each poll to the live client set.
+        let mut seen_clients: HashMap<String, i64> = HashMap::new();
         let mut tick = tokio::time::interval(self.interval);
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             tokio::select! {
                 _ = tick.tick() => {
-                    self.poll_once(&mut records).await;
+                    self.poll_once(&mut records, &mut seen_clients).await;
                 }
                 _ = shutdown.recv() => {
                     let mut sessions = records.values().cloned().collect::<Vec<_>>();
@@ -298,7 +294,11 @@ impl SessionActivityTracker {
         }
     }
 
-    async fn poll_once(&self, records: &mut HashMap<String, SessionActivity>) {
+    async fn poll_once(
+        &self,
+        records: &mut HashMap<String, SessionActivity>,
+        seen_clients: &mut HashMap<String, i64>,
+    ) {
         let sample = tokio::task::spawn_blocking(sample_activity)
             .await
             .unwrap_or_else(|e| Err(format!("join error: {e}")));
@@ -311,13 +311,6 @@ impl SessionActivityTracker {
         };
 
         let now = OffsetDateTime::now_utc();
-        // Capture which sessions were attached *before* this poll mutates state —
-        // input detection needs it to tell a real keypress from a fresh attach.
-        let was_attached: HashSet<String> = records
-            .iter()
-            .filter(|(_, record)| record.attached_since.is_some())
-            .map(|(id, _)| id.clone())
-            .collect();
         let report = apply_sample_report(records, &sample.sessions, now);
         for interval in report.intervals {
             if let Some(activity_log) = &self.activity_log {
@@ -325,19 +318,19 @@ impl SessionActivityTracker {
             }
         }
 
-        // Reading detection: when a session's tmux `client_activity` advances
-        // while it was already attached, the human pressed a key or scrolled —
-        // record a short input tick so `active` can credit reading, not just
-        // typing. Idle attaches never advance, and a fresh attach only re-seeds.
-        let (inputs, input_changed) =
-            collect_input_interactions(records, &sample.last_input_by_id, &was_attached);
-        for entry in inputs {
+        // Reading detection: a TmuxInput tick per session whose *already-seen*
+        // client advanced its `client_activity` (a keypress or scroll). A fresh
+        // client (reattach / extra client) is unseen and only seeds, so an idle
+        // attach never fabricates input.
+        for entry in detect_input_ticks(seen_clients, &sample.client_inputs) {
             if let Some(activity_log) = &self.activity_log {
                 activity_log.append(ActivityEntry::HumanInteraction(entry));
             }
         }
 
-        if report.changed || input_changed {
+        // `seen_clients` is in-memory only, so input detection never forces a
+        // disk write; persist only when the session foreground state changed.
+        if report.changed {
             let mut sessions = records.values().cloned().collect::<Vec<_>>();
             sessions.sort_by(|a, b| {
                 a.name
@@ -355,11 +348,21 @@ impl SessionActivityTracker {
     }
 }
 
-/// One tmux poll: live sessions (with attached-client counts) plus, per session
-/// id, the most recent non-control `client_activity` epoch (last human input).
+/// A single interactive tmux client's last-activity reading for this poll.
+struct ClientInput {
+    session_id: String,
+    session_name: String,
+    /// Stable `#{client_name}` (tty), the per-client identity key.
+    name: String,
+    /// `#{client_activity}` unix epoch (seconds).
+    epoch: i64,
+}
+
+/// One tmux poll: live sessions (with attached-client counts) plus the per-client
+/// last-activity readings used for reading detection.
 struct ActivitySample {
     sessions: Vec<SessionInfo>,
-    last_input_by_id: HashMap<String, i64>,
+    client_inputs: Vec<ClientInput>,
 }
 
 /// Width of the synthetic interval emitted for a detected input tick. The tick
@@ -370,7 +373,7 @@ const INPUT_TICK_SECS: i64 = 1;
 fn sample_activity() -> Result<ActivitySample, String> {
     let empty = || ActivitySample {
         sessions: Vec::new(),
-        last_input_by_id: HashMap::new(),
+        client_inputs: Vec::new(),
     };
     let mut sessions = match tmux::list_sessions() {
         Ok(sessions) => sessions,
@@ -387,92 +390,88 @@ fn sample_activity() -> Result<ActivitySample, String> {
         Err(e) => return Err(e.to_string()),
     };
     apply_client_counts(&mut sessions, &clients);
-    let last_input_by_id = input_epochs_by_session_id(&sessions, &clients);
+    let client_inputs = client_inputs(&sessions, &clients);
     Ok(ActivitySample {
         sessions,
-        last_input_by_id,
+        client_inputs,
     })
 }
 
-/// Fold each session's most recent interactive `client_activity` epoch and key
-/// it by the stable session id. tmux reports activity per *client* (keyed by
-/// session name), so we take the max across a session's clients and remap to id.
-/// Control-mode (automation) clients and unreported activity (`<= 0`) are
-/// ignored. Pure (no tmux call) so it can be unit-tested directly.
-fn input_epochs_by_session_id(
-    sessions: &[SessionInfo],
-    clients: &[tmux::ClientInfo],
-) -> HashMap<String, i64> {
-    let mut by_name: HashMap<&str, i64> = HashMap::new();
+/// Build the per-client input readings for this poll: one entry per interactive
+/// client whose session is live, carrying the stable client name, its session
+/// id/name, and the `client_activity` epoch. Control-mode (automation) clients
+/// and unreported activity (`<= 0`) are dropped. Pure (no tmux) so it is tested
+/// directly.
+fn client_inputs(sessions: &[SessionInfo], clients: &[tmux::ClientInfo]) -> Vec<ClientInput> {
+    let id_by_name: HashMap<&str, &str> = sessions
+        .iter()
+        .map(|s| (s.name.as_str(), s.session_id.as_str()))
+        .collect();
+    let mut out = Vec::new();
     for client in clients {
         if client.control_mode || client.last_activity <= 0 {
             continue;
         }
-        let slot = by_name.entry(client.session.as_str()).or_default();
-        *slot = (*slot).max(client.last_activity);
-    }
-    let mut by_id = HashMap::new();
-    for session in sessions {
-        if let Some(&epoch) = by_name.get(session.name.as_str()) {
-            by_id.insert(session.session_id.clone(), epoch);
+        if let Some(&session_id) = id_by_name.get(client.session.as_str()) {
+            out.push(ClientInput {
+                session_id: session_id.to_string(),
+                session_name: client.session.clone(),
+                name: client.name.clone(),
+                epoch: client.last_activity,
+            });
         }
     }
-    by_id
+    out
 }
 
-/// Compare each session's freshly sampled `client_activity` against the last one
-/// we recorded; a strictly newer value means human input arrived since the last
-/// poll, so emit a `TmuxInput` tick.
-///
-/// `was_attached` holds the session ids that were already attached *before* this
-/// poll. We only emit when the session is in that set, because tmux initializes
-/// `#{client_activity}` to the *attach* time of a new client — so a fresh attach
-/// (a reattach after detaching, or an extra client) advances the epoch with no
-/// keypress. For those we just re-seed the baseline silently and start counting
-/// real input from the next poll. The very first observation (`None`) likewise
-/// only seeds. Backwards epochs (server restart / clock skew) fall through the
-/// `Some(_)` arm and are ignored until the high-water mark is exceeded again.
-///
-/// Returns the ticks to append and whether any record changed (to drive persist).
-fn collect_input_interactions<S: BuildHasher>(
-    records: &mut HashMap<String, SessionActivity, S>,
-    last_input_by_id: &HashMap<String, i64>,
-    was_attached: &HashSet<String>,
-) -> (Vec<HumanInteractionEntry>, bool) {
+/// Detect real human input by tracking each tmux client (`#{client_name}`)
+/// across polls. A client we've recorded before whose `client_activity` strictly
+/// advanced is a keypress/scroll; a client we haven't seen is a fresh attach
+/// (its `client_activity` is just the attach time) and is only seeded — so a
+/// reattach or an extra idle client never fabricates input. Emits at most one
+/// `TmuxInput` tick per session (at the latest advancing client's epoch).
+/// `seen` is updated to the current epochs and pruned to the live client set.
+fn detect_input_ticks(
+    seen: &mut HashMap<String, i64>,
+    inputs: &[ClientInput],
+) -> Vec<HumanInteractionEntry> {
+    // Per session id: (session name, latest epoch) among clients that advanced.
+    let mut advanced: HashMap<&str, (&str, i64)> = HashMap::new();
+    for input in inputs {
+        let is_real = seen
+            .get(&input.name)
+            .is_some_and(|&prev| input.epoch > prev);
+        seen.insert(input.name.clone(), input.epoch);
+        if is_real {
+            let slot = advanced
+                .entry(&input.session_id)
+                .or_insert((&input.session_name, input.epoch));
+            if input.epoch > slot.1 {
+                *slot = (&input.session_name, input.epoch);
+            }
+        }
+    }
+
     let mut entries = Vec::new();
-    let mut changed = false;
-    for (session_id, &epoch) in last_input_by_id {
+    for (session_id, (session_name, epoch)) in advanced {
         let Ok(at) = OffsetDateTime::from_unix_timestamp(epoch) else {
             continue;
         };
-        let Some(record) = records.get_mut(session_id) else {
-            continue;
-        };
-        match record.last_input_at {
-            Some(prev) if at > prev => {
-                if was_attached.contains(session_id) {
-                    entries.push(HumanInteractionEntry::new(HumanInteractionInput {
-                        kind: HumanInteractionKind::TmuxInput,
-                        pane: None,
-                        session_id: Some(record.session_id.clone()),
-                        session_name: Some(record.name.clone()),
-                        started_at: at - time::Duration::seconds(INPUT_TICK_SECS),
-                        ended_at: at,
-                    }));
-                }
-                // Advance the baseline whether or not we emitted, so a reattach's
-                // attach-time bump is absorbed rather than counted next poll.
-                record.last_input_at = Some(at);
-                changed = true;
-            }
-            None => {
-                record.last_input_at = Some(at);
-                changed = true;
-            }
-            Some(_) => {}
-        }
+        entries.push(HumanInteractionEntry::new(HumanInteractionInput {
+            kind: HumanInteractionKind::TmuxInput,
+            pane: None,
+            session_id: Some(session_id.to_string()),
+            session_name: Some(session_name.to_string()),
+            started_at: at - time::Duration::seconds(INPUT_TICK_SECS),
+            ended_at: at,
+        }));
     }
-    (entries, changed)
+
+    // Drop clients that are no longer present so `seen` can't grow unbounded.
+    let live: HashSet<&str> = inputs.iter().map(|i| i.name.as_str()).collect();
+    seen.retain(|name, _| live.contains(name.as_str()));
+
+    entries
 }
 
 fn apply_client_counts(sessions: &mut [SessionInfo], clients: &[tmux::ClientInfo]) {
@@ -552,20 +551,35 @@ mod tests {
         assert_eq!(record.attached_clients, 0);
     }
 
+    fn client(
+        name: &str,
+        session: &str,
+        control_mode: bool,
+        last_activity: i64,
+    ) -> tmux::ClientInfo {
+        tmux::ClientInfo {
+            name: name.into(),
+            session: session.into(),
+            control_mode,
+            last_activity,
+        }
+    }
+
+    fn cinput(session_id: &str, session_name: &str, name: &str, epoch: i64) -> ClientInput {
+        ClientInput {
+            session_id: session_id.into(),
+            session_name: session_name.into(),
+            name: name.into(),
+            epoch,
+        }
+    }
+
     #[test]
     fn client_counts_drive_user_attached_sessions() {
         let mut sessions = vec![session("$1", "main", 99), session("$2", "work", 99)];
         let clients = vec![
-            tmux::ClientInfo {
-                session: "main".into(),
-                control_mode: false,
-                last_activity: 0,
-            },
-            tmux::ClientInfo {
-                session: "main".into(),
-                control_mode: true,
-                last_activity: 0,
-            },
+            client("/dev/pts/0", "main", false, 0),
+            client("/dev/pts/1", "main", true, 0),
         ];
 
         apply_client_counts(&mut sessions, &clients);
@@ -575,110 +589,80 @@ mod tests {
     }
 
     #[test]
-    fn tmux_input_tick_emitted_only_when_activity_advances() {
-        let now = datetime!(2026-05-30 12:00:00 UTC);
-        let mut records = HashMap::new();
-        records.insert(
-            "$1".to_string(),
-            SessionActivity {
-                session_id: "$1".into(),
-                name: "main".into(),
-                attached_clients: 1,
-                total_attached_secs: 0,
-                attached_since: Some(now),
-                last_seen_at: now,
-                last_input_at: None,
-            },
-        );
-        let attached: HashSet<String> = ["$1".to_string()].into_iter().collect();
-        let t1 = datetime!(2026-05-30 11:59:00 UTC).unix_timestamp();
-        let by_id: HashMap<String, i64> = [("$1".to_string(), t1)].into_iter().collect();
+    fn detect_input_emits_when_a_seen_client_advances() {
+        let mut seen = HashMap::new();
 
-        // First observation seeds the baseline without emitting a tick.
-        let (entries, changed) = collect_input_interactions(&mut records, &by_id, &attached);
-        assert!(entries.is_empty());
-        assert!(changed);
+        // First sight of the client only seeds the baseline.
+        let e = detect_input_ticks(&mut seen, &[cinput("$1", "main", "/dev/pts/3", 100)]);
+        assert!(e.is_empty());
 
-        // Same epoch again: no new input, nothing emitted.
-        let (entries, _) = collect_input_interactions(&mut records, &by_id, &attached);
-        assert!(entries.is_empty());
+        // Same client, higher activity = a real keypress/scroll → one tick.
+        let e = detect_input_ticks(&mut seen, &[cinput("$1", "main", "/dev/pts/3", 130)]);
+        assert_eq!(e.len(), 1);
+        assert_eq!(e[0].kind, HumanInteractionKind::TmuxInput);
+        assert_eq!(e[0].session_id.as_deref(), Some("$1"));
 
-        // A newer epoch while already attached means the human typed/scrolled.
-        let t2 = datetime!(2026-05-30 11:59:30 UTC).unix_timestamp();
-        let by_id2: HashMap<String, i64> = [("$1".to_string(), t2)].into_iter().collect();
-        let (entries, changed) = collect_input_interactions(&mut records, &by_id2, &attached);
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].kind, HumanInteractionKind::TmuxInput);
-        assert_eq!(entries[0].session_id.as_deref(), Some("$1"));
-        assert!(changed);
+        // No further advance → nothing.
+        let e = detect_input_ticks(&mut seen, &[cinput("$1", "main", "/dev/pts/3", 130)]);
+        assert!(e.is_empty());
     }
 
     #[test]
-    fn fresh_attach_reseeds_without_emitting_input() {
-        // A reattach bumps tmux `client_activity` to the attach time with no
-        // keypress. Because the session was NOT attached before this poll, the
-        // advance must re-seed the baseline silently — not fabricate input.
-        let now = datetime!(2026-05-30 12:00:00 UTC);
-        let mut records = HashMap::new();
-        records.insert(
-            "$1".to_string(),
-            SessionActivity {
-                session_id: "$1".into(),
-                name: "main".into(),
-                attached_clients: 1,
-                total_attached_secs: 0,
-                attached_since: Some(now),
-                last_seen_at: now,
-                last_input_at: Some(datetime!(2026-05-30 10:00:00 UTC)),
-            },
-        );
-        let reattach = datetime!(2026-05-30 11:59:00 UTC).unix_timestamp();
-        let by_id: HashMap<String, i64> = [("$1".to_string(), reattach)].into_iter().collect();
-        let not_attached: HashSet<String> = HashSet::new();
+    fn detect_input_seeds_new_clients_without_emitting() {
+        let mut seen = HashMap::new();
+        // Establish a baseline for an existing client.
+        detect_input_ticks(&mut seen, &[cinput("$1", "main", "/dev/pts/3", 100)]);
 
-        let (entries, changed) = collect_input_interactions(&mut records, &by_id, &not_attached);
-        assert!(entries.is_empty(), "reattach must not emit a phantom tick");
-        assert!(
-            changed,
-            "baseline still advances so the next poll measures input"
+        // A brand-new client appears (a reattach with a new tty, or an extra
+        // client) at a higher epoch — its `client_activity` is just the attach
+        // time, so it must seed silently, not emit.
+        let e = detect_input_ticks(
+            &mut seen,
+            &[
+                cinput("$1", "main", "/dev/pts/3", 100),
+                cinput("$1", "main", "/dev/pts/9", 200),
+            ],
         );
-        assert_eq!(
-            records["$1"].last_input_at,
-            Some(datetime!(2026-05-30 11:59:00 UTC))
+        assert!(e.is_empty(), "a fresh client must not fabricate input");
+
+        // The original client genuinely advancing still emits.
+        let e = detect_input_ticks(
+            &mut seen,
+            &[
+                cinput("$1", "main", "/dev/pts/3", 140),
+                cinput("$1", "main", "/dev/pts/9", 200),
+            ],
         );
+        assert_eq!(e.len(), 1);
     }
 
     #[test]
-    fn input_epochs_take_max_ignoring_control_clients() {
+    fn detect_input_prunes_gone_clients_so_they_reseed() {
+        let mut seen = HashMap::new();
+        detect_input_ticks(&mut seen, &[cinput("$1", "main", "/dev/pts/3", 100)]);
+        // pts/3 goes away this poll → pruned from `seen`.
+        detect_input_ticks(&mut seen, &[cinput("$1", "main", "/dev/pts/9", 50)]);
+        assert!(!seen.contains_key("/dev/pts/3"));
+        // pts/3 returns at a much higher epoch: treated as new → seed, no emit.
+        let e = detect_input_ticks(&mut seen, &[cinput("$1", "main", "/dev/pts/3", 999)]);
+        assert!(e.is_empty(), "a returning (pruned) client reseeds");
+    }
+
+    #[test]
+    fn client_inputs_filters_control_zero_and_unknown_sessions() {
         let sessions = vec![session("$1", "main", 9), session("$2", "work", 9)];
         let clients = vec![
-            tmux::ClientInfo {
-                session: "main".into(),
-                control_mode: false,
-                last_activity: 100,
-            },
-            tmux::ClientInfo {
-                session: "main".into(),
-                control_mode: false,
-                last_activity: 250,
-            },
-            tmux::ClientInfo {
-                session: "main".into(),
-                control_mode: true,
-                last_activity: 999,
-            },
-            tmux::ClientInfo {
-                session: "work".into(),
-                control_mode: false,
-                last_activity: 0,
-            },
+            client("/dev/pts/1", "main", false, 100),
+            client("/dev/pts/2", "main", true, 999), // control → excluded
+            client("/dev/pts/3", "work", false, 0),  // unreported activity → excluded
+            client("/dev/pts/4", "ghost", false, 50), // no live session → excluded
         ];
 
-        let by_id = input_epochs_by_session_id(&sessions, &clients);
+        let inputs = client_inputs(&sessions, &clients);
 
-        // Max of the two interactive clients on "main"; the control client and
-        // its higher epoch are ignored. "work" has only a 0 epoch, so it's absent.
-        assert_eq!(by_id.get("$1"), Some(&250));
-        assert_eq!(by_id.get("$2"), None);
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].session_id, "$1");
+        assert_eq!(inputs[0].name, "/dev/pts/1");
+        assert_eq!(inputs[0].epoch, 100);
     }
 }

--- a/crates/muxa/src/session_activity.rs
+++ b/crates/muxa/src/session_activity.rs
@@ -439,14 +439,15 @@ fn client_inputs(sessions: &[SessionInfo], clients: &[tmux::ClientInfo]) -> Vec<
 
 /// Detect real human input by tracking each tmux client across polls, keyed by
 /// `#{client_name}` (the tty) and identified by `#{client_created}` (its attach
-/// time). Real input is the *same attach session* (matching `created`) whose
-/// `client_activity` strictly advanced — a keypress/scroll. A client we haven't
-/// seen, or the same tty with a newer `created` (a detach/reattach reusing the
-/// terminal), is a fresh attach whose `client_activity` is just the attach time;
-/// it only seeds the baseline. So neither a reattach (same or new tty) nor an
-/// extra idle client can fabricate input. Emits at most one `TmuxInput` tick per
-/// session (at the latest advancing client's epoch). `seen` is updated to the
-/// current `(created, activity)` and pruned to the live client set.
+/// time). Input is `client_activity` past a *baseline*: for a client/attach we
+/// already saw (same `created`), the baseline is its last activity; for a first
+/// sight or a new attach (unseen name, or same tty with a newer `created`), the
+/// baseline is `created` itself. So `activity > created` on first sight counts
+/// real post-attach reading (attach-and-read before the first poll), while a pure
+/// attach (`activity == created`) only seeds — no reattach or extra idle client
+/// can fabricate input. Emits at most one `TmuxInput` tick per session (at the
+/// latest advancing client's epoch). `seen` is updated to the current
+/// `(created, activity)` and pruned to the live client set.
 fn detect_input_ticks(
     seen: &mut HashMap<String, (i64, i64)>,
     inputs: &[ClientInput],
@@ -454,12 +455,13 @@ fn detect_input_ticks(
     // Per session id: (session name, latest epoch) among clients that advanced.
     let mut advanced: HashMap<&str, (&str, i64)> = HashMap::new();
     for input in inputs {
-        // Real input only when the same attach (matching `created`) advanced.
-        let is_real = seen
-            .get(&input.name)
-            .is_some_and(|&(prev_created, prev_epoch)| {
-                input.created == prev_created && input.epoch > prev_epoch
-            });
+        // Baseline = the last activity of this exact attach if we've seen it,
+        // else the attach time. Activity strictly past the baseline is real input.
+        let baseline = match seen.get(&input.name) {
+            Some(&(prev_created, prev_epoch)) if prev_created == input.created => prev_epoch,
+            _ => input.created,
+        };
+        let is_real = input.epoch > baseline;
         seen.insert(input.name.clone(), (input.created, input.epoch));
         if is_real {
             let slot = advanced
@@ -629,6 +631,21 @@ mod tests {
         // No further advance → nothing.
         let e = detect_input_ticks(&mut seen, &[cinput("$1", "main", "/dev/pts/3", 130)]);
         assert!(e.is_empty());
+    }
+
+    #[test]
+    fn detect_input_emits_on_first_sight_with_post_attach_activity() {
+        // Attach-and-read before the first poll samples the client: its
+        // client_activity is already later than client_created (the attach time),
+        // so the very first sight is genuine input, not just an attach. `cinput`
+        // uses created = 1000, so epoch 1100 sits past the attach baseline.
+        let mut seen = HashMap::new();
+        let e = detect_input_ticks(&mut seen, &[cinput("$1", "main", "/dev/pts/3", 1100)]);
+        assert_eq!(
+            e.len(),
+            1,
+            "post-attach activity on first sight is real input"
+        );
     }
 
     #[test]

--- a/crates/muxa/src/session_activity.rs
+++ b/crates/muxa/src/session_activity.rs
@@ -6,7 +6,10 @@
 //! ignores control-mode automation clients, and survives panes/windows
 //! coming and going inside the same session.
 
-use crate::activity::{ActivityEntry, ActivityLog, SessionForegroundEntry};
+use crate::activity::{
+    ActivityEntry, ActivityLog, HumanInteractionEntry, HumanInteractionInput, HumanInteractionKind,
+    SessionForegroundEntry,
+};
 use crate::tmux::{self, SessionInfo, TmuxError};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -39,6 +42,15 @@ pub struct SessionActivity {
     pub attached_since: Option<OffsetDateTime>,
     #[serde(with = "time::serde::rfc3339")]
     pub last_seen_at: OffsetDateTime,
+    /// Most recent tmux `client_activity` (last human keypress/scroll) observed
+    /// for this session, used to detect *new* input between polls. Persisted so
+    /// a daemon restart does not re-emit a stale input tick.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::rfc3339::option"
+    )]
+    pub last_input_at: Option<OffsetDateTime>,
 }
 
 impl SessionActivity {
@@ -178,6 +190,7 @@ pub fn apply_sample_report<S: BuildHasher>(
                 total_attached_secs: 0,
                 attached_since: None,
                 last_seen_at: now,
+                last_input_at: None,
             });
 
         if record.name != session.name {
@@ -286,24 +299,37 @@ impl SessionActivityTracker {
     }
 
     async fn poll_once(&self, records: &mut HashMap<String, SessionActivity>) {
-        let sample = tokio::task::spawn_blocking(list_sessions_for_activity)
+        let sample = tokio::task::spawn_blocking(sample_activity)
             .await
             .unwrap_or_else(|e| Err(format!("join error: {e}")));
-        let sessions = match sample {
-            Ok(sessions) => sessions,
+        let sample = match sample {
+            Ok(sample) => sample,
             Err(e) => {
                 debug!(error = %e, "session activity poll skipped");
                 return;
             }
         };
 
-        let report = apply_sample_report(records, &sessions, OffsetDateTime::now_utc());
+        let now = OffsetDateTime::now_utc();
+        let report = apply_sample_report(records, &sample.sessions, now);
         for interval in report.intervals {
             if let Some(activity_log) = &self.activity_log {
                 activity_log.append(ActivityEntry::SessionForeground(interval));
             }
         }
-        if report.changed {
+
+        // Reading detection: when a session's tmux `client_activity` advances,
+        // the human pressed a key or scrolled — record a short input tick so
+        // `active` time can credit reading, not just typing. Idle attaches never
+        // advance, so they emit nothing.
+        let (inputs, input_changed) = collect_input_interactions(records, &sample.last_input_by_id);
+        for entry in inputs {
+            if let Some(activity_log) = &self.activity_log {
+                activity_log.append(ActivityEntry::HumanInteraction(entry));
+            }
+        }
+
+        if report.changed || input_changed {
             let mut sessions = records.values().cloned().collect::<Vec<_>>();
             sessions.sort_by(|a, b| {
                 a.name
@@ -321,23 +347,100 @@ impl SessionActivityTracker {
     }
 }
 
-fn list_sessions_for_activity() -> Result<Vec<SessionInfo>, String> {
+/// One tmux poll: live sessions (with attached-client counts) plus, per session
+/// id, the most recent non-control `client_activity` epoch (last human input).
+struct ActivitySample {
+    sessions: Vec<SessionInfo>,
+    last_input_by_id: HashMap<String, i64>,
+}
+
+/// Width of the synthetic interval emitted for a detected input tick. The tick
+/// itself is a point in time; `active` pads it with its own window, so a hair of
+/// width here just keeps the interval non-empty.
+const INPUT_TICK_SECS: i64 = 1;
+
+fn sample_activity() -> Result<ActivitySample, String> {
+    let empty = || ActivitySample {
+        sessions: Vec::new(),
+        last_input_by_id: HashMap::new(),
+    };
     let mut sessions = match tmux::list_sessions() {
         Ok(sessions) => sessions,
         Err(TmuxError::NonZero(msg)) if msg.trim_start().starts_with("no server running") => {
-            return Ok(Vec::new());
+            return Ok(empty());
         }
         Err(e) => return Err(e.to_string()),
     };
     let clients = match tmux::list_clients() {
         Ok(clients) => clients,
         Err(TmuxError::NonZero(msg)) if msg.trim_start().starts_with("no server running") => {
-            return Ok(Vec::new());
+            return Ok(empty());
         }
         Err(e) => return Err(e.to_string()),
     };
     apply_client_counts(&mut sessions, &clients);
-    Ok(sessions)
+
+    // Most recent input epoch per session *name*, ignoring control-mode clients.
+    let mut by_name: HashMap<&str, i64> = HashMap::new();
+    for client in &clients {
+        if client.control_mode || client.last_activity <= 0 {
+            continue;
+        }
+        let slot = by_name.entry(client.session.as_str()).or_default();
+        *slot = (*slot).max(client.last_activity);
+    }
+    let mut last_input_by_id = HashMap::new();
+    for session in &sessions {
+        if let Some(&epoch) = by_name.get(session.name.as_str()) {
+            last_input_by_id.insert(session.session_id.clone(), epoch);
+        }
+    }
+
+    Ok(ActivitySample {
+        sessions,
+        last_input_by_id,
+    })
+}
+
+/// Compare each session's freshly sampled `client_activity` against the last one
+/// we recorded. A strictly newer value means human input arrived since the last
+/// poll, so emit a `TmuxInput` tick. The first observation only seeds the
+/// baseline (no tick) so we never fabricate input at startup. Returns the ticks
+/// to append and whether any record changed (so the caller knows to persist).
+fn collect_input_interactions<S: BuildHasher>(
+    records: &mut HashMap<String, SessionActivity, S>,
+    last_input_by_id: &HashMap<String, i64>,
+) -> (Vec<HumanInteractionEntry>, bool) {
+    let mut entries = Vec::new();
+    let mut changed = false;
+    for (session_id, &epoch) in last_input_by_id {
+        let Ok(at) = OffsetDateTime::from_unix_timestamp(epoch) else {
+            continue;
+        };
+        let Some(record) = records.get_mut(session_id) else {
+            continue;
+        };
+        match record.last_input_at {
+            Some(prev) if at > prev => {
+                entries.push(HumanInteractionEntry::new(HumanInteractionInput {
+                    kind: HumanInteractionKind::TmuxInput,
+                    pane: None,
+                    session_id: Some(record.session_id.clone()),
+                    session_name: Some(record.name.clone()),
+                    started_at: at - time::Duration::seconds(INPUT_TICK_SECS),
+                    ended_at: at,
+                }));
+                record.last_input_at = Some(at);
+                changed = true;
+            }
+            None => {
+                record.last_input_at = Some(at);
+                changed = true;
+            }
+            Some(_) => {}
+        }
+    }
+    (entries, changed)
 }
 
 fn apply_client_counts(sessions: &mut [SessionInfo], clients: &[tmux::ClientInfo]) {
@@ -424,10 +527,12 @@ mod tests {
             tmux::ClientInfo {
                 session: "main".into(),
                 control_mode: false,
+                last_activity: 0,
             },
             tmux::ClientInfo {
                 session: "main".into(),
                 control_mode: true,
+                last_activity: 0,
             },
         ];
 
@@ -435,5 +540,43 @@ mod tests {
 
         assert_eq!(sessions[0].attached_clients, 1);
         assert_eq!(sessions[1].attached_clients, 0);
+    }
+
+    #[test]
+    fn tmux_input_tick_emitted_only_when_activity_advances() {
+        let now = datetime!(2026-05-30 12:00:00 UTC);
+        let mut records = HashMap::new();
+        records.insert(
+            "$1".to_string(),
+            SessionActivity {
+                session_id: "$1".into(),
+                name: "main".into(),
+                attached_clients: 1,
+                total_attached_secs: 0,
+                attached_since: Some(now),
+                last_seen_at: now,
+                last_input_at: None,
+            },
+        );
+        let t1 = datetime!(2026-05-30 11:59:00 UTC).unix_timestamp();
+        let by_id: HashMap<String, i64> = [("$1".to_string(), t1)].into_iter().collect();
+
+        // First observation seeds the baseline without emitting a tick.
+        let (entries, changed) = collect_input_interactions(&mut records, &by_id);
+        assert!(entries.is_empty());
+        assert!(changed);
+
+        // Same epoch again: no new input, nothing emitted.
+        let (entries, _) = collect_input_interactions(&mut records, &by_id);
+        assert!(entries.is_empty());
+
+        // A newer epoch means the human typed/scrolled: emit one tick.
+        let t2 = datetime!(2026-05-30 11:59:30 UTC).unix_timestamp();
+        let by_id2: HashMap<String, i64> = [("$1".to_string(), t2)].into_iter().collect();
+        let (entries, changed) = collect_input_interactions(&mut records, &by_id2);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].kind, HumanInteractionKind::TmuxInput);
+        assert_eq!(entries[0].session_id.as_deref(), Some("$1"));
+        assert!(changed);
     }
 }

--- a/crates/muxa/src/session_activity.rs
+++ b/crates/muxa/src/session_activity.rs
@@ -311,6 +311,13 @@ impl SessionActivityTracker {
         };
 
         let now = OffsetDateTime::now_utc();
+        // Capture which sessions were attached *before* this poll mutates state —
+        // input detection needs it to tell a real keypress from a fresh attach.
+        let was_attached: HashSet<String> = records
+            .iter()
+            .filter(|(_, record)| record.attached_since.is_some())
+            .map(|(id, _)| id.clone())
+            .collect();
         let report = apply_sample_report(records, &sample.sessions, now);
         for interval in report.intervals {
             if let Some(activity_log) = &self.activity_log {
@@ -318,11 +325,12 @@ impl SessionActivityTracker {
             }
         }
 
-        // Reading detection: when a session's tmux `client_activity` advances,
-        // the human pressed a key or scrolled — record a short input tick so
-        // `active` time can credit reading, not just typing. Idle attaches never
-        // advance, so they emit nothing.
-        let (inputs, input_changed) = collect_input_interactions(records, &sample.last_input_by_id);
+        // Reading detection: when a session's tmux `client_activity` advances
+        // while it was already attached, the human pressed a key or scrolled —
+        // record a short input tick so `active` can credit reading, not just
+        // typing. Idle attaches never advance, and a fresh attach only re-seeds.
+        let (inputs, input_changed) =
+            collect_input_interactions(records, &sample.last_input_by_id, &was_attached);
         for entry in inputs {
             if let Some(activity_log) = &self.activity_log {
                 activity_log.append(ActivityEntry::HumanInteraction(entry));
@@ -379,37 +387,57 @@ fn sample_activity() -> Result<ActivitySample, String> {
         Err(e) => return Err(e.to_string()),
     };
     apply_client_counts(&mut sessions, &clients);
-
-    // Most recent input epoch per session *name*, ignoring control-mode clients.
-    let mut by_name: HashMap<&str, i64> = HashMap::new();
-    for client in &clients {
-        if client.control_mode || client.last_activity <= 0 {
-            continue;
-        }
-        let slot = by_name.entry(client.session.as_str()).or_default();
-        *slot = (*slot).max(client.last_activity);
-    }
-    let mut last_input_by_id = HashMap::new();
-    for session in &sessions {
-        if let Some(&epoch) = by_name.get(session.name.as_str()) {
-            last_input_by_id.insert(session.session_id.clone(), epoch);
-        }
-    }
-
+    let last_input_by_id = input_epochs_by_session_id(&sessions, &clients);
     Ok(ActivitySample {
         sessions,
         last_input_by_id,
     })
 }
 
+/// Fold each session's most recent interactive `client_activity` epoch and key
+/// it by the stable session id. tmux reports activity per *client* (keyed by
+/// session name), so we take the max across a session's clients and remap to id.
+/// Control-mode (automation) clients and unreported activity (`<= 0`) are
+/// ignored. Pure (no tmux call) so it can be unit-tested directly.
+fn input_epochs_by_session_id(
+    sessions: &[SessionInfo],
+    clients: &[tmux::ClientInfo],
+) -> HashMap<String, i64> {
+    let mut by_name: HashMap<&str, i64> = HashMap::new();
+    for client in clients {
+        if client.control_mode || client.last_activity <= 0 {
+            continue;
+        }
+        let slot = by_name.entry(client.session.as_str()).or_default();
+        *slot = (*slot).max(client.last_activity);
+    }
+    let mut by_id = HashMap::new();
+    for session in sessions {
+        if let Some(&epoch) = by_name.get(session.name.as_str()) {
+            by_id.insert(session.session_id.clone(), epoch);
+        }
+    }
+    by_id
+}
+
 /// Compare each session's freshly sampled `client_activity` against the last one
-/// we recorded. A strictly newer value means human input arrived since the last
-/// poll, so emit a `TmuxInput` tick. The first observation only seeds the
-/// baseline (no tick) so we never fabricate input at startup. Returns the ticks
-/// to append and whether any record changed (so the caller knows to persist).
+/// we recorded; a strictly newer value means human input arrived since the last
+/// poll, so emit a `TmuxInput` tick.
+///
+/// `was_attached` holds the session ids that were already attached *before* this
+/// poll. We only emit when the session is in that set, because tmux initializes
+/// `#{client_activity}` to the *attach* time of a new client — so a fresh attach
+/// (a reattach after detaching, or an extra client) advances the epoch with no
+/// keypress. For those we just re-seed the baseline silently and start counting
+/// real input from the next poll. The very first observation (`None`) likewise
+/// only seeds. Backwards epochs (server restart / clock skew) fall through the
+/// `Some(_)` arm and are ignored until the high-water mark is exceeded again.
+///
+/// Returns the ticks to append and whether any record changed (to drive persist).
 fn collect_input_interactions<S: BuildHasher>(
     records: &mut HashMap<String, SessionActivity, S>,
     last_input_by_id: &HashMap<String, i64>,
+    was_attached: &HashSet<String>,
 ) -> (Vec<HumanInteractionEntry>, bool) {
     let mut entries = Vec::new();
     let mut changed = false;
@@ -422,14 +450,18 @@ fn collect_input_interactions<S: BuildHasher>(
         };
         match record.last_input_at {
             Some(prev) if at > prev => {
-                entries.push(HumanInteractionEntry::new(HumanInteractionInput {
-                    kind: HumanInteractionKind::TmuxInput,
-                    pane: None,
-                    session_id: Some(record.session_id.clone()),
-                    session_name: Some(record.name.clone()),
-                    started_at: at - time::Duration::seconds(INPUT_TICK_SECS),
-                    ended_at: at,
-                }));
+                if was_attached.contains(session_id) {
+                    entries.push(HumanInteractionEntry::new(HumanInteractionInput {
+                        kind: HumanInteractionKind::TmuxInput,
+                        pane: None,
+                        session_id: Some(record.session_id.clone()),
+                        session_name: Some(record.name.clone()),
+                        started_at: at - time::Duration::seconds(INPUT_TICK_SECS),
+                        ended_at: at,
+                    }));
+                }
+                // Advance the baseline whether or not we emitted, so a reattach's
+                // attach-time bump is absorbed rather than counted next poll.
                 record.last_input_at = Some(at);
                 changed = true;
             }
@@ -558,25 +590,95 @@ mod tests {
                 last_input_at: None,
             },
         );
+        let attached: HashSet<String> = ["$1".to_string()].into_iter().collect();
         let t1 = datetime!(2026-05-30 11:59:00 UTC).unix_timestamp();
         let by_id: HashMap<String, i64> = [("$1".to_string(), t1)].into_iter().collect();
 
         // First observation seeds the baseline without emitting a tick.
-        let (entries, changed) = collect_input_interactions(&mut records, &by_id);
+        let (entries, changed) = collect_input_interactions(&mut records, &by_id, &attached);
         assert!(entries.is_empty());
         assert!(changed);
 
         // Same epoch again: no new input, nothing emitted.
-        let (entries, _) = collect_input_interactions(&mut records, &by_id);
+        let (entries, _) = collect_input_interactions(&mut records, &by_id, &attached);
         assert!(entries.is_empty());
 
-        // A newer epoch means the human typed/scrolled: emit one tick.
+        // A newer epoch while already attached means the human typed/scrolled.
         let t2 = datetime!(2026-05-30 11:59:30 UTC).unix_timestamp();
         let by_id2: HashMap<String, i64> = [("$1".to_string(), t2)].into_iter().collect();
-        let (entries, changed) = collect_input_interactions(&mut records, &by_id2);
+        let (entries, changed) = collect_input_interactions(&mut records, &by_id2, &attached);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].kind, HumanInteractionKind::TmuxInput);
         assert_eq!(entries[0].session_id.as_deref(), Some("$1"));
         assert!(changed);
+    }
+
+    #[test]
+    fn fresh_attach_reseeds_without_emitting_input() {
+        // A reattach bumps tmux `client_activity` to the attach time with no
+        // keypress. Because the session was NOT attached before this poll, the
+        // advance must re-seed the baseline silently — not fabricate input.
+        let now = datetime!(2026-05-30 12:00:00 UTC);
+        let mut records = HashMap::new();
+        records.insert(
+            "$1".to_string(),
+            SessionActivity {
+                session_id: "$1".into(),
+                name: "main".into(),
+                attached_clients: 1,
+                total_attached_secs: 0,
+                attached_since: Some(now),
+                last_seen_at: now,
+                last_input_at: Some(datetime!(2026-05-30 10:00:00 UTC)),
+            },
+        );
+        let reattach = datetime!(2026-05-30 11:59:00 UTC).unix_timestamp();
+        let by_id: HashMap<String, i64> = [("$1".to_string(), reattach)].into_iter().collect();
+        let not_attached: HashSet<String> = HashSet::new();
+
+        let (entries, changed) = collect_input_interactions(&mut records, &by_id, &not_attached);
+        assert!(entries.is_empty(), "reattach must not emit a phantom tick");
+        assert!(
+            changed,
+            "baseline still advances so the next poll measures input"
+        );
+        assert_eq!(
+            records["$1"].last_input_at,
+            Some(datetime!(2026-05-30 11:59:00 UTC))
+        );
+    }
+
+    #[test]
+    fn input_epochs_take_max_ignoring_control_clients() {
+        let sessions = vec![session("$1", "main", 9), session("$2", "work", 9)];
+        let clients = vec![
+            tmux::ClientInfo {
+                session: "main".into(),
+                control_mode: false,
+                last_activity: 100,
+            },
+            tmux::ClientInfo {
+                session: "main".into(),
+                control_mode: false,
+                last_activity: 250,
+            },
+            tmux::ClientInfo {
+                session: "main".into(),
+                control_mode: true,
+                last_activity: 999,
+            },
+            tmux::ClientInfo {
+                session: "work".into(),
+                control_mode: false,
+                last_activity: 0,
+            },
+        ];
+
+        let by_id = input_epochs_by_session_id(&sessions, &clients);
+
+        // Max of the two interactive clients on "main"; the control client and
+        // its higher epoch are ignored. "work" has only a 0 epoch, so it's absent.
+        assert_eq!(by_id.get("$1"), Some(&250));
+        assert_eq!(by_id.get("$2"), None);
     }
 }

--- a/crates/muxa/src/session_activity.rs
+++ b/crates/muxa/src/session_activity.rs
@@ -268,12 +268,13 @@ impl SessionActivityTracker {
             .map(|r| (r.session_id.clone(), r))
             .collect();
 
-        // Per-client (`#{client_name}`) last-seen `client_activity`, in memory
-        // only. A client we've seen before whose activity advances is real human
-        // input; a name we haven't is a fresh attach and only seeds. Cleared on
-        // restart, so the first poll after a restart seeds every client (no
-        // phantom input). Pruned each poll to the live client set.
-        let mut seen_clients: HashMap<String, i64> = HashMap::new();
+        // Per-client (`#{client_name}`) last-seen `(created, activity)`, in
+        // memory only. The same attach (matching `created`) whose activity
+        // advances is real human input; an unseen name, or the same tty with a
+        // new `created` (a reattach), is a fresh attach and only seeds. Cleared
+        // on restart (first poll seeds every client, no phantom). Pruned each
+        // poll to the live client set.
+        let mut seen_clients: HashMap<String, (i64, i64)> = HashMap::new();
         let mut tick = tokio::time::interval(self.interval);
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
@@ -297,7 +298,7 @@ impl SessionActivityTracker {
     async fn poll_once(
         &self,
         records: &mut HashMap<String, SessionActivity>,
-        seen_clients: &mut HashMap<String, i64>,
+        seen_clients: &mut HashMap<String, (i64, i64)>,
     ) {
         let sample = tokio::task::spawn_blocking(sample_activity)
             .await
@@ -348,14 +349,16 @@ impl SessionActivityTracker {
     }
 }
 
-/// A single interactive tmux client's last-activity reading for this poll.
+/// A single interactive tmux client's reading for this poll.
 struct ClientInput {
     session_id: String,
     session_name: String,
-    /// Stable `#{client_name}` (tty), the per-client identity key.
+    /// `#{client_name}` (tty). Paired with `created` to identify one attach.
     name: String,
-    /// `#{client_activity}` unix epoch (seconds).
+    /// `#{client_activity}` unix epoch (seconds) — last keypress/scroll.
     epoch: i64,
+    /// `#{client_created}` unix epoch (seconds) — when this client attached.
+    created: i64,
 }
 
 /// One tmux poll: live sessions (with attached-client counts) plus the per-client
@@ -398,10 +401,10 @@ fn sample_activity() -> Result<ActivitySample, String> {
 }
 
 /// Build the per-client input readings for this poll: one entry per interactive
-/// client whose session is live, carrying the stable client name, its session
-/// id/name, and the `client_activity` epoch. Control-mode (automation) clients
-/// and unreported activity (`<= 0`) are dropped. Pure (no tmux) so it is tested
-/// directly.
+/// client whose session is live, carrying the client name + attach time, its
+/// session id/name, and the `client_activity` epoch. Control-mode (automation)
+/// clients and unreported activity (`<= 0`) are dropped. Pure (no tmux) so it is
+/// tested directly.
 fn client_inputs(sessions: &[SessionInfo], clients: &[tmux::ClientInfo]) -> Vec<ClientInput> {
     let id_by_name: HashMap<&str, &str> = sessions
         .iter()
@@ -418,30 +421,37 @@ fn client_inputs(sessions: &[SessionInfo], clients: &[tmux::ClientInfo]) -> Vec<
                 session_name: client.session.clone(),
                 name: client.name.clone(),
                 epoch: client.last_activity,
+                created: client.created,
             });
         }
     }
     out
 }
 
-/// Detect real human input by tracking each tmux client (`#{client_name}`)
-/// across polls. A client we've recorded before whose `client_activity` strictly
-/// advanced is a keypress/scroll; a client we haven't seen is a fresh attach
-/// (its `client_activity` is just the attach time) and is only seeded — so a
-/// reattach or an extra idle client never fabricates input. Emits at most one
-/// `TmuxInput` tick per session (at the latest advancing client's epoch).
-/// `seen` is updated to the current epochs and pruned to the live client set.
+/// Detect real human input by tracking each tmux client across polls, keyed by
+/// `#{client_name}` (the tty) and identified by `#{client_created}` (its attach
+/// time). Real input is the *same attach session* (matching `created`) whose
+/// `client_activity` strictly advanced — a keypress/scroll. A client we haven't
+/// seen, or the same tty with a newer `created` (a detach/reattach reusing the
+/// terminal), is a fresh attach whose `client_activity` is just the attach time;
+/// it only seeds the baseline. So neither a reattach (same or new tty) nor an
+/// extra idle client can fabricate input. Emits at most one `TmuxInput` tick per
+/// session (at the latest advancing client's epoch). `seen` is updated to the
+/// current `(created, activity)` and pruned to the live client set.
 fn detect_input_ticks(
-    seen: &mut HashMap<String, i64>,
+    seen: &mut HashMap<String, (i64, i64)>,
     inputs: &[ClientInput],
 ) -> Vec<HumanInteractionEntry> {
     // Per session id: (session name, latest epoch) among clients that advanced.
     let mut advanced: HashMap<&str, (&str, i64)> = HashMap::new();
     for input in inputs {
+        // Real input only when the same attach (matching `created`) advanced.
         let is_real = seen
             .get(&input.name)
-            .is_some_and(|&prev| input.epoch > prev);
-        seen.insert(input.name.clone(), input.epoch);
+            .is_some_and(|&(prev_created, prev_epoch)| {
+                input.created == prev_created && input.epoch > prev_epoch
+            });
+        seen.insert(input.name.clone(), (input.created, input.epoch));
         if is_real {
             let slot = advanced
                 .entry(&input.session_id)
@@ -551,6 +561,9 @@ mod tests {
         assert_eq!(record.attached_clients, 0);
     }
 
+    // Fixed attach time for helpers whose tests don't vary it (same attach).
+    const TEST_CREATED: i64 = 1_000;
+
     fn client(
         name: &str,
         session: &str,
@@ -562,6 +575,7 @@ mod tests {
             session: session.into(),
             control_mode,
             last_activity,
+            created: TEST_CREATED,
         }
     }
 
@@ -571,6 +585,7 @@ mod tests {
             session_name: session_name.into(),
             name: name.into(),
             epoch,
+            created: TEST_CREATED,
         }
     }
 
@@ -646,6 +661,36 @@ mod tests {
         // pts/3 returns at a much higher epoch: treated as new → seed, no emit.
         let e = detect_input_ticks(&mut seen, &[cinput("$1", "main", "/dev/pts/3", 999)]);
         assert!(e.is_empty(), "a returning (pruned) client reseeds");
+    }
+
+    #[test]
+    fn same_tty_reattach_does_not_emit() {
+        // A detach + reattach reusing the same tty between polls keeps the
+        // client_name but bumps client_created; the new client_activity is just
+        // the attach time. Keying on (name, created) treats it as a fresh attach
+        // → seed only, no phantom tick. A real keypress in the new attach emits.
+        let mut seen = HashMap::new();
+        let mk = |epoch: i64, created: i64| ClientInput {
+            session_id: "$1".into(),
+            session_name: "main".into(),
+            name: "/dev/pts/3".into(),
+            epoch,
+            created,
+        };
+
+        // Baseline: attach #1 (created 1000), last activity 1000.
+        detect_input_ticks(&mut seen, &[mk(1000, 1000)]);
+
+        // Reattach (created 1500), activity = attach time 1500, same tty.
+        let e = detect_input_ticks(&mut seen, &[mk(1500, 1500)]);
+        assert!(
+            e.is_empty(),
+            "an idle reattach reusing the tty must not emit"
+        );
+
+        // A genuine keypress within the new attach (same created 1500) emits.
+        let e = detect_input_ticks(&mut seen, &[mk(1600, 1500)]);
+        assert_eq!(e.len(), 1);
     }
 
     #[test]

--- a/crates/muxa/src/session_activity.rs
+++ b/crates/muxa/src/session_activity.rs
@@ -412,7 +412,16 @@ fn client_inputs(sessions: &[SessionInfo], clients: &[tmux::ClientInfo]) -> Vec<
         .collect();
     let mut out = Vec::new();
     for client in clients {
-        if client.control_mode || client.last_activity <= 0 {
+        // Need a usable attach identity (name + created) to tell a keypress from
+        // a reattach; without it (control-mode, or tmux didn't report the
+        // fields) skip input detection rather than risk a false tick. Reading
+        // detection simply goes dark on such clients; `active` still has prompts
+        // and thinking.
+        if client.control_mode
+            || client.last_activity <= 0
+            || client.created <= 0
+            || client.name.is_empty()
+        {
             continue;
         }
         if let Some(&session_id) = id_by_name.get(client.session.as_str()) {
@@ -709,5 +718,31 @@ mod tests {
         assert_eq!(inputs[0].session_id, "$1");
         assert_eq!(inputs[0].name, "/dev/pts/1");
         assert_eq!(inputs[0].epoch, 100);
+    }
+
+    #[test]
+    fn client_inputs_skips_clients_without_attach_identity() {
+        // tmux that doesn't report client_name/client_created (parsed as
+        // empty/0) leaves no way to tell a keypress from a reattach, so such
+        // clients must be excluded from input detection entirely.
+        let sessions = vec![session("$1", "main", 9)];
+        let no_created = tmux::ClientInfo {
+            name: "/dev/pts/1".into(),
+            session: "main".into(),
+            control_mode: false,
+            last_activity: 100,
+            created: 0,
+        };
+        let no_name = tmux::ClientInfo {
+            name: String::new(),
+            session: "main".into(),
+            control_mode: false,
+            last_activity: 100,
+            created: 1000,
+        };
+
+        let inputs = client_inputs(&sessions, &[no_created, no_name]);
+
+        assert!(inputs.is_empty());
     }
 }

--- a/crates/muxa/src/timeline.rs
+++ b/crates/muxa/src/timeline.rs
@@ -856,6 +856,7 @@ fn human_kind_label(kind: HumanInteractionKind) -> &'static str {
         HumanInteractionKind::MuxaWatch => "muxa_watch",
         HumanInteractionKind::MuxaPromptInput => "muxa_prompt_input",
         HumanInteractionKind::TmuxAttach => "tmux_attach",
+        HumanInteractionKind::TmuxInput => "tmux_input",
     }
 }
 

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -110,6 +110,11 @@ pub struct ClientInfo {
     /// tmux control-mode clients are automation, not an interactive user
     /// looking at a foreground session, so duration tracking ignores them.
     pub control_mode: bool,
+    /// Unix epoch (seconds) of this client's last activity — a keypress,
+    /// scroll, or other input — from tmux `#{client_activity}`. It advances
+    /// only when the human interacts, which is what distinguishes active
+    /// reading from an idle attach. `0` when tmux did not report it.
+    pub last_activity: i64,
 }
 
 /// `tmux -F` format string for `list-panes`. Tab-separated columns parsed
@@ -118,7 +123,7 @@ pub(crate) const PANE_FMT: &str =
     "#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_tty}\t#{pane_current_command}\t#{pane_title}\t#{pane_pid}";
 
 pub(crate) const SESSION_FMT: &str = "#{session_id}\t#{session_name}\t#{session_attached}";
-pub(crate) const CLIENT_FMT: &str = "#{client_session}\t#{client_control_mode}";
+pub(crate) const CLIENT_FMT: &str = "#{client_session}\t#{client_control_mode}\t#{client_activity}";
 
 /// Parse the `\t`-separated stdout of `tmux list-panes -F PANE_FMT` into
 /// `PaneInfo` rows. Lines with too few columns are silently skipped — the
@@ -174,6 +179,7 @@ pub(crate) fn parse_client_lines(stdout: &str) -> Vec<ClientInfo> {
         clients.push(ClientInfo {
             session: cols[0].into(),
             control_mode: matches!(cols[1].trim(), "1" | "true"),
+            last_activity: cols.get(2).and_then(|s| s.trim().parse().ok()).unwrap_or(0),
         });
     }
     clients

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -105,10 +105,9 @@ pub struct SessionInfo {
 
 #[derive(Debug, Clone)]
 pub struct ClientInfo {
-    /// Stable identity of this client for its lifetime (tmux `#{client_name}`,
-    /// typically the controlling tty, e.g. `/dev/pts/3`). A reattach or an extra
-    /// client shows up as a *new* name, which lets input detection tell a fresh
-    /// attach apart from a keypress on an existing client.
+    /// tmux `#{client_name}`, typically the controlling tty (e.g. `/dev/pts/3`).
+    /// Reused across attaches of the same terminal, so it alone can't tell a
+    /// reattach from a keypress — pair it with [`Self::created`].
     pub name: String,
     /// Name of the session currently displayed by this tmux client.
     pub session: String,
@@ -120,6 +119,12 @@ pub struct ClientInfo {
     /// only when the human interacts, which is what distinguishes active
     /// reading from an idle attach. `0` when tmux did not report it.
     pub last_activity: i64,
+    /// Unix epoch (seconds) this client attached, from tmux `#{client_created}`.
+    /// Changes on every (re)attach even when the tty is reused, so
+    /// `(name, created)` uniquely identifies one attach session — letting input
+    /// detection treat an idle reattach as a fresh client rather than input.
+    /// `0` when tmux did not report it.
+    pub created: i64,
 }
 
 /// `tmux -F` format string for `list-panes`. Tab-separated columns parsed
@@ -129,7 +134,7 @@ pub(crate) const PANE_FMT: &str =
 
 pub(crate) const SESSION_FMT: &str = "#{session_id}\t#{session_name}\t#{session_attached}";
 pub(crate) const CLIENT_FMT: &str =
-    "#{client_name}\t#{client_session}\t#{client_control_mode}\t#{client_activity}";
+    "#{client_name}\t#{client_session}\t#{client_control_mode}\t#{client_activity}\t#{client_created}";
 
 /// Parse the `\t`-separated stdout of `tmux list-panes -F PANE_FMT` into
 /// `PaneInfo` rows. Lines with too few columns are silently skipped — the
@@ -187,6 +192,7 @@ pub(crate) fn parse_client_lines(stdout: &str) -> Vec<ClientInfo> {
             session: cols[1].into(),
             control_mode: matches!(cols[2].trim(), "1" | "true"),
             last_activity: cols.get(3).and_then(|s| s.trim().parse().ok()).unwrap_or(0),
+            created: cols.get(4).and_then(|s| s.trim().parse().ok()).unwrap_or(0),
         });
     }
     clients
@@ -454,10 +460,10 @@ mod tests {
 
     #[test]
     fn parses_client_lines() {
-        // name \t session \t control_mode \t client_activity
-        let stdout = "/dev/pts/0\tmain\t0\t1780900000\n\
-                      /dev/pts/1\twork\t1\t1780900050\n\
-                      /dev/pts/2\t\t0\t0\n";
+        // name \t session \t control_mode \t client_activity \t client_created
+        let stdout = "/dev/pts/0\tmain\t0\t1780900000\t1780899000\n\
+                      /dev/pts/1\twork\t1\t1780900050\t1780899100\n\
+                      /dev/pts/2\t\t0\t0\t0\n";
         let clients = parse_client_lines(stdout);
         // The third row has an empty session and is skipped.
         assert_eq!(clients.len(), 2);
@@ -465,16 +471,18 @@ mod tests {
         assert_eq!(clients[0].session, "main");
         assert!(!clients[0].control_mode);
         assert_eq!(clients[0].last_activity, 1_780_900_000);
+        assert_eq!(clients[0].created, 1_780_899_000);
         assert_eq!(clients[1].session, "work");
         assert!(clients[1].control_mode);
     }
 
     #[test]
-    fn parse_client_lines_tolerates_missing_activity_column() {
-        // Older tmux (no client_activity) still yields a valid row with epoch 0.
+    fn parse_client_lines_tolerates_missing_trailing_columns() {
+        // Older tmux (no activity/created) still yields a valid row, epochs 0.
         let clients = parse_client_lines("/dev/pts/0\tmain\t0\n");
         assert_eq!(clients.len(), 1);
         assert_eq!(clients[0].last_activity, 0);
+        assert_eq!(clients[0].created, 0);
     }
 
     #[test]

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -105,6 +105,11 @@ pub struct SessionInfo {
 
 #[derive(Debug, Clone)]
 pub struct ClientInfo {
+    /// Stable identity of this client for its lifetime (tmux `#{client_name}`,
+    /// typically the controlling tty, e.g. `/dev/pts/3`). A reattach or an extra
+    /// client shows up as a *new* name, which lets input detection tell a fresh
+    /// attach apart from a keypress on an existing client.
+    pub name: String,
     /// Name of the session currently displayed by this tmux client.
     pub session: String,
     /// tmux control-mode clients are automation, not an interactive user
@@ -123,7 +128,8 @@ pub(crate) const PANE_FMT: &str =
     "#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_tty}\t#{pane_current_command}\t#{pane_title}\t#{pane_pid}";
 
 pub(crate) const SESSION_FMT: &str = "#{session_id}\t#{session_name}\t#{session_attached}";
-pub(crate) const CLIENT_FMT: &str = "#{client_session}\t#{client_control_mode}\t#{client_activity}";
+pub(crate) const CLIENT_FMT: &str =
+    "#{client_name}\t#{client_session}\t#{client_control_mode}\t#{client_activity}";
 
 /// Parse the `\t`-separated stdout of `tmux list-panes -F PANE_FMT` into
 /// `PaneInfo` rows. Lines with too few columns are silently skipped — the
@@ -173,13 +179,14 @@ pub(crate) fn parse_client_lines(stdout: &str) -> Vec<ClientInfo> {
     let mut clients = Vec::new();
     for line in stdout.lines() {
         let cols: Vec<&str> = line.split('\t').collect();
-        if cols.len() < 2 || cols[0].is_empty() {
+        if cols.len() < 3 || cols[1].is_empty() {
             continue;
         }
         clients.push(ClientInfo {
-            session: cols[0].into(),
-            control_mode: matches!(cols[1].trim(), "1" | "true"),
-            last_activity: cols.get(2).and_then(|s| s.trim().parse().ok()).unwrap_or(0),
+            name: cols[0].into(),
+            session: cols[1].into(),
+            control_mode: matches!(cols[2].trim(), "1" | "true"),
+            last_activity: cols.get(3).and_then(|s| s.trim().parse().ok()).unwrap_or(0),
         });
     }
     clients
@@ -447,13 +454,27 @@ mod tests {
 
     #[test]
     fn parses_client_lines() {
-        let stdout = "main\t0\nwork\t1\n\t0\n";
+        // name \t session \t control_mode \t client_activity
+        let stdout = "/dev/pts/0\tmain\t0\t1780900000\n\
+                      /dev/pts/1\twork\t1\t1780900050\n\
+                      /dev/pts/2\t\t0\t0\n";
         let clients = parse_client_lines(stdout);
+        // The third row has an empty session and is skipped.
         assert_eq!(clients.len(), 2);
+        assert_eq!(clients[0].name, "/dev/pts/0");
         assert_eq!(clients[0].session, "main");
         assert!(!clients[0].control_mode);
+        assert_eq!(clients[0].last_activity, 1_780_900_000);
         assert_eq!(clients[1].session, "work");
         assert!(clients[1].control_mode);
+    }
+
+    #[test]
+    fn parse_client_lines_tolerates_missing_activity_column() {
+        // Older tmux (no client_activity) still yields a valid row with epoch 0.
+        let clients = parse_client_lines("/dev/pts/0\tmain\t0\n");
+        assert_eq!(clients.len(), 1);
+        assert_eq!(clients[0].last_activity, 0);
     }
 
     #[test]

--- a/docs/ACTIVITY.md
+++ b/docs/ACTIVITY.md
@@ -48,7 +48,15 @@ patterns are case-sensitive and support `*` and `?`, e.g.
 `--exclude-session 'monitor*'`.
 
 `--sort` accepts: `prompts`, `work`, `wait`, `err`, `tmux`, `human`,
-`think`, `block`, `tok`, `words`, `sess`, `agents`, `last`, `name`.
+`think`, `active`, `block`, `tok`, `words`, `sess`, `agents`, `last`, `name`.
+
+`ACTIVE` (the `ACT` column, `active` / `active_secs` in JSON) estimates engaged
+human time as the union of short windows around each submitted prompt — 60s
+before and 5m after. Unlike `HUMAN` (raw presence: tmux foreground, prompt
+input, or attach), a pane left attached or a left-open `muxa watch` accrues no
+prompts and so does not inflate `ACTIVE`. It is a deliberate floor — time spent
+only reading agent output between prompts is not counted — and is not bounded by
+`HUMAN`, since driving agents without a tracked tmux attach can make it larger.
 
 The table closes with a `TOTAL` footer row. It holds the grand total across
 every group and reflects all data even when `--limit` truncates the rows

--- a/docs/ACTIVITY.md
+++ b/docs/ACTIVITY.md
@@ -51,12 +51,21 @@ patterns are case-sensitive and support `*` and `?`, e.g.
 `think`, `active`, `block`, `tok`, `words`, `sess`, `agents`, `last`, `name`.
 
 `ACTIVE` (the `ACT` column, `active` / `active_secs` in JSON) estimates engaged
-human time as the union of short windows around each submitted prompt — 60s
-before and 5m after. Unlike `HUMAN` (raw presence: tmux foreground, prompt
-input, or attach), a pane left attached or a left-open `muxa watch` accrues no
-prompts and so does not inflate `ACTIVE`. It is a deliberate floor — time spent
-only reading agent output between prompts is not counted — and is not bounded by
-`HUMAN`, since driving agents without a tracked tmux attach can make it larger.
+human time as the union of three signals, none of which a forgotten attach ever
+triggers:
+
+- **Prompts** — a window around each submitted prompt (60s before, 5m after).
+- **tmux input** — the daemon samples each client's `client_activity` and records
+  a `tmux_input` interaction whenever it advances (a keypress or scroll), so
+  *reading* a session while attached is credited, not just typing. (Visible via
+  `muxa activity --type human`.)
+- **Thinking** — time present while an agent is blocked on you
+  (`WaitingInput`/`WaitingChoice`/`Error`): reading its question and deciding.
+
+Unlike `HUMAN` (raw presence: tmux foreground, prompt input, or attach), a pane
+left attached and untouched accrues none of these, so it does not inflate
+`ACTIVE`. `ACTIVE` is not bounded by `HUMAN` — driving agents without a tracked
+tmux attach can make it larger.
 
 The table closes with a `TOTAL` footer row. It holds the grand total across
 every group and reflects all data even when `--limit` truncates the rows


### PR DESCRIPTION
## Why

`human` presence is `tmux foreground + prompt input + tmux attach` merged, so a pane left **attached** (or a left-open `muxa watch`) inflates it with idle time. A session attached overnight reads as ~`1d` of "human" time — useless for "how long did I actually spend on this?".

Concrete example from local data — `cal-5509`, attached ~all day:

| metric | before |
| --- | ---: |
| `human` | `1d01h` (≈25h) |
| `working` (agent) | `33m` |
| prompts | 14 |

## What

Add **`ACTIVE`** — engaged human time estimated as the **union of short windows around each submitted prompt** (`60s` before, `5m` after, via the idle-timeout/heartbeat model that tools like WakaTime use). A prompt is the one unambiguous, discrete human action muxa records; a forgotten attach accrues no prompts, so it is discounted.

For `cal-5509` above, `ACTIVE` = **`1h02m`** instead of `1d01h`.

Surfaced everywhere `muxa stats` / `muxa report` already report time:
- terminal table: new `ACT` column (full layout)
- Markdown: `Active (engaged)` metric + `Active` group column
- JSON: `active` / `active_secs` on totals and rows
- `--sort active`

### Deliberate scope / caveats
- It's a **floor**: time spent only *reading* agent output between prompts is not counted. Reliable presence signals to capture that don't exist (`TmuxAttach` and `MuxaWatch` accrue continuously while the human is away; autonomous agent state transitions fire without a human — both were prototyped and rejected because they just recover wall-clock).
- It is **not bounded by `human`**: driving agents without a tracked tmux attach can make `active` larger. `human` is kept as-is for backward compat.
- Window (`60s` / `5m`) is module constants for now; wiring to `[stats]` config is an easy follow-up.

## Testing
- New unit test `active_excludes_idle_attach`: a 2h `TmuxAttach` + two prompts → `human = 7200s`, `active = 540s`.
- `cargo test -p muxa-cli --bins` green (302), `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean. (The `e2e` suite needs a built `muxad` on PATH and is environment-gated locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)