### PR TITLE
feat: MUXA_TMUX_SOCKET scan scoping + watch-centric demo refresh

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -7,6 +7,13 @@
 # tmux socket to attach to for control mode. Default: auto-detect from $TMUX.
 # tmux_socket = "default"
 
+# Env-only: MUXA_TMUX_SOCKET scopes the multi-server pane scan to a single
+# tmux socket path instead of enumerating every server under /tmp/tmux-$UID.
+# Opt-in — unset keeps the default global view across all your tmux servers.
+# Useful to isolate muxa to one server (single-server users, tests, or an
+# isolated demo/CI recording that must not pick up unrelated tmux servers):
+#   MUXA_TMUX_SOCKET=/tmp/tmux-1000/work muxad
+
 [ui]
 # theme = "classic"      # classic (default), oh-my-muxa, focus, ops, mono, high-contrast, minimal
 

--- a/crates/muxa/src/tmux/scanner.rs
+++ b/crates/muxa/src/tmux/scanner.rs
@@ -87,7 +87,25 @@ pub struct ScanResult {
 /// so we deduplicate by canonical path). Each entry must be a Unix
 /// socket; regular files and subdirectories are filtered out.
 pub fn enumerate_sockets() -> Vec<PathBuf> {
-    let mut socks = enumerate_sockets_in(&default_socket_dirs());
+    enumerate_sockets_with(scoped_socket(), &default_socket_dirs())
+}
+
+/// `MUXA_TMUX_SOCKET`, when set to a tmux socket path, scopes the multi-server
+/// pane scan to that single server instead of globbing every socket under the
+/// standard dirs. Opt-in — unset keeps the default global view. Lets an
+/// isolated context (a demo recording, integration tests, a single-server
+/// user) avoid picking up unrelated tmux servers running under the same uid.
+fn scoped_socket() -> Option<PathBuf> {
+    let v = std::env::var("MUXA_TMUX_SOCKET").ok()?;
+    let trimmed = v.trim();
+    (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
+}
+
+fn enumerate_sockets_with(scoped: Option<PathBuf>, dirs: &[PathBuf]) -> Vec<PathBuf> {
+    let mut socks = match scoped {
+        Some(sock) => vec![sock],
+        None => enumerate_sockets_in(dirs),
+    };
     // Drop dead socket files before any caller spawns a `tmux -S <sock>`
     // against them. tmux only unlinks a server's *own* socket on a clean
     // shutdown, so a server killed abnormally (test timeout, SIGKILL,
@@ -381,6 +399,25 @@ mod tests {
         let found = enumerate_sockets_in(&[dir.path().to_path_buf()]);
         assert_eq!(found.len(), 1, "expected only the socket: {found:?}");
         assert_eq!(found[0], sock_path);
+    }
+
+    #[test]
+    fn enumerate_sockets_with_scopes_to_a_single_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let scoped = dir.path().join("muxa-demo");
+        let _s = std::os::unix::net::UnixListener::bind(&scoped).unwrap();
+        // A sibling live socket that a global scan would also pick up.
+        let other = dir.path().join("default");
+        let _o = std::os::unix::net::UnixListener::bind(&other).unwrap();
+
+        // Scoped: only the named socket, sibling ignored even though it's live.
+        let scoped_found =
+            enumerate_sockets_with(Some(scoped.clone()), &[dir.path().to_path_buf()]);
+        assert_eq!(scoped_found, vec![scoped]);
+
+        // Unscoped: the full dir scan finds both live sockets.
+        let all = enumerate_sockets_with(None, &[dir.path().to_path_buf()]);
+        assert_eq!(all.len(), 2, "unscoped scan should see both: {all:?}");
     }
 
     #[test]

--- a/docs/demo-setup.sh
+++ b/docs/demo-setup.sh
@@ -121,6 +121,63 @@ TMUX_PANE="$PA" muxa hook claude --event stop \
 TMUX_PANE="$PA" muxa hook claude --event user_prompt_submit \
   <<<'{"session_id":"s-a","prompt":"continue with protocol compatibility tests and update the watch session summary docs"}'
 
+# In-flight Task subagents on the main Claude agent so `muxa watch --view swarm`
+# renders a populated subagent tree (each is a pre_tool_use{Task} with no
+# matching post, so they stay live for the recording).
+for spec in "Explore:trace the pane→session cache" \
+            "general-purpose:write the round-trip tests" \
+            "code-reviewer:review the framing diff"; do
+  k=${spec%%:*}; d=${spec#*:}
+  TMUX_PANE="$PA" muxa hook claude --event pre_tool_use \
+    <<<"{\"session_id\":\"s-a\",\"tool_name\":\"Task\",\"tool_input\":{\"subagent_type\":\"$k\",\"description\":\"$d\"}}"
+done
+
+# 3b) A richer fleet for the `muxa watch` hero — more sessions across every
+#     state, with a second subagent-bearing agent, so the session view and the
+#     swarm view both read as a real fleet-at-a-glance.
+mk() { # <session>  → echoes the pane id
+  "$TM" -u -L "$TMUX_LBL" new-session -d -s "$1" -x 200 -y 40 cat
+  "$TM" -u -L "$TMUX_LBL" display-message -p -t "$1:0.0" '#{pane_id}'
+}
+P_API=$(mk api)
+P_WEB=$(mk web)
+P_INFRA=$(mk infra)
+P_AUTH=$(mk auth)
+P_DATA=$(mk data)
+
+# api — Claude working, with its own Task subagents (second tree in swarm).
+TMUX_PANE="$P_API" muxa hook claude --event user_prompt_submit \
+  <<<'{"session_id":"s-api","prompt":"port the reconciler onto the new PaneBackend trait"}'
+for spec in "Explore:map the reconcile call sites" "general-purpose:port and de-dup"; do
+  k=${spec%%:*}; d=${spec#*:}
+  TMUX_PANE="$P_API" muxa hook claude --event pre_tool_use \
+    <<<"{\"session_id\":\"s-api\",\"tool_name\":\"Task\",\"tool_input\":{\"subagent_type\":\"$k\",\"description\":\"$d\"}}"
+done
+
+# infra — Codex working (another spinner).
+TMUX_PANE="$P_INFRA" muxa hook codex --event user_prompt_submit \
+  <<<'{"session_id":"s-infra","prompt":"terraform: split the network module and pin providers"}'
+TMUX_PANE="$P_INFRA" muxa hook codex --event pre_tool_use \
+  <<<'{"session_id":"s-infra","tool_name":"shell"}'
+
+# web — Claude waiting on input (yellow, needs you).
+TMUX_PANE="$P_WEB" muxa hook claude --event user_prompt_submit \
+  <<<'{"session_id":"s-web","prompt":"fix the SSE reconnect backoff"}'
+TMUX_PANE="$P_WEB" muxa hook claude --event notification \
+  <<<'{"session_id":"s-web","notification_type":"permission_prompt","message":"Allow edit to crates/muxa/src/dashboard/server.rs?"}'
+
+# auth — Claude blocked on a choice (magenta menu).
+TMUX_PANE="$P_AUTH" muxa hook claude --event user_prompt_submit \
+  <<<'{"session_id":"s-auth","prompt":"rotate the JWT signing keys across environments"}'
+TMUX_PANE="$P_AUTH" muxa hook claude --event pre_tool_use \
+  <<<'{"session_id":"s-auth","tool_name":"AskUserQuestion"}'
+
+# data — Claude idle, just finished a turn (the "done" resting state).
+TMUX_PANE="$P_DATA" muxa hook claude --event user_prompt_submit \
+  <<<'{"session_id":"s-data","prompt":"backfill the analytics rollups for last week"}'
+TMUX_PANE="$P_DATA" muxa hook claude --event stop \
+  <<<'{"session_id":"s-data"}'
+
 # 4) Seed activity.ndjson. The live hooks above prove agent ingest works, but
 #    a short GIF cannot wait minutes for durations to accumulate. These closed
 #    intervals make the stats/activity scenes representative while staying

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,18 +1,17 @@
-# muxa demo — "which of your agents needs you right now?"
+# muxa demo — "your whole agent fleet on one screen"
 #
 #   vhs docs/demo.tape   →   docs/demo.gif
 #
-# Story arc (see docs/demo-README.md):
-#   0–3s   overwhelm     — muxa status: claude working, codex blocked, gemini waiting
-#   3–7s   the accountant — muxa stats: where the day actually went
-#   7–12s  the god view  — prefix+s → muxa watch, all agents one screen, with the
-#                          real prompt/response in the preview
-#   12–17s the finale    — `muxa attend` teleports to the longest-blocked agent
-#                          (codex, mid shell-approval) — the strongest note to end on
+# muxa watch is the hero. Arc:
+#   0–6s    the fleet      — `muxa watch`: every session on one screen, working
+#                            agents spinning, attention floated to the top
+#   6–13s   the swarm      — `muxa watch --view swarm`: k9s-style clusters with
+#                            live dot spinners and an expandable subagent tree
+#   13–17s  teleport       — `muxa attend` jumps to whoever's blocked longest
 #
-# Depends on docs/demo-setup.sh painting the codex/gemini panes with
-# docs/demo-paint.sh instead of bare `cat`, so attend/attach land on a
-# believable agent frame rather than an empty shell.
+# Depends on docs/demo-setup.sh standing up a rich isolated fleet (many
+# sessions, varied states, in-flight Task subagents) and docs/demo-paint.sh
+# painting the codex approval pane attend lands on.
 
 Output docs/demo.gif
 
@@ -25,10 +24,8 @@ Set Theme "GitHub Dark"
 Set TypingSpeed 45ms
 Set PlaybackSpeed 1
 
-# ── Prelude — invisible setup (same isolation as the old tape) ───────────
+# ── Prelude — invisible setup (isolated demo daemon + tmux) ──────────────
 Hide
-# Resolve the real tmux BEFORE the shim shadows it on PATH, so attach/detach
-# work whether tmux lives at /usr/bin (Docker/CI) or Homebrew (mac).
 Type "export MUXA_DEMO_TMUX=$(command -v tmux)"
 Enter
 Type "export PATH=$HOME/.cargo/bin:/tmp/muxa-demo-shim:$PATH"
@@ -47,11 +44,31 @@ Type "cat > $MUXA_CONFIG <<'EOF'"
 Enter
 Type "[ui]"
 Enter
-Type "theme = 'high-contrast'"
+Type "theme = 'oh-my-muxa'"
+Enter
+Type "[discovery]"
+Enter
+Type "enabled = false"
+Enter
+Type "[reconciler]"
+Enter
+Type "enabled = false"
+Enter
+Type "[state]"
+Enter
+Type "enabled = false"
+Enter
+Type "[history]"
+Enter
+Type "enabled = false"
+Enter
+Type "[activity]"
+Enter
+Type "enabled = false"
 Enter
 Type "[watch]"
 Enter
-Type "theme = 'high-contrast'"
+Type "theme = 'oh-my-muxa'"
 Enter
 Type "view = 'session'"
 Enter
@@ -67,14 +84,23 @@ Type "rm -rf $XDG_DATA_HOME"
 Enter
 Type "rm -f $MUXA_SOCKET"
 Enter
-Type "muxad >/dev/null 2>&1 &"
+# Scope muxad's tmux scan to the demo server only, so a real tmux fleet on the
+# same host can't leak into the recording. Resolve the socket path from a
+# throwaway server, then let demo-setup recreate `-L muxa-demo` at that path.
+Type "$MUXA_DEMO_TMUX -L muxa-demo new-session -d -s _probe cat"
+Enter
+Type "export MUXA_TMUX_SOCKET=$($MUXA_DEMO_TMUX -L muxa-demo display-message -p '#{socket_path}')"
+Enter
+Type "$MUXA_DEMO_TMUX -L muxa-demo kill-server"
+Enter
+Type "muxad --config $MUXA_CONFIG >/dev/null 2>&1 &"
 Enter
 Sleep 500ms
 Type "until [ -S $MUXA_SOCKET ]; do sleep 0.1; done"
 Enter
 Type "bash docs/demo-setup.sh >/dev/null"
 Enter
-Sleep 300ms
+Sleep 400ms
 Type "clear"
 Enter
 Type "exec $MUXA_DEMO_TMUX -u -L muxa-demo attach -t main:0"
@@ -82,52 +108,36 @@ Enter
 Sleep 1500ms
 Show
 
-# All shell commands run FIRST, from the main:0 bash pane, so nothing is
-# ever typed into a non-shell (painted) pane. `muxa attend` teleports us
-# away for the finale, so it must come last.
-
-# ── 1. Overwhelm (0–3s) ──────────────────────────────────────────────────
-# status-right at the top already shows this pane's agent glyph. The table
-# makes the fleet legible: one working, one blocked on approval, one waiting.
-Type "muxa status"
+# ── 1. The fleet (0–6s) ──────────────────────────────────────────────────
+# muxa watch: the whole fleet on one screen. Working agents spin; sort=state
+# floats the agents that need you (input/choice) to the top; the gutter shows
+# each session's state at a glance.
+Type "muxa watch"
 Enter
-Sleep 3000ms
-
-# ── 2. The accountant (3–7s) ─────────────────────────────────────────────
-# muxa also quantifies the day: how long agents worked, how long they sat
-# blocked on you, how long you actually spent driving.
-Type "clear"
-Enter
-Type "muxa stats --since today --limit 4"
-Enter
-Sleep 3200ms
-
-# ── 3. The god view (7–12s) ──────────────────────────────────────────────
-# prefix + s pops muxa watch. sort=['state'] floats blocked/error agents to
-# the top; the status gutter shows multi/single/bare sessions at a glance.
-Type "clear"
-Enter
-Ctrl+B
-Type "s"
-Sleep 2200ms
-# p — preview the highlighted agent's real prompt + response body
-# (default_content=prompt_response), then q q back out to the shell.
-Type "p"
-Sleep 2600ms
+Sleep 3800ms
+Down@600ms 2
+Sleep 2400ms
 Type "q"
-Sleep 400ms
-Type "q"
-Sleep 600ms
+Sleep 500ms
 
-# ── 4. The finale — teleport to whoever needs you (12–17s) ───────────────
-# Don't hunt across windows. One command jumps the tmux client to whichever
-# agent has been blocked the longest — here, codex on the shell approval.
-# demo-paint.sh has painted a real-looking approval prompt, so the teleport
-# lands somewhere that reads as genuine. Strongest note to end on.
+# ── 2. The swarm (6–13s) ─────────────────────────────────────────────────
+# The k9s-style swarm console: one cluster per session, animated dot spinners
+# on the working agents, and an expandable subagent tree under the agents that
+# spawned Task children.
+Type "muxa watch --view swarm"
+Enter
+Sleep 5500ms
+Down@700ms 2
+Sleep 1600ms
+Type "q"
+Sleep 500ms
+
+# ── 3. Teleport (13–17s) ─────────────────────────────────────────────────
+# Don't hunt across windows — jump the tmux client straight to whichever agent
+# has been blocked the longest.
 Type "muxa attend"
 Enter
-Sleep 700ms
-Sleep 3200ms
+Sleep 3400ms
 Ctrl+B
 Type "d"
 Sleep 600ms


### PR DESCRIPTION
## Summary
Two related changes toward isolating muxa and showcasing `muxa watch`.

### `MUXA_TMUX_SOCKET` — scope the tmux pane scan (verified)
Opt-in env var that restricts muxa's multi-server tmux scan to a single socket instead of globbing every server under `/tmp/tmux-$UID`. Default unchanged (global view). Useful for single-server users, integration tests, and demo/CI recordings that must not pick up unrelated tmux servers on the same host.
- `scanner::enumerate_sockets` honors `MUXA_TMUX_SOCKET` (+ unit test `enumerate_sockets_with_scopes_to_a_single_socket`)
- documented in `config.example.toml`

### Watch-centric demo refresh
- `demo.tape` rebuilt around **`muxa watch` as the hero**: session view (spinners + gutter) → **k9s-style swarm view** (dot spinners + subagent tree) → `muxa attend`, on the **oh-my-muxa violet** theme.
- `demo-setup.sh` seeds a **richer fleet** (8+ sessions across working / waiting-input / waiting-choice / idle, **in-flight Task subagents on two agents**) and scopes the demo daemon (`MUXA_TMUX_SOCKET` + discovery/reconciler/state/history/activity disabled) so it renders cleanly in isolation.

### ⚠️ `docs/demo.gif` not regenerated here
The gif must be re-rendered with `vhs docs/demo.tape` in a **clean environment** (CI / container / a host with no competing muxa daemon or tmux). On a live dev host the real daemon + tmux cross-scan into the recording (shared `/tmp/tmux-$UID`, global `MUXA_SOCKET`, state hydration). The tape + `MUXA_TMUX_SOCKET` make an isolated render clean. The old gif is retained until then.

### Also surfaced (follow-up, not fixed here)
muxad appears to hydrate `state.json` regardless of a runtime `XDG_DATA_HOME` override — worth a look separately.

clippy (--all-targets -D warnings) + fmt clean; scanner unit test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)