### PR TITLE
feat(ui): add [ui] icons = unicode|ascii glyph toggle

### DIFF
--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -19,7 +19,7 @@ use comfy_table::{Cell, ColumnConstraint, ContentArrangement, Table, Width};
 use muxa::adapters::{
     claude, run_hook, ClaudeAdapter, CodexAdapter, GeminiAdapter, OpencodeAdapter,
 };
-use muxa::config::{WatchConfig, WatchSortKey, WatchTheme};
+use muxa::config::{IconSet, WatchConfig, WatchSortKey, WatchTheme};
 use muxa::ipc::Client;
 use muxa::state::Agent;
 use muxa::{
@@ -261,6 +261,7 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let config_path = args.config.clone().or_else(paths::default_config_file);
     let cfg = Config::load_or_default(config_path.as_deref()).context("loading config")?;
+    set_icon_set(cfg.ui.icons);
     let socket = args
         .socket
         .or_else(|| cfg.socket.clone())
@@ -1053,7 +1054,30 @@ pub(crate) fn truncate_cell(value: &str, max_chars: usize) -> String {
     out
 }
 
+/// Process-wide glyph set, recorded once at startup from `[ui] icons`.
+///
+/// Mirrors `use_colors()` as a global display predicate so the pure
+/// `state_icon` / `state_marker` helpers don't need a config parameter
+/// threaded through every call site. Unset (e.g. in unit tests) defaults
+/// to `Unicode`, preserving prior behavior.
+static ICON_SET: std::sync::OnceLock<IconSet> = std::sync::OnceLock::new();
+
+pub(crate) fn set_icon_set(set: IconSet) {
+    let _ = ICON_SET.set(set);
+}
+
+pub(crate) fn icon_set() -> IconSet {
+    ICON_SET.get().copied().unwrap_or_default()
+}
+
 pub(crate) fn state_icon(state: AgentState) -> &'static str {
+    match icon_set() {
+        IconSet::Unicode => state_icon_unicode(state),
+        IconSet::Ascii => state_icon_ascii(state),
+    }
+}
+
+fn state_icon_unicode(state: AgentState) -> &'static str {
     match state {
         AgentState::Working => "●",
         AgentState::Idle => "○",
@@ -1062,6 +1086,18 @@ pub(crate) fn state_icon(state: AgentState) -> &'static str {
         AgentState::Error => "■",
         AgentState::Stopped => "×",
         AgentState::Starting => "◌",
+    }
+}
+
+fn state_icon_ascii(state: AgentState) -> &'static str {
+    match state {
+        AgentState::Working => "*",
+        AgentState::Idle => "o",
+        AgentState::WaitingInput => ">",
+        AgentState::WaitingChoice => "?",
+        AgentState::Error => "!",
+        AgentState::Stopped => "x",
+        AgentState::Starting => "~",
     }
 }
 
@@ -1393,18 +1429,42 @@ mod tests {
         }
     }
 
+    const ALL_STATES: [AgentState; 7] = [
+        AgentState::Working,
+        AgentState::WaitingInput,
+        AgentState::WaitingChoice,
+        AgentState::Error,
+        AgentState::Idle,
+        AgentState::Starting,
+        AgentState::Stopped,
+    ];
+
     #[test]
     fn status_line_icons_are_single_cell() {
-        for state in [
-            AgentState::Working,
-            AgentState::WaitingInput,
-            AgentState::WaitingChoice,
-            AgentState::Error,
-            AgentState::Idle,
-            AgentState::Starting,
-            AgentState::Stopped,
-        ] {
+        for state in ALL_STATES {
             assert_eq!(UnicodeWidthStr::width(state_icon(state)), 1);
+        }
+    }
+
+    #[test]
+    fn icon_sets_are_single_cell_and_distinct() {
+        // Both glyph sets must stay one cell wide and unambiguous so the
+        // [ui] icons toggle never breaks column alignment or readability.
+        for build in [state_icon_unicode, state_icon_ascii] {
+            let mut seen = std::collections::HashSet::new();
+            for state in ALL_STATES {
+                let glyph = build(state);
+                assert_eq!(
+                    UnicodeWidthStr::width(glyph),
+                    1,
+                    "{glyph:?} not single-cell"
+                );
+                assert!(seen.insert(glyph), "duplicate glyph {glyph:?}");
+            }
+        }
+        // The ascii set must be pure ASCII to survive font-less terminals.
+        for state in ALL_STATES {
+            assert!(state_icon_ascii(state).is_ascii());
         }
     }
 

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -33,7 +33,7 @@ use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
-use muxa::config::{WatchConfig, WatchSortKey, WatchTheme, WatchView, WidthSpec};
+use muxa::config::{IconSet, WatchConfig, WatchSortKey, WatchTheme, WatchView, WidthSpec};
 use muxa::event::RateLimitScope;
 use muxa::ipc::{Client, RuntimeError};
 use muxa::session_activity::SessionActivity;
@@ -1089,7 +1089,14 @@ pub(crate) fn help_overlay_text() -> Vec<&'static str> {
         "  t              sort by state (ST)",
         "",
         "State markers",
-        "  ● working  ▶ input  ◆ choice  ■ error  ○ idle  ◌ starting  × stopped",
+        match crate::icon_set() {
+            IconSet::Unicode => {
+                "  ● working  ▶ input  ◆ choice  ■ error  ○ idle  ◌ starting  × stopped"
+            }
+            IconSet::Ascii => {
+                "  * working  > input  ? choice  ! error  o idle  ~ starting  x stopped"
+            }
+        },
         "",
         "Quick actions (act on selected row)",
         "  c              copy last prompt to clipboard",
@@ -2144,16 +2151,9 @@ fn session_label(s: &SessionRow, theme: WatchThemeSpec) -> Text<'static> {
 }
 
 fn state_marker(state: AgentState, theme: WatchThemeSpec) -> (&'static str, Style) {
-    let symbol = match state {
-        AgentState::Working => "●",
-        AgentState::WaitingInput => "▶",
-        AgentState::WaitingChoice => "◆",
-        AgentState::Error => "■",
-        AgentState::Idle => "○",
-        AgentState::Starting => "◌",
-        AgentState::Stopped => "×",
-    };
-    (symbol, theme.state_style(state))
+    // Share the one glyph source of truth with `muxa status`/`status-line`
+    // so the `[ui] icons` toggle (unicode|ascii) applies everywhere.
+    (crate::state_icon(state), theme.state_style(state))
 }
 
 fn session_time_text(s: &SessionRow, now: OffsetDateTime) -> Text<'static> {

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -149,14 +149,34 @@ fn default_active_timeout_secs() -> u64 {
 pub struct UiConfig {
     /// Visual preset used by table output and, unless overridden, `muxa watch`.
     pub theme: WatchTheme,
+    /// Glyph set for agent-state icons across `status`, `status-line`,
+    /// `attend`, and `watch`. Defaults to the Unicode geometric glyphs;
+    /// set `ascii` for terminals whose font lacks them (or substitutes a
+    /// mismatched-size fallback font).
+    pub icons: IconSet,
 }
 
 impl Default for UiConfig {
     fn default() -> Self {
         Self {
             theme: WatchTheme::Classic,
+            icons: IconSet::Unicode,
         }
     }
+}
+
+/// Glyph set for agent-state icons in human-facing terminal output.
+///
+/// `unicode` uses the basic Geometric Shapes glyphs (`●▶◆■○◌×`), which are
+/// present in virtually every monospace font. `ascii` falls back to single
+/// `[char]` markers for terminals whose primary font lacks those codepoints
+/// and would otherwise borrow a mismatched-size glyph from a fallback font.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IconSet {
+    #[default]
+    Unicode,
+    Ascii,
 }
 
 /// `[sinks]` config — opt-in fan-out to external systems.

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -69,6 +69,26 @@ template = "{last_response || last_prompt || last_notification}"
 
 TUI 동작, column, sort, keybinding은 [WATCH.ko.md](WATCH.ko.md)에 있습니다.
 
+## UI
+
+```toml
+[ui]
+theme = "classic"
+icons = "unicode"
+```
+
+사람이 보는 터미널 출력(`status`, `status-line`, `attend`, `watch`)의 공통
+시각 기본값입니다.
+
+- `theme` — 시각 프리셋: `classic`, `oh-my-muxa`, `focus`, `ops`, 또는
+  모노크롬 프리셋. 한 번만 적용하려면 `--theme` 플래그로 덮어씁니다.
+- `icons` — agent 상태 글리프 세트:
+  - `unicode` (기본) — Geometric Shapes 글리프(`●` working, `▶` input,
+    `◆` choice, `■` error, `○` idle, `◌` starting, `×` stopped).
+  - `ascii` — 단일 문자 폴백(`*` working, `>` input, `?` choice, `!` error,
+    `o` idle, `~` starting, `x` stopped). 기본 폰트에 유니코드 글리프가 없거나
+    크기가 다른 폴백 폰트로 대체되는 터미널을 위한 옵션.
+
 ## Reconciler
 
 ```toml

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -70,6 +70,27 @@ template = "{last_response || last_prompt || last_notification}"
 
 See [WATCH.md](WATCH.md) for TUI behavior, columns, sort, and keybindings.
 
+## UI
+
+```toml
+[ui]
+theme = "classic"
+icons = "unicode"
+```
+
+Shared visual defaults for human-facing terminal output (`status`,
+`status-line`, `attend`, and `watch`).
+
+- `theme` — visual preset: `classic`, `oh-my-muxa`, `focus`, `ops`, or a
+  monochrome preset. A one-shot `--theme` flag overrides it per run.
+- `icons` — agent-state glyph set:
+  - `unicode` (default) — Geometric Shapes glyphs (`●` working, `▶` input,
+    `◆` choice, `■` error, `○` idle, `◌` starting, `×` stopped).
+  - `ascii` — single-character fallbacks (`*` working, `>` input, `?`
+    choice, `!` error, `o` idle, `~` starting, `x` stopped) for terminals
+    whose font lacks the Unicode glyphs or substitutes a mismatched-size
+    fallback font for them.
+
 ## Reconciler
 
 ```toml


### PR DESCRIPTION
## Why

Agent-state glyphs use the basic Geometric Shapes block (`●▶◆■○◌×`), which renders consistently in virtually every monospace font. But some terminals lack those codepoints and either show tofu (□) or silently borrow a **mismatched-size fallback font** — the same class of issue that made `◐` look oversized (fixed in `336135f`).

Following the **lazygit `nerdFontsVersion` / k9s `noIcons`** pattern, this adds an opt-in ASCII glyph set as the robustness layer ("layer 2") for terminals whose font can't render the Unicode set.

## What

- **New config `[ui] icons`** (default `unicode`). `ascii` maps each state to a single ASCII char:

  | state | unicode | ascii |
  |-------|:-:|:-:|
  | working | `●` | `*` |
  | input | `▶` | `>` |
  | choice | `◆` | `?` |
  | error | `■` | `!` |
  | idle | `○` | `o` |
  | starting | `◌` | `~` |
  | stopped | `×` | `x` |

- Glyph selection is recorded **once at startup** in a process-global (mirrors the existing `use_colors()` display predicate), so the pure `state_icon` / `state_marker` helpers stay parameter-free — no threading config through every call site.
- `state_marker` (watch TUI) now **delegates to `state_icon`**, unifying the one glyph source of truth across `status`, `status-line`, `attend`, and `watch`.
- The `watch` help-overlay legend follows the active set.
- **Webhook notifications keep Unicode** — they render in external apps (phone/Slack) where terminal font fallback doesn't apply.

## Tests / verification

- New test asserts **both** glyph sets are single-cell and mutually distinct; ascii set is pure-ASCII.
- Full suite green (`muxa-cli` + `muxa` unit + snapshot + e2e), `fmt` + `clippy` clean.
- Smoke-tested live against the daemon:
  - `status-line` → `* muxa:0 claude_code` (ascii) vs `● muxa:0 claude_code` (unicode)
  - invalid value (`icons = "emoji"`) is rejected at config load.
- Docs updated: `docs/CONFIGURATION.md` + `docs/CONFIGURATION.ko.md` (new `## UI` section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)