### PR TITLE
fix(reconciler): defer mass reaps until a second pass agrees

### DIFF
--- a/crates/muxa/src/reconcile.rs
+++ b/crates/muxa/src/reconcile.rs
@@ -357,7 +357,12 @@ impl<L: LivenessSource> Reconciler<L> {
             u64::try_from(workload_started.elapsed().as_micros()).unwrap_or(u64::MAX);
         let reconcile_started = Instant::now();
         let report = self.store.reconcile_observation(&observation).await;
-        let workload_changed = if pane_observation_complete {
+        // A deferred mass reap means the store distrusted this pane set even
+        // though the backend called it complete. The rows survived; feeding
+        // the same set to `update_workloads` would blank the workload of
+        // every row the guard just rescued.
+        let observation_trusted = pane_observation_complete && report.stale_reap_deferred == 0;
+        let workload_changed = if observation_trusted {
             self.store.update_workloads(&workloads).await
         } else {
             0
@@ -437,6 +442,7 @@ impl<L: LivenessSource> Reconciler<L> {
                 pane_observation_complete,
                 workloads = workloads.len(),
                 stale = report.stale_panes_reaped,
+                stale_deferred = report.stale_reap_deferred,
                 synthetic = report.synthetic_demoted,
                 duplicates = report.duplicates_collapsed,
                 correlated = report.paneless_correlated,
@@ -453,6 +459,7 @@ impl<L: LivenessSource> Reconciler<L> {
                 pane_observation_complete,
                 workloads = workloads.len(),
                 stale = report.stale_panes_reaped,
+                stale_deferred = report.stale_reap_deferred,
                 synthetic = report.synthetic_demoted,
                 duplicates = report.duplicates_collapsed,
                 correlated = report.paneless_correlated,
@@ -510,7 +517,9 @@ mod tests {
     //!   (defense-in-depth, planted via the public `Store::hydrate` seam).
     use super::*;
     use crate::event::{AgentEvent, AgentId, AgentKind};
+    use crate::process_tree::WorkloadSummary;
     use crate::state::Store;
+    use std::collections::HashMap;
     use std::sync::Mutex;
     use time::macros::datetime;
 
@@ -635,6 +644,42 @@ mod tests {
             agent.state,
             AgentState::Idle,
             "pane-independent stuck-state maintenance should still run",
+        );
+    }
+
+    /// Rescuing a row from a distrusted observation is pointless if the same
+    /// observation is still allowed to blank what the row carried. A deferred
+    /// mass reap means "this pane set is not to be believed" — that has to
+    /// govern the workload update too, not just the reap.
+    #[tokio::test]
+    async fn deferred_mass_reap_does_not_blank_rescued_workloads() {
+        let store = Store::shared();
+        let t0 = datetime!(2026-04-24 12:00:00 UTC);
+        let mut seeded = HashMap::new();
+        for i in 0..6 {
+            let pane = format!("%{i}");
+            store.apply(&started(&format!("s{i}"), &pane, t0)).await;
+            seeded.insert(
+                pane,
+                WorkloadSummary {
+                    process_count: 3,
+                    ..WorkloadSummary::default()
+                },
+            );
+        }
+        store.update_workloads(&seeded).await;
+
+        // A believable-looking but empty reading: every pane appears gone.
+        let source = FakeLiveness::new(Vec::new());
+        let r = Reconciler::new(store.clone(), source, Duration::from_millis(10));
+        let report = r.reconcile_once().await;
+
+        assert_eq!(report.stale_reap_deferred, 6, "guard should hold the rows");
+        assert_eq!(report.stale_panes_reaped, 0);
+        let agent = store.by_session("s0").await.expect("row rescued");
+        assert_eq!(
+            agent.workload.process_count, 3,
+            "the rescued row must keep the workload the good tick gave it",
         );
     }
 

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -24,9 +24,10 @@ use crate::process_tree::WorkloadSummary;
 use crate::tmux::PaneInfo;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
-use std::sync::Arc;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use time::OffsetDateTime;
 use tokio::sync::{broadcast, Notify, RwLock};
@@ -117,19 +118,31 @@ const MASS_REAP_DIVISOR: usize = 2;
 /// making them linger an extra tick would be more surprising than the reap.
 const MASS_REAP_MIN_ROWS: usize = 5;
 
-/// Consecutive passes that must independently propose the same mass reap
-/// before it executes. Two is enough to outlast a transient observation fault
-/// while costing a legitimate mass close only one extra tick.
+/// Consecutive passes that must propose the *same* mass reap before it
+/// executes. Two is enough to outlast a single bad observation while costing a
+/// legitimate mass close only one extra tick.
 const MASS_REAP_CONFIRMATIONS: u32 = 2;
+
+/// A mass reap that was proposed and held back, waiting to see whether the
+/// next pass says the same thing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MassReapWatch {
+    /// Identity of the doomed set, so that "the next pass agreed" means it
+    /// named the same rows — not merely that it also wanted a mass reap.
+    fingerprint: u64,
+    /// How many consecutive passes have now proposed exactly this set.
+    confirmations: u32,
+}
 
 /// Outcome of the mass-reap guard for one reconcile pass.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReapVerdict {
-    /// Sweep is ordinary, or a proposed mass reap has now been confirmed by
+    /// Sweep is ordinary, or this exact mass reap has now been proposed by
     /// enough consecutive passes. Reap normally.
     Allowed,
-    /// This pass alone wanted to take out most of the pane-governed registry.
-    /// Keep the rows and wait for the next pass to agree.
+    /// This pass wanted to take out most of the pane-governed registry and no
+    /// earlier pass had named the same rows. Keep them and see what the next
+    /// pass says.
     Deferred { doomed: usize, governed: usize },
 }
 
@@ -359,11 +372,12 @@ pub struct Store {
     /// bounds the blast radius (handler cap + timeouts), but this invariant is
     /// what keeps lock hold time in the microsecond range to begin with.
     agents: RwLock<HashMap<String, Agent>>,
-    /// Consecutive reconcile passes that have proposed a mass reap (see
-    /// [`Store::reap_guard_verdict`]). A single pass never executes one; the
-    /// registry only drops the rows once `MASS_REAP_CONFIRMATIONS` passes in a
-    /// row agree, and any pass that disagrees resets this to zero.
-    mass_reap_confirmations: AtomicU32,
+    /// The mass reap currently being held back, if any (see
+    /// [`Store::reap_guard_verdict`]). A plain mutex, not an atomic: every
+    /// access already happens under the `agents` write lock, so it is never
+    /// contended, and pretending otherwise would imply a lock-free protocol
+    /// this doesn't have.
+    mass_reap_watch: Mutex<Option<MassReapWatch>>,
     transitions: broadcast::Sender<Transition>,
     prompts: broadcast::Sender<PromptRecord>,
     /// Disk-backed audit log of every prompt. Lives separately from
@@ -409,7 +423,7 @@ impl Store {
         let (prompts_tx, _) = broadcast::channel(PROMPT_CHANNEL_CAPACITY);
         Self {
             agents: RwLock::default(),
-            mass_reap_confirmations: AtomicU32::new(0),
+            mass_reap_watch: Mutex::new(None),
             transitions: tx,
             prompts: prompts_tx,
             history,
@@ -1563,7 +1577,11 @@ impl Store {
     ///
     /// 1. **Reap stale**: any agent whose pane no longer exists in the
     ///    snapshot is dropped. Without this the registry accumulates
-    ///    forever as users close panes.
+    ///    forever as users close panes. One exception: a pass that would
+    ///    take out most of the pane-governed registry at once is held back
+    ///    until a second pass names the same rows, so this step is not
+    ///    guaranteed to have converged after any *single* call — see
+    ///    [`Self::reap_guard_verdict`].
     /// 2. **Demote synthetic**: synthetic placeholders for panes that also
     ///    have a real session are dropped — the real entry is always the
     ///    authoritative one.
@@ -1579,9 +1597,27 @@ impl Store {
     /// Returns counts so callers can log non-trivial sweeps without spamming.
     pub async fn reconcile_observation(&self, observation: &PaneObservation) -> ReconcileReport {
         if !observation.is_complete() {
+            // Not a pass, as far as the mass-reap guard is concerned: an
+            // observation we already distrust can neither confirm nor break
+            // a deferral.
+            self.clear_mass_reap_watch();
             return ReconcileReport::default();
         }
         self.reconcile(&observation.panes).await
+    }
+
+    /// Forget any held-back mass reap.
+    ///
+    /// Called when a pass can't be counted as evidence either way — today,
+    /// when the observation came back `Incomplete`. A reading we already
+    /// distrust is not agreement, and it isn't disagreement either; letting
+    /// the watch survive it would let two faults minutes apart confirm each
+    /// other as if they were consecutive.
+    fn clear_mass_reap_watch(&self) {
+        *self
+            .mass_reap_watch
+            .lock()
+            .expect("mass reap watch poisoned") = None;
     }
 
     /// Decide whether this pass may execute its stale-pane reap.
@@ -1589,13 +1625,25 @@ impl Store {
     /// Ordinary sweeps are always allowed. The guard exists for the one shape
     /// that is nearly always a bug rather than reality: a single pass claiming
     /// that most of the pane-governed registry died at once. Completeness
-    /// checks in the backend already catch the failure modes we know about
-    /// (`observe_panes` reporting `Incomplete`); this is the backstop for the
-    /// ones we don't, and it costs a legitimate mass close only one tick.
+    /// checks in the backend already catch the observation faults we know
+    /// about (`observe_panes` reporting `Incomplete`); this is the backstop
+    /// for a fault that slips past them as an empty-yet-`Complete` reading.
     ///
-    /// Deferral is deliberately *not* sticky: the counter only advances while
-    /// consecutive passes keep proposing the same wipe, so a real mass close
-    /// converges on the next tick and a transient fault resets it to zero.
+    /// Agreement is by *identity*, not by count: the watch remembers which
+    /// rows were doomed, so a pass proposing a different wipe starts its own
+    /// deferral rather than confirming someone else's. Without that, a fault
+    /// rolling across tmux servers — server A blacking out, then B — would
+    /// have each pass confirm the previous one's unrelated proposal and reap
+    /// live rows that were only ever named once.
+    ///
+    /// **This buys protection against a transient fault, not a persistent
+    /// one.** A user closing every pane and a backend wrongly reporting every
+    /// pane closed are indistinguishable here — tmux's own "no server running"
+    /// is a legitimate empty reading — so a fault that keeps naming the same
+    /// rows still gets its wipe, one tick late. Telling those two apart needs
+    /// a signal this layer doesn't have (is the socket still connectable? are
+    /// the agent processes still alive?) and belongs in the backend, next to
+    /// the completeness check. What this rules out is the single bad tick.
     fn reap_guard_verdict(
         &self,
         agents: &HashMap<String, Agent>,
@@ -1609,26 +1657,43 @@ impl Store {
             .values()
             .filter(|a| a.pid.is_none() && a.pane.is_some())
             .count();
-        let doomed = agents
-            .values()
-            .filter(|a| !pane_is_live(a, panes_by_id))
-            .count();
+        let mut doomed_ids: Vec<&str> = agents
+            .iter()
+            .filter(|(_, a)| !pane_is_live(a, panes_by_id))
+            .map(|(sid, _)| sid.as_str())
+            .collect();
+        let doomed = doomed_ids.len();
         let is_mass_reap =
             doomed >= MASS_REAP_MIN_ROWS && doomed.saturating_mul(MASS_REAP_DIVISOR) >= governed;
+        let mut watch = self
+            .mass_reap_watch
+            .lock()
+            .expect("mass reap watch poisoned");
         if !is_mass_reap {
-            self.mass_reap_confirmations
-                .store(0, AtomicOrdering::Relaxed);
+            *watch = None;
             return ReapVerdict::Allowed;
         }
-        let confirmations = self
-            .mass_reap_confirmations
-            .fetch_add(1, AtomicOrdering::Relaxed)
-            + 1;
+
+        // `agents` is a HashMap, so iteration order is not stable across
+        // passes — sort before hashing or the same set fingerprints
+        // differently every tick and nothing ever confirms.
+        doomed_ids.sort_unstable();
+        let mut hasher = DefaultHasher::new();
+        doomed_ids.hash(&mut hasher);
+        let fingerprint = hasher.finish();
+
+        let confirmations = match *watch {
+            Some(prev) if prev.fingerprint == fingerprint => prev.confirmations + 1,
+            _ => 1,
+        };
         if confirmations >= MASS_REAP_CONFIRMATIONS {
-            self.mass_reap_confirmations
-                .store(0, AtomicOrdering::Relaxed);
+            *watch = None;
             return ReapVerdict::Allowed;
         }
+        *watch = Some(MassReapWatch {
+            fingerprint,
+            confirmations,
+        });
         ReapVerdict::Deferred { doomed, governed }
     }
 
@@ -3979,6 +4044,115 @@ mod tests {
 
         assert_eq!(report.stale_panes_reaped, MASS_REAP_MIN_ROWS - 1);
         assert_eq!(report.stale_reap_deferred, 0);
+    }
+
+    /// A fault rolling across tmux servers must not let each pass confirm the
+    /// previous one's unrelated proposal. Rows named by exactly one pass are
+    /// live rows as far as the guard knows, and must survive it.
+    #[tokio::test]
+    async fn disjoint_doomed_sets_do_not_confirm_each_other() {
+        let store = Store::shared();
+        let panes = seed_pane_agents(&store, 12).await;
+
+        // Tick 1: server A blacks out — %0..%5 doomed (6 of 12 governed).
+        let first = store.reconcile(&panes[6..]).await;
+        assert_eq!(first.stale_reap_deferred, 6);
+        assert_eq!(first.stale_panes_reaped, 0);
+
+        // Tick 2: A is back, but B blacks out — a completely different set is
+        // doomed. This is that set's first and only proposal.
+        let second = store.reconcile(&panes[..6]).await;
+
+        assert_eq!(
+            second.stale_panes_reaped, 0,
+            "a set proposed once must not ride the previous set's deferral",
+        );
+        assert_eq!(second.stale_reap_deferred, 6);
+        assert_eq!(store.snapshot().await.len(), 12, "all rows still live");
+    }
+
+    /// An `Incomplete` observation is not evidence: it can neither confirm a
+    /// held-back wipe nor count as the disagreement that clears one. Letting
+    /// the watch survive it would let two faults, arbitrarily far apart, act
+    /// as if they were consecutive passes.
+    #[tokio::test]
+    async fn incomplete_observation_clears_a_pending_deferral() {
+        let store = Store::shared();
+        seed_pane_agents(&store, 6).await;
+
+        let armed = store
+            .reconcile_observation(&PaneObservation::complete(Vec::new()))
+            .await;
+        assert_eq!(armed.stale_reap_deferred, 6, "first fault arms the watch");
+
+        // The backend goes explicitly unreliable for a tick.
+        store
+            .reconcile_observation(&PaneObservation::incomplete(Vec::new()))
+            .await;
+
+        // A later, unrelated fault must start over, not inherit confirmation.
+        let later = store
+            .reconcile_observation(&PaneObservation::complete(Vec::new()))
+            .await;
+
+        assert_eq!(
+            later.stale_panes_reaped, 0,
+            "a fault after an unusable reading must re-earn its confirmation",
+        );
+        assert_eq!(later.stale_reap_deferred, 6);
+        assert_eq!(store.snapshot().await.len(), 6);
+    }
+
+    /// Pins the reset-on-disagree half of the lifecycle: an ordinary pass
+    /// between two faults must disarm the watch, so the second fault is a
+    /// first proposal rather than a confirmation.
+    #[tokio::test]
+    async fn ordinary_pass_between_faults_disarms_the_watch() {
+        let store = Store::shared();
+        let panes = seed_pane_agents(&store, 6).await;
+
+        let first = store.reconcile(&[]).await;
+        assert_eq!(first.stale_reap_deferred, 6);
+
+        // Everything is visible again — this pass disagrees.
+        store.reconcile(&panes).await;
+
+        let second = store.reconcile(&[]).await;
+
+        assert_eq!(
+            second.stale_panes_reaped, 0,
+            "the good pass must have reset the counter",
+        );
+        assert_eq!(second.stale_reap_deferred, 6);
+        assert_eq!(store.snapshot().await.len(), 6);
+    }
+
+    /// Pins the ratio itself, which the total-wipe cases can't: at 5 doomed of
+    /// 10 governed the sweep is exactly half and must defer...
+    #[tokio::test]
+    async fn reap_at_the_ratio_boundary_is_deferred() {
+        let store = Store::shared();
+        let panes = seed_pane_agents(&store, 10).await;
+
+        let report = store.reconcile(&panes[5..]).await;
+
+        assert_eq!(report.stale_panes_reaped, 0);
+        assert_eq!(report.stale_reap_deferred, 5);
+    }
+
+    /// ...while the same 5 rows out of 11 are a minority and reap immediately.
+    /// Together these two fix `MASS_REAP_DIVISOR`; without them the ratio term
+    /// could be deleted outright and the suite would stay green.
+    #[tokio::test]
+    async fn reap_just_under_the_ratio_is_not_deferred() {
+        let store = Store::shared();
+        let panes = seed_pane_agents(&store, 11).await;
+
+        let report = store.reconcile(&panes[5..]).await;
+
+        assert_eq!(report.stale_panes_reaped, 5);
+        assert_eq!(report.stale_reap_deferred, 0);
+        assert_eq!(store.snapshot().await.len(), 6);
     }
 
     /// Paneless rows aren't reapable by this sweep, so they must not pad the

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -25,6 +25,7 @@ use crate::tmux::PaneInfo;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use time::OffsetDateTime;
@@ -104,6 +105,33 @@ const TRANSITION_CHANNEL_CAPACITY: usize = 256;
 /// from `Transition` payloads. Slow subscribers see `RecvError::Lagged`
 /// and should log + continue (same pattern as the notifier).
 const PROMPT_CHANNEL_CAPACITY: usize = 256;
+
+/// Share of pane-governed rows a single pass may reap before the sweep is
+/// treated as suspicious, as `doomed * DIVISOR >= governed` — i.e. half the
+/// registry. Half of it vanishing between two ticks is a far better match for
+/// a bad pane observation than for real user activity.
+const MASS_REAP_DIVISOR: usize = 2;
+
+/// Floor on how many rows a pass must be dropping before the ratio is even
+/// consulted. Closing the handful of panes you had open is ordinary, and
+/// making them linger an extra tick would be more surprising than the reap.
+const MASS_REAP_MIN_ROWS: usize = 5;
+
+/// Consecutive passes that must independently propose the same mass reap
+/// before it executes. Two is enough to outlast a transient observation fault
+/// while costing a legitimate mass close only one extra tick.
+const MASS_REAP_CONFIRMATIONS: u32 = 2;
+
+/// Outcome of the mass-reap guard for one reconcile pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReapVerdict {
+    /// Sweep is ordinary, or a proposed mass reap has now been confirmed by
+    /// enough consecutive passes. Reap normally.
+    Allowed,
+    /// This pass alone wanted to take out most of the pane-governed registry.
+    /// Keep the rows and wait for the next pass to agree.
+    Deferred { doomed: usize, governed: usize },
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Agent {
@@ -331,6 +359,11 @@ pub struct Store {
     /// bounds the blast radius (handler cap + timeouts), but this invariant is
     /// what keeps lock hold time in the microsecond range to begin with.
     agents: RwLock<HashMap<String, Agent>>,
+    /// Consecutive reconcile passes that have proposed a mass reap (see
+    /// [`Store::reap_guard_verdict`]). A single pass never executes one; the
+    /// registry only drops the rows once `MASS_REAP_CONFIRMATIONS` passes in a
+    /// row agree, and any pass that disagrees resets this to zero.
+    mass_reap_confirmations: AtomicU32,
     transitions: broadcast::Sender<Transition>,
     prompts: broadcast::Sender<PromptRecord>,
     /// Disk-backed audit log of every prompt. Lives separately from
@@ -376,6 +409,7 @@ impl Store {
         let (prompts_tx, _) = broadcast::channel(PROMPT_CHANNEL_CAPACITY);
         Self {
             agents: RwLock::default(),
+            mass_reap_confirmations: AtomicU32::new(0),
             transitions: tx,
             prompts: prompts_tx,
             history,
@@ -1550,6 +1584,54 @@ impl Store {
         self.reconcile(&observation.panes).await
     }
 
+    /// Decide whether this pass may execute its stale-pane reap.
+    ///
+    /// Ordinary sweeps are always allowed. The guard exists for the one shape
+    /// that is nearly always a bug rather than reality: a single pass claiming
+    /// that most of the pane-governed registry died at once. Completeness
+    /// checks in the backend already catch the failure modes we know about
+    /// (`observe_panes` reporting `Incomplete`); this is the backstop for the
+    /// ones we don't, and it costs a legitimate mass close only one tick.
+    ///
+    /// Deferral is deliberately *not* sticky: the counter only advances while
+    /// consecutive passes keep proposing the same wipe, so a real mass close
+    /// converges on the next tick and a transient fault resets it to zero.
+    fn reap_guard_verdict(
+        &self,
+        agents: &HashMap<String, Agent>,
+        panes_by_id: &HashMap<&str, Vec<&PaneInfo>>,
+    ) -> ReapVerdict {
+        // Only rows this sweep could actually reap belong in the ratio.
+        // pid-tracked rows answer to process liveness and paneless rows to the
+        // orphan sweep; counting either would inflate the denominator and let
+        // a wipe of every real pane row slip under the threshold.
+        let governed = agents
+            .values()
+            .filter(|a| a.pid.is_none() && a.pane.is_some())
+            .count();
+        let doomed = agents
+            .values()
+            .filter(|a| !pane_is_live(a, panes_by_id))
+            .count();
+        let is_mass_reap =
+            doomed >= MASS_REAP_MIN_ROWS && doomed.saturating_mul(MASS_REAP_DIVISOR) >= governed;
+        if !is_mass_reap {
+            self.mass_reap_confirmations
+                .store(0, AtomicOrdering::Relaxed);
+            return ReapVerdict::Allowed;
+        }
+        let confirmations = self
+            .mass_reap_confirmations
+            .fetch_add(1, AtomicOrdering::Relaxed)
+            + 1;
+        if confirmations >= MASS_REAP_CONFIRMATIONS {
+            self.mass_reap_confirmations
+                .store(0, AtomicOrdering::Relaxed);
+            return ReapVerdict::Allowed;
+        }
+        ReapVerdict::Deferred { doomed, governed }
+    }
+
     /// Converge against a pane set already known to be complete.
     ///
     /// Most runtime callers should use [`Self::reconcile_observation`]. This
@@ -1573,22 +1655,36 @@ impl Store {
         let reaped_at = OffsetDateTime::now_utc();
         let mut stale_transitions = Vec::new();
         let before = agents.len();
-        agents.retain(|_, a| {
-            let keep = pane_is_live(a, &panes_by_id);
-            if !keep && a.state != AgentState::Stopped {
-                let mut stopped = a.clone();
-                let from = stopped.state;
-                stopped.state = AgentState::Stopped;
-                stopped.state_entered_at = reaped_at;
-                stopped.last_activity_at = reaped_at;
-                stale_transitions.push(Transition {
-                    from,
-                    to: AgentState::Stopped,
-                    agent: Arc::new(stopped),
-                });
-            }
-            keep
-        });
+        // A complete observation is still only as good as the backend that
+        // produced it. Hold back a sweep that would take out most of the
+        // registry until a second pass independently agrees.
+        let verdict = self.reap_guard_verdict(&agents, &panes_by_id);
+        if let ReapVerdict::Deferred { doomed, governed } = verdict {
+            report.stale_reap_deferred = doomed;
+            tracing::warn!(
+                doomed,
+                governed,
+                "deferring mass reap of {doomed}/{governed} pane-governed agent(s) — \
+                 holding rows until another pass agrees",
+            );
+        } else {
+            agents.retain(|_, a| {
+                let keep = pane_is_live(a, &panes_by_id);
+                if !keep && a.state != AgentState::Stopped {
+                    let mut stopped = a.clone();
+                    let from = stopped.state;
+                    stopped.state = AgentState::Stopped;
+                    stopped.state_entered_at = reaped_at;
+                    stopped.last_activity_at = reaped_at;
+                    stale_transitions.push(Transition {
+                        from,
+                        to: AgentState::Stopped,
+                        agent: Arc::new(stopped),
+                    });
+                }
+                keep
+            });
+        }
         report.stale_panes_reaped = before - agents.len();
 
         // Adopt panes onto paneless codex hook rows via cwd match BEFORE the
@@ -1685,6 +1781,11 @@ impl Store {
 pub struct ReconcileReport {
     /// Records dropped because their pane is no longer in tmux.
     pub stale_panes_reaped: usize,
+    /// Records this pass wanted to drop but held back, because reaping them
+    /// would have taken out most of the pane-governed registry in one tick.
+    /// Non-zero means the guard fired — the rows survive until another pass
+    /// independently agrees. See [`Store::reap_guard_verdict`].
+    pub stale_reap_deferred: usize,
     /// Synthetic placeholders dropped because a real entry owns the same pane.
     pub synthetic_demoted: usize,
     /// Older / duplicate real records collapsed onto the canonical row.
@@ -3800,6 +3901,129 @@ mod tests {
         let report = store.reconcile(&[default_pane]).await;
         assert_eq!(report.stale_panes_reaped, 1);
         assert!(store.by_session("amux-only").await.is_none());
+    }
+
+    /// Seed `n` pane-bearing agents on panes `%0..%n`, returning their panes.
+    async fn seed_pane_agents(store: &Store, n: usize) -> Vec<PaneInfo> {
+        let t0 = datetime!(2026-04-24 12:00:00 UTC);
+        let mut panes = Vec::new();
+        for i in 0..n {
+            let pane_id = format!("%{i}");
+            store
+                .apply(&AgentEvent::Started {
+                    id: AgentId {
+                        tmux_socket: None,
+                        kind: AgentKind::ClaudeCode,
+                        session_id: format!("s{i}"),
+                        surface: None,
+                        pane: Some(pane_id.clone()),
+                        cwd: None,
+                    },
+                    at: t0,
+                })
+                .await;
+            panes.push(pane(&pane_id));
+        }
+        panes
+    }
+
+    /// The incident this guard exists for: a pane observation that wrongly
+    /// reports an empty host must not empty the registry. Completeness checks
+    /// in the backend are the first line of defence — this is the backstop for
+    /// when a *new* fault sneaks an empty pane set past them as `Complete`.
+    #[tokio::test]
+    async fn transient_pane_blackout_does_not_wipe_registry() {
+        let store = Store::shared();
+        let panes = seed_pane_agents(&store, 6).await;
+
+        // The bad tick: host claims every pane is gone.
+        let report = store.reconcile(&[]).await;
+
+        assert_eq!(report.stale_panes_reaped, 0, "guard must hold the rows");
+        assert_eq!(report.stale_reap_deferred, 6);
+        assert_eq!(store.snapshot().await.len(), 6);
+
+        // Next tick sees the panes again — the wipe is never confirmed.
+        let report = store.reconcile(&panes).await;
+
+        assert_eq!(report.stale_panes_reaped, 0);
+        assert_eq!(report.stale_reap_deferred, 0);
+        assert_eq!(store.snapshot().await.len(), 6, "registry survived intact");
+    }
+
+    /// The guard delays a real mass close by one tick, it doesn't block it:
+    /// once a second pass independently agrees, the rows go.
+    #[tokio::test]
+    async fn mass_close_reaps_once_a_second_pass_agrees() {
+        let store = Store::shared();
+        seed_pane_agents(&store, 6).await;
+
+        let first = store.reconcile(&[]).await;
+        assert_eq!(first.stale_panes_reaped, 0);
+        assert_eq!(first.stale_reap_deferred, 6);
+
+        let second = store.reconcile(&[]).await;
+        assert_eq!(second.stale_panes_reaped, 6, "confirmed wipe executes");
+        assert_eq!(second.stale_reap_deferred, 0);
+        assert!(store.snapshot().await.is_empty());
+    }
+
+    /// Closing the last couple of panes you had open is ordinary. Guarding
+    /// tiny registries would make them linger for no reason.
+    #[tokio::test]
+    async fn guard_ignores_small_registries() {
+        let store = Store::shared();
+        seed_pane_agents(&store, MASS_REAP_MIN_ROWS - 1).await;
+
+        let report = store.reconcile(&[]).await;
+
+        assert_eq!(report.stale_panes_reaped, MASS_REAP_MIN_ROWS - 1);
+        assert_eq!(report.stale_reap_deferred, 0);
+    }
+
+    /// Paneless rows aren't reapable by this sweep, so they must not pad the
+    /// denominator — otherwise a registry carrying a pile of detached codex
+    /// rows would let every real pane row be wiped in one unconfirmed pass.
+    #[tokio::test]
+    async fn paneless_rows_do_not_dilute_the_guard() {
+        let store = Store::shared();
+        seed_pane_agents(&store, 6).await;
+        let t0 = datetime!(2026-04-24 12:00:00 UTC);
+        for i in 0..20 {
+            store
+                .apply(&AgentEvent::Started {
+                    id: AgentId {
+                        tmux_socket: None,
+                        kind: AgentKind::Codex,
+                        session_id: format!("detached{i}"),
+                        surface: None,
+                        pane: None,
+                        cwd: None,
+                    },
+                    at: t0,
+                })
+                .await;
+        }
+
+        let report = store.reconcile(&[]).await;
+
+        assert_eq!(report.stale_panes_reaped, 0, "guard must still fire");
+        assert_eq!(report.stale_reap_deferred, 6);
+    }
+
+    /// A minority of rows losing their panes is the everyday case and must
+    /// still reap on the very first pass.
+    #[tokio::test]
+    async fn ordinary_minority_reap_is_not_deferred() {
+        let store = Store::shared();
+        let mut panes = seed_pane_agents(&store, 8).await;
+        panes.pop();
+
+        let report = store.reconcile(&panes).await;
+
+        assert_eq!(report.stale_panes_reaped, 1);
+        assert_eq!(report.stale_reap_deferred, 0);
+        assert_eq!(store.snapshot().await.len(), 7);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

A reconcile pass reaps every registry row whose pane is missing from the pane observation it was handed. This fires on a 30s timer, and the rows are **hard-deleted** — the `cwd`, `model`, and prompt they carried do not come back.

This actually happened on my box earlier today: 38 of 46 rows were wiped in a single tick and re-discovered seconds later as bare `synthetic-` shells with `cwd: null`. `muxa watch` showed "No agents tracked" in the window between.

`68cfba4` fixed the known trigger — `list_panes()` collapsed a failed tmux call into an empty `Vec`, which reconcile could not distinguish from "no panes exist". Observations now carry completeness and an `Incomplete` one skips the reap entirely. That is the right fix and this PR does not touch it.

But completeness only covers the faults we know about. Anything that hands reconcile an empty-yet-`Complete` observation still wipes the registry in one unconfirmed tick, and the failure is silent and irreversible. This adds a backstop that does not depend on correctly classifying the fault.

## What

A pass that would reap most of the pane-governed registry is held back until a second, independent pass proposes the same thing:

- A transient fault resets the counter and the rows stay.
- A genuine mass close simply converges one tick later.
- Small sweeps (< 5 rows) are never guarded — closing the panes you had open is ordinary.
- Deferrals log at `WARN` and surface as `ReconcileReport::stale_reap_deferred`, so the guard firing is visible rather than a mystery.

Only rows this sweep could actually reap count toward the ratio. pid-tracked rows answer to process liveness and paneless rows to the orphan sweep; counting either would inflate the denominator and let a wipe of every real pane row slip under the threshold.

## Scope

`muxa prune` goes through `prune_orphans` and is unaffected — an explicit user command is never subject to the heuristic.

I considered making the reap a soft delete (flip to `Stopped`, let the GC collect) and **deliberately did not**: `config.example.toml` documents that closed panes disappear from `muxa watch` within seconds, and the picker view is meant to stay clean. Prompt history already lives outside the registry by design.

## Tests

Four new tests, including the incident itself (`transient_pane_blackout_does_not_wipe_registry`) and proof the guard delays rather than blocks a real mass close. `paneless_rows_do_not_dilute_the_guard` was verified to fail against the naive denominator before the fix.

`cargo test -p muxa --lib` (422 passed), workspace `clippy -D warnings`, and `fmt --check` all clean. Also ran a patched `muxad` against the live tmux host on a scratch socket for several reconcile ticks: no false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)