### PR TITLE
fix(stats): keep full stats table within ~128 cols (ACT replaces WORDS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whenever it advances (a keypress or scroll), so *reading* while attached counts,
   not just typing; and `thinking` time (present while an agent is blocked on you).
   A pane left attached but untouched no longer balloons the figure the way raw
-  `human` presence does. `active` is not bounded by `human`.
+  `human` presence does. `active` is not bounded by `human`. In the terminal
+  table `ACT` takes the slot previously held by `WORDS` (kept in `--format json`
+  / `markdown`) so the full layout still fits a ~128-column terminal; the compact
+  layout shows `ACT` too.
 
 ## [0.8.3] - 2026-06-08
 

--- a/crates/muxa-cli/src/stats.rs
+++ b/crates/muxa-cli/src/stats.rs
@@ -117,7 +117,7 @@ enum SortKey {
     Name,
 }
 
-const FULL_STATS_TABLE_WIDTH: usize = 136;
+const FULL_STATS_TABLE_WIDTH: usize = 128;
 const COMPACT_STATS_TABLE_WIDTH: usize = 76;
 const MIN_GROUP_COLUMN_WIDTH: usize = 7;
 const MAX_GROUP_COLUMN_WIDTH: usize = 36;
@@ -1526,7 +1526,6 @@ enum StatsColumn {
     Active,
     AttentionEvents,
     TokenEstimate,
-    Words,
     AgentSessions,
     LiveAgents,
     LastPromptAge,
@@ -1591,11 +1590,6 @@ const FULL_STATS_COLUMNS: &[StatsTableColumn] = &[
         value: StatsColumn::TokenEstimate,
     },
     StatsTableColumn {
-        header: "WORDS",
-        width: 6,
-        value: StatsColumn::Words,
-    },
-    StatsTableColumn {
         header: "SESS",
         width: 4,
         value: StatsColumn::AgentSessions,
@@ -1632,6 +1626,11 @@ const COMPACT_STATS_COLUMNS: &[StatsTableColumn] = &[
         header: "TMUX",
         width: 6,
         value: StatsColumn::Foreground,
+    },
+    StatsTableColumn {
+        header: "ACT",
+        width: 6,
+        value: StatsColumn::Active,
     },
     StatsTableColumn {
         header: "THINK",
@@ -1768,7 +1767,6 @@ fn stats_total_value(totals: &Totals, column: StatsColumn) -> String {
         StatsColumn::Active => totals.active.clone(),
         StatsColumn::AttentionEvents => totals.attention_events.to_string(),
         StatsColumn::TokenEstimate => totals.token_estimate.to_string(),
-        StatsColumn::Words => totals.words.to_string(),
         StatsColumn::AgentSessions => totals.agent_sessions.to_string(),
         StatsColumn::LiveAgents => totals.live_agents.to_string(),
         StatsColumn::LastPromptAge => totals.last_prompt_age.clone(),
@@ -1777,10 +1775,9 @@ fn stats_total_value(totals: &Totals, column: StatsColumn) -> String {
 
 fn stats_column_tone(column: StatsColumn) -> TableTone {
     match column {
-        StatsColumn::Prompts
-        | StatsColumn::TokenEstimate
-        | StatsColumn::Words
-        | StatsColumn::AgentSessions => TableTone::Accent,
+        StatsColumn::Prompts | StatsColumn::TokenEstimate | StatsColumn::AgentSessions => {
+            TableTone::Accent
+        }
         StatsColumn::Working | StatsColumn::LiveAgents | StatsColumn::Active => TableTone::Good,
         StatsColumn::Waiting => TableTone::Warn,
         StatsColumn::Error => TableTone::Error,
@@ -1831,7 +1828,6 @@ fn stats_column_value(row: &GroupRow, column: StatsColumn) -> String {
         StatsColumn::Active => row.active.clone(),
         StatsColumn::AttentionEvents => row.attention_events.to_string(),
         StatsColumn::TokenEstimate => row.token_estimate.to_string(),
-        StatsColumn::Words => row.words.to_string(),
         StatsColumn::AgentSessions => row.agent_sessions.to_string(),
         StatsColumn::LiveAgents => row.live_agents.to_string(),
         StatsColumn::LastPromptAge => row.last_prompt_age.clone(),
@@ -2751,7 +2747,7 @@ mod tests {
         let rendered = render_stats_table(&doc, 140, CliTheme::plain());
 
         assert!(rendered.contains("TOK EST"));
-        assert!(rendered.contains("WORDS"));
+        assert!(rendered.contains("ACT"));
         assert!(rendered.contains("AGENTS"));
         for line in rendered.lines() {
             assert!(


### PR DESCRIPTION
## Why
Shipping the `ACT` column bumped the full-table minimum width 128 → 136, so a ~128-col terminal silently dropped to the **compact** layout — losing `HUMAN` and not even showing `ACT` (only the ACTIVE note showed). Reported after upgrading locally.

## Fix
- Drop the redundant `WORDS` column from the terminal table (`TOK EST` already conveys prompt size); it stays in `--format json` / `markdown`. `ACT` takes its slot, so the full table is the **same width as before** (threshold back to 128) and now shows both `HUMAN` and `ACT` at ~128 cols.
- Add `ACT` to the compact layout for narrower terminals.

## Verify
- width 128 → full: `… TMUX HUMAN ACT THINK BLOCK TOK EST SESS AGENTS LAST`
- width 120 → compact: `PRM WORK WAIT TMUX ACT THINK LAST`
- `cargo test -p muxa-cli` green, clippy `-D warnings` clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)