### PR TITLE
feat(stats): render report as tables; add --json/--markdown to stats & report

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -85,7 +85,7 @@ muxa watch
 | `muxa status-line [--pane %N]` | tmux status-line 출력. |
 | `muxa recap [--pane %N]` | 보관된 disk history에서 최근 prompt 조회. |
 | `muxa stats --since today` | day/project/agent/session 단위 summary. |
-| `muxa report --since week` | Markdown stats report. |
+| `muxa report --since week` | day/project/agent/session 모든 breakdown을 테이블로 표시 (`--json` / `--markdown`로 export). |
 | `muxa timeline --since today` | session별로 묶은 interactive timeline. `--session main`, `--agent codex`로 필터링하고 `--sort waiting` 정렬이나 `--view heatmap`을 사용할 수 있음. |
 | `muxa activity --type agent\|tmux\|human` | raw activity ledger interval 조회. |
 | `muxa sync` | tmux pane scan으로 registry backfill. |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ rollback details, see [docs/INSTALL.md](docs/INSTALL.md).
 | `muxa status-line [--pane %N]` | tmux status-line output. |
 | `muxa recap [--pane %N]` | Recent prompts from retained disk history. |
 | `muxa stats --since today` | Summary table; group by day/project/agent/session. |
-| `muxa report --since week` | Markdown stats report. |
+| `muxa report --since week` | All breakdowns (day/project/agent/session) as tables; add `--json` or `--markdown` to export. |
 | `muxa timeline --since today` | Interactive session-grouped timeline; filter with `--session main` / `--agent codex`, sort with `--sort waiting`, or use `--view heatmap`. |
 | `muxa activity --type agent\|tmux\|human` | Raw activity ledger intervals. |
 | `muxa sync` | Backfill the registry by scanning tmux panes. |

--- a/crates/muxa-cli/src/stats.rs
+++ b/crates/muxa-cli/src/stats.rs
@@ -18,6 +18,8 @@ use crate::time_range::TimeRange;
 use crate::{terminal_width, truncate_cell, use_colors};
 
 #[derive(Debug, clap::Args)]
+// CLI flags are independent toggles, not a state machine to fold into an enum.
+#[allow(clippy::struct_excessive_bools)]
 pub struct Args {
     /// Time window to include: today, yesterday, week, month, last-week, last-month, 24h, 7d, RFC3339 timestamp, or all.
     #[arg(long, default_value = "7d")]
@@ -30,6 +32,14 @@ pub struct Args {
     /// Output format.
     #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
     format: OutputFormat,
+
+    /// Shortcut for `--format json`. Overrides `--format`.
+    #[arg(long, conflicts_with = "markdown")]
+    json: bool,
+
+    /// Shortcut for `--format markdown`. Overrides `--format`.
+    #[arg(long)]
+    markdown: bool,
 
     /// Maximum rows to print. Set 0 for all rows.
     #[arg(long, default_value_t = 10)]
@@ -80,6 +90,14 @@ pub struct ReportArgs {
     #[arg(long, default_value_t = 10)]
     limit: usize,
 
+    /// Emit JSON instead of the section tables.
+    #[arg(long, conflicts_with = "markdown")]
+    json: bool,
+
+    /// Emit Markdown instead of the section tables.
+    #[arg(long)]
+    markdown: bool,
+
     /// Exclude pane ids matching a glob. Repeat or comma-separate values.
     #[arg(long = "exclude-pane", value_name = "GLOB", value_delimiter = ',')]
     exclude_pane: Vec<String>,
@@ -87,6 +105,16 @@ pub struct ReportArgs {
     /// Exclude tmux session names or ids matching a glob. Repeat or comma-separate values.
     #[arg(long = "exclude-session", value_name = "GLOB", value_delimiter = ',')]
     exclude_session: Vec<String>,
+
+    /// One-shot visual theme override for table output.
+    #[arg(long, value_enum)]
+    theme: Option<ThemeArg>,
+
+    /// Print the full explanatory notes (methodology for THINK/ACTIVE, the
+    /// retained-history window, ledger fallbacks). Without this, the tables
+    /// only report that notes exist. JSON/markdown always include them.
+    #[arg(long, short = 'v', default_value_t = false)]
+    verbose: bool,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
@@ -94,6 +122,21 @@ enum OutputFormat {
     Table,
     Json,
     Markdown,
+}
+
+impl OutputFormat {
+    /// Fold the boolean `--json` / `--markdown` shortcuts onto a base format.
+    /// `--json` and `--markdown` are mutually exclusive at the clap layer, so at
+    /// most one is set; either one wins over the base, otherwise the base stands.
+    fn resolve(base: OutputFormat, json: bool, markdown: bool) -> OutputFormat {
+        if json {
+            OutputFormat::Json
+        } else if markdown {
+            OutputFormat::Markdown
+        } else {
+            base
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
@@ -152,7 +195,7 @@ pub async fn run(client: &Client, cfg: &Config, args: Args) -> Result<()> {
     let exclusions = ScopeExclusions::new(args.exclude_pane.clone(), args.exclude_session.clone());
     let data = load_data(client, cfg, &args.since, &exclusions).await?;
     let doc = build_document(&data, args.group_by, args.limit, args.sort, args.reverse);
-    match args.format {
+    match OutputFormat::resolve(args.format, args.json, args.markdown) {
         OutputFormat::Table => render_table(
             &doc,
             theme::for_config(cfg, args.theme, use_colors()),
@@ -173,7 +216,17 @@ pub async fn run_report(client: &Client, cfg: &Config, args: ReportArgs) -> Resu
         build_document(&data, GroupBy::Agent, args.limit, SortKey::Prompts, false),
         build_document(&data, GroupBy::Session, args.limit, SortKey::Prompts, false),
     ];
-    print!("{}", render_markdown_report(&docs));
+    // Report defaults to the same tables as `stats`; `--json`/`--markdown` opt
+    // into the machine- and document-friendly formats.
+    match OutputFormat::resolve(OutputFormat::Table, args.json, args.markdown) {
+        OutputFormat::Table => render_report_tables(
+            &docs,
+            theme::for_config(cfg, args.theme, use_colors()),
+            args.verbose,
+        ),
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&docs)?),
+        OutputFormat::Markdown => print!("{}", render_markdown_report(&docs)),
+    }
     Ok(())
 }
 
@@ -1650,14 +1703,7 @@ fn notes(data: &StatsData) -> Vec<String> {
 }
 
 fn render_table(doc: &StatsDocument, theme: CliTheme, verbose: bool) {
-    println!("muxa stats");
-    println!("Range: {}", doc.range.label);
-    if let Some(since_at) = doc.range.since_at.as_deref() {
-        println!("Since: {since_at}");
-    }
-    if let Some(until_at) = doc.range.until_at.as_deref() {
-        println!("Until: {until_at}");
-    }
+    print_range_header("muxa stats", doc);
     println!();
 
     if doc.rows.is_empty() {
@@ -1666,24 +1712,72 @@ fn render_table(doc: &StatsDocument, theme: CliTheme, verbose: bool) {
         let terminal_width = terminal_width();
         println!("{}", render_stats_table(doc, terminal_width, theme));
         if stats_table_layout(terminal_width) != StatsTableLayout::Full {
-            println!(
-                "note: Table compacted for terminal width; use --format json or --format markdown for every column."
-            );
+            println!("{}", compaction_hint());
         }
     }
 
-    if !doc.notes.is_empty() {
-        if verbose {
-            for note in &doc.notes {
-                println!("note: {note}");
-            }
+    print_notes(&doc.notes, verbose, "muxa stats --verbose");
+}
+
+/// Table output for `muxa report`: the same range header and per-section tables
+/// as `stats`, one table per group-by dimension. Totals/notes are identical
+/// across the documents (they aggregate the same data), so the range header and
+/// notes are printed once, from the first document.
+fn render_report_tables(docs: &[StatsDocument], theme: CliTheme, verbose: bool) {
+    let Some(first) = docs.first() else {
+        return;
+    };
+    print_range_header("muxa report", first);
+    println!();
+
+    let terminal_width = terminal_width();
+    let mut compacted = false;
+    for doc in docs {
+        println!("By {}", GroupByLabel(&doc.group_by));
+        if doc.rows.is_empty() {
+            println!("no rows in this view");
         } else {
-            println!(
-                "note: {n} explanatory note{plural} hidden; run `muxa stats --verbose` for methodology, or `muxa doctor` to check health.",
-                n = doc.notes.len(),
-                plural = if doc.notes.len() == 1 { "" } else { "s" },
-            );
+            println!("{}", render_stats_table(doc, terminal_width, theme));
+            compacted |= stats_table_layout(terminal_width) != StatsTableLayout::Full;
         }
+        println!();
+    }
+    if compacted {
+        println!("{}", compaction_hint());
+    }
+
+    print_notes(&first.notes, verbose, "muxa report --verbose");
+}
+
+fn print_range_header(title: &str, doc: &StatsDocument) {
+    println!("{title}");
+    println!("Range: {}", doc.range.label);
+    if let Some(since_at) = doc.range.since_at.as_deref() {
+        println!("Since: {since_at}");
+    }
+    if let Some(until_at) = doc.range.until_at.as_deref() {
+        println!("Until: {until_at}");
+    }
+}
+
+fn compaction_hint() -> &'static str {
+    "note: Table compacted for terminal width; use --json or --markdown for every column."
+}
+
+fn print_notes(notes: &[String], verbose: bool, verbose_cmd: &str) {
+    if notes.is_empty() {
+        return;
+    }
+    if verbose {
+        for note in notes {
+            println!("note: {note}");
+        }
+    } else {
+        println!(
+            "note: {n} explanatory note{plural} hidden; run `{verbose_cmd}` for methodology, or `muxa doctor` to check health.",
+            n = notes.len(),
+            plural = if notes.len() == 1 { "" } else { "s" },
+        );
     }
 }
 
@@ -3013,6 +3107,27 @@ mod tests {
             lines[total_idx - 1].starts_with('╞'),
             "expected a separator rule above TOTAL, got {:?}",
             lines[total_idx - 1]
+        );
+    }
+
+    #[test]
+    fn output_format_resolve_applies_shortcut_precedence() {
+        // --json / --markdown override the base; neither set leaves the base.
+        assert_eq!(
+            OutputFormat::resolve(OutputFormat::Table, true, false),
+            OutputFormat::Json
+        );
+        assert_eq!(
+            OutputFormat::resolve(OutputFormat::Table, false, true),
+            OutputFormat::Markdown
+        );
+        assert_eq!(
+            OutputFormat::resolve(OutputFormat::Markdown, false, false),
+            OutputFormat::Markdown
+        );
+        assert_eq!(
+            OutputFormat::resolve(OutputFormat::Table, false, false),
+            OutputFormat::Table
         );
     }
 


### PR DESCRIPTION
## What

- **`muxa report` now renders like `muxa stats`** — a range header followed by one bordered table per breakdown (day/project/agent/session), each with the shared `TOTAL` footer, instead of always emitting Markdown.
- **Added `--json` and `--markdown` to both `stats` and `report`.** They're mutually exclusive at the clap layer. On `stats` they override `--format`; on `report` they opt out of the new default tables (Markdown output is unchanged, just no longer the default).
- `report` also gains `--theme` and `-v/--verbose` so its table mode matches `stats` (notes hidden behind `--verbose`).

## How

- `OutputFormat::resolve(base, json, markdown)` folds the boolean shortcuts onto a base format (`--format` for stats, `Table` for report).
- `render_table` split into shared helpers (`print_range_header`, `print_notes`, `compaction_hint`); new `render_report_tables` reuses the existing `render_stats_table` per section.
- `report --json` emits a JSON array of the four section documents.

## Test

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p muxa-cli` all green.
- New unit test `output_format_resolve_applies_shortcut_precedence`; manual smoke test against the live daemon for table/json/markdown + the `--json --markdown` conflict guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)