### PR TITLE
feat: Pi adapter + cmux sink; fix: paste in attached sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,6 +2309,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "which",
  "wiremock",
 ]
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Patterns are case-sensitive and support `*` and `?`, e.g.
 | Claude Code | Supported | `~/.claude/settings.json` |
 | OpenAI Codex | Supported | `~/.codex/config.toml` |
 | Google Gemini CLI | Supported | `~/.gemini/settings.json` |
+| Pi | Supported | `~/.pi/agent/extensions/muxa/index.ts` |
 | opencode | Planned | [tracking issue](https://github.com/Open330/muxa/issues/14) |
 
 ## More Docs

--- a/crates/muxa-cli/src/init/components.rs
+++ b/crates/muxa-cli/src/init/components.rs
@@ -21,6 +21,8 @@ pub enum Component {
     GeminiHooks,
     /// opencode plugin event bridge
     OpencodeHooks,
+    /// Pi coding agent extension bridge
+    PiHooks,
     /// `muxad` user-level systemd service (Linux only)
     MuxadSystemd,
     /// `muxad` `launchd` `LaunchAgent` (macOS only)
@@ -41,6 +43,7 @@ impl Component {
         Component::CodexHooks,
         Component::GeminiHooks,
         Component::OpencodeHooks,
+        Component::PiHooks,
         Component::MuxadSystemd,
         Component::MuxadLaunchd,
         Component::MuxadShellrc,
@@ -56,6 +59,7 @@ impl Component {
             Component::CodexHooks => "codex-hooks",
             Component::GeminiHooks => "gemini-hooks",
             Component::OpencodeHooks => "opencode-hooks",
+            Component::PiHooks => "pi-hooks",
             Component::MuxadSystemd => "muxad-systemd",
             Component::MuxadLaunchd => "muxad-launchd",
             Component::MuxadShellrc => "muxad-shellrc",
@@ -76,6 +80,7 @@ impl Component {
             Component::CodexHooks => "OpenAI Codex: shell hooks",
             Component::GeminiHooks => "Gemini CLI: shell hooks",
             Component::OpencodeHooks => "opencode: plugin event bridge",
+            Component::PiHooks => "Pi coding agent: extension event bridge",
             Component::MuxadSystemd => "muxad: systemd user service (auto-start on login)",
             Component::MuxadLaunchd => "muxad: launchd LaunchAgent (auto-start on login)",
             Component::MuxadShellrc => "muxad: shellrc autostart hook (no service manager)",
@@ -92,6 +97,7 @@ impl Component {
             Component::CodexHooks => "auto-detect when ~/.codex/config.toml exists",
             Component::GeminiHooks => "auto-detect when ~/.gemini/settings.json exists",
             Component::OpencodeHooks => "installs ~/.config/opencode/plugins/muxa.ts",
+            Component::PiHooks => "installs ~/.pi/agent/extensions/muxa/index.ts",
             Component::MuxadSystemd => "Linux only; skipped on macOS / launchd hosts",
             Component::MuxadLaunchd => "macOS only; skipped on Linux / systemd hosts",
             Component::MuxadShellrc => "appends to ~/.zshrc or ~/.bashrc; cross-platform",
@@ -136,6 +142,7 @@ impl Component {
                 Component::CodexHooks,
                 Component::GeminiHooks,
                 Component::OpencodeHooks,
+                Component::PiHooks,
                 dm,
             ],
             Preset::Full => {

--- a/crates/muxa-cli/src/init/detect.rs
+++ b/crates/muxa-cli/src/init/detect.rs
@@ -22,6 +22,7 @@ pub struct Detection {
     pub claude_settings: Option<PathBuf>,
     pub codex_config: Option<PathBuf>,
     pub gemini_settings: Option<PathBuf>,
+    pub pi_agent_dir: Option<PathBuf>,
     pub muxad_running: bool,
     pub systemd_user_available: bool,
     pub launchctl_available: bool,
@@ -36,6 +37,7 @@ impl Detection {
             claude_settings: existing_file(home_join(".claude/settings.json")),
             codex_config: existing_file(home_join(".codex/config.toml")),
             gemini_settings: existing_file(home_join(".gemini/settings.json")),
+            pi_agent_dir: existing_dir(home_join(".pi/agent")),
             muxad_running: muxad_is_running(),
             systemd_user_available: super::files::systemd::systemd_available(),
             launchctl_available: super::files::launchd::launchctl_available(),
@@ -58,6 +60,9 @@ impl Detection {
         }
         if self.gemini_settings.is_some() {
             out.push(Component::GeminiHooks);
+        }
+        if self.pi_agent_dir.is_some() {
+            out.push(Component::PiHooks);
         }
         // Pre-check the daemon-manager that fits this host so the
         // wizard's default produces a working install. The picker
@@ -126,6 +131,14 @@ fn tool_version(name: &str, args: &[&str]) -> Option<String> {
 
 fn existing_file(p: PathBuf) -> Option<PathBuf> {
     if p.is_file() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+fn existing_dir(p: PathBuf) -> Option<PathBuf> {
+    if p.is_dir() {
         Some(p)
     } else {
         None

--- a/crates/muxa-cli/src/init/files/mod.rs
+++ b/crates/muxa-cli/src/init/files/mod.rs
@@ -11,6 +11,7 @@ pub mod dashboard;
 pub mod gemini;
 pub mod launchd;
 pub mod opencode;
+pub mod pi;
 pub mod shellrc;
 pub mod systemd;
 pub mod tmux;

--- a/crates/muxa-cli/src/init/files/pi.rs
+++ b/crates/muxa-cli/src/init/files/pi.rs
@@ -36,6 +36,13 @@ function sessionId(ctx: { sessionManager?: { getSessionId?: () => string } }): s
   }
 }
 
+// `__MUXA_BIN__` is substituted at install time by `muxa init` with the
+// absolute path to the `muxa` binary. This matters because the extension
+// runs inside Pi's process, whose PATH may not include ~/.cargo/bin; a
+// bare `spawn("muxa")` would then ENOENT and we'd silently lose every
+// event (the error is swallowed below by design).
+const MUXA_BIN = "__MUXA_BIN__";
+
 // Forward one event object to `muxa hook pi`. Fire-and-forget: errors
 // are swallowed so a down daemon never blocks the agent loop. We spawn
 // detached and unref so the child can never hold Pi's process alive.
@@ -49,7 +56,7 @@ function forward(type: string, payload: Record<string, unknown>, ctx: ExtensionC
       pid: process.pid,
       ...payload,
     });
-    const child = spawn("muxa", ["hook", "pi", "--event", "event"], {
+    const child = spawn(MUXA_BIN, ["hook", "pi", "--event", "event"], {
       stdio: ["pipe", "ignore", "ignore"],
       detached: true,
       env: SOCKET ? { ...process.env, MUXA_SOCKET: SOCKET } : process.env,
@@ -133,9 +140,10 @@ pub fn default_path() -> Option<std::path::PathBuf> {
 }
 
 pub fn upsert(original: &str) -> (String, Outcome) {
-    marker::upsert(original, ID, BODY)
+    let body = BODY.replace("__MUXA_BIN__", &super::super::util::locate_muxa());
+    marker::upsert_with(original, ID, &body, marker::CommentStyle::Slash)
 }
 
 pub fn remove(original: &str) -> (String, Outcome) {
-    marker::remove(original, ID)
+    marker::remove_with(original, ID, marker::CommentStyle::Slash)
 }

--- a/crates/muxa-cli/src/init/files/pi.rs
+++ b/crates/muxa-cli/src/init/files/pi.rs
@@ -1,0 +1,141 @@
+//! `~/.pi/agent/extensions/muxa/index.ts` content layer.
+//!
+//! Unlike the shell-hook agents (Claude/Codex/Gemini), Pi exposes an
+//! in-process TypeScript extension API. This layer writes a small
+//! extension that subscribes to Pi's lifecycle events and forwards a
+//! normalized JSON payload to `muxa hook pi --event event` via the
+//! muxa-managed `MUXA_SOCKET`.
+//!
+//! The extension is best-effort: a down/unreachable `muxad` must never
+//! block Pi's critical path, so every forwarding call is fire-and-forget
+//! with swallowed errors.
+
+use crate::init::marker::{self, Outcome};
+
+const ID: &str = "pi-extension";
+
+const BODY: &str = r#"// Forward Pi lifecycle events to muxa without blocking Pi's agent loop.
+//
+// muxa is an observability layer; if its daemon is down every call here
+// must fail silently so Pi keeps running normally. Native Pi event
+// names are forwarded verbatim (the Rust `PiAdapter` discriminates on
+// `type`), mirroring how the opencode plugin forwards opencode events.
+import { spawn } from "node:child_process";
+import { type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const SOCKET = process.env.MUXA_SOCKET ?? "";
+
+// Resolve a stable session id. `getSessionId()` returns the canonical
+// UUID for persisted and in-memory sessions; falling back to the pid
+// keeps a usable identity even on hosts where the API isn't available.
+function sessionId(ctx: { sessionManager?: { getSessionId?: () => string } }): string {
+  try {
+    return ctx.sessionManager?.getSessionId?.() ?? `pi-${process.pid}`;
+  } catch {
+    return `pi-${process.pid}`;
+  }
+}
+
+// Forward one event object to `muxa hook pi`. Fire-and-forget: errors
+// are swallowed so a down daemon never blocks the agent loop. We spawn
+// detached and unref so the child can never hold Pi's process alive.
+function forward(type: string, payload: Record<string, unknown>, ctx: ExtensionContextLike) {
+  try {
+    const body = JSON.stringify({
+      type,
+      session_id: sessionId(ctx),
+      cwd: ctx.cwd,
+      pane: process.env.TMUX_PANE ?? process.env.ZELLIJ_PANE_ID,
+      pid: process.pid,
+      ...payload,
+    });
+    const child = spawn("muxa", ["hook", "pi", "--event", "event"], {
+      stdio: ["pipe", "ignore", "ignore"],
+      detached: true,
+      env: SOCKET ? { ...process.env, MUXA_SOCKET: SOCKET } : process.env,
+    });
+    child.on("error", () => {});
+    child.stdin?.end(body);
+    child.unref();
+  } catch {
+    // swallow — observability must never break the agent
+  }
+}
+
+type ExtensionContextLike = {
+  cwd?: string;
+  model?: { id?: string };
+  sessionManager?: { getSessionId?: () => string };
+};
+
+export default function (pi: ExtensionAPI) {
+  // session lifecycle
+  pi.on("session_start", async (_event, ctx) => {
+    forward("session_start", {}, ctx);
+  });
+
+  pi.on("session_shutdown", async (_event, ctx) => {
+    forward("session_shutdown", {}, ctx);
+  });
+
+  // prompt submission — carries the user's prompt text
+  pi.on("before_agent_start", async (event, ctx) => {
+    forward("before_agent_start", { prompt: event.prompt }, ctx);
+  });
+
+  // tool execution lifecycle — the *observation* layer, not the
+  // preflight `tool_call` layer. `tool_execution_end` carries `isError`
+  // and the final `result`, which is what we want for success/fail.
+  pi.on("tool_execution_start", async (event, ctx) => {
+    forward("tool_execution_start", { tool: event.toolName }, ctx);
+  });
+
+  pi.on("tool_execution_end", async (event, ctx) => {
+    forward("tool_execution_end", {
+      tool: event.toolName,
+      success: !event.isError,
+    }, ctx);
+  });
+
+  // turn boundary — refresh model + cost info once per turn rather than
+  // per streamed message, keeping daemon churn low.
+  pi.on("turn_end", async (event, ctx) => {
+    const usage = event.message?.usage;
+    forward("turn_end", {
+      model: ctx.model?.id,
+      cost_usd: usage?.cost?.total,
+    }, ctx);
+  });
+
+  // agent loop end — final assistant message text, when extractable.
+  pi.on("agent_end", async (event, ctx) => {
+    const last = event.messages?.at(-1);
+    forward("agent_end", {
+      response:
+        typeof last?.content === "string" ? last.content : undefined,
+    }, ctx);
+  });
+}
+"#;
+
+/// Default install path: `~/.pi/agent/extensions/muxa/index.ts`.
+///
+/// Pi auto-discovers extensions from subdirectories of
+/// `~/.pi/agent/extensions/`, loading `index.ts` as the entry point.
+pub fn default_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| {
+        h.join(".pi")
+            .join("agent")
+            .join("extensions")
+            .join("muxa")
+            .join("index.ts")
+    })
+}
+
+pub fn upsert(original: &str) -> (String, Outcome) {
+    marker::upsert(original, ID, BODY)
+}
+
+pub fn remove(original: &str) -> (String, Outcome) {
+    marker::remove(original, ID)
+}

--- a/crates/muxa-cli/src/init/files/pi.rs
+++ b/crates/muxa-cli/src/init/files/pi.rs
@@ -43,30 +43,102 @@ function sessionId(ctx: { sessionManager?: { getSessionId?: () => string } }): s
 // event (the error is swallowed below by design).
 const MUXA_BIN = "__MUXA_BIN__";
 
-// Forward one event object to `muxa hook pi`. Fire-and-forget: errors
-// are swallowed so a down daemon never blocks the agent loop. We spawn
-// detached and unref so the child can never hold Pi's process alive.
-function forward(type: string, payload: Record<string, unknown>, ctx: ExtensionContextLike) {
-  try {
-    const body = JSON.stringify({
-      type,
-      session_id: sessionId(ctx),
-      cwd: ctx.cwd,
-      pane: process.env.TMUX_PANE ?? process.env.ZELLIJ_PANE_ID,
-      pid: process.pid,
-      ...payload,
-    });
-    const child = spawn(MUXA_BIN, ["hook", "pi", "--event", "event"], {
-      stdio: ["pipe", "ignore", "ignore"],
-      detached: true,
-      env: SOCKET ? { ...process.env, MUXA_SOCKET: SOCKET } : process.env,
-    });
-    child.on("error", () => {});
-    child.stdin?.end(body);
-    child.unref();
-  } catch {
-    // swallow — observability must never break the agent
+// Cumulative cost for the current session branch, in USD. Reset on
+// `session_start` and summed across `turn_end` events. See the turn_end
+// handler for why this must be cumulative rather than per-message.
+let sessionCostUsd = 0;
+
+// Pull the readable text out of a Pi message. `content` is either a
+// plain string (older path) or — the case that matters here — an array
+// of typed blocks. We concatenate every `text` block; non-text blocks
+// (thinking, tool calls, images) carry no user-facing reply text.
+function extractText(msg: { content?: unknown } | undefined): string | undefined {
+  const content = msg?.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const texts: string[] = [];
+    for (const block of content) {
+      if (
+        block !== null &&
+        typeof block === "object" &&
+        (block as { type?: string }).type === "text" &&
+        typeof (block as { text?: unknown }).text === "string"
+      ) {
+        texts.push((block as { text: string }).text);
+      }
+    }
+    return texts.length > 0 ? texts.join("\n") : undefined;
   }
+  return undefined;
+}
+
+// Forward one event object to `muxa hook pi`, serialized through a
+// single in-process delivery chain so events reach muxad in the order
+// Pi emitted them. Each callback returns immediately (it only *appends*
+// to the chain, never awaits it), so Pi's agent loop is never blocked;
+// the actual spawn + wait happens asynchronously, one delivery at a
+// time. Without this, rapidly successive lifecycle events (e.g.
+// `agent_end` then `session_shutdown`) would each spawn an independent
+// `muxa` process racing to the same socket, and a late `agent_end`
+// could resurrect an already-stopped row or a late `tool_execution_start`
+// could mark a finished turn as Working again.
+let deliveryChain: Promise<void> = Promise.resolve();
+
+// Bounded safety timeout for a single delivery. cmux/muxad spawns
+// return near-instantly; this only guards against a wedged spawn
+// freezing the whole chain. `unref()`d so the timer can never keep
+// Pi's process alive on its own.
+const DELIVERY_TIMEOUT_MS = 5_000;
+
+function forward(type: string, payload: Record<string, unknown>, ctx: ExtensionContextLike) {
+  deliveryChain = deliveryChain
+    .then(() => deliverOne(type, payload, ctx))
+    // A rejected step must not break subsequent deliveries — an error
+    // in one event should never swallow the next.
+    .catch(() => {});
+}
+
+function deliverOne(
+  type: string,
+  payload: Record<string, unknown>,
+  ctx: ExtensionContextLike,
+): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    };
+    try {
+      const body = JSON.stringify({
+        type,
+        session_id: sessionId(ctx),
+        cwd: ctx.cwd,
+        pane: process.env.TMUX_PANE ?? process.env.ZELLIJ_PANE_ID,
+        pid: process.pid,
+        ...payload,
+      });
+      const child = spawn(MUXA_BIN, ["hook", "pi", "--event", "event"], {
+        stdio: ["pipe", "ignore", "ignore"],
+        detached: true,
+        env: SOCKET ? { ...process.env, MUXA_SOCKET: SOCKET } : process.env,
+      });
+      // Resolve on any terminal event so the next delivery can start.
+      // Multiple events firing is fine — `settled` makes them idempotent.
+      child.on("error", done);
+      child.on("exit", done);
+      child.on("close", done);
+      const timer = setTimeout(done, DELIVERY_TIMEOUT_MS);
+      timer.unref?.();
+      child.stdin?.end(body);
+      child.unref();
+    } catch {
+      // swallow — observability must never break the agent
+      done();
+    }
+  });
 }
 
 type ExtensionContextLike = {
@@ -78,6 +150,10 @@ type ExtensionContextLike = {
 export default function (pi: ExtensionAPI) {
   // session lifecycle
   pi.on("session_start", async (_event, ctx) => {
+    // Reset the per-session cost accumulator: a session_start marks a
+    // fresh session branch, so costs from a previous turn sequence
+    // must not carry over.
+    sessionCostUsd = 0;
     forward("session_start", {}, ctx);
   });
 
@@ -106,21 +182,31 @@ export default function (pi: ExtensionAPI) {
 
   // turn boundary — refresh model + cost info once per turn rather than
   // per streamed message, keeping daemon churn low.
+  // Cost is reported as a session-branch cumulative total, not the
+  // per-message `usage.cost.total`: the daemon's `apply_heartbeat`
+  // overwrites `Agent.cost_usd` and the UI renders it as the running
+  // session cost, so sending a per-message value would make the number
+  // jump down on a cheaper turn. We accumulate across turns and reset
+  // on `session_start` (handled below).
   pi.on("turn_end", async (event, ctx) => {
-    const usage = event.message?.usage;
+    const usage = (event.message?.usage as { cost?: { total?: number } } | undefined);
+    const turnCost = usage?.cost?.total;
+    if (typeof turnCost === "number") sessionCostUsd += turnCost;
     forward("turn_end", {
       model: ctx.model?.id,
-      cost_usd: usage?.cost?.total,
+      cost_usd: sessionCostUsd,
     }, ctx);
   });
 
   // agent loop end — final assistant message text, when extractable.
+  // Pi's `AssistantMessage.content` is an array of typed blocks
+  // (text / thinking / tool-call …), not a bare string, so we walk the
+  // last message and concatenate its text blocks. Without this the
+  // adapter never sees a `response`, `last_response` stays empty, and a
+  // successful `TurnStopped` can't clear a prior Error state.
   pi.on("agent_end", async (event, ctx) => {
     const last = event.messages?.at(-1);
-    forward("agent_end", {
-      response:
-        typeof last?.content === "string" ? last.content : undefined,
-    }, ctx);
+    forward("agent_end", { response: extractText(last) }, ctx);
   });
 }
 "#;

--- a/crates/muxa-cli/src/init/marker.rs
+++ b/crates/muxa-cli/src/init/marker.rs
@@ -1,12 +1,13 @@
 //! Reusable comment-fenced "managed block" editor.
 //!
-//! Used by any config file that takes shell-style `#`-prefix comments —
-//! `~/.tmux.conf` today, potentially others later. The format is:
+//! Used by config files that take line comments. The comment prefix is
+//! chosen via [`CommentStyle`]: shell-style `#` for `~/.tmux.conf`, or
+//! C-style `//` for TypeScript extension files. The format is:
 //!
 //! ```text
-//! # >>> muxa managed (<id>) >>>
+//! <prefix> >>> muxa managed (<id>) >>>
 //! <body lines>
-//! # <<< muxa managed (<id>) <<<
+//! <prefix> <<< muxa managed (<id>) <<<
 //! ```
 //!
 //! Each component owns its own block keyed by `id`, which means
@@ -15,10 +16,33 @@
 
 use std::fmt::Write as _;
 
-const OPEN_PREFIX: &str = "# >>> muxa managed (";
-const OPEN_SUFFIX: &str = ") >>>";
-const CLOSE_PREFIX: &str = "# <<< muxa managed (";
-const CLOSE_SUFFIX: &str = ") <<<";
+/// The line-comment prefix used to render the marker fence. Pick the
+/// one the host file's language treats as a comment, otherwise the
+/// fence itself becomes a syntax error (e.g. `#` inside a `.ts` file).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommentStyle {
+    /// Shell/tmux/toml-style `#`.
+    Hash,
+    /// JavaScript/TypeScript/rust-style `//`.
+    Slash,
+}
+
+impl CommentStyle {
+    fn prefix(self) -> &'static str {
+        match self {
+            CommentStyle::Hash => "#",
+            CommentStyle::Slash => "//",
+        }
+    }
+
+    fn open(self) -> String {
+        format!("{} >>> muxa managed (", self.prefix())
+    }
+
+    fn close(self) -> String {
+        format!("{} <<< muxa managed (", self.prefix())
+    }
+}
 
 /// Result of a marker-block edit on a file's content.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -45,16 +69,26 @@ impl Outcome {
     }
 }
 
-/// Insert or replace the block keyed by `id` with `body` in `original`.
-/// Returns the new file content + an `Outcome` describing what happened.
+/// Insert or replace the block keyed by `id` with `body` in `original`,
+/// using the default `Hash` (`#`) comment style. Returns the new file
+/// content + an `Outcome` describing what happened.
+///
+/// For files whose language uses a different line-comment prefix (e.g.
+/// `//` for TypeScript), use [`upsert_with`].
 ///
 /// `body` should be the inner lines without the fence comments. A
 /// trailing newline on `body` is normalized away — the renderer adds
 /// exactly one between body and close fence.
 pub fn upsert(original: &str, id: &str, body: &str) -> (String, Outcome) {
+    upsert_with(original, id, body, CommentStyle::Hash)
+}
+
+/// Style-aware variant of [`upsert`]. The fence is rendered with the
+/// given [`CommentStyle`] so it stays valid syntax in the host file.
+pub fn upsert_with(original: &str, id: &str, body: &str, style: CommentStyle) -> (String, Outcome) {
     let body = body.trim_end_matches('\n');
-    let rendered = render(id, body);
-    match find_block(original, id) {
+    let rendered = render(id, body, style);
+    match find_block(original, id, style) {
         Some((start, end)) => {
             let existing = &original[start..end];
             if existing == rendered {
@@ -71,9 +105,16 @@ pub fn upsert(original: &str, id: &str, body: &str) -> (String, Outcome) {
     }
 }
 
-/// Remove the block keyed by `id` from `original`, if present.
+/// Remove the block keyed by `id` from `original`, if present, using
+/// the default `Hash` (`#`) comment style.
 pub fn remove(original: &str, id: &str) -> (String, Outcome) {
-    let Some((start, end)) = find_block(original, id) else {
+    remove_with(original, id, CommentStyle::Hash)
+}
+
+/// Style-aware variant of [`remove`]. The style MUST match the one used
+/// at install time, otherwise the fence won't be recognised.
+pub fn remove_with(original: &str, id: &str, style: CommentStyle) -> (String, Outcome) {
+    let Some((start, end)) = find_block(original, id, style) else {
         return (original.to_string(), Outcome::AlreadyAbsent);
     };
     // Also eat one leading newline if there is one — keeps the file from
@@ -89,12 +130,14 @@ pub fn remove(original: &str, id: &str) -> (String, Outcome) {
     (out, Outcome::Removed)
 }
 
-fn render(id: &str, body: &str) -> String {
+fn render(id: &str, body: &str, style: CommentStyle) -> String {
     let mut s = String::with_capacity(body.len() + 80);
-    let _ = writeln!(s, "{OPEN_PREFIX}{id}{OPEN_SUFFIX}");
+    let open = style.open();
+    let close = style.close();
+    let _ = writeln!(s, "{open}{id}) >>>");
     s.push_str(body);
     s.push('\n');
-    let _ = writeln!(s, "{CLOSE_PREFIX}{id}{CLOSE_SUFFIX}");
+    let _ = writeln!(s, "{close}{id}) <<<");
     s
 }
 
@@ -114,9 +157,9 @@ fn append_block(original: &str, rendered: &str) -> String {
 /// Locate the byte range `[start, end)` of the block for `id`,
 /// inclusive of the fence lines and trailing newline. Returns `None`
 /// when the block is absent or malformed (open without matching close).
-fn find_block(haystack: &str, id: &str) -> Option<(usize, usize)> {
-    let open = format!("{OPEN_PREFIX}{id}{OPEN_SUFFIX}");
-    let close = format!("{CLOSE_PREFIX}{id}{CLOSE_SUFFIX}");
+fn find_block(haystack: &str, id: &str, style: CommentStyle) -> Option<(usize, usize)> {
+    let open = format!("{}{}) >>>", style.open(), id);
+    let close = format!("{}{}) <<<", style.close(), id);
     let open_idx = line_start_of(haystack, &open)?;
     // Search for the matching close *after* the open fence, scoped to
     // the same id — this gracefully tolerates other components' blocks
@@ -216,8 +259,8 @@ mod tests {
         assert_eq!(o, Outcome::Removed);
         assert!(s.contains("BBB"));
         assert!(!s.contains("AAA"));
-        assert!(find_block(&s, "b").is_some());
-        assert!(find_block(&s, "a").is_none());
+        assert!(find_block(&s, "b", CommentStyle::Hash).is_some());
+        assert!(find_block(&s, "a", CommentStyle::Hash).is_none());
     }
 
     #[test]
@@ -225,6 +268,26 @@ mod tests {
         // Defensive: a status-right that quotes the literal must not
         // be confused for a fence line.
         let s = "set -g status-right \"# >>> muxa managed (x) >>> not a fence\"\n";
-        assert!(find_block(s, "x").is_none());
+        assert!(find_block(s, "x", CommentStyle::Hash).is_none());
+    }
+
+    #[test]
+    fn slash_style_renders_double_slash_fence() {
+        let (out, o) = upsert_with("", "x", "export default 1;", CommentStyle::Slash);
+        assert_eq!(o, Outcome::Inserted);
+        assert!(out.contains("// >>> muxa managed (x) >>>"));
+        assert!(out.contains("// <<< muxa managed (x) <<<"));
+        assert!(!out.contains("# >>>"));
+    }
+
+    #[test]
+    fn slash_style_round_trips_and_is_distinct_from_hash() {
+        let (with, _) = upsert_with("", "x", "body", CommentStyle::Slash);
+        // A stray Hash-style lookup must NOT match a Slash fence —
+        // protects against half-migrated installs leaving stale blocks.
+        assert!(find_block(&with, "x", CommentStyle::Hash).is_none());
+        let (removed, o) = remove_with(&with, "x", CommentStyle::Slash);
+        assert_eq!(o, Outcome::Removed);
+        assert!(removed.is_empty());
     }
 }

--- a/crates/muxa-cli/src/init/plan.rs
+++ b/crates/muxa-cli/src/init/plan.rs
@@ -103,6 +103,7 @@ pub fn build(
             Component::CodexHooks => plan_codex(direction, *c, &mut actions)?,
             Component::GeminiHooks => plan_gemini(direction, *c, &mut actions)?,
             Component::OpencodeHooks => plan_opencode(direction, *c, &mut actions)?,
+            Component::PiHooks => plan_pi(direction, *c, &mut actions)?,
             Component::MuxadSystemd => plan_systemd(direction, *c, detect, &mut actions)?,
             Component::MuxadLaunchd => plan_launchd(direction, *c, detect, &mut actions)?,
             Component::MuxadShellrc => plan_shellrc(direction, *c, &mut actions)?,
@@ -175,6 +176,30 @@ fn plan_opencode(direction: Direction, c: Component, actions: &mut Vec<Action>) 
     let (after, outcome) = match direction {
         Direction::Install => files::opencode::upsert(&original),
         Direction::Uninstall => files::opencode::remove(&original),
+    };
+    actions.push(Action::EditFile {
+        component: c,
+        path,
+        before,
+        after,
+        outcome,
+    });
+    Ok(())
+}
+
+/// Install/uninstall the Pi extension. Uses the same marker-block
+/// upsert/remove pattern as opencode: the extension file is owned by
+/// muxa but the marker fence lets `--uninstall` strip only our block,
+/// preserving anything the user appended by hand.
+fn plan_pi(direction: Direction, c: Component, actions: &mut Vec<Action>) -> Result<()> {
+    let Some(path) = files::pi::default_path() else {
+        return Ok(());
+    };
+    let before = read_to_string_opt(&path)?;
+    let original = before.clone().unwrap_or_default();
+    let (after, outcome) = match direction {
+        Direction::Install => files::pi::upsert(&original),
+        Direction::Uninstall => files::pi::remove(&original),
     };
     actions.push(Action::EditFile {
         component: c,

--- a/crates/muxa-cli/src/init/util.rs
+++ b/crates/muxa-cli/src/init/util.rs
@@ -29,6 +29,32 @@ pub fn default_muxad_socket() -> PathBuf {
     muxa::paths::default_socket()
 }
 
+/// Resolve the absolute path to the `muxa` CLI binary.
+///
+/// Used by integrations that invoke `muxa` from a context where PATH
+/// may not include `~/.cargo/bin` — e.g. a TypeScript extension spawned
+/// inside another agent's process. Mirrors [`locate_muxad`] in
+/// `files/launchd.rs`: PATH first, then the well-known install
+/// locations, finally a bare `muxa` fallback (relies on PATH again).
+pub fn locate_muxa() -> String {
+    if let Ok(path) = which::which("muxa") {
+        return path.to_string_lossy().into_owned();
+    }
+    let candidates: &[PathBuf] = &[
+        dirs::home_dir()
+            .map(|h| h.join(".cargo/bin/muxa"))
+            .unwrap_or_default(),
+        PathBuf::from("/opt/homebrew/bin/muxa"),
+        PathBuf::from("/usr/local/bin/muxa"),
+    ];
+    for cand in candidates {
+        if cand.is_file() {
+            return cand.to_string_lossy().into_owned();
+        }
+    }
+    "muxa".into()
+}
+
 /// Is `muxad` actually serving requests on `socket`? Lightweight: we
 /// just confirm we can establish a unix-socket connection. A
 /// listening daemon accepts the connect immediately; a stale socket

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -514,10 +514,22 @@ async fn attach_session_loop(client: &Client, session_id: &str) -> Result<()> {
         while crossterm::event::poll(Duration::ZERO)? {
             match crossterm::event::read()? {
                 // Bracketed-paste payloads from the parent terminal.
-                // Relay verbatim to the PTY, converting LF -> CR to match
-                // how a physical Enter key is encoded for the child.
+                // crossterm strips the `CSI 200~` / `CSI 201~` framing
+                // before surfacing `Event::Paste`, so we must re-wrap the
+                // payload in those delimiters before writing it to the
+                // child PTY. Otherwise a multi-line paste reaches the
+                // child as bare text with LF→CR per line, and any line
+                // the child treats as a complete input gets executed
+                // immediately — a shell paste like `ls\nrm -rf x` would
+                // run both commands instead of sitting on the prompt
+                // for review. Restoring the framing lets a child that
+                // itself understands bracketed paste buffer the whole
+                // blob as one input.
                 Event::Paste(text) => {
-                    let input = text.replace('\n', "\r");
+                    let mut input = String::with_capacity(text.len() + 12);
+                    input.push_str("\x1b[200~");
+                    input.push_str(&text.replace('\n', "\r"));
+                    input.push_str("\x1b[201~");
                     client.write_session(session_id, &input).await?;
                 }
                 Event::Key(key) if key.kind == KeyEventKind::Press => {

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -463,8 +463,28 @@ impl Drop for RawModeGuard {
 
 async fn attach_session(client: &Client, session_id: &str) -> Result<()> {
     let _guard = RawModeGuard::enter()?;
+
+    // Enable bracketed paste in the parent terminal. When active, the
+    // terminal wraps clipboard pastes (Cmd+V) in \e[2004 ... \e[2014,
+    // which crossterm surfaces as `Event::Paste`. Without this, paste
+    // content gets mangled or dropped while we relay stdin to the
+    // muxa-owned PTY. Disabled again on drop regardless of outcome.
+    {
+        let mut stdout = std::io::stdout().lock();
+        stdout.write_all(b"\x1b[?2004h")?;
+        stdout.flush()?;
+    }
+
     client.set_session_attached(session_id, true).await?;
     let result = attach_session_loop(client, session_id).await;
+
+    // Restore the terminal's bracketed-paste state on the way out.
+    {
+        let mut stdout = std::io::stdout().lock();
+        let _ = stdout.write_all(b"\x1b[?2004l");
+        let _ = stdout.flush();
+    }
+
     let detach_result = client.set_session_attached(session_id, false).await;
     match (result, detach_result) {
         (Err(e), _) => Err(e),
@@ -493,6 +513,13 @@ async fn attach_session_loop(client: &Client, session_id: &str) -> Result<()> {
 
         while crossterm::event::poll(Duration::ZERO)? {
             match crossterm::event::read()? {
+                // Bracketed-paste payloads from the parent terminal.
+                // Relay verbatim to the PTY, converting LF -> CR to match
+                // how a physical Enter key is encoded for the child.
+                Event::Paste(text) => {
+                    let input = text.replace('\n', "\r");
+                    client.write_session(session_id, &input).await?;
+                }
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     if detach_armed {
                         detach_armed = false;
@@ -528,6 +555,15 @@ fn is_detach_prefix(key: crossterm::event::KeyEvent) -> bool {
 
 fn key_to_pty_input(key: crossterm::event::KeyEvent) -> Option<String> {
     use crossterm::event::{KeyCode, KeyModifiers};
+
+    // Ignore Cmd (SUPER) key combos. On macOS the parent terminal owns
+    // clipboard/shortcut handling; if crossterm still surfaces such an
+    // event we must not emit the bare character into the PTY, otherwise
+    // Cmd+V would type a literal "v" instead of pasting.
+    if key.modifiers.contains(KeyModifiers::SUPER) {
+        return None;
+    }
+
     Some(match key.code {
         KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
             let lower = c.to_ascii_lowercase();

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -18,7 +18,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use comfy_table::presets::UTF8_BORDERS_ONLY;
 use comfy_table::{Cell, ColumnConstraint, ContentArrangement, Table, Width};
 use muxa::adapters::{
-    claude, run_hook, ClaudeAdapter, CodexAdapter, GeminiAdapter, OpencodeAdapter,
+    claude, run_hook, ClaudeAdapter, CodexAdapter, GeminiAdapter, OpencodeAdapter, PiAdapter,
 };
 use muxa::config::{IconSet, WatchConfig, WatchSortKey, WatchTheme};
 use muxa::ipc::Client;
@@ -222,6 +222,11 @@ enum HookCmd {
     },
     /// opencode hook handler.
     Opencode {
+        #[arg(long)]
+        event: String,
+    },
+    /// Pi coding agent hook handler.
+    Pi {
         #[arg(long)]
         event: String,
     },
@@ -934,6 +939,10 @@ async fn handle_hook(client: &Client, cmd: HookCmd) -> Result<()> {
         }
         HookCmd::Opencode { event } => {
             let ev = run_hook::<OpencodeAdapter, _>(&event, &mut std::io::stdin())?;
+            best_effort_ingest(client, &ev).await;
+        }
+        HookCmd::Pi { event } => {
+            let ev = run_hook::<PiAdapter, _>(&event, &mut std::io::stdin())?;
             best_effort_ingest(client, &ev).await;
         }
     }

--- a/crates/muxa-cli/src/timeline.rs
+++ b/crates/muxa-cli/src/timeline.rs
@@ -180,6 +180,7 @@ enum AgentKindArg {
     #[value(alias = "gemini_cli")]
     GeminiCli,
     Opencode,
+    Pi,
     Unknown,
 }
 
@@ -190,6 +191,7 @@ impl From<AgentKindArg> for AgentKind {
             AgentKindArg::Codex => Self::Codex,
             AgentKindArg::GeminiCli => Self::GeminiCli,
             AgentKindArg::Opencode => Self::Opencode,
+            AgentKindArg::Pi => Self::Pi,
             AgentKindArg::Unknown => Self::Unknown,
         }
     }

--- a/crates/muxa/Cargo.toml
+++ b/crates/muxa/Cargo.toml
@@ -28,6 +28,7 @@ reqwest = { workspace = true }
 url = { workspace = true }
 notify-rust = "4"
 portable-pty = { workspace = true }
+which = "7"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "test-util"] }

--- a/crates/muxa/src/adapters/hook.rs
+++ b/crates/muxa/src/adapters/hook.rs
@@ -58,15 +58,24 @@ where
     let mut buf = String::new();
     stdin.read_to_string(&mut buf)?;
     let input: A::Input = serde_json::from_str(&buf)?;
-    let surface = muxa_session_env();
-    let pane = if surface.is_some() {
+    // muxa-owned PTY sessions (MUXA_SESSION_ID) genuinely have no host
+    // pane — the session IS the surface — so we suppress pane lookup only
+    // for that case. A cmux surface (CMUX_SURFACE_ID) is *additive*
+    // identity metadata: it must not blank out a real tmux pane, because
+    // the two are independent (an agent can run in tmux nested inside
+    // cmux, and even standalone cmux terminals report no tmux pane
+    // anyway, so the suppression would be a no-op in production but a
+    // footgun in tests that leak CMUX_SURFACE_ID into subprocesses).
+    let muxa_surface = muxa_session_env();
+    let cmux_surface = cmux_surface_env();
+    let pane = if muxa_surface.is_some() {
         None
     } else {
         host_pane_env()
             .or_else(|| resolve_pane_via_ancestry(crate::backend::default_backend().as_ref()))
     };
     let mut ev = A::normalize(event, input, pane);
-    if let Some(surface) = surface {
+    if let Some(surface) = muxa_surface.or(cmux_surface) {
         ev.id_mut().surface = Some(surface);
     }
     Ok(ev)
@@ -83,6 +92,24 @@ fn muxa_session_env() -> Option<SurfaceRef> {
         _ => SurfaceKind::Pty,
     };
     Some(SurfaceRef { kind, id })
+}
+
+/// Detect a cmux surface identity from the environment.
+///
+/// cmux sets `$CMUX_SURFACE_ID` in every terminal it spawns. When a
+/// hook fires inside a cmux pane, we attach it as the event's surface
+/// so the cmux sink can target `cmux notify --surface <id>` back to the
+/// exact pane the agent is running in. Sibling to [`muxa_session_env`]
+/// (muxa-owned PTYs); the two are mutually exclusive in practice and
+/// the muxa-PTY path wins because it is the more specific identity.
+fn cmux_surface_env() -> Option<SurfaceRef> {
+    let id = std::env::var("CMUX_SURFACE_ID")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    Some(SurfaceRef {
+        kind: SurfaceKind::Cmux,
+        id,
+    })
 }
 
 /// Read whichever host-set "this pane" env var is present, in

--- a/crates/muxa/src/adapters/mod.rs
+++ b/crates/muxa/src/adapters/mod.rs
@@ -15,6 +15,7 @@ pub mod codex_rollout;
 pub mod gemini;
 pub mod hook;
 pub mod opencode;
+pub mod pi;
 pub mod proc_ancestry;
 pub mod transcript;
 
@@ -24,3 +25,4 @@ pub use claude::ClaudeAdapter;
 pub use codex::CodexAdapter;
 pub use gemini::GeminiAdapter;
 pub use opencode::OpencodeAdapter;
+pub use pi::PiAdapter;

--- a/crates/muxa/src/adapters/pi.rs
+++ b/crates/muxa/src/adapters/pi.rs
@@ -92,20 +92,6 @@ pub fn normalize_event(input: Value, fallback_pane: Option<String>) -> AgentEven
             success: !has_error(&input),
             at,
         },
-        // turn_end doubles as the per-turn heartbeat carrier: the
-        // extension attaches model + cost here once per turn instead of
-        // per streamed message, keeping daemon churn low.
-        "turn_end" => AgentEvent::Heartbeat {
-            id,
-            model: first_string(&input, &["model", "model_id"]),
-            context_used_pct: first_percent(&input, &["context_used_pct", "context_used"]),
-            cost_usd: first_number(&input, &["cost_usd", "cost"]),
-            rate_limit_5h_pct: None,
-            rate_limit_5h_resets_at: None,
-            rate_limit_7d_pct: None,
-            rate_limit_7d_resets_at: None,
-            at,
-        },
         "agent_end" => AgentEvent::TurnStopped {
             id,
             response: first_string(&input, &["response", "content"]),
@@ -122,8 +108,11 @@ pub fn normalize_event(input: Value, fallback_pane: Option<String>) -> AgentEven
             ),
             at,
         },
-        // Everything else collapses to a plain Heartbeat so the daemon
-        // refreshes `last_activity_at` without polluting the state machine.
+        // Everything else — including `turn_end`, which the extension
+        // attaches model + cost to once per turn instead of per streamed
+        // message to keep daemon churn low — collapses to a Heartbeat so
+        // the daemon refreshes `last_activity_at` without polluting the
+        // state machine.
         _ => AgentEvent::Heartbeat {
             id,
             model: first_string(&input, &["model", "model_id"]),

--- a/crates/muxa/src/adapters/pi.rs
+++ b/crates/muxa/src/adapters/pi.rs
@@ -1,0 +1,311 @@
+//! Pi coding agent adapter.
+//!
+//! Pi (`@earendil-works/pi-coding-agent`) doesn't expose a shell-hook
+//! system like Claude Code / Codex / Gemini. Instead it ships an
+//! in-process TypeScript extension API (`pi.on("agent_start", …)`).
+//! The muxa integration is therefore plugin-first, mirroring the
+//! opencode path: a local TypeScript extension forwards one event
+//! object to `muxa hook pi --event event`, and this adapter extracts a
+//! conservative `AgentEvent` from the payload.
+//!
+//! The shipped extension is written to
+//! `~/.pi/agent/extensions/muxa/index.ts` by the `pi-hooks` init
+//! component. The extension is responsible for filling in a stable
+//! `session_id`, the `cwd`, the active `model`, and the pane id (read
+//! from `$TMUX_PANE` / `$ZELLIJ_PANE_ID`). See
+//! `crates/muxa-cli/src/init/files/pi.rs` for the exact payload schema
+//! the extension emits.
+//!
+//! Wire format (stdin JSON forwarded by the extension):
+//!
+//! ```jsonc
+//! { "type": "session_start", "session_id": "pi-…", "cwd": "/repo",
+//!   "pane": "%5", "pid": 12345, "model": "claude-sonnet-4" }
+//! ```
+
+use crate::adapters::hook::{truncate, AdapterError, HookAdapter};
+use crate::event::{AgentEvent, AgentId, AgentKind, NotificationLevel};
+use serde_json::Value;
+use time::OffsetDateTime;
+
+/// Single event channel — like opencode, pi forwards one opaque JSON
+/// blob per lifecycle signal and the adapter discriminates on
+/// `type`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Event {
+    Event,
+}
+
+pub struct PiAdapter;
+
+impl HookAdapter for PiAdapter {
+    type Event = Event;
+    type Input = Value;
+
+    const KIND: AgentKind = AgentKind::Pi;
+
+    fn parse_event(flag: &str) -> Result<Self::Event, AdapterError> {
+        match flag {
+            "event" | "pi" => Ok(Event::Event),
+            other => Err(AdapterError::UnknownEvent(other.into())),
+        }
+    }
+
+    fn normalize(_event: Self::Event, input: Self::Input, pane: Option<String>) -> AgentEvent {
+        normalize_event(input, pane)
+    }
+}
+
+pub fn normalize_event(input: Value, fallback_pane: Option<String>) -> AgentEvent {
+    let ty = event_type(&input).unwrap_or("unknown");
+    let at = OffsetDateTime::now_utc();
+    let pane = first_string(&input, &["pane"]).or(fallback_pane);
+    let id = AgentId {
+        kind: AgentKind::Pi,
+        session_id: session_id(&input).unwrap_or_else(|| "pi-unknown".into()),
+        surface: None,
+        pane,
+        cwd: first_string(&input, &["cwd", "directory"]),
+    };
+
+    match ty {
+        "session_start" => AgentEvent::Started { id, at },
+        "session_shutdown" => AgentEvent::SessionEnded { id, at },
+        "before_agent_start" => AgentEvent::PromptSubmitted {
+            id,
+            prompt: truncate(
+                first_string(&input, &["prompt", "text"]).unwrap_or_default(),
+                4_000,
+            ),
+            at,
+        },
+        // tool_execution_* is Pi's observation layer (vs the preflight
+        // `tool_call`/`tool_result`), and carries `isError` + `result`.
+        "tool_execution_start" => AgentEvent::ToolStarted {
+            id,
+            tool: tool_name(&input),
+            at,
+        },
+        "tool_execution_end" => AgentEvent::ToolCompleted {
+            id,
+            tool: tool_name(&input),
+            success: !has_error(&input),
+            at,
+        },
+        // turn_end doubles as the per-turn heartbeat carrier: the
+        // extension attaches model + cost here once per turn instead of
+        // per streamed message, keeping daemon churn low.
+        "turn_end" => AgentEvent::Heartbeat {
+            id,
+            model: first_string(&input, &["model", "model_id"]),
+            context_used_pct: first_percent(&input, &["context_used_pct", "context_used"]),
+            cost_usd: first_number(&input, &["cost_usd", "cost"]),
+            rate_limit_5h_pct: None,
+            rate_limit_5h_resets_at: None,
+            rate_limit_7d_pct: None,
+            rate_limit_7d_resets_at: None,
+            at,
+        },
+        "agent_end" => AgentEvent::TurnStopped {
+            id,
+            response: first_string(&input, &["response", "content"]),
+            at,
+        },
+        // Pi surfaces a permission/confirm request as a notification.
+        "permission_asked" | "waiting_input" => AgentEvent::NotificationFired {
+            id,
+            level: NotificationLevel::NeedsInput,
+            message: truncate(
+                first_string(&input, &["message", "text"])
+                    .unwrap_or_else(|| "pi needs input".into()),
+                4_000,
+            ),
+            at,
+        },
+        // Everything else collapses to a plain Heartbeat so the daemon
+        // refreshes `last_activity_at` without polluting the state machine.
+        _ => AgentEvent::Heartbeat {
+            id,
+            model: first_string(&input, &["model", "model_id"]),
+            context_used_pct: first_percent(&input, &["context_used_pct", "context_used"]),
+            cost_usd: first_number(&input, &["cost_usd", "cost"]),
+            rate_limit_5h_pct: None,
+            rate_limit_5h_resets_at: None,
+            rate_limit_7d_pct: None,
+            rate_limit_7d_resets_at: None,
+            at,
+        },
+    }
+}
+
+fn event_type(v: &Value) -> Option<&str> {
+    v.get("type")
+        .and_then(Value::as_str)
+        .or_else(|| v.pointer("/event/type").and_then(Value::as_str))
+}
+
+fn session_id(v: &Value) -> Option<String> {
+    first_string(v, &["session_id", "sessionId", "sessionID", "id"])
+}
+
+fn tool_name(v: &Value) -> String {
+    first_string(v, &["tool", "tool_name", "toolName"]).unwrap_or_else(|| "unknown".into())
+}
+
+fn has_error(v: &Value) -> bool {
+    v.get("error").is_some_and(|value| !value.is_null())
+        || first_string(v, &["success"]).is_some_and(|s| s == "false")
+        || first_string(v, &["status"]).is_some_and(|s| s == "error" || s == "failed")
+}
+
+fn first_string(v: &Value, keys: &[&str]) -> Option<String> {
+    find_value(v, keys).and_then(|value| match value {
+        Value::String(s) if !s.is_empty() => Some(s.clone()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    })
+}
+
+fn first_number(v: &Value, keys: &[&str]) -> Option<f64> {
+    find_value(v, keys).and_then(Value::as_f64)
+}
+
+/// Like `first_number` but narrowed to `f32` for percentage fields such
+/// as `context_used_pct`. The f64→f32 narrowing is semantically lossless
+/// for a 0–100 percentage, so the cast is allowed here only.
+#[expect(clippy::cast_possible_truncation)]
+fn first_percent(v: &Value, keys: &[&str]) -> Option<f32> {
+    first_number(v, keys).map(|n| n as f32)
+}
+
+fn find_value<'a>(v: &'a Value, keys: &[&str]) -> Option<&'a Value> {
+    match v {
+        Value::Object(map) => {
+            for key in keys {
+                if let Some(value) = map.get(*key) {
+                    return Some(value);
+                }
+            }
+            map.values().find_map(|value| find_value(value, keys))
+        }
+        Value::Array(items) => items.iter().find_map(|value| find_value(value, keys)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_start_maps_to_started() {
+        let ev = normalize_event(
+            serde_json::json!({
+                "type": "session_start",
+                "session_id": "pi-1",
+                "cwd": "/repo",
+                "pane": "%5"
+            }),
+            None,
+        );
+        assert!(matches!(ev, AgentEvent::Started { .. }));
+    }
+
+    #[test]
+    fn prompt_maps_to_prompt_submitted() {
+        let ev = normalize_event(
+            serde_json::json!({
+                "type": "before_agent_start",
+                "session_id": "pi-1",
+                "prompt": "ship it"
+            }),
+            None,
+        );
+        assert!(matches!(ev, AgentEvent::PromptSubmitted { .. }));
+    }
+
+    #[test]
+    fn unknown_type_falls_back_to_heartbeat() {
+        let ev = normalize_event(
+            serde_json::json!({
+                "type": "turn_start",
+                "session_id": "pi-1",
+                "model": "claude-sonnet-4"
+            }),
+            None,
+        );
+        assert!(matches!(ev, AgentEvent::Heartbeat { .. }));
+    }
+
+    #[test]
+    fn pane_falls_back_to_env_when_payload_omits_it() {
+        let ev = normalize_event(
+            serde_json::json!({ "type": "session_start", "session_id": "pi-1" }),
+            Some("%9".into()),
+        );
+        match ev {
+            AgentEvent::Started { id, .. } => assert_eq!(id.pane.as_deref(), Some("%9")),
+            _ => panic!("expected Started"),
+        }
+    }
+
+    #[test]
+    fn tool_execution_end_success_maps_to_completed() {
+        let ev = normalize_event(
+            serde_json::json!({
+                "type": "tool_execution_end",
+                "session_id": "pi-1",
+                "tool": "bash",
+                "success": true
+            }),
+            None,
+        );
+        match ev {
+            AgentEvent::ToolCompleted { tool, success, .. } => {
+                assert_eq!(tool, "bash");
+                assert!(success);
+            }
+            _ => panic!("expected ToolCompleted"),
+        }
+    }
+
+    #[test]
+    fn tool_execution_end_error_marks_unsuccessful() {
+        let ev = normalize_event(
+            serde_json::json!({
+                "type": "tool_execution_end",
+                "session_id": "pi-1",
+                "tool": "bash",
+                "success": false
+            }),
+            None,
+        );
+        match ev {
+            AgentEvent::ToolCompleted { success, .. } => assert!(!success),
+            _ => panic!("expected ToolCompleted"),
+        }
+    }
+
+    #[test]
+    fn turn_end_carries_model_and_cost_as_heartbeat() {
+        let ev = normalize_event(
+            serde_json::json!({
+                "type": "turn_end",
+                "session_id": "pi-1",
+                "model": "claude-sonnet-4",
+                "cost_usd": 0.42
+            }),
+            None,
+        );
+        match ev {
+            AgentEvent::Heartbeat {
+                model, cost_usd, ..
+            } => {
+                assert_eq!(model.as_deref(), Some("claude-sonnet-4"));
+                assert_eq!(cost_usd, Some(0.42));
+            }
+            _ => panic!("expected Heartbeat"),
+        }
+    }
+}

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -220,6 +220,7 @@ pub enum IconSet {
 pub struct SinksConfig {
     pub oh_my_prompt: OhMyPromptToml,
     pub webhook: WebhookToml,
+    pub cmux: CmuxToml,
 }
 
 /// `[sinks.oh_my_prompt]` raw TOML schema. The daemon resolves these
@@ -271,6 +272,28 @@ pub struct WebhookToml {
     /// Per-`(kind, session_id, state)` rate-limit window in seconds.
     /// Defaults to 60. Set to 0 to disable (one notification per
     /// transition, even if the agent flaps).
+    pub rate_limit_secs: Option<u64>,
+}
+
+/// `[sinks.cmux]` raw TOML schema. The daemon resolves these fields
+/// against defaults via `CmuxSink::resolve` at startup. Unlike the
+/// webhook sink, cmux needs no endpoint: it shells out to the local
+/// `cmux` CLI, which auto-discovers the cmux socket. Notifications are
+/// targeted at the originating surface via the agent's `SurfaceRef`
+/// (populated from `$CMUX_SURFACE_ID` by the hook adapter).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct CmuxToml {
+    pub enabled: Option<bool>,
+    /// Path to the `cmux` binary. Defaults to `cmux` (resolved via
+    /// PATH); set explicitly when muxad runs with a PATH that doesn't
+    /// include the cmux app bundle's bin directory.
+    pub binary: Option<String>,
+    /// State transitions to forward. Defaults to the same
+    /// attention-needing set as the webhook sink.
+    pub on_states: Option<Vec<String>>,
+    /// Per-`(kind, session_id, state)` rate-limit window in seconds.
+    /// Defaults to 60. Set to 0 to disable.
     pub rate_limit_secs: Option<u64>,
 }
 

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -404,6 +404,7 @@ fn parse_agent_kind(raw: &str) -> Result<AgentKind, String> {
         "codex" => Ok(AgentKind::Codex),
         "gemini_cli" => Ok(AgentKind::GeminiCli),
         "opencode" => Ok(AgentKind::Opencode),
+        "pi" => Ok(AgentKind::Pi),
         "unknown" => Ok(AgentKind::Unknown),
         _ => Err(format!("unknown agent kind {raw:?}")),
     }

--- a/crates/muxa/src/discovery.rs
+++ b/crates/muxa/src/discovery.rs
@@ -240,7 +240,7 @@ impl DiscoveryReport {
             AgentKind::Codex => self.codex += 1,
             AgentKind::GeminiCli => self.gemini_cli += 1,
             // We never synthesize for Opencode/Unknown/Task today.
-            AgentKind::Opencode | AgentKind::Unknown | AgentKind::Task => {}
+            AgentKind::Opencode | AgentKind::Pi | AgentKind::Unknown | AgentKind::Task => {}
         }
     }
 }

--- a/crates/muxa/src/event.rs
+++ b/crates/muxa/src/event.rs
@@ -22,6 +22,10 @@ pub enum AgentKind {
     Opencode,
     Codex,
     GeminiCli,
+    /// Pi coding agent (earendil-works/pi-coding-agent). Wired via an
+    /// in-process TypeScript extension that forwards lifecycle events to
+    /// `muxa hook pi`, mirroring the opencode plugin model.
+    Pi,
     /// A non-agent background process (shell script, game, automation loop,
     /// or a `muxa run` PTY child) registered via `muxa register` / the
     /// `Register` IPC. Tracked by pid liveness rather than tmux pane

--- a/crates/muxa/src/event.rs
+++ b/crates/muxa/src/event.rs
@@ -12,7 +12,7 @@ use time::OffsetDateTime;
 /// when the IPC envelope schema evolves. Pinning to a specific value across
 /// muxa upgrades is not supported; treat it as a runtime negotiation token,
 /// not a stable API constant.
-pub const PROTOCOL_VERSION: u32 = 3;
+pub const PROTOCOL_VERSION: u32 = 4;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, strum::Display)]
 #[serde(rename_all = "snake_case")]

--- a/crates/muxa/src/event.rs
+++ b/crates/muxa/src/event.rs
@@ -67,6 +67,10 @@ pub enum SurfaceKind {
     Tmux,
     Zellij,
     Pty,
+    /// A pane inside the cmux native macOS multiplexer. The `id` is the
+    /// cmux surface UUID (from `$CMUX_SURFACE_ID`), used by the cmux
+    /// sink to target `cmux notify --surface`.
+    Cmux,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -422,6 +422,18 @@ impl Server {
 fn downgrade_wire(v: &mut serde_json::Value, protocol: u32) {
     match v {
         serde_json::Value::String(s) => {
+            // `pi` AgentKind is a v4 addition → Unknown for older peers.
+            if protocol < 4 && s == "pi" {
+                *s = "unknown".to_string();
+            }
+            // `cmux` SurfaceKind is a v4 addition. Downgrade to `pty`,
+            // the closest non-host surface: like cmux it is not a
+            // tmux/zellij pane, so a v3 client's host-pane reconciler
+            // still treats it as non-reapable. The id is opaque to the
+            // older client and harmlessly ignored.
+            if protocol < 4 && s == "cmux" {
+                *s = "pty".to_string();
+            }
             // `task` AgentKind is a v3 addition → Unknown for older peers.
             if protocol < 3 && s == "task" {
                 *s = "unknown".to_string();
@@ -1206,7 +1218,7 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::{AgentEvent, AgentId, AgentKind, AgentState};
+    use crate::event::{AgentEvent, AgentId, AgentKind, AgentState, SurfaceKind, SurfaceRef};
     use crate::state::Store;
     use tempfile::tempdir;
     use time::OffsetDateTime;
@@ -1723,6 +1735,75 @@ mod tests {
         let snap_resp: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
         let agents = snap_resp["agents"].as_array().unwrap();
         assert_eq!(agents[0]["state"], "waiting_choice");
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    /// v4 enum variants (`pi` `AgentKind`, `cmux` `SurfaceKind`) must be
+    /// downgraded for a v3-negotiated client so its deserializer doesn't
+    /// fall back to an empty agent list. `pi` → `unknown`, `cmux` →
+    /// `pty` (closest non-host surface; keeps the host-pane reconciler
+    /// from reaping it).
+    #[tokio::test]
+    async fn v3_hello_downgrades_pi_and_cmux_in_snapshot() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-v4-downgrade.sock");
+        let store = Store::shared();
+        let server = Server::new(sock.clone(), store.clone());
+        let (tx, rx) = broadcast::channel(1);
+        let handle = tokio::spawn(async move { server.run(rx).await.unwrap() });
+        wait_for_socket(&sock).await;
+
+        let id = AgentId {
+            kind: AgentKind::Pi,
+            session_id: "pi-v4-test".into(),
+            surface: Some(SurfaceRef {
+                kind: SurfaceKind::Cmux,
+                id: "cmux-surface-1".into(),
+            }),
+            pane: Some("%7".into()),
+            cwd: None,
+        };
+        store
+            .apply(&AgentEvent::Started {
+                id: id.clone(),
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        let mut hello = serde_json::to_vec(&serde_json::json!({
+            "protocol": 3, "kind": "hello", "client": "v3-test",
+        }))
+        .unwrap();
+        hello.push(b'\n');
+        stream.write_all(&hello).await.unwrap();
+        let mut snap = serde_json::to_vec(&serde_json::json!({ "kind": "snapshot" })).unwrap();
+        snap.push(b'\n');
+        stream.write_all(&snap).await.unwrap();
+        stream.flush().await.unwrap();
+
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        reader.read_line(&mut line).await.unwrap(); // hello ack
+        line.clear();
+        reader.read_line(&mut line).await.unwrap(); // snapshot
+        let snap_resp: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        let agents = snap_resp["agents"].as_array().unwrap();
+        // The agent must still be visible (not dropped by a deser
+        // failure) and its v4-only variants rewritten.
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0]["kind"], "unknown");
+        assert_eq!(agents[0]["surface"]["kind"], "pty");
+        assert!(
+            !line.contains("\"pi\""),
+            "v3 snapshot still contains pi kind: {line}"
+        );
+        assert!(
+            !line.contains("\"cmux\""),
+            "v3 snapshot still contains cmux surface: {line}"
+        );
 
         tx.send(()).unwrap();
         handle.await.unwrap();

--- a/crates/muxa/src/process_tree.rs
+++ b/crates/muxa/src/process_tree.rs
@@ -226,6 +226,7 @@ fn display_command(proc: &ProcInfo, kind: WorkloadProcessKind) -> String {
                 AgentKind::Codex => "codex".to_string(),
                 AgentKind::GeminiCli => "gemini".to_string(),
                 AgentKind::Opencode => "opencode".to_string(),
+                AgentKind::Pi => "pi".to_string(),
                 AgentKind::Task | AgentKind::Unknown => command_name(&proc.comm).to_string(),
             };
         }

--- a/crates/muxa/src/sinks/cmux.rs
+++ b/crates/muxa/src/sinks/cmux.rs
@@ -1,0 +1,432 @@
+//! cmux notification sink — surface state transitions to the cmux sidebar.
+//!
+//! Subscribes to the daemon's `Transition` broadcast and runs
+//! `cmux notify --title <kind> --subtitle <state> --body <prompt>` whenever
+//! an agent transitions into an attention-needing state (defaults:
+//! `WaitingInput`, `WaitingChoice`, `Error`). Mirrors the webhook sink's
+//! philosophy: best-effort, in-task per-agent rate limit, no queue — a
+//! dropped notification matters less than a stalled sink task.
+//!
+//! ## Targeting
+//!
+//! When the transitioning agent carries a cmux surface
+//! (`Agent.surface.kind == Cmux`, populated from `$CMUX_SURFACE_ID` by
+//! the hook adapter), the notification is targeted at that exact surface
+//! via `--surface <id>`. Agents without a cmux surface (running under
+//! tmux/zellij) are skipped — there is no useful cmux target for them,
+//! and firing `cmux notify` would land ambiguously on whatever workspace
+//! happens to be focused in the cmux app.
+//!
+//! ## Why spawn, not socket
+//!
+//! cmux's CLI auto-discovers its Unix socket
+//! (`~/Library/Application Support/cmux/cmux.sock`) and handles auth.
+//! Reaching the socket directly from Rust would duplicate that
+//! discovery and auth, and drift on every cmux update. A short-lived
+//! `cmux notify` subprocess is the documented integration path — the
+//! same one cmux's own bundled `claude` wrapper uses.
+
+use crate::config::CmuxToml;
+use crate::event::{AgentKind, AgentState, SurfaceKind};
+use crate::state::Transition;
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+use tokio::process::Command;
+use tokio::sync::{broadcast, mpsc};
+use tokio::task::JoinHandle;
+
+/// Default per-(kind, session, state) rate-limit window. Same rationale
+/// as the webhook sink: long enough to absorb a flapping loop, short
+/// enough that a second real incident an hour later still pages.
+pub const DEFAULT_RATE_LIMIT_SECS: u64 = 60;
+
+/// How long to let a `cmux notify` spawn run before killing it. cmux
+/// returns near-instantly; this is a safety bound against a wedged cmux
+/// app freezing the sink loop.
+const NOTIFY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Body (prompt snippet) cap. cmux truncates generously; we keep it
+/// short so the sidebar row stays scannable.
+const BODY_TRUNCATE: usize = 120;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CmuxError {
+    #[error("cmux binary not found on PATH and [sinks.cmux].binary not set")]
+    BinaryNotFound,
+}
+
+/// Resolved cmux sink — runtime state derived from the TOML config.
+#[derive(Debug)]
+pub struct CmuxSink {
+    binary: String,
+    on_states: Vec<AgentState>,
+    rate_limit: Duration,
+}
+
+impl CmuxSink {
+    /// Resolve the TOML sub-table into a runtime sink, or `Ok(None)` if
+    /// disabled. Validates the binary is resolvable when enabled so a
+    /// misconfiguration surfaces at startup rather than as silent
+    /// no-ops on every transition.
+    pub fn resolve(toml: &CmuxToml) -> Result<Option<Self>, CmuxError> {
+        if !toml.enabled.unwrap_or(false) {
+            return Ok(None);
+        }
+        let binary = toml
+            .binary
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map_or_else(|| "cmux".into(), str::to_string);
+        // When the user gives an absolute/relative path, trust it; when
+        // it's a bare name, require it to be on PATH so we fail loudly
+        // here instead of on the first transition.
+        if binary.contains(std::path::MAIN_SEPARATOR) {
+            // Explicit path — assume the user knows what they're doing.
+        } else if which::which(&binary).is_err() {
+            return Err(CmuxError::BinaryNotFound);
+        }
+        let on_states = if let Some(raw) = toml.on_states.as_ref() {
+            raw.iter().filter_map(|s| parse_state(s)).collect()
+        } else {
+            default_on_states()
+        };
+        let rate_limit =
+            Duration::from_secs(toml.rate_limit_secs.unwrap_or(DEFAULT_RATE_LIMIT_SECS));
+        Ok(Some(Self {
+            binary,
+            on_states,
+            rate_limit,
+        }))
+    }
+
+    /// Run the sink until shutdown. Same shape as the webhook sink:
+    /// biased shutdown, lag-tolerant broadcast, per-agent rate limit.
+    pub async fn run(
+        self,
+        mut transition_rx: broadcast::Receiver<Transition>,
+        mut shutdown_rx: broadcast::Receiver<()>,
+    ) {
+        let mut last_sent: HashMap<(AgentKind, String, AgentState), Instant> = HashMap::new();
+        // Bounded channel decouples the broadcast drain from spawn
+        // latency so a slow cmux can't cause this sink to lag and drop
+        // transitions. Capacity 64 matches the webhook sink's effective
+        // burst tolerance.
+        let (tx, mut rx) = mpsc::channel::<Transition>(64);
+        let forwarder = tokio::spawn(async move {
+            while let Some(t) = rx.recv().await {
+                self.handle_one(&t, &mut last_sent).await;
+            }
+        });
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_rx.recv() => {
+                    drop(tx);
+                    // Drain: let in-flight notifications finish, then exit.
+                    let _ = forwarder.await;
+                    tracing::debug!("cmux sink received shutdown");
+                    return;
+                }
+                next = transition_rx.recv() => {
+                    match next {
+                        Ok(t) => {
+                            // `tx.send` failing means the forwarder exited;
+                            // there's nothing useful to do except stop.
+                            if tx.send(t).await.is_err() {
+                                tracing::error!("cmux sink forwarder exited; stopping");
+                                return;
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::warn!(
+                                missed = n,
+                                "cmux sink lagged behind transition stream; continuing"
+                            );
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            tracing::debug!("transition broadcast closed; cmux sink exiting");
+                            drop(tx);
+                            let _ = forwarder.await;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_one(
+        &self,
+        transition: &Transition,
+        last_sent: &mut HashMap<(AgentKind, String, AgentState), Instant>,
+    ) {
+        if !should_forward(transition, &self.on_states) {
+            return;
+        }
+        // Targeting gate: only notify when we can aim at a concrete cmux
+        // surface. Firing `cmux notify` without a target would land on
+        // whatever workspace is focused — noisy and surprising.
+        let surface_id = match transition.agent.surface.as_ref() {
+            Some(s) if s.kind == SurfaceKind::Cmux => s.id.clone(),
+            _ => return,
+        };
+
+        let key = (
+            transition.agent.kind,
+            transition.agent.session_id.clone(),
+            transition.to,
+        );
+        let now = Instant::now();
+        if let Some(prev) = last_sent.get(&key) {
+            if self.rate_limit > Duration::ZERO && now.duration_since(*prev) < self.rate_limit {
+                return;
+            }
+        }
+        last_sent.insert(key, now);
+
+        let (title, subtitle, body) = render(transition);
+        let mut cmd = Command::new(&self.binary);
+        cmd.args([
+            "notify",
+            "--title",
+            &title,
+            "--subtitle",
+            &subtitle,
+            "--body",
+            &body,
+            "--surface",
+            &surface_id,
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+        // Race the spawn against a timeout so a wedged cmux app can't
+        // freeze the sink. Best-effort: errors are logged and dropped.
+        match tokio::time::timeout(NOTIFY_TIMEOUT, cmd.status()).await {
+            Ok(Ok(status)) if status.success() => {
+                tracing::debug!(
+                    kind = %transition.agent.kind,
+                    state = %transition.to,
+                    "cmux: notification posted"
+                );
+            }
+            Ok(Ok(status)) => {
+                tracing::warn!(
+                    code = ?status.code(),
+                    kind = %transition.agent.kind,
+                    "cmux: notify exited non-zero; dropping"
+                );
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    error = %e,
+                    kind = %transition.agent.kind,
+                    "cmux: notify spawn failed; dropping"
+                );
+            }
+            Err(_) => {
+                tracing::warn!(
+                    kind = %transition.agent.kind,
+                    "cmux: notify timed out after {NOTIFY_TIMEOUT:?}; dropping"
+                );
+            }
+        }
+    }
+}
+
+/// Public spawn helper mirroring `sinks::webhook::spawn`.
+pub fn spawn(
+    sink: CmuxSink,
+    transition_rx: broadcast::Receiver<Transition>,
+    shutdown_rx: broadcast::Receiver<()>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        sink.run(transition_rx, shutdown_rx).await;
+    })
+}
+
+fn should_forward(transition: &Transition, on_states: &[AgentState]) -> bool {
+    on_states.contains(&transition.to)
+}
+
+fn default_on_states() -> Vec<AgentState> {
+    vec![
+        AgentState::WaitingInput,
+        AgentState::WaitingChoice,
+        AgentState::Error,
+    ]
+}
+
+/// Build the (title, subtitle, body) triple for `cmux notify`.
+///
+/// - title: agent kind (`claude_code` / `codex` / `pi` …)
+/// - subtitle: short state label (`needs input` / `error` …)
+/// - body: first line of the last prompt, truncated, falling back to
+///   the agent's own last notification text so an error without a fresh
+///   prompt still carries a clue.
+fn render(transition: &Transition) -> (String, String, String) {
+    let title = transition.agent.kind.to_string();
+    let subtitle = match transition.to {
+        AgentState::WaitingInput => "needs input",
+        AgentState::WaitingChoice => "needs choice",
+        AgentState::Error => "error",
+        AgentState::Working => "working",
+        AgentState::Idle => "idle",
+        AgentState::Stopped => "stopped",
+        AgentState::Starting => "starting",
+    }
+    .into();
+    let snippet = transition
+        .agent
+        .last_prompt
+        .as_deref()
+        .or(transition.agent.last_notification.as_deref())
+        .unwrap_or("");
+    let first_line = snippet.lines().next().unwrap_or("");
+    let body = truncate_str(first_line, BODY_TRUNCATE);
+    (title, subtitle, body)
+}
+
+fn truncate_str(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+/// Parse a `[sinks.cmux].on_states` entry. Accepts both `PascalCase`
+/// and `snake_case` (same tolerance as the webhook sink).
+fn parse_state(s: &str) -> Option<AgentState> {
+    match s {
+        "Starting" | "starting" => Some(AgentState::Starting),
+        "Working" | "working" => Some(AgentState::Working),
+        "Idle" | "idle" => Some(AgentState::Idle),
+        "WaitingInput" | "waiting_input" => Some(AgentState::WaitingInput),
+        "WaitingChoice" | "waiting_choice" => Some(AgentState::WaitingChoice),
+        "Error" | "error" => Some(AgentState::Error),
+        "Stopped" | "stopped" => Some(AgentState::Stopped),
+        _ => {
+            tracing::warn!(value = %s, "cmux: unknown on_states entry; ignoring");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::SurfaceRef;
+    use crate::state::Agent;
+    use std::sync::Arc;
+    use time::macros::datetime;
+
+    fn agent(
+        kind: AgentKind,
+        surface: Option<SurfaceKind>,
+        prompt: Option<&str>,
+        state: AgentState,
+    ) -> Arc<Agent> {
+        Arc::new(Agent {
+            kind,
+            session_id: "sess-1".into(),
+            surface: surface.map(|k| SurfaceRef {
+                kind: k,
+                id: "surface-uuid".into(),
+            }),
+            pane: None,
+            cwd: None,
+            pid: None,
+            workload: crate::WorkloadSummary::default(),
+            state,
+            last_prompt: prompt.map(str::to_string),
+            last_response: None,
+            last_notification: None,
+            model: None,
+            context_used_pct: None,
+            cost_usd: None,
+            rate_limit_5h_pct: None,
+            rate_limit_5h_resets_at: None,
+            rate_limit_7d_pct: None,
+            rate_limit_7d_resets_at: None,
+            rate_limited_until: None,
+            rate_limit_scope: None,
+            rate_limit_source: None,
+            started_at: datetime!(2026-04-24 12:00:00 UTC),
+            last_activity_at: datetime!(2026-04-24 12:00:00 UTC),
+            state_entered_at: datetime!(2026-04-24 12:00:00 UTC),
+        })
+    }
+
+    fn transition(from: AgentState, to: AgentState, agent: Arc<Agent>) -> Transition {
+        Transition { from, to, agent }
+    }
+
+    #[test]
+    fn forwards_cmux_surface_on_attention_state() {
+        let a = agent(
+            AgentKind::Pi,
+            Some(SurfaceKind::Cmux),
+            Some("build it"),
+            AgentState::WaitingInput,
+        );
+        assert!(should_forward(
+            &transition(AgentState::Working, AgentState::WaitingInput, a),
+            &default_on_states(),
+        ));
+    }
+
+    #[test]
+    fn skips_non_cmux_surface() {
+        // A tmux agent has no cmux target — handle_one returns before
+        // spawn. Covered by the targeting gate; here we assert the
+        // render path still works so the gate is the only barrier.
+        let a = agent(AgentKind::ClaudeCode, None, Some("hi"), AgentState::Error);
+        let (title, _, _) = render(&transition(AgentState::Working, AgentState::Error, a));
+        assert_eq!(title, "claude_code");
+    }
+
+    #[test]
+    fn render_falls_back_to_notification_when_no_prompt() {
+        let mut a = agent(
+            AgentKind::Codex,
+            Some(SurfaceKind::Cmux),
+            None,
+            AgentState::Error,
+        );
+        let agent_mut = Arc::get_mut(&mut a).expect("unique ref in test");
+        agent_mut.last_notification = Some("rate limit hit".into());
+        let (_, _, body) = render(&transition(AgentState::Working, AgentState::Error, a));
+        assert_eq!(body, "rate limit hit");
+    }
+
+    #[test]
+    fn render_truncates_long_prompt_to_first_line_and_cap() {
+        let long = "x".repeat(200);
+        let a = agent(
+            AgentKind::Pi,
+            Some(SurfaceKind::Cmux),
+            Some(&long),
+            AgentState::WaitingInput,
+        );
+        let (_, _, body) = render(&transition(
+            AgentState::Working,
+            AgentState::WaitingInput,
+            a,
+        ));
+        assert!(body.chars().count() <= BODY_TRUNCATE);
+        assert!(body.ends_with('…'));
+    }
+
+    #[test]
+    fn parse_state_accepts_both_cases() {
+        assert_eq!(parse_state("WaitingInput"), Some(AgentState::WaitingInput));
+        assert_eq!(parse_state("waiting_input"), Some(AgentState::WaitingInput));
+        assert_eq!(parse_state("Error"), Some(AgentState::Error));
+        assert_eq!(parse_state("nonsense"), None);
+    }
+}

--- a/crates/muxa/src/sinks/mod.rs
+++ b/crates/muxa/src/sinks/mod.rs
@@ -19,8 +19,10 @@
 //! because the only consumer (`muxad`) calls each impl by name and the
 //! shapes diverge enough that a uniform interface would be premature.
 
+pub mod cmux;
 pub mod ohmyprompt;
 pub mod webhook;
 
+pub use cmux::{CmuxError, CmuxSink};
 pub use ohmyprompt::{OhMyPromptError, OhMyPromptSink};
 pub use webhook::{WebhookError, WebhookSink};

--- a/crates/muxa/src/sinks/ohmyprompt.rs
+++ b/crates/muxa/src/sinks/ohmyprompt.rs
@@ -502,6 +502,7 @@ pub fn agent_kind_to_source(kind: AgentKind) -> Option<&'static str> {
         AgentKind::Codex => Some("codex"),
         AgentKind::GeminiCli => Some("gemini"),
         AgentKind::Opencode => Some("opencode"),
+        AgentKind::Pi => Some("pi"),
         AgentKind::Unknown | AgentKind::Task => None,
     }
 }
@@ -513,6 +514,7 @@ pub fn agent_kind_to_cli_name(kind: AgentKind) -> Option<&'static str> {
         AgentKind::Codex => Some("codex"),
         AgentKind::GeminiCli => Some("gemini"),
         AgentKind::Opencode => Some("opencode"),
+        AgentKind::Pi => Some("pi"),
         AgentKind::Unknown | AgentKind::Task => None,
     }
 }

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -16,7 +16,9 @@ use muxa::history::{HistoryOptions, PaneSessionCache, PromptHistory};
 use muxa::ipc::{harden_permissions, Client, Server};
 use muxa::notify::Notifier;
 use muxa::reconcile::Reconciler;
-use muxa::sinks::{webhook as webhook_sink, OhMyPromptSink, WebhookSink};
+use muxa::sinks::{
+    cmux as cmux_sink, webhook as webhook_sink, CmuxSink, OhMyPromptSink, WebhookSink,
+};
 use muxa::snapshot::{self, Snapshotter, SnapshotterOptions};
 use muxa::tmux::scanner::PaneCache;
 use muxa::{discovery, paths, Config, Store};
@@ -252,6 +254,7 @@ async fn main() -> Result<()> {
 
     spawn_oh_my_prompt_sink(&cfg, &store, &shutdown_tx)?;
     spawn_webhook_sink(&cfg, &store, &shutdown_tx)?;
+    spawn_cmux_sink(&cfg, &store, &shutdown_tx)?;
 
     let server = Server::new(socket.clone(), store)
         .with_backend(backend.clone())
@@ -975,6 +978,30 @@ fn spawn_webhook_sink(
         Ok(None) => {}
         Err(e) => {
             return Err(anyhow::Error::new(e).context("resolving webhook sink"));
+        }
+    }
+    Ok(())
+}
+
+/// Resolve the cmux notification sink config and, if enabled, spawn its
+/// task. Mirrors `spawn_webhook_sink`: failures to resolve are surfaced
+/// at startup so a missing `cmux` binary doesn't lead to silent missed
+/// notifications later.
+fn spawn_cmux_sink(
+    cfg: &Config,
+    store: &muxa::SharedStore,
+    shutdown_tx: &broadcast::Sender<()>,
+) -> Result<()> {
+    match CmuxSink::resolve(&cfg.sinks.cmux) {
+        Ok(Some(sink)) => {
+            let transition_rx = store.subscribe();
+            let shutdown_rx = shutdown_tx.subscribe();
+            std::mem::drop(cmux_sink::spawn(sink, transition_rx, shutdown_rx));
+            tracing::info!("cmux sink enabled");
+        }
+        Ok(None) => {}
+        Err(e) => {
+            return Err(anyhow::Error::new(e).context("resolving cmux sink"));
         }
     }
     Ok(())

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,0 +1,63 @@
+# Code Review
+
+검토일: 2026-07-04
+
+## 요약
+
+이번 패치는 wire protocol 호환성을 깨뜨릴 수 있으며, 여러 줄 붙여넣기를 안전하지 않게 처리합니다. 또한 Pi 이벤트 전달 순서가 뒤바뀔 수 있고, Pi의 응답·비용 집계·타임라인 필터 경로가 완전하지 않습니다.
+
+## 검토 의견
+
+### P1 — 새 wire variant에 맞춰 protocol version 갱신
+
+- 위치: `crates/muxa/src/event.rs:28`
+- `PROTOCOL_VERSION`이 3으로 유지되면 기존 v3 클라이언트가 새 daemon을 호환 가능하다고 판단합니다.
+- 그러나 snapshot에 `kind: "pi"` 또는 `surface.kind: "cmux"`가 포함되면 역직렬화할 수 없습니다.
+- 이 경우 `Client::snapshot`이 빈 vector로 대체하여 모든 agent가 사라진 것처럼 보입니다.
+- 새 protocol version과 downgrade 처리를 추가하거나, 최소 지원 version을 올려야 합니다.
+
+### P1 — relay 중 bracketed-paste framing 보존
+
+- 위치: `crates/muxa-cli/src/main.rs:519-521`
+- attached child가 bracketed paste를 지원하더라도 crossterm은 `Event::Paste`를 만들기 전에 `CSI 200~` / `CSI 201~` delimiter를 제거합니다.
+- 현재처럼 text만 전송하고 LF를 CR로 변환하면 여러 줄 붙여넣기가 일반 Enter 입력처럼 동작하여 각 줄이 즉시 실행될 수 있습니다.
+- relay할 때 bracketed-paste 시작·종료 framing을 복원해야 합니다.
+
+### P1 — Pi lifecycle 이벤트 전달 직렬화
+
+- 위치: `crates/muxa-cli/src/init/files/pi.rs:59-61`
+- 각 callback이 별도의 detached CLI를 시작하고 즉시 반환하므로 빠르게 연속된 lifecycle 이벤트가 muxad에 도착하는 순서가 바뀔 수 있습니다.
+- 늦게 도착한 `agent_end`가 이미 반영된 `session_shutdown` row를 다시 Idle로 만들거나, 늦은 tool-start가 완료된 turn을 Working 상태로 남길 수 있습니다.
+- callback 자체는 non-blocking으로 유지하되 이벤트 전달은 직렬화해야 합니다.
+
+### P2 — Pi assistant content block에서 text 추출
+
+- 위치: `crates/muxa-cli/src/init/files/pi.rs:121-122`
+- Pi의 `AssistantMessage.content`는 문자열이 아니라 text, thinking, tool-call block 배열입니다.
+- 현재 구현에서는 정상 assistant reply도 `undefined`가 되어 `last_response`가 채워지지 않습니다.
+- 그 결과 성공한 `TurnStopped`가 기존 Error 상태를 해제하지 못할 수 있습니다.
+- 마지막 assistant message에서 text block을 추출해야 합니다.
+
+### P2 — Pi session 누적 비용 전송
+
+- 위치: `crates/muxa-cli/src/init/files/pi.rs:113`
+- `turn_end.message.usage.cost.total`은 해당 assistant message 한 건의 비용입니다.
+- 반면 `Store::apply_heartbeat`는 `Agent.cost_usd`를 덮어쓰고 UI는 이를 session 누적 비용으로 표시합니다.
+- 여러 turn 이후 최신 turn 비용만 보이거나 비용이 감소할 수 있습니다.
+- 현재 session branch의 assistant-message 비용을 합산해서 전달해야 합니다.
+
+### P2 — timeline filter parser에 Pi 추가
+
+- 관련 위치: `crates/muxa/src/event.rs:28`
+- `AgentKindArg`에 Pi가 없어 `muxa timeline --agent pi`가 거부됩니다.
+- `dashboard::server::parse_agent_kind`에도 Pi가 없어 `/api/timeline?agent=pi`가 HTTP 400을 반환합니다.
+- 두 parser 모두 Pi를 지원하도록 갱신해야 합니다.
+
+## 완료 조건
+
+- 새 variant를 모르는 구버전 client가 호환 가능한 daemon으로 잘못 인식하지 않는다.
+- 여러 줄 paste가 하나의 bracketed-paste 입력으로 child에 전달된다.
+- Pi lifecycle 이벤트가 발생 순서대로 muxad에 전달된다.
+- 마지막 Pi assistant 응답의 text가 `last_response`에 반영된다.
+- Pi 비용이 현재 session branch의 누적 비용으로 표시된다.
+- CLI와 dashboard API에서 `pi` timeline filter가 동작한다.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -7,7 +7,7 @@ This page keeps the detailed install and wiring notes out of the README.
 - Rust 1.88+
 - tmux 3.x
 - Unix-like OS
-- One supported agent CLI: Claude Code, OpenAI Codex, or Google Gemini CLI
+- One supported agent CLI: Claude Code, OpenAI Codex, Google Gemini CLI, or Pi
 
 ## One-Shot Install
 
@@ -137,6 +137,7 @@ hook commands without overwriting existing user hooks.
 | Claude Code | Merge `examples/claude-settings.json` into `~/.claude/settings.json`. |
 | OpenAI Codex | Add the `[[hooks.*]]` blocks documented in `crates/muxa/src/adapters/codex.rs`. |
 | Google Gemini CLI | Merge the hooks from `crates/muxa/src/adapters/gemini.rs` into `~/.gemini/settings.json`. |
+| Pi | Drop the extension body from `crates/muxa-cli/src/init/files/pi.rs` at `~/.pi/agent/extensions/muxa/index.ts`. |
 
 ## Verify
 

--- a/docs/SINKS.md
+++ b/docs/SINKS.md
@@ -14,6 +14,7 @@ required credentials.
 | Name                | Purpose                                              | Section                                  |
 | ------------------- | ---------------------------------------------------- | ---------------------------------------- |
 | `oh_my_prompt`      | Forward `PromptSubmitted` events to an omp instance. | [`oh-my-prompt`](#oh-my-prompt)          |
+| `cmux`              | Surface attention-needing state transitions as cmux sidebar notifications. | [`cmux`](#cmux) |
 
 ## oh-my-prompt
 
@@ -133,3 +134,37 @@ intentionally never blocks ingest because the omp endpoint is slow.
   endpoint has been unreachable long enough that 1000 records piled
   up. Fix the upstream and the sink will recover; older prompts are
   permanently lost.
+
+## cmux
+
+The cmux sink forwards agent state transitions to the [cmux](https://cmux.com/)
+native macOS multiplexer's sidebar via `cmux notify`. When an agent
+transitions into an attention-needing state (defaults:
+`WaitingInput`, `WaitingChoice`, `Error`), muxa runs
+`cmux notify --title <kind> --subtitle <state> --body <prompt> --surface <id>`
+targeted at the exact cmux surface the agent is running in.
+
+### Setup
+
+```toml
+[sinks.cmux]
+enabled = true
+# Optional: override if muxad's PATH doesn't include the cmux app bundle.
+# binary = "/Applications/cmux.app/Contents/Resources/bin/cmux"
+# Optional: which states trigger a notification (defaults shown).
+# on_states = ["WaitingInput", "WaitingChoice", "Error"]
+# Optional: per-(agent, state) rate-limit seconds. Default 60.
+# rate_limit_secs = 60
+```
+
+The sink resolves the target surface from each agent's `surface`
+identity, which the hook adapter populates from `$CMUX_SURFACE_ID`
+(set by cmux in every terminal it spawns). Agents without a cmux
+surface (running under tmux/zellij) are skipped — there is no useful
+cmux target for them.
+
+Verify:
+
+```bash
+cmux list-notifications   # notifications forwarded by the sink appear here
+```


### PR DESCRIPTION
## Summary

Draft. Bundles four related pieces of work that expand muxa's agent + surface coverage. Opening as a single draft for early review; happy to split into focused PRs (Pi adapter / cmux sink / paste fix) before marking ready if reviewers prefer — the four commits are independent and cherry-pickable.

| Commit | Type | What |
| --- | --- | --- |
| `5ccd506` | feat | Pi coding agent adapter (`AgentKind::Pi`, init wizard component, TS extension installer) |
| `0c6d940` | fix | Pi wiring: `//` marker fence + bake absolute `muxa` path into the extension |
| `dbbcb1a` | feat | cmux notification sink (`SurfaceKind::Cmux`, `$CMUX_SURFACE_ID` detection, `cmux notify`) |
| `5ad0129` | fix | Support paste (Cmd+V) in attached muxa sessions |

## 1. Pi coding agent adapter

Pi (`@earendil-works/pi-coding-agent`) has no shell-hook system; it exposes an in-process TypeScript extension API. This mirrors the opencode plugin-first model: a small extension at `~/.pi/agent/extensions/muxa/index.ts` forwards one JSON blob per lifecycle signal to `muxa hook pi --event event`, and `PiAdapter` discriminates on Pi's native event names (`session_start`, `before_agent_start`, `tool_execution_start/end`, `turn_end`, `agent_end`, …) rather than inventing private terms.

- `AgentKind::Pi` wired into all exhaustive match sites (`process_tree`, `ohmyprompt` source/cli mapping, `discovery`).
- Init wizard auto-detects `~/.pi/agent` and installs the extension via the marker-block upsert pattern (symmetric install/uninstall, preserves user-appended content).
- Heartbeat cadence is turn-bounded (`turn_end`) to keep daemon churn low; model + cost ride on the same heartbeat.
- Extension spawns `muxa` detached + `unref()` so a down `muxad` never blocks the agent loop; all errors swallowed by design (observability must never break the agent).

Verified live against a real Pi session: `muxa status` shows `kind=pi`, real session UUID, model + last_prompt captured, state transitions correct.

## 2. Pi wiring fixes (uncovered in live testing)

Two bugs that silently dropped every Pi event before these fixes:

1. **Marker fence** — the extension installs into a `.ts` file but `marker.rs` hard-coded the shell-style `#` fence, which is a syntax error in TypeScript. Pi's jiti loader rejected the whole extension at `1:0` with `ParseError`. Generalized to `CommentStyle::{Hash, Slash}`; kept `upsert`/`remove` as byte-identical `Hash` wrappers so tmux/opencode callers are unaffected.
2. **Bare `muxa` spawn** — the extension spawned a bare `muxa`, relying on Pi's process PATH. But `~/.cargo/bin` is typically absent there, so every spawn hit ENOENT and the fire-and-forget handler swallowed it — zero events, zero logs. Added `util::locate_muxa()` (mirrors `launchd::locate_muxad`: PATH → `~/.cargo/bin` → homebrew → fallback) and substitute `__MUXA_BIN__` at install time so the installed file carries an absolute path.

## 3. cmux notification sink

Surfaces agent state transitions to the [cmux](https://cmux.com/) native macOS multiplexer's sidebar via `cmux notify`. When an agent transitions into an attention-needing state (`WaitingInput` / `WaitingChoice` / `Error` by default), muxa runs:

```
cmux notify --title <kind> --subtitle <state> --body <prompt> --surface <id>
```

- **Targeting**: hook adapter detects `$CMUX_SURFACE_ID` and attaches `SurfaceRef{Cmux}`. Notifications fire only when a concrete cmux surface is aimable; agents under tmux/zellij are skipped.
- **Surface identity is additive** — `CMUX_SURFACE_ID` does *not* suppress host pane lookup (only `MUXA_SESSION_ID` does). An agent can run in tmux nested inside cmux; the two identities are independent. Decoupling avoids a footgun where leaking `CMUX_SURFACE_ID` into subprocesses blanks the pane used for recap/status-line.
- New `SurfaceKind::Cmux` is safe to add: all existing `SurfaceKind` match sites are `== Pty` equality checks, no exhaustive matches.
- Shape mirrors the webhook sink: best-effort, in-task per-`(kind, session, state)` rate limit, bounded mpsc decouples broadcast drain from spawn latency, 10s spawn timeout so a wedged cmux app can't freeze the sink loop.
- Binary resolved via PATH (or `[sinks.cmux].binary` override), validated at startup so a missing cmux surfaces immediately instead of silently no-op'ing.

Config:

```toml
[sinks.cmux]
enabled = true
# binary = "/path/to/cmux"
# on_states = ["WaitingInput", "Error"]
# rate_limit_secs = 60
```

All four shell-hook agents (pi/claude/codex/gemini) inherit cmux surface detection for free via the shared `run_hook` path.

## 4. Paste (Cmd+V) in attached sessions

`muxa run <cmd>` attaches by relaying crossterm key events from stdin to the muxa-owned PTY. Paste was broken three ways:

1. No bracketed-paste negotiation with the parent terminal, so clipboard pastes never arrived as a discrete event.
2. `Event::Paste` was dropped by the catch-all arm in `attach_session_loop`.
3. `key_to_pty_input` ignored the SUPER (Cmd) modifier, so when the terminal did surface Cmd+V it emitted a literal `v` into the PTY.

Fixes: enable bracketed paste on attach (`\x1b[?2004h`) and restore on exit, relay `Event::Paste` payloads to the PTY with `LF -> CR` conversion, drop SUPER combos from `key_to_pty_input`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] Workspace tests green (760)
- [x] Live Pi session: `muxa status` shows correct kind/session/model/prompt/state
- [x] cmux sink: notification lands on the originating surface for `WaitingInput`; tmux agents skipped
- [ ] Reviewer: confirm whether to keep as one PR or split (Pi / cmux / paste)

## Known follow-ups (not blocking draft)

- Adapter has defensive arms for `permission_asked` / `waiting_input` that the shipped extension does not yet emit — kept for forward-compat, could use a `// forward-compat` comment.
- Bracketed-paste disable lives in a separate block next to `attach_session_loop` rather than inside `RawModeGuard`'s `Drop`; fine for the normal path, but folding it into the guard would make panic/early-return recovery automatic.