### PR TITLE
feat(backend): herdr support — pane host backend, hook correlation, event bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **herdr web dashboard panes view.** The dashboard's `/api/panes` route
+  (and the timeline's pane→session map) now populate on herdr hosts. The
+  daemon threads its active pane backend into the dashboard; when the host
+  is herdr the pane-cache refresh sources rows from `HerdrBackend::list_panes()`
+  over the socket and folds them into the scanner's result shape instead of
+  the tmux multi-socket scanner (which sees nothing on herdr). Panes carry
+  their herdr-native fields (`herdr:<id>`, workspace as session, tab as
+  window) plus a synthetic `"herdr"` socket identity for the UI's
+  socket-filter chip. `MUXA_TMUX_SOCKET` scopes tmux sockets only and is not
+  applied to herdr panes; the tmux path is unchanged. See `docs/HERDR.md`.
 - **herdr watch session view.** `muxa watch --view session` (the default
   view) now populates on herdr hosts: sessions are derived from herdr
   workspaces over the socket (`workspace.list`) instead of `tmux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **herdr backend (Phase 1).** muxa now observes agents inside
+  [herdr](https://herdr.dev) panes: a full `PaneBackend` over herdr's local
+  socket API (`pane.list`/`pane.read`/`pane.process_info`/`pane.focus`, so
+  pane inventory, live captures, pid maps, and watch-attach all work with
+  no plugin), hook correlation via `$HERDR_PANE_ID` (rows are namespaced
+  `herdr:<pane_id>`), host auto-detection inside herdr panes plus a
+  `MUXA_HOST=herdr` override for the daemon, and a cross-host reaping
+  guard so a tmux-backend daemon never reaps live `herdr:`/`zellij:` rows
+  (and vice versa) while both hosts are in use. Verified end-to-end
+  against herdr 0.7.4 (protocol 16). See `docs/HERDR.md`.
+- **herdr event bridge (Phase 2).** On herdr hosts the daemon now
+  subscribes to herdr's `pane.agent_status_changed` stream and translates
+  it into synthetic muxa rows, so agents muxa has no hooks for (cursor,
+  amp, copilot, …) still appear in `muxa status`/`watch`/stats:
+  `working`→working, `blocked`→waiting, `idle`/`done`→turn-stop; unknown
+  agents map to `AgentKind::Unknown` carrying the herdr agent name.
+  Real hook events stay authoritative — a hooked agent owns its pane and
+  bridge state never clobbers it. Verified live against herdr 0.7.4. See
+  `docs/HERDR.md`.
+
 ### Fixed
 
 - **The `muxa Watch` BarShelf widget no longer goes blank after a muxa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   card names the fix ("Update muxa Watch") rather than showing a generic
   offline state — and an actionable fault is never hidden behind the
   last-good-render fallback the way a dropped SSH connection is.
+- **herdr backend hardening (review follow-ups).** Several correctness fixes to
+  the herdr support: (1) foreign-host rows the daemon can't observe (e.g. a
+  `herdr:` row left after switching the daemon back to tmux) now age out to
+  `Stopped` after the paneless-orphan timeout instead of ghosting forever;
+  (2) nested-host policy is now consistent — **herdr wins presence ties over
+  tmux** in *both* host detection and hook pane-stamping (herdr launched from
+  a tmux shell is the common case; its shells inherit the outer `$TMUX_PANE`),
+  with `MUXA_HOST=tmux` as the escape hatch for the rarer tmux-inside-herdr
+  nesting; (3) socket presence uses `try_exists()` so a stat error
+  (EACCES/EIO/stalled automount) degrades to a transient error instead of an
+  authoritative "no panes" that mass-reaps; (4) the socket request loop now has
+  an aggregate read deadline (a chatty server streaming unrelated lines can no
+  longer wedge reconcile/watch) and per-`pane.list` process-info enrichment is
+  time-budgeted; (5) the web dashboard on a herdr host now merges the tmux
+  scan with the herdr pane list instead of replacing it, so tmux panes no
+  longer vanish from `/api/panes`/timeline during mixed-host migration. See
+  `docs/HERDR.md`.
 
 - **`code_mode_host` codex sessions now correlate to their tmux pane instead of
   splitting into two rows.** Such a session runs its turns — and fires its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **herdr watch session view.** `muxa watch --view session` (the default
+  view) now populates on herdr hosts: sessions are derived from herdr
+  workspaces over the socket (`workspace.list`) instead of `tmux
+  list-sessions`, so each workspace shows as a session row keyed by its raw
+  `workspace_id` with the workspace **label** as its display name (falling
+  back to the id). The DUR column lights up from the existing
+  session-activity ledger (keyed by the same `workspace_id`), and Enter-twice
+  attach is host-dispatched to herdr's `pane.focus`, never a tmux-only
+  action. See `docs/HERDR.md`.
 - **herdr session foreground time.** The foreground-time ledger now works on
   herdr hosts: instead of `tmux list-clients` (which finds no server on
   herdr), the sampler queries the focused herdr **workspace** over the herdr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Real hook events stay authoritative — a hooked agent owns its pane and
   bridge state never clobbers it. Verified live against herdr 0.7.4. See
   `docs/HERDR.md`.
+- **herdr reverse path (`pane.report_agent`).** On herdr hosts the daemon
+  now pushes muxa's authoritative hook-derived state for REAL
+  (non-synthetic) `herdr:` rows into herdr's own UI: a transition
+  subscriber maps `Working`→`working`, `WaitingInput`/`WaitingChoice`/`Error`
+  →`blocked` (carrying the notification/error text), `Idle`→`idle`, and
+  `Stopped`→`pane.release_agent` (handing authority back to herdr's
+  detection). Reports carry `source = "muxa"`, a herdr-aligned agent slug,
+  the real session id, and a monotonic `seq`. Synthetic bridge rows are
+  never reported back, so the two directions can't feedback-loop. Failures
+  are best-effort and non-fatal. Verified live against herdr 0.7.4. See
+  `docs/HERDR.md`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **herdr session foreground time.** The foreground-time ledger now works on
+  herdr hosts: instead of `tmux list-clients` (which finds no server on
+  herdr), the sampler queries the focused herdr **workspace** over the herdr
+  socket (`workspace.list`) and credits foreground time to it, keyed by the
+  raw `workspace_id` so `muxa stats`/`report` ACT numbers and
+  `muxa watch --view session` populate exactly as on tmux. Only the sampling
+  source branches; all downstream accounting is shared. Known limitation:
+  herdr exposes no client-attach state, so focus time accrues even when the
+  server is detached with no client attached (inflates ACT for always-on
+  detached servers; mitigation out of scope). See `docs/HERDR.md`.
 - **herdr backend (Phase 1).** muxa now observes agents inside
   [herdr](https://herdr.dev) panes: a full `PaneBackend` over herdr's local
   socket API (`pane.list`/`pane.read`/`pane.process_info`/`pane.focus`, so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,6 +2357,7 @@ dependencies = [
  "anyhow",
  "clap 4.6.1",
  "muxa",
+ "serde_json",
  "time",
  "tokio",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ and Google Gemini CLI through their existing hook/event systems, then
 correlates those events with tmux panes and sessions.
 
 It does not fork tmux or modify agent binaries. tmux is the default full
-backend; zellij has a CLI baseline and a planned richer plugin path.
+backend; [herdr](https://herdr.dev) is supported through its socket API
+(see [docs/HERDR.md](docs/HERDR.md)); zellij has a CLI baseline and a
+planned richer plugin path.
 
 <div align="center">
   <img src="docs/demo.gif" alt="muxa demo" width="900" />

--- a/crates/muxa-cli/src/dashboard_tui.rs
+++ b/crates/muxa-cli/src/dashboard_tui.rs
@@ -455,6 +455,7 @@ fn push_action_target(targets: &mut Vec<ActionTarget>, target: ActionTarget) {
 enum CardHost {
     Tmux,
     Zellij,
+    Herdr,
     Pty,
     Pane,
     Agent,
@@ -465,6 +466,7 @@ impl CardHost {
         match self {
             Self::Tmux => "tmux",
             Self::Zellij => "zellij",
+            Self::Herdr => "herdr",
             Self::Pty => "pty",
             Self::Pane => "pane",
             Self::Agent => "agent",
@@ -1142,6 +1144,7 @@ fn build_dashboard_data(
         let card_host = match host {
             HostKind::Tmux => CardHost::Tmux,
             HostKind::Zellij => CardHost::Zellij,
+            HostKind::Herdr => CardHost::Herdr,
         };
         let key = format!("{}:{}", card_host.label(), pane.session);
         let builder = builders
@@ -1288,6 +1291,7 @@ fn card_identity(
             let card_host = match host {
                 HostKind::Tmux => CardHost::Tmux,
                 HostKind::Zellij => CardHost::Zellij,
+                HostKind::Herdr => CardHost::Herdr,
             };
             return CardIdentity {
                 key: format!("{}:{}", card_host.label(), info.session),
@@ -2148,7 +2152,7 @@ fn compact_card_lines(
 
 fn card_title(card: &SessionCard) -> String {
     let prefix = match card.host {
-        CardHost::Tmux | CardHost::Zellij => "",
+        CardHost::Tmux | CardHost::Zellij | CardHost::Herdr => "",
         CardHost::Pty => "pty:",
         CardHost::Pane => "pane:",
         CardHost::Agent => "agent:",

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -866,6 +866,7 @@ fn jump_to_pane(pane_id: &str) {
     match backend.kind() {
         muxa::HostKind::Tmux => jump_to_pane_tmux(pane_id),
         muxa::HostKind::Zellij => jump_to_pane_zellij(backend.as_ref(), pane_id),
+        muxa::HostKind::Herdr => jump_to_pane_herdr(backend.as_ref(), pane_id),
     }
 }
 
@@ -911,6 +912,17 @@ fn jump_to_pane_tmux(pane_id: &str) {
 fn jump_to_pane_zellij(backend: &dyn muxa::PaneBackend, pane_id: &str) {
     if !backend.focus_pane(pane_id) {
         eprintln!("muxa: zellij focus-pane-with-id {pane_id} failed — pane may have closed");
+    }
+}
+
+/// Jump on herdr: `pane.focus` over the herdr socket is the whole story,
+/// same single-call shape as zellij. Focus moves the herdr UI wherever a
+/// client is attached; there is no bare-shell attach handover analog.
+fn jump_to_pane_herdr(backend: &dyn muxa::PaneBackend, pane_id: &str) {
+    if !backend.focus_pane(pane_id) {
+        eprintln!(
+            "muxa: herdr pane.focus {pane_id} failed — pane may have closed or the herdr server is down"
+        );
     }
 }
 
@@ -1340,6 +1352,9 @@ fn cmd_panes() {
                 "(zellij CLI baseline: pane inventory is plugin-only — install the muxa zellij plugin to populate)"
             ),
             muxa::HostKind::Zellij => println!("(no zellij panes)"),
+            muxa::HostKind::Herdr => {
+                println!("(no herdr panes — server may be down or socket unreachable)");
+            }
         }
         return;
     }

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -6959,6 +6959,7 @@ mod tests {
             &app.panes,
             watch_theme(WatchTheme::Classic),
             Spinner::OFF,
+            app.watch_cfg.summary,
         );
         let cell = text
             .lines

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -668,7 +668,12 @@ pub(crate) enum RowIdentity {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SessionRow {
+    /// Stable group key — `PaneInfo.session` (tmux session name / herdr
+    /// `workspace_id`). Used for grouping, sorting, and the activity bridge.
     pub session: String,
+    /// Human-facing name shown in the session view. Equals `session` on tmux;
+    /// resolves to the workspace label on herdr.
+    pub display_name: String,
     pub pane_ids: Vec<String>,
     pub representative_pane: Option<String>,
     pub latest_agent: Option<Agent>,
@@ -1841,6 +1846,13 @@ impl App {
 struct SortContext<'a> {
     pane_by_id: HashMap<&'a str, &'a PaneInfo>,
     session_id_by_name: HashMap<&'a str, &'a str>,
+    /// Display name for a group key. A group is keyed by `PaneInfo.session`:
+    /// the session name on tmux, the `workspace_id` on herdr. Mapped from
+    /// both `SessionInfo.name` and `SessionInfo.session_id` so a key resolves
+    /// however the pane spells it — on tmux both entries point at the same
+    /// name (identity display); on herdr the `workspace_id` entry surfaces
+    /// the human label.
+    display_by_key: HashMap<&'a str, &'a str>,
     activity_by_id: HashMap<&'a str, &'a SessionActivity>,
     now: OffsetDateTime,
 }
@@ -1852,12 +1864,18 @@ impl<'a> SortContext<'a> {
         session_activity: &'a [SessionActivity],
         now: OffsetDateTime,
     ) -> Self {
+        let mut display_by_key = HashMap::new();
+        for s in sessions {
+            display_by_key.insert(s.name.as_str(), s.name.as_str());
+            display_by_key.insert(s.session_id.as_str(), s.name.as_str());
+        }
         Self {
             pane_by_id: panes.iter().map(|p| (p.pane_id.as_str(), p)).collect(),
             session_id_by_name: sessions
                 .iter()
                 .map(|s| (s.name.as_str(), s.session_id.as_str()))
                 .collect(),
+            display_by_key,
             activity_by_id: session_activity
                 .iter()
                 .map(|a| (a.session_id.as_str(), a))
@@ -1870,10 +1888,27 @@ impl<'a> SortContext<'a> {
         self.pane_by_id.get(pane_id).copied()
     }
 
+    /// The human-facing display name for a group key, falling back to the key
+    /// itself when no session metadata matches (e.g. a stale pane).
+    fn display_name(&self, session: &str) -> String {
+        self.display_by_key
+            .get(session)
+            .copied()
+            .unwrap_or(session)
+            .to_string()
+    }
+
     fn activity_for_session_name(&self, session: &str) -> Option<&'a SessionActivity> {
+        // tmux keys panes by the mutable session *name* but the ledger by the
+        // stable session *id*, so bridge name → id → activity. On herdr the
+        // pane's session is already the stable `workspace_id` (= the ledger
+        // key), so the name lookup misses and we fall back to keying the
+        // ledger directly. The fallback is a no-op on tmux (session names
+        // never collide with `$N` session ids) and only fires after a miss.
         self.session_id_by_name
             .get(session)
             .and_then(|id| self.activity_by_id.get(*id).copied())
+            .or_else(|| self.activity_by_id.get(session).copied())
     }
 
     fn session_duration_secs(&self, session: &str) -> u64 {
@@ -2062,6 +2097,7 @@ fn build_session_rows(
                 .map(|agent| ((agent.kind, agent.session_id.clone()), agent.state))
                 .collect();
             SessionRow {
+                display_name: sort_context.display_name(&b.session),
                 session: b.session,
                 pane_ids: b.panes.iter().map(|p| p.pane_id.clone()).collect(),
                 representative_pane,
@@ -2333,7 +2369,7 @@ fn state_summary_spans_from_parts(parts: &[StateSummaryPart]) -> Vec<Span<'stati
 
 fn session_label(s: &SessionRow, theme: WatchThemeSpec, spin: Spinner) -> Text<'static> {
     let mut spans = state_summary_gutter_spans(s.agent_states.values().copied(), theme, spin);
-    spans.push(Span::raw(s.session.clone()));
+    spans.push(Span::raw(s.display_name.clone()));
 
     Text::from(Line::from(spans))
 }
@@ -2809,7 +2845,16 @@ fn apply_single_agent_to_session(app: &mut App, agent: Agent) {
 
     let mut agent_states = HashMap::new();
     agent_states.insert((agent.kind, agent.session_id.clone()), agent.state);
+    // Resolve the workspace label from the last full refresh's session list
+    // (herdr); on tmux and for an unknown key this is the key itself. The next
+    // `Full` tick rebuilds the row via `build_session_rows` regardless.
+    let display_name = app
+        .sessions
+        .iter()
+        .find(|s| s.session_id == session || s.name == session)
+        .map_or_else(|| session.clone(), |s| s.name.clone());
     app.rows.push(WatchRow::Session(Box::new(SessionRow {
+        display_name,
         session,
         pane_ids: agent.pane.clone().into_iter().collect(),
         representative_pane: agent.pane.clone(),
@@ -2879,13 +2924,31 @@ async fn compute_refresh(
     let backend_for_blocking = backend.clone();
     let panes_task = tokio::task::spawn_blocking(move || backend_for_blocking.list_panes());
 
-    let is_tmux = backend.kind() == muxa::HostKind::Tmux;
-    let sessions_task = tokio::task::spawn_blocking(move || {
-        if is_tmux {
-            muxa::tmux::list_sessions().unwrap_or_default()
-        } else {
-            Vec::new()
+    // Source the "sessions" list per host. tmux shells `list-sessions`;
+    // herdr derives sessions from its workspaces over the socket (session
+    // id = raw `workspace_id`, matching `PaneInfo.session` and the
+    // session-activity ledger key so the DUR column resolves; display name =
+    // workspace label, falling back to the id). zellij has no session
+    // concept here, so it stays empty. Any host: this may shell out or hit a
+    // socket, so it MUST NOT run on a tokio worker.
+    let host = backend.kind();
+    let sessions_task = tokio::task::spawn_blocking(move || match host {
+        muxa::HostKind::Tmux => muxa::tmux::list_sessions().unwrap_or_default(),
+        muxa::HostKind::Herdr => {
+            let socket = muxa::backend::herdr::default_socket_path();
+            muxa::backend::herdr::herdr_list_workspaces(&socket)
+                .into_iter()
+                .map(|ws| SessionInfo {
+                    session_id: ws.id,
+                    name: ws.label,
+                    // herdr's socket API exposes no client-attach state
+                    // (see docs/HERDR.md); watch never reads this field for
+                    // display, and foreground time comes from the ledger.
+                    attached_clients: 0,
+                })
+                .collect()
         }
+        muxa::HostKind::Zellij => Vec::new(),
     });
 
     let session_activity_task = async move {
@@ -6847,6 +6910,84 @@ mod tests {
             .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
             .collect::<String>();
         assert_eq!(cell, "1h05m");
+    }
+
+    #[test]
+    fn herdr_session_row_shows_label_and_resolves_duration_by_workspace_id() {
+        // herdr shape: the pane's session and the ledger key are both the
+        // stable `workspace_id` (`w1`); the SessionInfo carries the human
+        // label as its name (session_id == the workspace id). The row must
+        // display the label, and the DUR column must resolve via the
+        // session-id fallback even though no session *name* matches `w1`.
+        let now = time::macros::datetime!(2026-04-28 10:00:00 UTC);
+        let cfg = WatchConfig {
+            view: WatchView::Session,
+            ..WatchConfig::default()
+        };
+        let mut app = App::with_config(cfg);
+        app.set_data_with_sessions(
+            vec![],
+            vec![fake_pane("herdr:p1", "w1", 0, 0, "zsh")],
+            vec![fake_session("w1", "muxa", 0)],
+            vec![fake_session_activity(
+                "w1",
+                "muxa",
+                3_600,
+                Some(now - time::Duration::minutes(5)),
+            )],
+        );
+
+        let WatchRow::Session(row) = &app.rows[0] else {
+            panic!("expected session row");
+        };
+        assert_eq!(row.session, "w1", "group key stays the workspace id");
+        assert_eq!(row.display_name, "muxa", "display name is the label");
+
+        let label = plain_text(&session_label(
+            row,
+            watch_theme(WatchTheme::Classic),
+            Spinner::OFF,
+        ));
+        assert!(
+            label.contains("muxa"),
+            "label renders the workspace label: {label}"
+        );
+
+        let text = WatchColumn::SessionTime.session_text(
+            row,
+            now,
+            &app.panes,
+            watch_theme(WatchTheme::Classic),
+            Spinner::OFF,
+        );
+        let cell = text
+            .lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect::<String>();
+        assert_eq!(cell, "1h05m", "DUR resolves by workspace id");
+    }
+
+    #[test]
+    fn herdr_session_row_falls_back_to_workspace_id_without_label() {
+        // No SessionInfo for the pane's workspace (e.g. the workspace list
+        // was unreachable this refresh): the display name degrades to the id.
+        let cfg = WatchConfig {
+            view: WatchView::Session,
+            ..WatchConfig::default()
+        };
+        let mut app = App::with_config(cfg);
+        app.set_data_with_sessions(
+            vec![],
+            vec![fake_pane("herdr:p1", "w1", 0, 0, "zsh")],
+            vec![],
+            vec![],
+        );
+
+        let WatchRow::Session(row) = &app.rows[0] else {
+            panic!("expected session row");
+        };
+        assert_eq!(row.display_name, "w1", "display name falls back to the id");
     }
 
     #[test]

--- a/crates/muxa/src/adapters/hook.rs
+++ b/crates/muxa/src/adapters/hook.rs
@@ -36,12 +36,13 @@ pub trait HookAdapter {
 ///
 /// Reads stdin to EOF, parses as `A::Input`, normalizes to `AgentEvent`.
 ///
-/// `pane` resolution, in order:
-/// 1. `$TMUX_PANE` (tmux sets this on every shell inside a pane).
-/// 2. `$ZELLIJ_PANE_ID` (zellij's analog).
-/// 3. `$HERDR_PANE_ID` (herdr's analog), namespaced to `herdr:<id>` — see
-///    [`host_pane_env`].
-/// 4. Walk the parent-pid chain and match against the active backend's
+/// `pane` resolution, in order (see [`host_pane_env`] for the tie-break
+/// rationale — herdr wins presence ties over tmux, `MUXA_HOST` overrides):
+/// 1. `$MUXA_HOST` override — forces the named host's pane var when present.
+/// 2. `$ZELLIJ_PANE_ID` (zellij's "this pane" var).
+/// 3. `$HERDR_PANE_ID` (herdr's analog), namespaced to `herdr:<id>`.
+/// 4. `$TMUX_PANE` (tmux sets this on every shell inside a pane).
+/// 5. Walk the parent-pid chain and match against the active backend's
 ///    `pane_pid_map()`. Linux reads `/proc`; macOS/BSD take one `ps` process
 ///    snapshot and walk it in memory. Useful when an agent hook subprocess
 ///    didn't inherit the host env var. Skipped when the backend's
@@ -103,10 +104,11 @@ fn muxa_session_env() -> Option<SurfaceRef> {
     Some(SurfaceRef { kind, id })
 }
 
-/// Read whichever host-set "this pane" env var is present, in
-/// `TMUX_PANE` → `ZELLIJ_PANE_ID` → `HERDR_PANE_ID` order. Empty string is
-/// treated as unset; see also `crate::backend::detect_host_env` for the
-/// host-selection precedence.
+/// Read whichever host-set "this pane" env var identifies the *innermost*
+/// host, in `MUXA_HOST` override → `ZELLIJ_PANE_ID` → `HERDR_PANE_ID` →
+/// `TMUX_PANE` order. Empty string is treated as unset. This mirrors
+/// `crate::backend::detect_from`'s host-selection precedence exactly, so the
+/// pane a hook is stamped onto and the backend that observes it always agree.
 ///
 /// tmux/zellij ids are returned verbatim (`%N`, `zellij:<id>` — the latter
 /// already carries its namespace). herdr's raw pane id is *not* namespaced
@@ -116,12 +118,14 @@ fn muxa_session_env() -> Option<SurfaceRef> {
 /// `pane_id_host_kind`); the prefix is stripped again before the id goes
 /// back over the herdr socket.
 ///
-/// tmux wins the precedence over herdr deliberately: when both env vars are
-/// present the process is a tmux pane running *inside* a herdr terminal, and
-/// `$TMUX_PANE` is the id that muxa's tmux backend can actually observe and
-/// reap — `$HERDR_PANE_ID` there names herdr's outer container, not a pane
-/// muxa tracks. (Nested the other way — herdr inside tmux — doesn't set
-/// `$TMUX_PANE` for the herdr pane, so this order is safe.)
+/// **herdr wins presence ties over tmux.** Nesting can't be inferred from env
+/// presence alone (both vars are inherited either way), so we pick the common
+/// real-world case: launching herdr from a tmux shell. Those herdr pane shells
+/// *do* inherit the outer `$TMUX_PANE`, so preferring tmux would (wrongly)
+/// stamp every herdr hook onto the single outer tmux pane. The rarer nesting —
+/// tmux running *inside* a herdr pane — is served by the `MUXA_HOST=tmux`
+/// escape hatch, which forces `$TMUX_PANE` here (and the tmux backend in
+/// `detect_from`). `MUXA_HOST=herdr`/`zellij` force the corresponding var.
 fn host_pane_env() -> Option<String> {
     host_pane_env_from(|name| std::env::var(name).ok())
 }
@@ -132,15 +136,49 @@ fn host_pane_env() -> Option<String> {
 /// (forbidden by the workspace's `forbid(unsafe_code)` posture, and racy under
 /// parallel test threads).
 fn host_pane_env_from(read: impl Fn(&str) -> Option<String>) -> Option<String> {
-    for name in ["TMUX_PANE", "ZELLIJ_PANE_ID"] {
-        if let Some(v) = read(name).filter(|v| !v.is_empty()) {
-            return Some(v);
+    use crate::backend::HostKind;
+
+    // `MUXA_HOST` override — explicit operator intent wins, same as
+    // `detect_from`. When the named host's pane var is actually present, use
+    // it; otherwise fall through to auto-detect (a typo or a host with no
+    // pane var set shouldn't strand the hook paneless).
+    if let Some(raw) = read("MUXA_HOST") {
+        let forced = match raw.trim().to_ascii_lowercase().as_str() {
+            "tmux" => Some(HostKind::Tmux),
+            "zellij" => Some(HostKind::Zellij),
+            "herdr" => Some(HostKind::Herdr),
+            _ => None,
+        };
+        if let Some(host) = forced {
+            if let Some(v) = pane_env_for(host, &read) {
+                return Some(v);
+            }
         }
     }
-    // herdr last, and prefixed — the raw `$HERDR_PANE_ID` is un-namespaced.
-    read("HERDR_PANE_ID")
-        .filter(|v| !v.is_empty())
-        .map(|v| format!("{}{v}", crate::backend::herdr::PANE_ID_PREFIX))
+
+    // Auto-detect: zellij, then herdr (wins over tmux on nested ties — see the
+    // `host_pane_env` doc), then tmux. Byte-for-byte the same order as
+    // `detect_from`, so hook stamping and backend observation never disagree.
+    pane_env_for(HostKind::Zellij, &read)
+        .or_else(|| pane_env_for(HostKind::Herdr, &read))
+        .or_else(|| pane_env_for(HostKind::Tmux, &read))
+}
+
+/// The muxa pane id for one host from its "this pane" env var, or `None` when
+/// that var is unset/empty. tmux/zellij ids pass through verbatim; herdr's raw
+/// id is stamped with the `herdr:` namespace prefix.
+fn pane_env_for(
+    host: crate::backend::HostKind,
+    read: &impl Fn(&str) -> Option<String>,
+) -> Option<String> {
+    use crate::backend::HostKind;
+    match host {
+        HostKind::Tmux => read("TMUX_PANE").filter(|v| !v.is_empty()),
+        HostKind::Zellij => read("ZELLIJ_PANE_ID").filter(|v| !v.is_empty()),
+        HostKind::Herdr => read("HERDR_PANE_ID")
+            .filter(|v| !v.is_empty())
+            .map(|v| format!("{}{v}", crate::backend::herdr::PANE_ID_PREFIX)),
+    }
 }
 
 /// Walk our parent PID chain and look each ancestor up in the
@@ -230,17 +268,58 @@ mod tests {
         );
     }
 
-    /// When both `$TMUX_PANE` and `$HERDR_PANE_ID` are set — a tmux pane
-    /// running inside a herdr terminal — tmux wins: `$TMUX_PANE` names the
-    /// pane muxa's tmux backend can actually observe and reap, whereas
-    /// `$HERDR_PANE_ID` there names herdr's outer container. The precedence
-    /// order keeps herdr last for exactly this reason.
+    /// When both `$TMUX_PANE` and `$HERDR_PANE_ID` are set, herdr wins by
+    /// default — the common case is a herdr pane launched from a tmux shell
+    /// (whose herdr shell inherits the outer `$TMUX_PANE`). Preferring tmux
+    /// would stamp every herdr hook onto the single outer tmux pane. Mirrors
+    /// `detect_from`'s herdr-before-tmux order.
     #[test]
-    fn host_pane_env_tmux_takes_precedence_over_herdr() {
+    fn host_pane_env_herdr_takes_precedence_over_tmux() {
         assert_eq!(
             host_pane_env_from(env_reader(&[("TMUX_PANE", "%1"), ("HERDR_PANE_ID", "9")])),
+            Some(format!("{}9", crate::backend::herdr::PANE_ID_PREFIX)),
+            "herdr pane id must win the presence tie over tmux",
+        );
+    }
+
+    /// `MUXA_HOST=tmux` is the escape hatch for the rarer nesting (tmux running
+    /// inside a herdr pane): it forces `$TMUX_PANE` even though `$HERDR_PANE_ID`
+    /// is also present. Symmetric with `detect_from`'s override.
+    #[test]
+    fn host_pane_env_muxa_host_tmux_forces_tmux_pane() {
+        assert_eq!(
+            host_pane_env_from(env_reader(&[
+                ("MUXA_HOST", "tmux"),
+                ("TMUX_PANE", "%1"),
+                ("HERDR_PANE_ID", "9"),
+            ])),
             Some("%1".to_string()),
-            "tmux pane id must win when nested inside a herdr terminal",
+            "MUXA_HOST=tmux must force the tmux pane id",
+        );
+    }
+
+    /// `MUXA_HOST=herdr` forces the herdr pane var (case/whitespace tolerant),
+    /// even against a present `$TMUX_PANE` — though that's also the default.
+    #[test]
+    fn host_pane_env_muxa_host_herdr_forces_herdr_pane() {
+        assert_eq!(
+            host_pane_env_from(env_reader(&[
+                ("MUXA_HOST", " Herdr "),
+                ("TMUX_PANE", "%1"),
+                ("HERDR_PANE_ID", "9"),
+            ])),
+            Some(format!("{}9", crate::backend::herdr::PANE_ID_PREFIX)),
+        );
+    }
+
+    /// A `MUXA_HOST` naming a host whose pane var isn't set falls through to
+    /// auto-detect rather than stranding the hook paneless.
+    #[test]
+    fn host_pane_env_muxa_host_falls_through_when_var_absent() {
+        assert_eq!(
+            host_pane_env_from(env_reader(&[("MUXA_HOST", "zellij"), ("TMUX_PANE", "%2")])),
+            Some("%2".to_string()),
+            "no ZELLIJ_PANE_ID ⇒ fall through to the present TMUX_PANE",
         );
     }
 

--- a/crates/muxa/src/adapters/hook.rs
+++ b/crates/muxa/src/adapters/hook.rs
@@ -39,7 +39,9 @@ pub trait HookAdapter {
 /// `pane` resolution, in order:
 /// 1. `$TMUX_PANE` (tmux sets this on every shell inside a pane).
 /// 2. `$ZELLIJ_PANE_ID` (zellij's analog).
-/// 3. Walk the parent-pid chain and match against the active backend's
+/// 3. `$HERDR_PANE_ID` (herdr's analog), namespaced to `herdr:<id>` — see
+///    [`host_pane_env`].
+/// 4. Walk the parent-pid chain and match against the active backend's
 ///    `pane_pid_map()`. Linux reads `/proc`; macOS/BSD take one `ps` process
 ///    snapshot and walk it in memory. Useful when an agent hook subprocess
 ///    didn't inherit the host env var. Skipped when the backend's
@@ -102,18 +104,43 @@ fn muxa_session_env() -> Option<SurfaceRef> {
 }
 
 /// Read whichever host-set "this pane" env var is present, in
-/// `TMUX_PANE` then `ZELLIJ_PANE_ID` order. Empty string is treated as
-/// unset; see also `crate::backend::detect_host_env` for the host-
-/// selection precedence.
+/// `TMUX_PANE` → `ZELLIJ_PANE_ID` → `HERDR_PANE_ID` order. Empty string is
+/// treated as unset; see also `crate::backend::detect_host_env` for the
+/// host-selection precedence.
+///
+/// tmux/zellij ids are returned verbatim (`%N`, `zellij:<id>` — the latter
+/// already carries its namespace). herdr's raw pane id is *not* namespaced
+/// by herdr, so we stamp `crate::backend::herdr::PANE_ID_PREFIX` (`herdr:`)
+/// here to match the `herdr:<id>` shape muxa uses everywhere internally
+/// (registry rows, `by_pane`, and the cross-host reaping guard's
+/// `pane_id_host_kind`); the prefix is stripped again before the id goes
+/// back over the herdr socket.
+///
+/// tmux wins the precedence over herdr deliberately: when both env vars are
+/// present the process is a tmux pane running *inside* a herdr terminal, and
+/// `$TMUX_PANE` is the id that muxa's tmux backend can actually observe and
+/// reap — `$HERDR_PANE_ID` there names herdr's outer container, not a pane
+/// muxa tracks. (Nested the other way — herdr inside tmux — doesn't set
+/// `$TMUX_PANE` for the herdr pane, so this order is safe.)
 fn host_pane_env() -> Option<String> {
+    host_pane_env_from(|name| std::env::var(name).ok())
+}
+
+/// Decoupled-from-process-env variant of [`host_pane_env`] for tests, mirroring
+/// `crate::backend::detect_from`. `read("VAR")` yields the env var's value if
+/// set, else `None`; tests pass a closure so we never mutate `std::env`
+/// (forbidden by the workspace's `forbid(unsafe_code)` posture, and racy under
+/// parallel test threads).
+fn host_pane_env_from(read: impl Fn(&str) -> Option<String>) -> Option<String> {
     for name in ["TMUX_PANE", "ZELLIJ_PANE_ID"] {
-        if let Ok(v) = std::env::var(name) {
-            if !v.is_empty() {
-                return Some(v);
-            }
+        if let Some(v) = read(name).filter(|v| !v.is_empty()) {
+            return Some(v);
         }
     }
-    None
+    // herdr last, and prefixed — the raw `$HERDR_PANE_ID` is un-namespaced.
+    read("HERDR_PANE_ID")
+        .filter(|v| !v.is_empty())
+        .map(|v| format!("{}{v}", crate::backend::herdr::PANE_ID_PREFIX))
 }
 
 /// Walk our parent PID chain and look each ancestor up in the
@@ -158,4 +185,88 @@ pub(crate) fn truncate(mut s: String, max: usize) -> String {
         s.push('…');
     }
     s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a `read` closure from a static lookup table, matching the
+    /// `backend::tests::env_reader` shape. Missing keys read as `None`.
+    fn env_reader(
+        pairs: &'static [(&'static str, &'static str)],
+    ) -> impl Fn(&str) -> Option<String> {
+        move |name| {
+            pairs
+                .iter()
+                .find(|(k, _)| *k == name)
+                .map(|(_, v)| (*v).to_string())
+        }
+    }
+
+    /// tmux and zellij pane ids pass through verbatim: `$TMUX_PANE` is
+    /// already `%N` and `$ZELLIJ_PANE_ID` already carries its `zellij:`
+    /// namespace, so muxa must not re-wrap either.
+    #[test]
+    fn host_pane_env_returns_tmux_and_zellij_verbatim() {
+        assert_eq!(
+            host_pane_env_from(env_reader(&[("TMUX_PANE", "%7")])),
+            Some("%7".to_string()),
+        );
+        assert_eq!(
+            host_pane_env_from(env_reader(&[("ZELLIJ_PANE_ID", "zellij:3")])),
+            Some("zellij:3".to_string()),
+        );
+    }
+
+    /// herdr's raw `$HERDR_PANE_ID` is un-namespaced, so the adapter stamps
+    /// the `herdr:` prefix — matching the `herdr:<id>` shape muxa uses in the
+    /// registry and the reaping guard's `pane_id_host_kind`.
+    #[test]
+    fn host_pane_env_prefixes_herdr_pane_id() {
+        assert_eq!(
+            host_pane_env_from(env_reader(&[("HERDR_PANE_ID", "42")])),
+            Some(format!("{}42", crate::backend::herdr::PANE_ID_PREFIX)),
+        );
+    }
+
+    /// When both `$TMUX_PANE` and `$HERDR_PANE_ID` are set — a tmux pane
+    /// running inside a herdr terminal — tmux wins: `$TMUX_PANE` names the
+    /// pane muxa's tmux backend can actually observe and reap, whereas
+    /// `$HERDR_PANE_ID` there names herdr's outer container. The precedence
+    /// order keeps herdr last for exactly this reason.
+    #[test]
+    fn host_pane_env_tmux_takes_precedence_over_herdr() {
+        assert_eq!(
+            host_pane_env_from(env_reader(&[("TMUX_PANE", "%1"), ("HERDR_PANE_ID", "9")])),
+            Some("%1".to_string()),
+            "tmux pane id must win when nested inside a herdr terminal",
+        );
+    }
+
+    /// An empty `$HERDR_PANE_ID` is treated as unset (never returned as a
+    /// bare `herdr:` prefix), matching the empty-string handling for the
+    /// tmux/zellij vars.
+    #[test]
+    fn host_pane_env_ignores_empty_herdr_pane_id() {
+        assert_eq!(
+            host_pane_env_from(env_reader(&[("HERDR_PANE_ID", "")])),
+            None
+        );
+        // Empty herdr but a real zellij id → the zellij id, not a stray prefix.
+        assert_eq!(
+            host_pane_env_from(env_reader(&[
+                ("HERDR_PANE_ID", ""),
+                ("ZELLIJ_PANE_ID", "zellij:5"),
+            ])),
+            Some("zellij:5".to_string()),
+        );
+    }
+
+    /// No host env at all → `None`; the caller then falls back to the
+    /// parent-pid ancestry walk.
+    #[test]
+    fn host_pane_env_none_when_unset() {
+        assert_eq!(host_pane_env_from(env_reader(&[])), None);
+    }
 }

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -22,8 +22,10 @@
 //! `{"id":"muxa-<n>","method":…,"params":{…}}` and read response lines
 //! until one echoes our `id`, skipping anything else (a concurrent
 //! subscription event, a stale reply). Read/write are bounded by a ~1s
-//! timeout matching [`crate::tmux`]'s `TMUX_COMMAND_TIMEOUT`, so a wedged
-//! server can't hold a watch refresh open. A success carries a
+//! per-read timeout matching [`crate::tmux`]'s `TMUX_COMMAND_TIMEOUT`, plus
+//! an aggregate ~2× read deadline over the whole reply loop so a server that
+//! *streams* unrelated lines sub-timeout can't wedge a watch refresh open. A
+//! success carries a
 //! `type`-tagged `result`; an `error` object (or a malformed line, or a
 //! timeout) degrades the call the way a host-down backend would — empty
 //! vec / `None` / `false`, never a panic.
@@ -35,7 +37,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -100,11 +102,12 @@ impl HerdrBackend {
     /// (must not drive destructive reaping) — see [`Self::observe_panes`].
     fn request(&self, method: &str, params: Value) -> Result<Value, HerdrError> {
         // A missing socket file means no server is listening — distinct
-        // from a connect/timeout error because it is authoritative:
-        // there are no herdr panes to observe.
-        if !self.socket_path.exists() {
-            return Err(HerdrError::SocketMissing);
-        }
+        // from a connect/timeout error because it is authoritative: there
+        // are no herdr panes to observe. `try_exists()` (not `exists()`)
+        // so a stat that *errors* — EACCES, EIO, a stalled automount — maps
+        // to a transient `Io` error rather than being swallowed as an
+        // authoritative "socket absent" and triggering a mass reap.
+        classify_socket_presence(self.socket_path.try_exists())?;
 
         let mut stream = UnixStream::connect(&self.socket_path).map_err(map_io)?;
         stream
@@ -127,8 +130,19 @@ impl HerdrBackend {
         // Read lines until one echoes our id. Skip non-matching lines
         // (subscription events carry no `id`; stale/foreign replies carry
         // a different one) and unparsable noise.
+        //
+        // The per-read socket timeout resets on every line, so a chatty
+        // server that streams unrelated lines *faster* than that timeout
+        // would loop here forever and wedge the reconciler / watch refresh.
+        // Bound the whole read with an aggregate wall-clock deadline
+        // (~2× the per-read timeout — enough for a healthy server's reply
+        // to arrive after at most one skipped line, but not unbounded).
+        let deadline = Instant::now() + self.timeout.saturating_mul(2);
         let reader = BufReader::new(&stream);
         for line in reader.lines() {
+            if Instant::now() >= deadline {
+                return Err(HerdrError::Timeout);
+            }
             let line = line.map_err(map_io)?;
             let Ok(value) = serde_json::from_str::<Value>(&line) else {
                 continue;
@@ -178,10 +192,21 @@ impl HerdrBackend {
             .cloned()
             .and_then(|p| serde_json::from_value(p).ok())
             .ok_or(HerdrError::Protocol("pane.list missing panes"))?;
+        // Per-pane `pane.process_info` enrichment is a full socket round-trip
+        // each, so N panes cost N× serial worst-case against a slow server.
+        // Cap the *total* enrichment time per list so one wedged server can't
+        // turn a single `pane.list` into an N-second stall: once the budget
+        // is spent we return the remaining panes with empty process fields
+        // (degraded `current_command`/`pane_pid`/`tty`) rather than block.
+        let enrich_deadline = Instant::now() + self.timeout.saturating_mul(2);
         Ok(panes
             .iter()
             .map(|pane| {
-                let process = self.process_info(&pane.pane_id);
+                let process = if Instant::now() < enrich_deadline {
+                    self.process_info(&pane.pane_id)
+                } else {
+                    None
+                };
                 to_pane_info(pane, process.as_ref())
             })
             .collect())
@@ -383,6 +408,21 @@ fn strip_prefix(pane_id: &str) -> &str {
     pane_id.strip_prefix(PANE_ID_PREFIX).unwrap_or(pane_id)
 }
 
+/// Classify a `try_exists()` result on the socket path. `Ok(false)` is the
+/// authoritative "no server listening" signal (`SocketMissing` — reaping may
+/// proceed); `Ok(true)` clears the check; an `Err` (EACCES, EIO, a stalled
+/// automount) is transient — mapped to `Io` so `observe_panes` yields
+/// `incomplete` and destructive reaping is withheld. Split out from
+/// [`HerdrBackend::request`] so the three-way mapping is unit-testable without
+/// having to provoke a real stat error.
+fn classify_socket_presence(exists: std::io::Result<bool>) -> Result<(), HerdrError> {
+    match exists {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(HerdrError::SocketMissing),
+        Err(_) => Err(HerdrError::Io),
+    }
+}
+
 /// Map an I/O failure to the classification `observe_panes` needs: a read
 /// that hit the socket timeout surfaces as `WouldBlock`/`TimedOut`, which
 /// we tag distinctly from other transport errors for clearer logs (both
@@ -529,6 +569,11 @@ mod tests {
         ForeignIdThen(Value),
         /// Accept the connection but never answer — drives the timeout.
         Hang,
+        /// Stream unrelated (foreign-id) lines faster than the per-read
+        /// timeout and never send the matching reply — drives the aggregate
+        /// read deadline (a per-read timeout alone would reset on every line
+        /// and loop forever).
+        Chatter,
     }
 
     /// Spin a `UnixListener` on a temp path, answering each connection via
@@ -582,6 +627,18 @@ mod tests {
                     Reply::Hang => {
                         // Hold the connection open with no reply.
                         thread::sleep(Duration::from_secs(30));
+                    }
+                    Reply::Chatter => {
+                        // Flood foreign-id lines sub-timeout, forever. The
+                        // client must bail at its aggregate read deadline
+                        // rather than loop on the resetting per-read timeout.
+                        loop {
+                            write_line(
+                                &mut stream,
+                                &json!({ "id": "muxa-foreign", "result": { "type": "ok" } }),
+                            );
+                            thread::sleep(Duration::from_millis(5));
+                        }
                     }
                 }
             }
@@ -712,6 +769,46 @@ mod tests {
             "a timeout is transient — must not authorize reaping",
         );
         assert!(observation.panes.is_empty());
+    }
+
+    #[test]
+    fn classify_socket_presence_maps_each_variant() {
+        // Present ⇒ proceed.
+        assert!(classify_socket_presence(Ok(true)).is_ok());
+        // Authoritatively absent ⇒ SocketMissing (reap-safe).
+        assert!(matches!(
+            classify_socket_presence(Ok(false)),
+            Err(HerdrError::SocketMissing),
+        ));
+        // Stat *errored* (EACCES/EIO/stalled automount) ⇒ transient Io, NOT
+        // an authoritative empty — this is the whole point of `try_exists`.
+        assert!(matches!(
+            classify_socket_presence(Err(std::io::Error::from(
+                std::io::ErrorKind::PermissionDenied
+            ))),
+            Err(HerdrError::Io),
+        ));
+    }
+
+    #[test]
+    fn observe_panes_incomplete_on_chatty_server() {
+        // The server streams unrelated (foreign-id) lines forever, faster
+        // than the per-read timeout — so only the aggregate read deadline can
+        // end the call. Without it the client loops on the resetting per-read
+        // timeout indefinitely and wedges the reconciler.
+        let (socket, _dir) = spawn_server(|_| Reply::Chatter);
+        let backend = backend_at(&socket).with_timeout(Duration::from_millis(100));
+        let start = std::time::Instant::now();
+        let observation = backend.observe_panes();
+        assert!(
+            !observation.is_complete(),
+            "an aggregate-deadline timeout is transient — must not authorize reaping",
+        );
+        assert!(observation.panes.is_empty());
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "call must bail at the ~2× aggregate deadline, not loop on chatter",
+        );
     }
 
     #[test]

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -332,6 +332,51 @@ pub(crate) fn herdr_focused_workspace(socket_path: &Path) -> Option<FocusedWorks
         })
 }
 
+/// A herdr workspace as the watch/session view needs it: the stable
+/// `workspace_id` (session id, matching [`to_pane_info`]'s `session` mapping
+/// and the `session_activity` ledger key) plus the mutable human-facing
+/// `label` (display name, falling back to the id when herdr reports none).
+pub struct WorkspaceSummary {
+    /// herdr `workspace_id` (e.g. `w1`). Same value `list_panes` puts in
+    /// [`PaneInfo::session`] and the ledger keys foreground time under.
+    pub id: String,
+    /// herdr workspace `label` — the display name. Falls back to the id.
+    pub label: String,
+}
+
+/// List every herdr workspace as a [`WorkspaceSummary`], so the watch
+/// session view can source "sessions" on herdr hosts (the tmux
+/// `list_sessions` analog). Uses `workspace.list` — the same cheap call
+/// [`herdr_focused_workspace`] uses, but returns *all* workspaces rather
+/// than only the focused one.
+///
+/// Returns an empty `Vec` when the server is unreachable/absent, reports no
+/// workspaces, or the reply is malformed — every failure degrades to "no
+/// sessions this refresh", mirroring `list_sessions().unwrap_or_default()`
+/// on tmux (a downed tmux server likewise yields no session rows).
+pub fn herdr_list_workspaces(socket_path: &Path) -> Vec<WorkspaceSummary> {
+    let backend = HerdrBackend::with_socket_path(socket_path.to_path_buf());
+    let Ok(result) = backend.request("workspace.list", json!({})) else {
+        return Vec::new();
+    };
+    let Some(workspaces) = result.get("workspaces").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    workspaces
+        .iter()
+        .filter_map(|ws| {
+            let id = ws.get("workspace_id").and_then(Value::as_str)?.to_string();
+            let label = ws
+                .get("label")
+                .and_then(Value::as_str)
+                .filter(|l| !l.is_empty())
+                .unwrap_or(&id)
+                .to_string();
+            Some(WorkspaceSummary { id, label })
+        })
+        .collect()
+}
+
 /// Strip the `herdr:` namespace before an id crosses the socket. Lenient:
 /// an already-bare id (or a foreign shape) passes through unchanged.
 fn strip_prefix(pane_id: &str) -> &str {
@@ -881,6 +926,68 @@ mod tests {
         });
         let ws = herdr_focused_workspace(&socket).unwrap();
         assert_eq!(ws.label, "w7", "empty label falls back to the id");
+    }
+
+    #[test]
+    fn list_workspaces_returns_all_with_label_or_id() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            "workspace.list" => Reply::Result(workspace_list_result()),
+            _ => Reply::Error,
+        });
+        let ws = herdr_list_workspaces(&socket);
+        assert_eq!(ws.len(), 2, "every workspace becomes a session row");
+        assert_eq!(ws[0].id, "w1");
+        assert_eq!(ws[0].label, "main");
+        assert_eq!(ws[1].id, "w2");
+        assert_eq!(ws[1].label, "scratch");
+    }
+
+    #[test]
+    fn list_workspaces_label_falls_back_to_id() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            "workspace.list" => Reply::Result(json!({
+                "type": "workspace_list",
+                "workspaces": [{
+                    "workspace_id": "w9",
+                    "number": 1,
+                    "label": "",
+                    "focused": false,
+                    "pane_count": 1,
+                    "tab_count": 1,
+                    "active_tab_id": "tab1",
+                    "agent_status": "idle",
+                }],
+            })),
+            _ => Reply::Error,
+        });
+        let ws = herdr_list_workspaces(&socket);
+        assert_eq!(ws.len(), 1);
+        assert_eq!(ws[0].label, "w9", "empty label falls back to the id");
+    }
+
+    #[test]
+    fn list_workspaces_empty_when_no_workspaces() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            "workspace.list" => Reply::Result(json!({
+                "type": "workspace_list",
+                "workspaces": [],
+            })),
+            _ => Reply::Error,
+        });
+        assert!(herdr_list_workspaces(&socket).is_empty());
+    }
+
+    #[test]
+    fn list_workspaces_empty_when_server_down() {
+        // No socket file ⇒ server absent ⇒ no session rows (list_sessions analog).
+        let missing = PathBuf::from("/definitely/missing/herdr-workspaces.sock");
+        assert!(herdr_list_workspaces(&missing).is_empty());
+    }
+
+    #[test]
+    fn list_workspaces_empty_on_error_reply() {
+        let (socket, _dir) = spawn_server(|_| Reply::Error);
+        assert!(herdr_list_workspaces(&socket).is_empty());
     }
 
     #[test]

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -1,0 +1,753 @@
+//! herdr backend — [`PaneBackend`] over the herdr socket API.
+//!
+//! herdr (<https://herdr.dev>) is an agent-native terminal multiplexer that
+//! serves a newline-delimited JSON API on a local unix socket (default
+//! `~/.config/herdr/herdr.sock`, overridden by `$HERDR_SOCKET_PATH` inside
+//! herdr panes). Unlike the zellij CLI baseline this gives muxa a full
+//! query surface without a plugin: `pane.list` for enumeration,
+//! `pane.read` for captures, `pane.process_info` for the pid map, and
+//! `pane.focus` for attach.
+//!
+//! Pane ids are namespaced as `herdr:<herdr_pane_id>` everywhere they
+//! enter muxa (registry rows, history keys, hook correlation) so they
+//! cannot collide with tmux `%N` ids and so cross-host code can tell
+//! which host governs a row. The prefix is stripped before ids are sent
+//! back over the herdr socket.
+//!
+//! ## Wire protocol
+//!
+//! Every call is a fresh connection (the surface is stateless — callers
+//! already wrap it in `spawn_blocking`, mirroring the tmux shell-out
+//! shape). We write one request line
+//! `{"id":"muxa-<n>","method":…,"params":{…}}` and read response lines
+//! until one echoes our `id`, skipping anything else (a concurrent
+//! subscription event, a stale reply). Read/write are bounded by a ~1s
+//! timeout matching [`crate::tmux`]'s `TMUX_COMMAND_TIMEOUT`, so a wedged
+//! server can't hold a watch refresh open. A success carries a
+//! `type`-tagged `result`; an `error` object (or a malformed line, or a
+//! timeout) degrades the call the way a host-down backend would — empty
+//! vec / `None` / `false`, never a panic.
+//!
+//! See `docs/HERDR.md` for the full design.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use super::{BackendCaps, HostKind, PaneBackend, PaneObservation};
+use crate::tmux::PaneInfo;
+
+/// Namespace prefix for herdr pane ids inside muxa.
+pub const PANE_ID_PREFIX: &str = "herdr:";
+
+/// Bound on each socket round-trip, mirroring `TMUX_COMMAND_TIMEOUT`. A
+/// herdr server that accepts the connection but never answers must not
+/// stall the reconciler or a watch refresh past this.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Monotonic request-id source. Only needs to disambiguate replies on a
+/// single connection, but a process-global counter keeps ids unique in
+/// logs across concurrent calls too. `Relaxed` is enough — we never
+/// order anything off this value.
+static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// [`PaneBackend`] implementation speaking the herdr socket API.
+///
+/// Cheap to construct (resolves the socket path, no I/O) and cheap to
+/// clone into an `Arc`. Holds no connection: each method opens, queries,
+/// and drops a `UnixStream`.
+pub struct HerdrBackend {
+    socket_path: PathBuf,
+    timeout: Duration,
+}
+
+impl HerdrBackend {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_socket_path(default_socket_path())
+    }
+
+    /// Build a backend pointed at an explicit socket path, bypassing env
+    /// resolution. Used by tests to target a temp-dir listener without
+    /// mutating `std::env` (forbidden by the workspace's
+    /// `forbid(unsafe_code)` posture).
+    #[must_use]
+    pub fn with_socket_path(socket_path: PathBuf) -> Self {
+        Self {
+            socket_path,
+            timeout: REQUEST_TIMEOUT,
+        }
+    }
+
+    /// Shorten the per-call timeout. Test-only so the "server accepts
+    /// then hangs" case exercises the real timeout path without a
+    /// full-second wait in the suite.
+    #[cfg(test)]
+    fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// One request/response round-trip. Returns the `result` value on a
+    /// success reply; classifies every failure so callers can tell an
+    /// absent server (its panes are truly gone) from a transient error
+    /// (must not drive destructive reaping) — see [`Self::observe_panes`].
+    fn request(&self, method: &str, params: Value) -> Result<Value, HerdrError> {
+        // A missing socket file means no server is listening — distinct
+        // from a connect/timeout error because it is authoritative:
+        // there are no herdr panes to observe.
+        if !self.socket_path.exists() {
+            return Err(HerdrError::SocketMissing);
+        }
+
+        let mut stream = UnixStream::connect(&self.socket_path).map_err(map_io)?;
+        stream
+            .set_read_timeout(Some(self.timeout))
+            .map_err(map_io)?;
+        stream
+            .set_write_timeout(Some(self.timeout))
+            .map_err(map_io)?;
+
+        let id = format!("muxa-{}", REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed));
+        let mut payload = serde_json::to_string(&json!({
+            "id": id,
+            "method": method,
+            "params": params,
+        }))
+        .map_err(|_| HerdrError::Protocol("serialize request"))?;
+        payload.push('\n');
+        stream.write_all(payload.as_bytes()).map_err(map_io)?;
+
+        // Read lines until one echoes our id. Skip non-matching lines
+        // (subscription events carry no `id`; stale/foreign replies carry
+        // a different one) and unparsable noise.
+        let reader = BufReader::new(&stream);
+        for line in reader.lines() {
+            let line = line.map_err(map_io)?;
+            let Ok(value) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
+            if value.get("id").and_then(Value::as_str) != Some(id.as_str()) {
+                continue;
+            }
+            if let Some(error) = value.get("error") {
+                let code = error
+                    .get("code")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                let message = error
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                tracing::debug!(method, code, message, "herdr returned an error");
+                return Err(HerdrError::Method);
+            }
+            return value
+                .get("result")
+                .cloned()
+                .ok_or(HerdrError::Protocol("response missing result"));
+        }
+        Err(HerdrError::Protocol(
+            "connection closed before a matching reply",
+        ))
+    }
+
+    /// `pane.process_info` for one raw (unprefixed) herdr pane id. Purely
+    /// enrichment — any failure degrades to `None` so a single pane's
+    /// process lookup can't fail a whole `pane.list`.
+    fn process_info(&self, raw_pane_id: &str) -> Option<HerdrProcessInfo> {
+        let result = self
+            .request("pane.process_info", json!({ "pane_id": raw_pane_id }))
+            .ok()?;
+        serde_json::from_value(result.get("process_info")?.clone()).ok()
+    }
+
+    /// `pane.list` plus per-pane `pane.process_info`, mapped into muxa
+    /// [`PaneInfo`]. Returns the classified error so [`Self::observe_panes`]
+    /// can decide whether an empty result is authoritative.
+    fn query_panes(&self) -> Result<Vec<PaneInfo>, HerdrError> {
+        let result = self.request("pane.list", json!({}))?;
+        let panes: Vec<HerdrPaneInfo> = result
+            .get("panes")
+            .cloned()
+            .and_then(|p| serde_json::from_value(p).ok())
+            .ok_or(HerdrError::Protocol("pane.list missing panes"))?;
+        Ok(panes
+            .iter()
+            .map(|pane| {
+                let process = self.process_info(&pane.pane_id);
+                to_pane_info(pane, process.as_ref())
+            })
+            .collect())
+    }
+}
+
+impl Default for HerdrBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PaneBackend for HerdrBackend {
+    fn kind(&self) -> HostKind {
+        HostKind::Herdr
+    }
+
+    fn list_panes(&self) -> Vec<PaneInfo> {
+        self.query_panes().unwrap_or_default()
+    }
+
+    fn observe_panes(&self) -> PaneObservation {
+        match self.query_panes() {
+            Ok(panes) => PaneObservation::complete(panes),
+            // Server truly down ⇒ its panes are gone; an empty set is
+            // authoritative (tmux semantics). Reaping may proceed.
+            Err(HerdrError::SocketMissing) => PaneObservation::complete(Vec::new()),
+            // Connect/protocol/timeout/error ⇒ transient; absence here is
+            // not evidence a pane died, so reaping must not proceed.
+            Err(err) => {
+                tracing::debug!(reason = err.describe(), "herdr observe_panes degraded");
+                PaneObservation::incomplete(Vec::new())
+            }
+        }
+    }
+
+    fn resolve_pane(&self, pane_id: &str) -> Option<PaneInfo> {
+        let raw = strip_prefix(pane_id);
+        let result = self.request("pane.get", json!({ "pane_id": raw })).ok()?;
+        let pane: HerdrPaneInfo = serde_json::from_value(result.get("pane")?.clone()).ok()?;
+        // Enrich with process metadata so resolve returns the same shape
+        // `list_panes` does (callers use `current_command` / `pane_pid`).
+        let process = self.process_info(&pane.pane_id);
+        Some(to_pane_info(&pane, process.as_ref()))
+    }
+
+    fn capture_pane(&self, pane_id: &str) -> Option<String> {
+        let raw = strip_prefix(pane_id);
+        let result = self
+            .request("pane.read", json!({ "pane_id": raw, "source": "visible" }))
+            .ok()?;
+        result.get("read")?.get("text")?.as_str().map(str::to_owned)
+    }
+
+    fn pane_pid_map(&self) -> HashMap<u32, String> {
+        self.query_panes()
+            .unwrap_or_default()
+            .into_iter()
+            // A zeroed `pane_pid` means the shell pid was null/absent —
+            // no process tree to walk, so it can't anchor an ancestry
+            // lookup. Skip it rather than mapping pid 0.
+            .filter(|pane| pane.pane_pid != 0)
+            .map(|pane| (pane.pane_pid, pane.pane_id))
+            .collect()
+    }
+
+    fn current_pane(&self) -> Option<String> {
+        std::env::var("HERDR_PANE_ID")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .map(|v| format!("{PANE_ID_PREFIX}{v}"))
+    }
+
+    fn focus_pane(&self, pane_id: &str) -> bool {
+        let raw = strip_prefix(pane_id);
+        // Any non-error reply means the focus landed; herdr answers with a
+        // `pane_focused` result, but we don't inspect the tag — a success
+        // envelope is the whole signal.
+        self.request("pane.focus", json!({ "pane_id": raw }))
+            .is_ok()
+    }
+
+    fn caps(&self) -> BackendCaps {
+        // The socket API covers every capability directly; nothing is
+        // plugin-gated the way zellij is.
+        BackendCaps::default()
+    }
+}
+
+/// Resolve the socket path the way herdr itself does: `$HERDR_SOCKET_PATH`
+/// wins, else `~/.config/herdr/herdr.sock`. herdr uses the XDG-style
+/// `~/.config` path on every platform (including macOS), so this joins
+/// `home` directly rather than going through `dirs::config_dir()`, which
+/// would resolve to `~/Library/Application Support` on macOS and miss the
+/// real socket.
+///
+/// `pub` so the Phase-2 event bridge (`muxad::herdr_bridge`) resolves the
+/// same socket the query backend does, keeping named-session support
+/// (`$HERDR_SOCKET_PATH`) consistent across both connections.
+pub fn default_socket_path() -> PathBuf {
+    if let Ok(path) = std::env::var("HERDR_SOCKET_PATH") {
+        if !path.is_empty() {
+            return PathBuf::from(path);
+        }
+    }
+    let rel = ".config/herdr/herdr.sock";
+    dirs::home_dir().map_or_else(|| PathBuf::from(rel), |home| home.join(rel))
+}
+
+/// Strip the `herdr:` namespace before an id crosses the socket. Lenient:
+/// an already-bare id (or a foreign shape) passes through unchanged.
+fn strip_prefix(pane_id: &str) -> &str {
+    pane_id.strip_prefix(PANE_ID_PREFIX).unwrap_or(pane_id)
+}
+
+/// Map an I/O failure to the classification `observe_panes` needs: a read
+/// that hit the socket timeout surfaces as `WouldBlock`/`TimedOut`, which
+/// we tag distinctly from other transport errors for clearer logs (both
+/// still degrade to `incomplete`).
+fn map_io(err: std::io::Error) -> HerdrError {
+    match err.kind() {
+        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut => HerdrError::Timeout,
+        _ => HerdrError::Io,
+    }
+}
+
+/// Map a herdr `PaneInfo` (+ optional process info) into muxa's flat
+/// [`PaneInfo`]. See `docs/HERDR.md` for the field-by-field rationale.
+fn to_pane_info(pane: &HerdrPaneInfo, process: Option<&HerdrProcessInfo>) -> PaneInfo {
+    let (current_command, pane_pid, tty) = match process {
+        Some(info) => (
+            info.foreground_command(),
+            info.shell_pid.unwrap_or(0),
+            info.tty.clone().unwrap_or_default(),
+        ),
+        None => (String::new(), 0, String::new()),
+    };
+    PaneInfo {
+        pane_id: format!("{PANE_ID_PREFIX}{}", pane.pane_id),
+        session: pane.workspace_id.clone(),
+        window_index: pane.tab_id.clone(),
+        pane_index: pane.pane_id.clone(),
+        tty,
+        current_command,
+        // Prefer the user/agent-facing title, fall back to the raw
+        // terminal title (OSC-set), then empty.
+        title: pane
+            .title
+            .clone()
+            .filter(|t| !t.is_empty())
+            .or_else(|| pane.terminal_title.clone())
+            .unwrap_or_default(),
+        current_path: pane.cwd.clone().unwrap_or_default(),
+        pane_pid,
+        socket: None,
+    }
+}
+
+/// Why a herdr call did not yield a usable result. The variant matters
+/// only to `observe_panes`, which reaps on [`Self::SocketMissing`] but not
+/// on the transient variants.
+enum HerdrError {
+    /// Socket file absent — no server ⇒ authoritatively no panes.
+    SocketMissing,
+    /// Connect or transport failure (server may be up but unreachable).
+    Io,
+    /// Read outlived the timeout — server accepted but didn't answer.
+    Timeout,
+    /// Server answered with an `error` object.
+    Method,
+    /// Reply was malformed or missing the expected shape.
+    Protocol(&'static str),
+}
+
+impl HerdrError {
+    /// A stable, log-friendly reason string for the reconciler trace.
+    fn describe(&self) -> &'static str {
+        match self {
+            Self::SocketMissing => "socket file missing",
+            Self::Io => "connect/transport error",
+            Self::Timeout => "read timed out",
+            Self::Method => "server returned an error",
+            Self::Protocol(reason) => reason,
+        }
+    }
+}
+
+/// herdr `PaneInfo` — only the fields muxa maps. serde ignores the rest
+/// (agent state, revision, scroll, tokens) by default.
+#[derive(Deserialize)]
+struct HerdrPaneInfo {
+    pane_id: String,
+    workspace_id: String,
+    tab_id: String,
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    terminal_title: Option<String>,
+}
+
+/// herdr `PaneProcessInfo`. `shell_pid`/`tty` are nullable; the
+/// foreground list is empty when herdr couldn't inspect the pane.
+#[derive(Deserialize)]
+struct HerdrProcessInfo {
+    #[serde(default)]
+    shell_pid: Option<u32>,
+    #[serde(default)]
+    tty: Option<String>,
+    #[serde(default)]
+    foreground_processes: Vec<HerdrProcess>,
+}
+
+impl HerdrProcessInfo {
+    /// The pane's foreground command name, tmux-`#{pane_current_command}`
+    /// style: prefer the deepest process that isn't the shell (the actual
+    /// running command), and fall back to the shell itself when it's the
+    /// only thing in the foreground group (an idle prompt).
+    fn foreground_command(&self) -> String {
+        self.foreground_processes
+            .iter()
+            .rev()
+            .find(|p| Some(p.pid) != self.shell_pid)
+            .or_else(|| self.foreground_processes.last())
+            .map(|p| p.name.clone())
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Deserialize)]
+struct HerdrProcess {
+    pid: u32,
+    name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+    use std::os::unix::net::UnixListener;
+    use std::path::Path;
+    use std::thread;
+
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// How the canned test server answers one request. The server always
+    /// echoes the request's real `id` (which increments globally), so
+    /// tests describe the payload, not the envelope.
+    enum Reply {
+        /// Wrap `value` as `{"id":…,"result":value}`.
+        Result(Value),
+        /// Reply `{"id":…,"error":{code,message}}`.
+        Error,
+        /// Emit a line under a foreign id first, then the real result —
+        /// exercises reply-id matching (the client must skip line one).
+        ForeignIdThen(Value),
+        /// Accept the connection but never answer — drives the timeout.
+        Hang,
+    }
+
+    /// Spin a `UnixListener` on a temp path, answering each connection via
+    /// `handler(method) -> Reply`. Returns the socket path plus the
+    /// `TempDir` guard (dropping it removes the socket). The accept loop
+    /// thread is detached; it dies with the test process.
+    fn spawn_server<F>(handler: F) -> (PathBuf, TempDir)
+    where
+        F: Fn(&str) -> Reply + Send + 'static,
+    {
+        let dir = TempDir::new().unwrap();
+        let socket_path = dir.path().join("herdr.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let reader_stream = stream.try_clone().unwrap();
+                let mut reader = BufReader::new(reader_stream);
+                let mut line = String::new();
+                if reader.read_line(&mut line).is_err() || line.is_empty() {
+                    continue;
+                }
+                let request: Value = match serde_json::from_str(&line) {
+                    Ok(value) => value,
+                    Err(_) => continue,
+                };
+                let id = request.get("id").and_then(Value::as_str).unwrap_or("");
+                let method = request.get("method").and_then(Value::as_str).unwrap_or("");
+                match handler(method) {
+                    Reply::Result(value) => {
+                        write_line(&mut stream, &json!({ "id": id, "result": value }));
+                    }
+                    Reply::Error => {
+                        write_line(
+                            &mut stream,
+                            &json!({
+                                "id": id,
+                                "error": { "code": "not_found", "message": "no such pane" },
+                            }),
+                        );
+                    }
+                    Reply::ForeignIdThen(value) => {
+                        // A subscription-style line without our id, then the
+                        // real answer. The client must skip the first.
+                        write_line(
+                            &mut stream,
+                            &json!({ "id": "muxa-foreign", "result": { "type": "ok" } }),
+                        );
+                        write_line(&mut stream, &json!({ "id": id, "result": value }));
+                    }
+                    Reply::Hang => {
+                        // Hold the connection open with no reply.
+                        thread::sleep(Duration::from_secs(30));
+                    }
+                }
+            }
+        });
+        (socket_path, dir)
+    }
+
+    fn write_line(stream: &mut UnixStream, value: &Value) {
+        let mut line = serde_json::to_string(value).unwrap();
+        line.push('\n');
+        let _ = stream.write_all(line.as_bytes());
+    }
+
+    /// A herdr `pane_list` result with one pane.
+    fn pane_list_result() -> Value {
+        json!({
+            "type": "pane_list",
+            "panes": [{
+                "pane_id": "p1",
+                "terminal_id": "t1",
+                "workspace_id": "ws1",
+                "tab_id": "tab1",
+                "focused": true,
+                "agent_status": "idle",
+                "revision": 1,
+                "cwd": "/home/u/proj",
+                "title": "editor",
+                "terminal_title": "raw-title",
+            }],
+        })
+    }
+
+    /// A herdr `pane_process_info` result: a shell with `vim` running in
+    /// the foreground.
+    fn process_info_result() -> Value {
+        json!({
+            "type": "pane_process_info",
+            "process_info": {
+                "pane_id": "p1",
+                "shell_pid": 4242,
+                "tty": "/dev/pts/3",
+                "foreground_processes": [
+                    { "pid": 4242, "name": "zsh" },
+                    { "pid": 5001, "name": "vim" },
+                ],
+            },
+        })
+    }
+
+    fn backend_at(socket_path: &Path) -> HerdrBackend {
+        HerdrBackend::with_socket_path(socket_path.to_path_buf())
+    }
+
+    #[test]
+    fn kind_reports_herdr() {
+        let backend = HerdrBackend::with_socket_path(PathBuf::from("/nonexistent.sock"));
+        assert_eq!(backend.kind(), HostKind::Herdr);
+    }
+
+    #[test]
+    fn caps_are_all_true() {
+        let backend = HerdrBackend::with_socket_path(PathBuf::from("/nonexistent.sock"));
+        assert_eq!(backend.caps(), BackendCaps::default());
+    }
+
+    #[test]
+    fn list_panes_maps_fields_and_prefixes_id() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            "pane.list" => Reply::Result(pane_list_result()),
+            "pane.process_info" => Reply::Result(process_info_result()),
+            _ => Reply::Error,
+        });
+        let panes = backend_at(&socket).list_panes();
+        assert_eq!(panes.len(), 1);
+        let p = &panes[0];
+        assert_eq!(p.pane_id, "herdr:p1", "id must carry the namespace prefix");
+        assert_eq!(p.pane_index, "p1", "pane_index is the raw herdr id");
+        assert_eq!(p.session, "ws1", "session ← workspace_id");
+        assert_eq!(p.window_index, "tab1", "window_index ← tab_id");
+        assert_eq!(p.current_path, "/home/u/proj", "current_path ← cwd");
+        assert_eq!(p.title, "editor", "title preferred over terminal_title");
+        assert_eq!(
+            p.current_command, "vim",
+            "foreground command, not the shell"
+        );
+        assert_eq!(p.pane_pid, 4242, "pane_pid ← shell_pid");
+        assert_eq!(p.tty, "/dev/pts/3");
+        assert!(
+            p.socket.is_none(),
+            "herdr never uses the tmux socket channel"
+        );
+    }
+
+    #[test]
+    fn observe_panes_complete_on_success() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            "pane.list" => Reply::Result(pane_list_result()),
+            "pane.process_info" => Reply::Result(process_info_result()),
+            _ => Reply::Error,
+        });
+        let observation = backend_at(&socket).observe_panes();
+        assert!(observation.is_complete());
+        assert_eq!(observation.panes.len(), 1);
+    }
+
+    #[test]
+    fn observe_panes_complete_empty_when_socket_missing() {
+        // No server, no socket file: authoritatively no panes.
+        let backend =
+            HerdrBackend::with_socket_path(PathBuf::from("/definitely/missing/herdr-test.sock"));
+        let observation = backend.observe_panes();
+        assert!(
+            observation.is_complete(),
+            "absent socket ⇒ server down ⇒ its panes are gone (reap-safe)",
+        );
+        assert!(observation.panes.is_empty());
+    }
+
+    #[test]
+    fn observe_panes_incomplete_on_timeout() {
+        // Socket exists and connects, but the server never answers. A
+        // shortened client timeout keeps the test fast.
+        let (socket, _dir) = spawn_server(|_| Reply::Hang);
+        let backend = backend_at(&socket).with_timeout(Duration::from_millis(150));
+        let observation = backend.observe_panes();
+        assert!(
+            !observation.is_complete(),
+            "a timeout is transient — must not authorize reaping",
+        );
+        assert!(observation.panes.is_empty());
+    }
+
+    #[test]
+    fn capture_pane_returns_visible_text() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            "pane.read" => Reply::Result(json!({
+                "type": "pane_read",
+                "read": {
+                    "pane_id": "p1",
+                    "workspace_id": "ws1",
+                    "tab_id": "tab1",
+                    "source": "visible",
+                    "format": "text",
+                    "text": "hello from the pane\n",
+                    "revision": 7,
+                    "truncated": false,
+                },
+            })),
+            _ => Reply::Error,
+        });
+        let text = backend_at(&socket).capture_pane("herdr:p1");
+        assert_eq!(text.as_deref(), Some("hello from the pane\n"));
+    }
+
+    #[test]
+    fn focus_pane_true_on_ok_reply() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            "pane.focus" => Reply::Result(json!({
+                "type": "pane_focused",
+                "pane_id": "p1",
+                "workspace_id": "ws1",
+            })),
+            _ => Reply::Error,
+        });
+        assert!(backend_at(&socket).focus_pane("herdr:p1"));
+    }
+
+    #[test]
+    fn pane_pid_map_keys_shell_pid_to_prefixed_id() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            "pane.list" => Reply::Result(pane_list_result()),
+            "pane.process_info" => Reply::Result(process_info_result()),
+            _ => Reply::Error,
+        });
+        let map = backend_at(&socket).pane_pid_map();
+        assert_eq!(map.get(&4242).map(String::as_str), Some("herdr:p1"));
+    }
+
+    #[test]
+    fn pane_pid_map_skips_panes_without_a_pid() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            "pane.list" => Reply::Result(pane_list_result()),
+            // Null shell_pid ⇒ no process tree ⇒ excluded from the map.
+            "pane.process_info" => Reply::Result(json!({
+                "type": "pane_process_info",
+                "process_info": { "pane_id": "p1", "shell_pid": null },
+            })),
+            _ => Reply::Error,
+        });
+        assert!(backend_at(&socket).pane_pid_map().is_empty());
+    }
+
+    #[test]
+    fn resolve_pane_strips_prefix_and_maps() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            "pane.get" => Reply::Result(json!({
+                "type": "pane_info",
+                "pane": {
+                    "pane_id": "p1",
+                    "terminal_id": "t1",
+                    "workspace_id": "ws1",
+                    "tab_id": "tab1",
+                    "focused": false,
+                    "agent_status": "idle",
+                    "revision": 1,
+                    "cwd": null,
+                    "title": null,
+                    "terminal_title": "fallback-title",
+                },
+            })),
+            "pane.process_info" => Reply::Result(process_info_result()),
+            _ => Reply::Error,
+        });
+        let pane = backend_at(&socket).resolve_pane("herdr:p1").unwrap();
+        assert_eq!(pane.pane_id, "herdr:p1");
+        assert_eq!(pane.current_path, "", "null cwd ⇒ empty string");
+        assert_eq!(
+            pane.title, "fallback-title",
+            "null title falls back to terminal_title",
+        );
+    }
+
+    #[test]
+    fn reply_id_matching_skips_foreign_lines() {
+        // The server emits a foreign-id line before the real reply; the
+        // client must ignore it and return the matching one.
+        let (socket, _dir) = spawn_server(|method| match method {
+            "pane.list" => Reply::ForeignIdThen(pane_list_result()),
+            "pane.process_info" => Reply::Result(process_info_result()),
+            _ => Reply::Error,
+        });
+        let panes = backend_at(&socket).list_panes();
+        assert_eq!(panes.len(), 1);
+        assert_eq!(panes[0].pane_id, "herdr:p1");
+    }
+
+    #[test]
+    fn error_reply_degrades_gracefully() {
+        let (socket, _dir) = spawn_server(|_| Reply::Error);
+        let backend = backend_at(&socket);
+        // Every operational method must swallow an error envelope.
+        assert!(backend.list_panes().is_empty());
+        assert!(!backend.observe_panes().is_complete());
+        assert!(backend.resolve_pane("herdr:p1").is_none());
+        assert!(backend.capture_pane("herdr:p1").is_none());
+        assert!(backend.pane_pid_map().is_empty());
+        assert!(!backend.focus_pane("herdr:p1"));
+    }
+
+    #[test]
+    fn backend_is_object_safe() {
+        let _b: Box<dyn PaneBackend> =
+            Box::new(HerdrBackend::with_socket_path(PathBuf::from("/x.sock")));
+    }
+}

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -33,7 +33,7 @@
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -289,6 +289,47 @@ pub fn default_socket_path() -> PathBuf {
     }
     let rel = ".config/herdr/herdr.sock";
     dirs::home_dir().map_or_else(|| PathBuf::from(rel), |home| home.join(rel))
+}
+
+/// The focused herdr workspace, mapped to muxa's foreground-tracking keys:
+/// the stable `workspace_id` becomes the session id (matching
+/// [`to_pane_info`]'s `session` mapping so ledger keys line up) and the
+/// mutable `label` becomes the display name (tmux session-name analog).
+pub(crate) struct FocusedWorkspace {
+    /// herdr `workspace_id` (e.g. `w1`). Same value `list_panes` puts in
+    /// [`PaneInfo::session`].
+    pub id: String,
+    /// herdr workspace `label` — the human-facing name. Falls back to the
+    /// id when absent.
+    pub label: String,
+}
+
+/// Query the herdr socket for the currently focused workspace, for
+/// `session_activity`'s herdr foreground-time analog. Uses `workspace.list`
+/// (the cheapest call that reports each workspace's `focused` flag —
+/// lighter than `session.snapshot`, which also serializes every tab, pane,
+/// and agent) and returns the one workspace herdr marks `focused`.
+///
+/// Returns `None` when the server is unreachable/absent, no workspace is
+/// focused, or the reply is malformed — the sampler treats all of these as
+/// "no focused workspace this tick" (see `session_activity`).
+pub(crate) fn herdr_focused_workspace(socket_path: &Path) -> Option<FocusedWorkspace> {
+    let backend = HerdrBackend::with_socket_path(socket_path.to_path_buf());
+    let result = backend.request("workspace.list", json!({})).ok()?;
+    let workspaces = result.get("workspaces")?.as_array()?;
+    workspaces
+        .iter()
+        .find(|ws| ws.get("focused").and_then(Value::as_bool) == Some(true))
+        .and_then(|ws| {
+            let id = ws.get("workspace_id").and_then(Value::as_str)?.to_string();
+            let label = ws
+                .get("label")
+                .and_then(Value::as_str)
+                .filter(|l| !l.is_empty())
+                .unwrap_or(&id)
+                .to_string();
+            Some(FocusedWorkspace { id, label })
+        })
 }
 
 /// Strip the `herdr:` namespace before an id crosses the socket. Lenient:
@@ -743,6 +784,103 @@ mod tests {
         assert!(backend.capture_pane("herdr:p1").is_none());
         assert!(backend.pane_pid_map().is_empty());
         assert!(!backend.focus_pane("herdr:p1"));
+    }
+
+    /// A herdr `workspace_list` result: `w1` focused, `w2` not.
+    fn workspace_list_result() -> Value {
+        json!({
+            "type": "workspace_list",
+            "workspaces": [
+                {
+                    "workspace_id": "w1",
+                    "number": 1,
+                    "label": "main",
+                    "focused": true,
+                    "pane_count": 2,
+                    "tab_count": 1,
+                    "active_tab_id": "tab1",
+                    "agent_status": "working",
+                },
+                {
+                    "workspace_id": "w2",
+                    "number": 2,
+                    "label": "scratch",
+                    "focused": false,
+                    "pane_count": 1,
+                    "tab_count": 1,
+                    "active_tab_id": "tab2",
+                    "agent_status": "idle",
+                },
+            ],
+        })
+    }
+
+    #[test]
+    fn focused_workspace_returns_the_focused_one() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            "workspace.list" => Reply::Result(workspace_list_result()),
+            _ => Reply::Error,
+        });
+        let ws = herdr_focused_workspace(&socket).expect("a workspace is focused");
+        assert_eq!(ws.id, "w1", "session id ← focused workspace_id");
+        assert_eq!(ws.label, "main", "display name ← workspace label");
+    }
+
+    #[test]
+    fn focused_workspace_none_when_no_workspace_focused() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            // Same list but nothing focused (e.g. a fully detached server).
+            "workspace.list" => Reply::Result(json!({
+                "type": "workspace_list",
+                "workspaces": [{
+                    "workspace_id": "w1",
+                    "number": 1,
+                    "label": "main",
+                    "focused": false,
+                    "pane_count": 1,
+                    "tab_count": 1,
+                    "active_tab_id": "tab1",
+                    "agent_status": "idle",
+                }],
+            })),
+            _ => Reply::Error,
+        });
+        assert!(herdr_focused_workspace(&socket).is_none());
+    }
+
+    #[test]
+    fn focused_workspace_none_when_server_down() {
+        // No socket file ⇒ server absent ⇒ no sample (tmux "no server" analog).
+        let missing = PathBuf::from("/definitely/missing/herdr-activity.sock");
+        assert!(herdr_focused_workspace(&missing).is_none());
+    }
+
+    #[test]
+    fn focused_workspace_none_on_error_reply() {
+        let (socket, _dir) = spawn_server(|_| Reply::Error);
+        assert!(herdr_focused_workspace(&socket).is_none());
+    }
+
+    #[test]
+    fn focused_workspace_label_falls_back_to_id() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            "workspace.list" => Reply::Result(json!({
+                "type": "workspace_list",
+                "workspaces": [{
+                    "workspace_id": "w7",
+                    "number": 1,
+                    "label": "",
+                    "focused": true,
+                    "pane_count": 1,
+                    "tab_count": 1,
+                    "active_tab_id": "tab1",
+                    "agent_status": "idle",
+                }],
+            })),
+            _ => Reply::Error,
+        });
+        let ws = herdr_focused_workspace(&socket).unwrap();
+        assert_eq!(ws.label, "w7", "empty label falls back to the id");
     }
 
     #[test]

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -325,22 +325,25 @@ impl<T: PaneBackend + ?Sized> PaneBackend for Arc<T> {
 ///
 /// Resolution order:
 ///
-/// 1. **`MUXA_HOST`** — if set to `"tmux"` or `"zellij"` (case-insensitive),
-///    that wins regardless of what `TMUX` / `ZELLIJ` look like. Provides
-///    an unambiguous override for nested-multiplexer setups (e.g. zellij
-///    inside tmux, or `tmux new-session` from inside zellij) where
-///    auto-detect can't tell which host the current shell really lives in.
-///    Other values are ignored (treated as unset) so a typo doesn't pin
-///    the daemon to the wrong host silently.
+/// 1. **`MUXA_HOST`** — if set to `"tmux"`, `"zellij"`, or `"herdr"`
+///    (case-insensitive), that wins regardless of what `TMUX` / `ZELLIJ` /
+///    `HERDR_*` look like. Provides an unambiguous override for
+///    nested-multiplexer setups (zellij inside tmux, `tmux new-session` from
+///    inside a herdr pane, …) where auto-detect can't tell which host the
+///    current shell really lives in. Other values are ignored (treated as
+///    unset) so a typo doesn't pin the daemon to the wrong host silently.
 /// 2. **`ZELLIJ`** set → [`HostKind::Zellij`].
-/// 3. **`TMUX`** set → [`HostKind::Tmux`].
+/// 3. **`HERDR_PANE_ID` / `HERDR_ENV`** set → [`HostKind::Herdr`].
+/// 4. **`TMUX`** set → [`HostKind::Tmux`].
 ///
-/// When both `TMUX` and `ZELLIJ` are present, zellij wins by default.
-/// The env doesn't carry "which one was set last" ordering, so this is
-/// a pragmatic pick rather than a principled one — `MUXA_HOST` is the
-/// escape hatch for the case where the auto-detect picks wrong.
+/// The tie-break for nested hosts (all ancestors' vars are inherited) is
+/// **newer host wins**: zellij, then herdr, then tmux. Launching herdr *from*
+/// a tmux shell is the common migration path, so herdr beats tmux on a
+/// presence tie — matching the hook adapter's `host_pane_env` so the pane a
+/// hook is stamped onto and the backend that observes it always agree. The
+/// rarer nesting (tmux inside a herdr pane) is served by `MUXA_HOST=tmux`.
 ///
-/// Returns `None` outside both hosts; callers fall through to a no-op
+/// Returns `None` outside all hosts; callers fall through to a no-op
 /// backend in that case.
 pub fn detect_host_env() -> Option<HostKind> {
     detect_from(|name| std::env::var(name).ok())
@@ -369,9 +372,11 @@ fn detect_from(read: impl Fn(&str) -> Option<String>) -> Option<HostKind> {
 
     // 2.–4. Auto-detect from host-set env vars. Ordering is a tie-break
     // for nested hosts (all ancestors' vars are inherited): newer hosts
-    // are checked before tmux on the assumption that running tmux *inside*
-    // herdr/zellij is rarer than the reverse migration path. Nested users
-    // for whom this guesses wrong have the `MUXA_HOST` override.
+    // are checked before tmux because launching herdr/zellij *from* a tmux
+    // shell is the common migration path — and the inner shell inherits the
+    // outer `$TMUX`, so it can't be disambiguated by presence alone. The
+    // rarer nesting (tmux inside a herdr pane) uses the `MUXA_HOST` override.
+    // `host_pane_env` in the hook adapter mirrors this exact order.
     if read("ZELLIJ").is_some() {
         return Some(HostKind::Zellij);
     }
@@ -461,6 +466,37 @@ mod tests {
         assert_eq!(
             detect_from(env_reader(&[("TMUX", "1"), ("ZELLIJ", "1")])),
             Some(HostKind::Zellij),
+        );
+    }
+
+    /// herdr beats tmux on a presence tie (herdr launched from a tmux shell,
+    /// the common migration path). Locks the policy that `host_pane_env`
+    /// mirrors so hook stamping and backend observation agree.
+    #[test]
+    fn detect_prefers_herdr_over_tmux() {
+        assert_eq!(
+            detect_from(env_reader(&[("HERDR_PANE_ID", "9"), ("TMUX", "1")])),
+            Some(HostKind::Herdr),
+        );
+        // `HERDR_ENV` alone (no pane id) still identifies herdr.
+        assert_eq!(
+            detect_from(env_reader(&[("HERDR_ENV", "1"), ("TMUX", "1")])),
+            Some(HostKind::Herdr),
+        );
+    }
+
+    /// `MUXA_HOST=tmux` forces tmux even against a present herdr env — the
+    /// escape hatch for tmux running inside a herdr pane.
+    #[test]
+    fn detect_muxa_host_tmux_overrides_herdr() {
+        assert_eq!(
+            detect_from(env_reader(&[
+                ("MUXA_HOST", "tmux"),
+                ("HERDR_PANE_ID", "9"),
+                ("TMUX", "1"),
+            ])),
+            Some(HostKind::Tmux),
+            "MUXA_HOST=tmux must beat a present HERDR env var",
         );
     }
 

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -52,6 +52,7 @@
 //! when zellij CLI cannot populate `pane_pid_map`), call sites consult
 //! [`BackendCaps`] returned by [`PaneBackend::caps`] before degrading.
 
+pub mod herdr;
 pub mod tmux;
 pub mod zellij;
 
@@ -127,6 +128,7 @@ pub type SharedBackend = Arc<dyn PaneBackend>;
 pub fn default_backend() -> SharedBackend {
     match detect_host_env() {
         Some(HostKind::Zellij) => Arc::new(zellij::ZellijBackend::new()),
+        Some(HostKind::Herdr) => Arc::new(herdr::HerdrBackend::new()),
         _ => Arc::new(tmux::TmuxBackend::new()),
     }
 }
@@ -139,6 +141,7 @@ pub fn default_backend() -> SharedBackend {
 pub enum HostKind {
     Tmux,
     Zellij,
+    Herdr,
 }
 
 /// Static capability descriptor. Callers that *need to know* whether a
@@ -355,6 +358,7 @@ fn detect_from(read: impl Fn(&str) -> Option<String>) -> Option<HostKind> {
         match raw.trim().to_ascii_lowercase().as_str() {
             "tmux" => return Some(HostKind::Tmux),
             "zellij" => return Some(HostKind::Zellij),
+            "herdr" => return Some(HostKind::Herdr),
             // Empty / unknown / typo → fall through to auto-detect.
             // Logging the bad value here would be noisy at startup;
             // the daemon traces the resolved host kind on the first
@@ -363,14 +367,50 @@ fn detect_from(read: impl Fn(&str) -> Option<String>) -> Option<HostKind> {
         }
     }
 
-    // 2. & 3. Auto-detect from host-set env vars.
+    // 2.–4. Auto-detect from host-set env vars. Ordering is a tie-break
+    // for nested hosts (all ancestors' vars are inherited): newer hosts
+    // are checked before tmux on the assumption that running tmux *inside*
+    // herdr/zellij is rarer than the reverse migration path. Nested users
+    // for whom this guesses wrong have the `MUXA_HOST` override.
     if read("ZELLIJ").is_some() {
         return Some(HostKind::Zellij);
+    }
+    if read("HERDR_PANE_ID").is_some() || read("HERDR_ENV").is_some() {
+        return Some(HostKind::Herdr);
     }
     if read("TMUX").is_some() {
         return Some(HostKind::Tmux);
     }
     None
+}
+
+/// Classify a namespaced pane id back to the host that governs it.
+///
+/// muxa namespaces every non-tmux pane id — `zellij:<id>` for zellij,
+/// `herdr:<id>` (see [`herdr::PANE_ID_PREFIX`]) for herdr — and leaves
+/// tmux's native `%N` ids as-is. The reconciler's cross-host reaping guard
+/// uses this to tell whether a registry row belongs to the *observing*
+/// backend: a `%`-id is tmux's, a `herdr:`-id is herdr's, a `zellij:`-id is
+/// zellij's. When it does not, that row's pane can't appear in this
+/// backend's observation, so its absence is not liveness evidence.
+///
+/// Returns `None` for shapes muxa doesn't recognize (legacy rows, paneless
+/// synthetic ids, a future host's ids) — those stay governed by whatever
+/// backend is active today, preserving pre-guard behavior.
+#[must_use]
+pub fn pane_id_host_kind(pane_id: &str) -> Option<HostKind> {
+    if pane_id.starts_with('%') {
+        Some(HostKind::Tmux)
+    } else if pane_id.starts_with("zellij:") {
+        // No shared const for zellij's prefix yet (its ids are minted by the
+        // WASM plugin as `zellij:<terminal-id>`); the literal is the single
+        // source of truth until one is introduced.
+        Some(HostKind::Zellij)
+    } else if pane_id.starts_with(herdr::PANE_ID_PREFIX) {
+        Some(HostKind::Herdr)
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -484,6 +524,33 @@ mod tests {
         assert_eq!(HostKind::Zellij.to_string(), "zellij");
     }
 
+    /// The cross-host reaping guard's classifier maps each host's pane-id
+    /// namespace back to its `HostKind`: tmux `%N`, `zellij:<id>`,
+    /// `herdr:<id>`. Unknown shapes return `None` so they stay governed by
+    /// the active backend (pre-guard behavior). Locks the exact prefixes the
+    /// reconciler relies on to avoid reaping another host's live rows.
+    #[test]
+    fn pane_id_host_kind_classifies_each_namespace() {
+        assert_eq!(pane_id_host_kind("%3"), Some(HostKind::Tmux));
+        assert_eq!(pane_id_host_kind("%0"), Some(HostKind::Tmux));
+        assert_eq!(pane_id_host_kind("zellij:7"), Some(HostKind::Zellij));
+        assert_eq!(
+            pane_id_host_kind("zellij:terminal:7"),
+            Some(HostKind::Zellij),
+        );
+        // Reference the const the herdr backend actually stamps, so a rename
+        // there fails this test rather than silently desyncing the guard.
+        assert_eq!(
+            pane_id_host_kind(&format!("{}42", herdr::PANE_ID_PREFIX)),
+            Some(HostKind::Herdr),
+        );
+        // Unknown / legacy / paneless-synthetic shapes: governed by whoever
+        // is the active backend, exactly as before the guard existed.
+        assert_eq!(pane_id_host_kind("synthetic-%1"), None);
+        assert_eq!(pane_id_host_kind("weird-id"), None);
+        assert_eq!(pane_id_host_kind(""), None);
+    }
+
     /// A minimal fake the rest of the test module reuses — keeps
     /// the boilerplate of a full `PaneBackend` impl out of every
     /// individual test body.
@@ -584,6 +651,11 @@ mod tests {
 
         let store = Store::shared();
         let t0 = datetime!(2026-04-28 12:00:00 UTC);
+        // `FakeBackend::kind()` is `Zellij`, so use zellij-namespaced pane ids
+        // here: the cross-host reaping guard only lets an observation reap
+        // rows whose pane id belongs to the observing host. Tmux `%N` rows
+        // under a zellij observation are (correctly) exempt, so this test
+        // must speak the observing host's namespace to exercise reaping.
         for sid in ["alive", "ghost"] {
             store
                 .apply(&AgentEvent::Started {
@@ -592,15 +664,15 @@ mod tests {
                         kind: AgentKind::ClaudeCode,
                         session_id: sid.into(),
                         surface: None,
-                        pane: Some(format!("%{sid}")),
+                        pane: Some(format!("zellij:{sid}")),
                         cwd: None,
                     },
                     at: t0,
                 })
                 .await;
         }
-        // Backend reports only %alive as live; %ghost should be reaped.
-        let backend = FakeBackend::with_panes(vec![fake_pane("%alive")]);
+        // Backend reports only zellij:alive as live; zellij:ghost is reaped.
+        let backend = FakeBackend::with_panes(vec![fake_pane("zellij:alive")]);
         let r = Reconciler::new(store.clone(), backend, Duration::from_millis(10));
         let report = r.reconcile_once().await;
         assert_eq!(report.stale_panes_reaped, 1);

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -200,22 +200,42 @@ impl AppState {
     }
 }
 
-/// Pull one pane inventory for the pane cache. On a herdr host the tmux
-/// scanner sees nothing, so we ask the daemon's [`HerdrBackend`] for
-/// `pane.list` (a blocking socket round-trip, hence `spawn_blocking`) and
-/// reshape it into the scanner's [`ScanResult`]. Every other backend — and
-/// the `None`/no-backend test path — runs the unchanged tmux
-/// [`scanner::scan`].
+/// Pull one pane inventory for the pane cache. On a herdr host we run BOTH
+/// the tmux multi-socket [`scanner::scan`] *and* the daemon's [`HerdrBackend`]
+/// `pane.list` (a blocking socket round-trip, hence `spawn_blocking`), then
+/// concat the two into one [`ScanResult`]. Running only the herdr side would
+/// drop live tmux panes during a mixed-host migration (tmux panes vanish from
+/// `/api/panes` and the timeline); merging keeps both. tmux per-socket
+/// failures keep flowing through `errors` as before. Every other backend — and
+/// the `None`/no-backend test path — runs the unchanged tmux scanner alone.
 async fn refresh_pane_scan(backend: Option<SharedBackend>) -> scanner::ScanResult {
     match backend {
         Some(backend) if backend.kind() == HostKind::Herdr => {
-            let panes = tokio::task::spawn_blocking(move || backend.list_panes())
+            let herdr_panes = tokio::task::spawn_blocking(move || backend.list_panes())
                 .await
                 .unwrap_or_default();
-            scanner::herdr_scan_result(panes)
+            merge_pane_scans(
+                scanner::scan().await,
+                scanner::herdr_scan_result(herdr_panes),
+            )
         }
         _ => scanner::scan().await,
     }
+}
+
+/// Concat a herdr pane inventory onto a tmux scan result. herdr panes are
+/// appended after the tmux panes; the tmux side's `errors` (per-socket partial
+/// failures) are preserved and any herdr-side errors folded in too (there are
+/// none today — a single in-process backend call has no per-socket failures).
+/// The `fetched_at` of the tmux scan is kept as the result timestamp (both are
+/// captured within the same refresh, so the difference is immaterial).
+fn merge_pane_scans(
+    mut tmux: scanner::ScanResult,
+    herdr: scanner::ScanResult,
+) -> scanner::ScanResult {
+    tmux.panes.extend(herdr.panes);
+    tmux.errors.extend(herdr.errors);
+    tmux
 }
 
 /// Build the dashboard router. Public so `muxad`'s integration tests
@@ -1372,12 +1392,65 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         let panes = v["panes"].as_array().expect("panes array");
-        assert_eq!(panes.len(), 1, "herdr pane must surface: {v:?}");
-        assert_eq!(panes[0]["pane_id"], "herdr:p1");
-        assert_eq!(panes[0]["session"], "ws1");
-        assert_eq!(panes[0]["window_index"], "tab1");
-        assert_eq!(panes[0]["socket"], "herdr");
-        assert_eq!(panes[0]["current_command"], "vim");
+        // The herdr branch now merges the tmux scan too, so any stray tmux
+        // server on the test host may add panes — find the herdr pane rather
+        // than asserting an exact count.
+        let herdr = panes
+            .iter()
+            .find(|p| p["pane_id"] == "herdr:p1")
+            .unwrap_or_else(|| panic!("herdr pane must surface: {v:?}"));
+        assert_eq!(herdr["session"], "ws1");
+        assert_eq!(herdr["window_index"], "tab1");
+        assert_eq!(herdr["socket"], "herdr");
+        assert_eq!(herdr["current_command"], "vim");
+    }
+
+    /// The herdr pane-scan path merges rather than replaces: a herdr backend's
+    /// panes are appended onto whatever the tmux scan returned, and the tmux
+    /// side's per-socket errors survive. Exercised on the pure merge helper so
+    /// the tmux side can be fabricated (a real tmux server isn't needed).
+    #[test]
+    fn merge_pane_scans_appends_herdr_onto_tmux_and_keeps_errors() {
+        use crate::tmux::scanner::{PaneSummary, ScanError, ScanResult};
+        use std::path::PathBuf;
+
+        let tmux_pane = PaneSummary {
+            pane_id: "%1".into(),
+            session: "main".into(),
+            window_index: "0".into(),
+            pane_index: "0".into(),
+            tty: String::new(),
+            current_command: "zsh".into(),
+            title: String::new(),
+            socket: PathBuf::from("default"),
+            attach_command: "tmux attach".into(),
+        };
+        let tmux = ScanResult {
+            panes: vec![tmux_pane],
+            errors: vec![ScanError {
+                socket: PathBuf::from("wedged"),
+                message: "timed out".into(),
+            }],
+            fetched_at: OffsetDateTime::now_utc(),
+        };
+        let herdr = scanner::herdr_scan_result(vec![crate::tmux::PaneInfo {
+            socket: None,
+            pane_id: "herdr:p1".into(),
+            session: "ws1".into(),
+            window_index: "tab1".into(),
+            pane_index: "p1".into(),
+            tty: String::new(),
+            current_command: "vim".into(),
+            title: String::new(),
+            pane_pid: 0,
+            current_path: String::new(),
+        }]);
+
+        let merged = merge_pane_scans(tmux, herdr);
+        let ids: Vec<&str> = merged.panes.iter().map(|p| p.pane_id.as_str()).collect();
+        assert_eq!(ids, ["%1", "herdr:p1"], "tmux first, herdr appended");
+        assert_eq!(merged.errors.len(), 1, "tmux scan errors preserved");
+        assert_eq!(merged.errors[0].socket, PathBuf::from("wedged"));
     }
 
     #[tokio::test]

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -38,6 +38,7 @@ use tokio::sync::broadcast;
 use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
 use tower_http::trace::TraceLayer;
 
+use crate::backend::{HostKind, SharedBackend};
 use crate::config::StatsConfig;
 use crate::dashboard::{assets, auth, DashboardConfig};
 use crate::event::{AgentKind, AgentState, PROTOCOL_VERSION};
@@ -97,6 +98,12 @@ pub struct AppState {
     pub config: Arc<DashboardConfig>,
     pub pane_cache: Arc<PaneCache>,
     pub sessions: SharedSessionBackend,
+    /// Active pane backend, threaded in so the `/api/panes` refresh can
+    /// source panes from the herdr socket when the host is herdr (the tmux
+    /// multi-socket [`scanner::scan`] sees nothing there). `None` keeps the
+    /// historical tmux-scanner path — the default for tests and any caller
+    /// that doesn't supply one (behaviour is byte-identical to before).
+    pub backend: Option<SharedBackend>,
     /// Lock-free runtime counters surfaced via `/api/metrics`. Cloned
     /// from the [`Store`](crate::state::Store)'s metrics so SSE
     /// connect/disconnect bumps live alongside event-apply bumps.
@@ -143,6 +150,7 @@ impl AppState {
             config,
             pane_cache,
             sessions,
+            backend: None,
             metrics,
             activity_path: None,
             session_activity_path: None,
@@ -172,6 +180,41 @@ impl AppState {
     pub fn with_stats_config(mut self, stats_config: StatsConfig) -> Self {
         self.stats_config = stats_config;
         self
+    }
+
+    #[must_use]
+    pub fn with_backend(mut self, backend: SharedBackend) -> Self {
+        self.backend = Some(backend);
+        self
+    }
+
+    /// Refresh the pane inventory through the pane cache, sourcing from the
+    /// herdr socket when the active backend is herdr and from the tmux
+    /// multi-socket scanner otherwise. Both `/api/panes` and the timeline's
+    /// pane→session map go through here so they agree on a herdr host.
+    async fn refresh_pane_scan(&self) -> scanner::ScanResult {
+        let backend = self.backend.clone();
+        self.pane_cache
+            .get_or_refresh(|| refresh_pane_scan(backend))
+            .await
+    }
+}
+
+/// Pull one pane inventory for the pane cache. On a herdr host the tmux
+/// scanner sees nothing, so we ask the daemon's [`HerdrBackend`] for
+/// `pane.list` (a blocking socket round-trip, hence `spawn_blocking`) and
+/// reshape it into the scanner's [`ScanResult`]. Every other backend — and
+/// the `None`/no-backend test path — runs the unchanged tmux
+/// [`scanner::scan`].
+async fn refresh_pane_scan(backend: Option<SharedBackend>) -> scanner::ScanResult {
+    match backend {
+        Some(backend) if backend.kind() == HostKind::Herdr => {
+            let panes = tokio::task::spawn_blocking(move || backend.list_panes())
+                .await
+                .unwrap_or_default();
+            scanner::herdr_scan_result(panes)
+        }
+        _ => scanner::scan().await,
     }
 }
 
@@ -247,10 +290,12 @@ pub async fn serve(
     store: SharedStore,
     pane_cache: Arc<PaneCache>,
     sessions: SharedSessionBackend,
+    backend: SharedBackend,
     runtime: DashboardRuntimeConfig,
     mut shutdown: broadcast::Receiver<()>,
 ) -> std::io::Result<()> {
     let state = AppState::new(store, config.clone(), pane_cache, sessions)
+        .with_backend(backend)
         .with_activity_paths(runtime.activity_path, runtime.session_activity_path)
         .with_stats_config(runtime.stats_config);
     let app = router(state);
@@ -415,7 +460,7 @@ struct PanesResponse {
 }
 
 async fn panes_handler(State(state): State<AppState>) -> impl IntoResponse {
-    let result = state.pane_cache.get_or_refresh(scanner::scan).await;
+    let result = state.refresh_pane_scan().await;
     Json(PanesResponse {
         panes: result.panes,
         errors: result.errors,
@@ -628,7 +673,7 @@ async fn timeline_handler(
     };
     let agents = state.store.snapshot().await;
     let prompt_entries = state.store.recent_prompts(None, 0).await;
-    let pane_scan = state.pane_cache.get_or_refresh(scanner::scan).await;
+    let pane_scan = state.refresh_pane_scan().await;
     let pane_sessions = pane_scan
         .panes
         .iter()
@@ -1253,6 +1298,86 @@ mod tests {
         assert!(v["panes"].is_array());
         assert!(v["errors"].is_array());
         assert!(v["fetched_at"].is_string());
+    }
+
+    /// On a herdr host `/api/panes` must source rows from the herdr backend,
+    /// not the (empty-on-herdr) tmux scanner. We stand up a minimal herdr
+    /// mock socket, point a real `HerdrBackend` at it, and assert the pane
+    /// surfaces with the herdr synthetic socket identity.
+    #[tokio::test]
+    async fn panes_endpoint_sources_from_herdr_backend_when_host_is_herdr() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("herdr.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        // Answer pane.list (+ per-pane pane.process_info) on a detached
+        // accept loop; the same newline-JSON shape herdr.rs tests use.
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                let mut line = String::new();
+                if reader.read_line(&mut line).is_err() || line.is_empty() {
+                    continue;
+                }
+                let req: Value = serde_json::from_str(&line).unwrap();
+                let id = req.get("id").and_then(Value::as_str).unwrap_or("");
+                let method = req.get("method").and_then(Value::as_str).unwrap_or("");
+                let result = match method {
+                    "pane.list" => json!({
+                        "type": "pane_list",
+                        "panes": [{
+                            "pane_id": "p1", "terminal_id": "t1",
+                            "workspace_id": "ws1", "tab_id": "tab1",
+                            "focused": true, "agent_status": "idle", "revision": 1,
+                            "cwd": "/home/u/proj", "title": "editor",
+                            "terminal_title": "raw",
+                        }],
+                    }),
+                    "pane.process_info" => json!({
+                        "type": "pane_process_info",
+                        "process_info": {
+                            "pane_id": "p1", "shell_pid": 4242, "tty": "/dev/pts/3",
+                            "foreground_processes": [
+                                { "pid": 4242, "name": "zsh" },
+                                { "pid": 5001, "name": "vim" },
+                            ],
+                        },
+                    }),
+                    _ => json!({ "type": "ok" }),
+                };
+                let mut out =
+                    serde_json::to_string(&json!({ "id": id, "result": result })).unwrap();
+                out.push('\n');
+                let _ = stream.write_all(out.as_bytes());
+            }
+        });
+
+        let backend: SharedBackend = Arc::new(
+            crate::backend::herdr::HerdrBackend::with_socket_path(socket_path),
+        );
+        let state = fresh_state().with_backend(backend);
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/panes")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        let panes = v["panes"].as_array().expect("panes array");
+        assert_eq!(panes.len(), 1, "herdr pane must surface: {v:?}");
+        assert_eq!(panes[0]["pane_id"], "herdr:p1");
+        assert_eq!(panes[0]["session"], "ws1");
+        assert_eq!(panes[0]["window_index"], "tab1");
+        assert_eq!(panes[0]["socket"], "herdr");
+        assert_eq!(panes[0]["current_command"], "vim");
     }
 
     #[tokio::test]

--- a/crates/muxa/src/dashboard/web/main.js
+++ b/crates/muxa/src/dashboard/web/main.js
@@ -1373,7 +1373,7 @@ function renderPanes() {
     : `${rows.length} shown`;
   renderDataMeta();
   if (rows.length === 0 && store.paneErrors.length === 0) {
-    dom.panesBody.innerHTML = `<tr class="empty"><td colspan="7">no panes (no tmux servers, or all filtered out)</td></tr>`;
+    dom.panesBody.innerHTML = `<tr class="empty"><td colspan="7">no panes (no running multiplexer server, or all filtered out)</td></tr>`;
     return;
   }
 

--- a/crates/muxa/src/lib.rs
+++ b/crates/muxa/src/lib.rs
@@ -118,7 +118,7 @@ pub use session::{
 };
 #[doc(hidden)]
 pub use session_activity::{
-    SessionActivity, SessionActivityTracker, SESSION_ACTIVITY_SCHEMA_VERSION,
+    SessionActivity, SessionActivitySource, SessionActivityTracker, SESSION_ACTIVITY_SCHEMA_VERSION,
 };
 #[doc(hidden)]
 pub use snapshot::{Snapshotter, SnapshotterOptions};

--- a/crates/muxa/src/reconcile.rs
+++ b/crates/muxa/src/reconcile.rs
@@ -35,7 +35,7 @@ use tokio::time::{interval, MissedTickBehavior};
 use tracing::{debug, warn};
 
 use crate::adapters::codex_rollout;
-use crate::backend::PaneObservation;
+use crate::backend::{HostKind, PaneObservation};
 use crate::event::{AgentEvent, AgentId, AgentKind, AgentState, RateLimitScope, RateLimitSource};
 use crate::metrics::Metrics;
 use crate::process_tree;
@@ -84,6 +84,16 @@ struct CodexPollTarget {
 /// and inherit the blanket impl (more realistic).
 pub trait LivenessSource: Send + Sync + 'static {
     fn observe_panes(&self) -> PaneObservation;
+
+    /// Which host produced this source's observations. The reconciler threads
+    /// it into [`Store::reconcile_observation`](crate::state::Store::reconcile_observation)
+    /// so the cross-host reaping guard only reaps rows whose pane id belongs to
+    /// the observing host — a tmux daemon must not reap live `herdr:`/`zellij:`
+    /// rows, and vice versa. Defaults to [`HostKind::Tmux`] for the hand-rolled
+    /// test fakes that predate the guard and only ever carry `%N` panes.
+    fn kind(&self) -> HostKind {
+        HostKind::Tmux
+    }
 }
 
 /// Every pane backend is a liveness source. Saves every backend impl
@@ -92,6 +102,9 @@ pub trait LivenessSource: Send + Sync + 'static {
 impl<B: crate::backend::PaneBackend> LivenessSource for B {
     fn observe_panes(&self) -> PaneObservation {
         crate::backend::PaneBackend::observe_panes(self)
+    }
+    fn kind(&self) -> HostKind {
+        crate::backend::PaneBackend::kind(self)
     }
 }
 
@@ -333,6 +346,9 @@ impl<L: LivenessSource> Reconciler<L> {
     pub async fn reconcile_once(&self) -> ReconcileReport {
         let started = Instant::now();
         // Pane observation shells out to tmux and must not block the runtime.
+        // Capture the observing host up front so the store's reaping guard can
+        // exempt rows namespaced to a *different* host (cross-host migration).
+        let observing_kind = self.source.kind();
         let src = self.source.clone();
         let list_started = Instant::now();
         let observation = tokio::task::spawn_blocking(move || src.observe_panes())
@@ -356,7 +372,10 @@ impl<L: LivenessSource> Reconciler<L> {
         let workload_scan_us =
             u64::try_from(workload_started.elapsed().as_micros()).unwrap_or(u64::MAX);
         let reconcile_started = Instant::now();
-        let report = self.store.reconcile_observation(&observation).await;
+        let report = self
+            .store
+            .reconcile_observation(&observation, observing_kind)
+            .await;
         let workload_changed = if pane_observation_complete {
             self.store.update_workloads(&workloads).await
         } else {

--- a/crates/muxa/src/reconcile.rs
+++ b/crates/muxa/src/reconcile.rs
@@ -417,6 +417,24 @@ impl<L: LivenessSource> Reconciler<L> {
                 "orphan-row sweep flipped {stale_paneless} paneless agent(s) to Stopped",
             );
         }
+        // Age out rows whose pane belongs to a host this daemon isn't
+        // observing (e.g. a `herdr:` row left behind after switching the
+        // daemon back to tmux). The cross-host guard exempts them from
+        // *immediate* reaping, but a single-backend daemon never sees them,
+        // so without this they'd ghost forever. Same inactivity window as the
+        // paneless sweep. Today the observing set is exactly the one active
+        // backend; a future multi-host daemon would pass all its live kinds.
+        let stale_cross_host = self
+            .store
+            .mark_stale_cross_host_stopped(&[observing_kind], self.paneless_stale_timeout)
+            .await;
+        if stale_cross_host > 0 {
+            tracing::info!(
+                stale_cross_host,
+                observing = %observing_kind,
+                "cross-host sweep flipped {stale_cross_host} foreign-host agent(s) to Stopped",
+            );
+        }
         // Poll codex rollouts for rate-limit state (no-op unless a sessions
         // root is configured). Codex has no rate-limit hook, so this is the
         // only signal — and it's the only path that catches a cap which

--- a/crates/muxa/src/session_activity.rs
+++ b/crates/muxa/src/session_activity.rs
@@ -10,6 +10,7 @@ use crate::activity::{
     ActivityEntry, ActivityLog, HumanInteractionEntry, HumanInteractionInput, HumanInteractionKind,
     SessionForegroundEntry,
 };
+use crate::backend::herdr;
 use crate::tmux::{self, SessionInfo, TmuxError};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -240,10 +241,31 @@ fn add_elapsed(record: &mut SessionActivity, since: OffsetDateTime, now: OffsetD
     record.total_attached_secs = record.total_attached_secs.saturating_add(secs);
 }
 
+/// Where a poll samples foreground state from. Only the *sampling* source
+/// differs between hosts — everything downstream (`apply_sample_report`,
+/// the ledger intervals, `session-activity.json`, input ticks) is shared.
+///
+/// - `Tmux`: interactive `tmux list-clients` rows grouped by session (also
+///   the fallback for zellij, which has no client-attach signal and so
+///   degrades to an empty sample, unchanged).
+/// - `Herdr`: the focused herdr *workspace* over the herdr socket. herdr
+///   has no client-attach or per-client input signal, so it produces the
+///   "workspace X is foregrounded" observation only — see
+///   [`sample_herdr_activity`] for the accrual limitation this implies.
+#[derive(Default)]
+pub enum SessionActivitySource {
+    #[default]
+    Tmux,
+    Herdr {
+        socket_path: PathBuf,
+    },
+}
+
 pub struct SessionActivityTracker {
     path: PathBuf,
     interval: Duration,
     activity_log: Option<Arc<ActivityLog>>,
+    source: SessionActivitySource,
 }
 
 impl SessionActivityTracker {
@@ -252,13 +274,41 @@ impl SessionActivityTracker {
             path,
             interval,
             activity_log: None,
+            source: SessionActivitySource::default(),
         }
+    }
+
+    /// Select the foreground-sampling source. Defaults to
+    /// [`SessionActivitySource::Tmux`]; the daemon sets
+    /// [`SessionActivitySource::Herdr`] on herdr hosts.
+    #[must_use]
+    pub fn with_source(mut self, source: SessionActivitySource) -> Self {
+        self.source = source;
+        self
     }
 
     #[must_use]
     pub fn with_activity_log(mut self, activity_log: Option<Arc<ActivityLog>>) -> Self {
         self.activity_log = activity_log;
         self
+    }
+
+    /// Take one foreground sample from the configured source, off the async
+    /// runtime (both the tmux shell-out and the herdr socket round-trip
+    /// block). The two sources produce the same [`ActivitySample`] shape, so
+    /// the caller's accounting is source-agnostic.
+    async fn sample(&self) -> Result<ActivitySample, String> {
+        match &self.source {
+            SessionActivitySource::Tmux => tokio::task::spawn_blocking(sample_activity)
+                .await
+                .unwrap_or_else(|e| Err(format!("join error: {e}"))),
+            SessionActivitySource::Herdr { socket_path } => {
+                let socket_path = socket_path.clone();
+                tokio::task::spawn_blocking(move || sample_herdr_activity(&socket_path))
+                    .await
+                    .map_err(|e| format!("join error: {e}"))
+            }
+        }
     }
 
     pub async fn run(self, mut shutdown: broadcast::Receiver<()>) {
@@ -300,9 +350,7 @@ impl SessionActivityTracker {
         records: &mut HashMap<String, SessionActivity>,
         seen_clients: &mut HashMap<String, (i64, i64)>,
     ) {
-        let sample = tokio::task::spawn_blocking(sample_activity)
-            .await
-            .unwrap_or_else(|e| Err(format!("join error: {e}")));
+        let sample = self.sample().await;
         let sample = match sample {
             Ok(sample) => sample,
             Err(e) => {
@@ -402,6 +450,38 @@ fn sample_activity() -> Result<ActivitySample, String> {
         sessions,
         client_inputs,
     })
+}
+
+/// herdr foreground sample: the currently focused herdr *workspace*, mapped
+/// to a single [`SessionInfo`] with one "attached client" so
+/// [`apply_sample_report`] credits foreground time to it exactly as it would
+/// an attached tmux session. The `session_id` is the raw `workspace_id`
+/// (`w1`), matching `HerdrBackend::list_panes`'s `PaneInfo.session` so the
+/// ledger keys line up with the pane rows. No focused workspace (or an
+/// unreachable/absent server) yields an empty sample — the tmux "no server
+/// running" analog, which closes any open foreground interval.
+///
+/// LIMITATION (documented, mitigation out of scope): herdr's socket API
+/// exposes no client-attach state — there is no `client.list` analog. So,
+/// unlike the tmux path (which credits time only while an interactive client
+/// is attached), herdr focus time accrues even when the server sits detached
+/// with no client attached. This inflates ACT for always-on detached herdr
+/// servers. herdr also has no per-client input/scroll signal, so
+/// `client_inputs` is always empty and no `HumanInteraction` (`TmuxInput` /
+/// `TmuxScroll`) ticks are ever emitted on herdr hosts.
+fn sample_herdr_activity(socket_path: &Path) -> ActivitySample {
+    let sessions = match herdr::herdr_focused_workspace(socket_path) {
+        Some(ws) => vec![SessionInfo {
+            session_id: ws.id,
+            name: ws.label,
+            attached_clients: 1,
+        }],
+        None => Vec::new(),
+    };
+    ActivitySample {
+        sessions,
+        client_inputs: Vec::new(),
+    }
 }
 
 /// Build the per-client input readings for this poll: one entry per interactive

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -13,7 +13,7 @@
 //! by the daemon's desktop-notifier task to wake users when an agent moves
 //! into `WaitingInput` or `Error`.
 
-use crate::backend::PaneObservation;
+use crate::backend::{HostKind, PaneObservation};
 use crate::event::{
     AgentEvent, AgentId, AgentKind, AgentState, NotificationLevel, RateLimitScope, RateLimitSource,
     SurfaceRef,
@@ -57,9 +57,28 @@ fn same_pane_identity(agent: &Agent, pane: &str, tmux_socket: Option<&str>) -> b
     }
 }
 
-fn pane_is_live(agent: &Agent, panes_by_id: &HashMap<&str, Vec<&PaneInfo>>) -> bool {
+fn pane_is_live(
+    agent: &Agent,
+    panes_by_id: &HashMap<&str, Vec<&PaneInfo>>,
+    observing_kind: HostKind,
+) -> bool {
     if agent.pid.is_some() {
         return true;
+    }
+    // Cross-host reaping guard: an observation from one backend only governs
+    // rows whose pane id belongs to that backend's host. A tmux-backend daemon
+    // physically cannot see herdr/zellij panes (and vice versa), so a namespaced
+    // id for *another* host missing from this snapshot is not death — it's just
+    // out of view. Treat such rows as live so a tmux→herdr migration (both hosts
+    // active) doesn't reap the other host's live rows every reconcile tick.
+    // Unknown-shape ids (`None`) fall through to the active backend's normal
+    // governance, exactly as before this guard existed.
+    if let Some(pane_id) = agent.pane.as_deref() {
+        if let Some(host) = crate::backend::pane_id_host_kind(pane_id) {
+            if host != observing_kind {
+                return true;
+            }
+        }
     }
     match agent.pane.as_deref() {
         Some(pane_id) => match (panes_by_id.get(pane_id), agent.tmux_socket.as_deref()) {
@@ -1633,19 +1652,44 @@ impl Store {
     ///
     /// Idempotent and safe to run on a timer regardless of event traffic.
     /// Returns counts so callers can log non-trivial sweeps without spamming.
-    pub async fn reconcile_observation(&self, observation: &PaneObservation) -> ReconcileReport {
+    pub async fn reconcile_observation(
+        &self,
+        observation: &PaneObservation,
+        observing_kind: HostKind,
+    ) -> ReconcileReport {
         if !observation.is_complete() {
             return ReconcileReport::default();
         }
-        self.reconcile(&observation.panes).await
+        self.reconcile_hosted(&observation.panes, observing_kind)
+            .await
     }
 
-    /// Converge against a pane set already known to be complete.
+    /// Converge against a pane set already known to be complete, assuming the
+    /// panes were observed by the **tmux** backend.
     ///
-    /// Most runtime callers should use [`Self::reconcile_observation`]. This
-    /// slice-based entry point remains for focused store tests and callers
-    /// that obtain their complete pane inventory without a [`PaneBackend`](crate::backend::PaneBackend).
+    /// Most runtime callers should use [`Self::reconcile_observation`], which
+    /// threads the real observing [`HostKind`] through so the cross-host
+    /// reaping guard can exempt other hosts' rows. This slice-based entry point
+    /// remains for focused store tests and callers that obtain their complete
+    /// pane inventory without a [`PaneBackend`](crate::backend::PaneBackend);
+    /// every such caller today observes tmux, so it defaults to
+    /// [`HostKind::Tmux`]. Tests exercising cross-host behavior call
+    /// [`Self::reconcile_hosted`] directly.
     pub async fn reconcile(&self, live_panes: &[PaneInfo]) -> ReconcileReport {
+        self.reconcile_hosted(live_panes, HostKind::Tmux).await
+    }
+
+    /// Converge against a complete pane set observed by `observing_kind`.
+    ///
+    /// The `observing_kind` is the host that produced `live_panes`. It gates
+    /// the stale-pane reap so an observation only governs rows whose pane id
+    /// belongs to that host (see [`pane_is_live`] and
+    /// [`crate::backend::pane_id_host_kind`]).
+    pub async fn reconcile_hosted(
+        &self,
+        live_panes: &[PaneInfo],
+        observing_kind: HostKind,
+    ) -> ReconcileReport {
         let mut agents = self.agents.write().await;
         let mut report = ReconcileReport::default();
 
@@ -1664,7 +1708,7 @@ impl Store {
         let mut stale_transitions = Vec::new();
         let before = agents.len();
         agents.retain(|_, a| {
-            let keep = pane_is_live(a, &panes_by_id);
+            let keep = pane_is_live(a, &panes_by_id, observing_kind);
             if !keep && a.state != AgentState::Stopped {
                 let mut stopped = a.clone();
                 let from = stopped.state;
@@ -3839,6 +3883,100 @@ mod tests {
             pane_pid: 0,
             current_path: String::new(),
         }
+    }
+
+    /// Start an agent on an arbitrary pane id (any host namespace) so the
+    /// cross-host reaping-guard tests can plant `herdr:…` / `zellij:…` / `%N`
+    /// rows without the `%1`-defaulting `id()` helper.
+    fn started_on(sid: &str, pane_id: &str) -> AgentEvent {
+        AgentEvent::Started {
+            id: AgentId {
+                tmux_socket: None,
+                kind: AgentKind::ClaudeCode,
+                session_id: sid.into(),
+                surface: None,
+                pane: Some(pane_id.into()),
+                cwd: None,
+            },
+            at: datetime!(2026-04-24 12:00:00 UTC),
+        }
+    }
+
+    /// Cross-host reaping guard: a `herdr:`-namespaced row must survive a
+    /// **tmux** observation that doesn't contain it. A tmux-backend daemon
+    /// physically can't see herdr panes, so their absence from its scan is not
+    /// death — reaping them would be fatal during a tmux→herdr migration where
+    /// both hosts run at once. The same-host tmux ghost is still reaped.
+    #[tokio::test]
+    async fn herdr_row_survives_tmux_observation() {
+        let store = Store::shared();
+        store.apply(&started_on("herdr-live", "herdr:7")).await;
+        store.apply(&started_on("tmux-live", "%1")).await;
+        store.apply(&started_on("tmux-ghost", "%2")).await;
+
+        // Tmux backend observed only %1. It never enumerates herdr panes.
+        let report = store.reconcile_hosted(&[pane("%1")], HostKind::Tmux).await;
+
+        assert_eq!(report.stale_panes_reaped, 1, "only the tmux ghost reaps");
+        let ids: Vec<String> = store
+            .snapshot()
+            .await
+            .into_iter()
+            .map(|a| a.session_id)
+            .collect();
+        assert!(ids.contains(&"herdr-live".to_string()), "herdr row exempt");
+        assert!(ids.contains(&"tmux-live".to_string()));
+        assert!(
+            !ids.contains(&"tmux-ghost".to_string()),
+            "tmux ghost reaped"
+        );
+    }
+
+    /// Mirror of the above from the other side: a tmux `%N` row survives a
+    /// **herdr** observation. A herdr-backend daemon can't see tmux panes, so
+    /// their absence isn't evidence of death. The same-host herdr ghost reaps.
+    #[tokio::test]
+    async fn tmux_row_survives_herdr_observation() {
+        let store = Store::shared();
+        store.apply(&started_on("tmux-live", "%9")).await;
+        store.apply(&started_on("herdr-live", "herdr:1")).await;
+        store.apply(&started_on("herdr-ghost", "herdr:2")).await;
+
+        // Herdr backend observed only herdr:1.
+        let report = store
+            .reconcile_hosted(&[pane("herdr:1")], HostKind::Herdr)
+            .await;
+
+        assert_eq!(report.stale_panes_reaped, 1, "only the herdr ghost reaps");
+        let ids: Vec<String> = store
+            .snapshot()
+            .await
+            .into_iter()
+            .map(|a| a.session_id)
+            .collect();
+        assert!(ids.contains(&"tmux-live".to_string()), "tmux row exempt");
+        assert!(ids.contains(&"herdr-live".to_string()));
+        assert!(
+            !ids.contains(&"herdr-ghost".to_string()),
+            "herdr ghost reaped"
+        );
+    }
+
+    /// An unknown-shape pane id (no `%` / `zellij:` / `herdr:` namespace) has
+    /// no host classification, so it stays governed by the active backend —
+    /// exactly as before the guard existed. Here a tmux observation without it
+    /// reaps it. Guards against the exemption silently swallowing legacy rows.
+    #[tokio::test]
+    async fn unknown_shape_pane_governed_by_active_backend() {
+        let store = Store::shared();
+        store.apply(&started_on("legacy", "weird-id")).await;
+
+        // Tmux observation contains no matching pane → legacy row reaped,
+        // because `pane_id_host_kind("weird-id")` is `None` (not exempt).
+        let report = store.reconcile_hosted(&[], HostKind::Tmux).await;
+
+        assert_eq!(report.stale_panes_reaped, 1, "unknown-shape row reaped");
+        assert!(store.snapshot().await.is_empty());
     }
 
     /// Synthetic must lose to a real session even when the real session is

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -1453,6 +1453,92 @@ impl Store {
         flipped
     }
 
+    /// Age out rows whose pane belongs to a host **no active observation
+    /// governs**, flipping them to `Stopped` after `threshold` of inactivity
+    /// so the regular GC can reap them. Returns the number flipped.
+    ///
+    /// This closes the flip side of the cross-host reaping guard. That guard
+    /// (see [`pane_is_live`]) deliberately exempts a foreign-host row from
+    /// *immediate* reaping — a tmux-backend daemon physically cannot see a
+    /// `herdr:`/`zellij:` pane, so its absence from a tmux scan is not death.
+    /// But a single-backend daemon never observes those panes at all, and the
+    /// GC only evicts `Stopped` rows — so without an age-out a foreign-host
+    /// row (e.g. a `herdr:` row left in `state.json` after the operator
+    /// switched the daemon back to tmux) would ghost forever. Flipping to
+    /// `Stopped` after the same inactivity window as
+    /// [`Self::mark_stale_paneless_stopped`] lets a genuinely-live remote row
+    /// keep itself alive by emitting activity, while a truly dead one ages out.
+    ///
+    /// `observing_kinds` is the set of hosts that *do* have a live observation
+    /// this pass (today always exactly one — the daemon's single active
+    /// backend — but taking a slice lets a future multi-host daemon pass
+    /// several without changing the shape). A row is foreign, and therefore a
+    /// candidate, only when its pane id classifies to a known host
+    /// ([`crate::backend::pane_id_host_kind`]) that is *not* in this set.
+    /// Same-host rows (governed by `reconcile`) and unclassifiable/paneless
+    /// rows (governed by the normal reap / `mark_stale_paneless_stopped`
+    /// paths) are left untouched.
+    ///
+    /// Conservative by construction, mirroring [`Self::mark_stale_paneless_stopped`]:
+    /// `threshold == Duration::ZERO` disables the sweep; `Task` and
+    /// pid-tracked rows are excluded (process liveness owns them); already
+    /// `Stopped` rows are skipped.
+    pub async fn mark_stale_cross_host_stopped(
+        &self,
+        observing_kinds: &[HostKind],
+        threshold: Duration,
+    ) -> usize {
+        if threshold.is_zero() {
+            return 0;
+        }
+        let cutoff = OffsetDateTime::now_utc() - threshold;
+        let mut agents = self.agents.write().await;
+        let mut flipped = 0_usize;
+        for agent in agents.values_mut() {
+            if agent.kind == AgentKind::Task || agent.pid.is_some() {
+                continue;
+            }
+            if agent.state == AgentState::Stopped {
+                continue;
+            }
+            // Only rows whose pane classifies to a host NOT currently
+            // observed — those are the ones no live observation can reap.
+            let Some(pane_id) = agent.pane.as_deref() else {
+                continue;
+            };
+            let Some(host) = crate::backend::pane_id_host_kind(pane_id) else {
+                continue;
+            };
+            if observing_kinds.contains(&host) {
+                continue;
+            }
+            if agent.last_activity_at > cutoff {
+                continue;
+            }
+            let prev = agent.state;
+            let now = OffsetDateTime::now_utc();
+            agent.state = AgentState::Stopped;
+            agent.state_entered_at = now;
+            // Measure the GC's Stopped-row TTL from when we gave up on the
+            // row, not from its last real activity — same rationale as
+            // `mark_stale_paneless_stopped`.
+            agent.last_activity_at = now;
+            flipped += 1;
+            // Same broadcast shape as `apply`/`mark_stale_paneless_stopped`
+            // so live subscribers see the row go Stopped immediately.
+            let _ = self.transitions.send(Transition {
+                from: prev,
+                to: agent.state,
+                agent: Arc::new(agent.clone()),
+            });
+        }
+        if flipped > 0 {
+            drop(agents);
+            self.dirty.notify_one();
+        }
+        flipped
+    }
+
     /// Refresh pane-backed workload summaries from the latest OS
     /// process-tree scan. This is metadata enrichment only: it must not
     /// touch `last_activity_at`, `state_entered_at`, or emit transitions,
@@ -2089,6 +2175,97 @@ mod tests {
         assert_ne!(
             store.by_session("orphan2").await.unwrap().state,
             AgentState::Stopped
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_stale_cross_host_ages_out_only_foreign_host_stale_rows() {
+        let store = Store::shared();
+        let old = datetime!(2026-04-24 12:00:00 UTC); // long before "now"
+        let fresh = OffsetDateTime::now_utc();
+
+        let started = |sid: &str, pane: &str, at| AgentEvent::Started {
+            id: AgentId {
+                tmux_socket: None,
+                kind: AgentKind::ClaudeCode,
+                session_id: sid.into(),
+                surface: None,
+                pane: Some(pane.into()),
+                cwd: None,
+            },
+            at,
+        };
+
+        // A tmux daemon observing tmux. A stale `herdr:` row is foreign and
+        // unobservable ⇒ must age out. A fresh `herdr:` row is spared by the
+        // age gate. A stale tmux `%N` row is same-host (governed by reconcile)
+        // ⇒ untouched here.
+        store.apply(&started("herdr-stale", "herdr:p1", old)).await;
+        store
+            .apply(&started("herdr-fresh", "herdr:p2", fresh))
+            .await;
+        store.apply(&started("tmux-stale", "%1", old)).await;
+
+        let flipped = store
+            .mark_stale_cross_host_stopped(&[HostKind::Tmux], Duration::from_secs(86_400))
+            .await;
+        assert_eq!(flipped, 1, "only the stale foreign-host row should flip");
+        assert_eq!(
+            store.by_session("herdr-stale").await.unwrap().state,
+            AgentState::Stopped,
+        );
+        assert_ne!(
+            store.by_session("herdr-fresh").await.unwrap().state,
+            AgentState::Stopped,
+            "a fresh foreign-host row keeps itself alive via activity",
+        );
+        assert_ne!(
+            store.by_session("tmux-stale").await.unwrap().state,
+            AgentState::Stopped,
+            "same-host reaping is unchanged — reconcile governs it, not this sweep",
+        );
+
+        // Idempotent, and a zero threshold disables the sweep.
+        assert_eq!(
+            store
+                .mark_stale_cross_host_stopped(&[HostKind::Tmux], Duration::from_secs(86_400))
+                .await,
+            0,
+        );
+        assert_eq!(
+            store
+                .mark_stale_cross_host_stopped(&[HostKind::Tmux], Duration::ZERO)
+                .await,
+            0,
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_stale_cross_host_spares_rows_of_an_observed_host() {
+        // A herdr daemon observing herdr must NOT age out its own `herdr:`
+        // rows even when stale — reconcile governs same-host liveness.
+        let store = Store::shared();
+        let old = datetime!(2026-04-24 12:00:00 UTC);
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    tmux_socket: None,
+                    kind: AgentKind::ClaudeCode,
+                    session_id: "herdr-own".into(),
+                    surface: None,
+                    pane: Some("herdr:p9".into()),
+                    cwd: None,
+                },
+                at: old,
+            })
+            .await;
+        let flipped = store
+            .mark_stale_cross_host_stopped(&[HostKind::Herdr], Duration::from_secs(86_400))
+            .await;
+        assert_eq!(flipped, 0);
+        assert_ne!(
+            store.by_session("herdr-own").await.unwrap().state,
+            AgentState::Stopped,
         );
     }
 

--- a/crates/muxa/src/tmux/scanner.rs
+++ b/crates/muxa/src/tmux/scanner.rs
@@ -12,6 +12,22 @@
 //! a wedged `attach-session` losing the controlling terminal) cannot
 //! stall the dashboard.
 //!
+//! ## Herdr hosts
+//!
+//! Herdr is a single-server-per-user model too, but — unlike zellij — it
+//! ships a socket API that enumerates every pane out of the box, so the
+//! dashboard's `/api/panes` route does *not* go through [`scan`] on a
+//! herdr host. Instead the daemon's active [`HerdrBackend`] answers
+//! `pane.list` directly and the result is folded into the same
+//! [`ScanResult`] shape by [`herdr_scan_result`]. The branch lives in the
+//! dashboard's pane-cache refresh closure (see
+//! `crate::dashboard::server`); the tmux path here is untouched. The
+//! `MUXA_TMUX_SOCKET` scope is a *tmux-socket* concept and never applies
+//! to herdr panes (consistent with the ingest scope gate treating a
+//! socket-less herdr event as in-scope).
+//!
+//! [`HerdrBackend`]: crate::backend::herdr::HerdrBackend
+//!
 //! ## Zellij hosts
 //!
 //! Zellij is a single-server-per-user model with no multi-socket
@@ -339,6 +355,56 @@ fn to_summary(p: PaneInfo, socket: PathBuf) -> PaneSummary {
         title: p.title,
         socket,
         attach_command,
+    }
+}
+
+/// The synthetic socket identity stamped on every herdr [`PaneSummary`].
+///
+/// A herdr [`PaneInfo`] carries `socket: None` (herdr never reuses the
+/// tmux-socket channel — see `backend::herdr::to_pane_info`), but the
+/// dashboard's [`PaneSummary`] socket is a required part of a pane's
+/// identity and the web UI splits it on `/` for the socket-filter chip.
+/// The daemon observes exactly one herdr server, so a single constant
+/// "server" name is both accurate and gives the UI one clean chip.
+const HERDR_SOCKET_LABEL: &str = "herdr";
+
+/// Fold the daemon's herdr `pane.list` result into the dashboard's
+/// [`ScanResult`] shape, so `/api/panes` renders herdr panes without the
+/// tmux multi-socket scanner (which sees nothing on a herdr host).
+///
+/// Called from the dashboard pane-cache refresh closure when the active
+/// backend is herdr; the [`scan`] tmux path is untouched. The muxa
+/// [`PaneInfo`] rows already carry herdr-native fields — `pane_id`
+/// `herdr:<id>`, `session` = workspace id, `window_index` = tab id,
+/// `current_command`/`current_path` enriched from `pane.process_info` —
+/// so this only supplies the two dashboard-only fields the herdr backend
+/// leaves blank: a synthetic [`HERDR_SOCKET_LABEL`] socket identity and an
+/// empty `attach_command` (herdr has no copyable shell attach line; the
+/// CLI attaches over the socket via `pane.focus`). `errors` is always
+/// empty — a single in-process backend call has no per-socket partial
+/// failures to collect. `MUXA_TMUX_SOCKET` is not consulted: it scopes
+/// tmux sockets only, and herdr panes are never subject to it.
+pub(crate) fn herdr_scan_result(panes: Vec<PaneInfo>) -> ScanResult {
+    ScanResult {
+        panes: panes.into_iter().map(to_herdr_summary).collect(),
+        errors: Vec::new(),
+        fetched_at: OffsetDateTime::now_utc(),
+    }
+}
+
+fn to_herdr_summary(p: PaneInfo) -> PaneSummary {
+    PaneSummary {
+        pane_id: p.pane_id,
+        session: p.session,
+        window_index: p.window_index,
+        pane_index: p.pane_index,
+        tty: p.tty,
+        current_command: p.current_command,
+        title: p.title,
+        socket: PathBuf::from(HERDR_SOCKET_LABEL),
+        // herdr has no `tmux attach`-style command a user copies; the CLI
+        // (`muxa` jump / `jump_to_pane`) focuses over the socket instead.
+        attach_command: String::new(),
     }
 }
 
@@ -698,6 +764,48 @@ mod tests {
             .await;
 
         assert_eq!(counter.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn herdr_scan_result_maps_panes_and_stamps_synthetic_socket() {
+        // Mirror what `HerdrBackend::list_panes` hands the dashboard: a
+        // muxa PaneInfo already namespaced/enriched, socket None.
+        let mut pane = fake_pane("herdr:p1", "ws1");
+        pane.window_index = "tab1".into();
+        pane.pane_index = "p1".into();
+        pane.current_command = "vim".into();
+        pane.title = "editor".into();
+        pane.current_path = "/home/u/proj".into();
+
+        let result = herdr_scan_result(vec![pane]);
+        assert!(
+            result.errors.is_empty(),
+            "single backend call has no per-socket errors"
+        );
+        assert_eq!(result.panes.len(), 1);
+        let s = &result.panes[0];
+        assert_eq!(s.pane_id, "herdr:p1");
+        assert_eq!(s.session, "ws1", "session ← workspace_id");
+        assert_eq!(s.window_index, "tab1", "window_index ← tab_id");
+        assert_eq!(s.pane_index, "p1", "pane_index is the raw herdr id");
+        assert_eq!(s.current_command, "vim");
+        assert_eq!(s.title, "editor");
+        assert_eq!(
+            s.socket,
+            PathBuf::from(HERDR_SOCKET_LABEL),
+            "herdr panes carry the synthetic socket identity, not None",
+        );
+        assert!(
+            s.attach_command.is_empty(),
+            "herdr has no copyable tmux-style attach command",
+        );
+    }
+
+    #[test]
+    fn herdr_scan_result_empty_input_is_well_formed() {
+        let result = herdr_scan_result(Vec::new());
+        assert!(result.panes.is_empty());
+        assert!(result.errors.is_empty());
     }
 
     #[test]

--- a/crates/muxa/src/tmux/scanner.rs
+++ b/crates/muxa/src/tmux/scanner.rs
@@ -15,16 +15,17 @@
 //! ## Herdr hosts
 //!
 //! Herdr is a single-server-per-user model too, but — unlike zellij — it
-//! ships a socket API that enumerates every pane out of the box, so the
-//! dashboard's `/api/panes` route does *not* go through [`scan`] on a
-//! herdr host. Instead the daemon's active [`HerdrBackend`] answers
-//! `pane.list` directly and the result is folded into the same
-//! [`ScanResult`] shape by [`herdr_scan_result`]. The branch lives in the
-//! dashboard's pane-cache refresh closure (see
-//! `crate::dashboard::server`); the tmux path here is untouched. The
-//! `MUXA_TMUX_SOCKET` scope is a *tmux-socket* concept and never applies
-//! to herdr panes (consistent with the ingest scope gate treating a
-//! socket-less herdr event as in-scope).
+//! ships a socket API that enumerates every pane out of the box. On a herdr
+//! host the dashboard's `/api/panes` refresh runs [`scan`] **and** asks the
+//! daemon's active [`HerdrBackend`] for `pane.list`, then concatenates the
+//! two: the herdr panes (folded into this [`ScanResult`] shape by
+//! [`herdr_scan_result`]) are appended onto the tmux scan. Running only the
+//! herdr side would drop live tmux panes during a mixed-host migration, so
+//! the merge keeps both. That branch lives in the dashboard's pane-cache
+//! refresh closure (see `crate::dashboard::server`); the tmux path here is
+//! untouched. The `MUXA_TMUX_SOCKET` scope is a *tmux-socket* concept and
+//! never applies to herdr panes (consistent with the ingest scope gate
+//! treating a socket-less herdr event as in-scope).
 //!
 //! [`HerdrBackend`]: crate::backend::herdr::HerdrBackend
 //!

--- a/crates/muxad/Cargo.toml
+++ b/crates/muxad/Cargo.toml
@@ -17,6 +17,7 @@ muxa = { workspace = true }
 
 anyhow = { workspace = true }
 clap = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/muxad/src/herdr_bridge.rs
+++ b/crates/muxad/src/herdr_bridge.rs
@@ -38,7 +38,7 @@
 //!
 //! A dropped connection is retried with capped exponential backoff.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -173,15 +173,15 @@ pub fn translate(envelope: &Value, at: OffsetDateTime) -> Result<BridgeUpdate, D
         .and_then(Value::as_str)
         .filter(|s| !s.is_empty())
         .ok_or(DropReason::MissingPaneId)?;
-    let status = data
-        .get("agent_status")
-        .and_then(Value::as_str)
-        .ok_or(DropReason::Malformed)?;
 
     // `agent` is herdr's canonical slug; `display_agent` is its pretty label.
     // The name (for the visible `model` metadata) prefers the pretty label;
     // the kind is classified from whichever is present. A pane with neither is
-    // a plain shell — nothing to synthesize.
+    // agent-less — herdr sees a plain shell (or the agent just exited). We
+    // resolve the name BEFORE the status so an agent-less envelope is reported
+    // as `NoAgent` even when it carries no `agent_status`; the caller
+    // ([`ingest_envelope`]) turns that into a "stop the synthetic row if the
+    // pane still has one" action rather than a silent drop.
     let canonical = data
         .get("agent")
         .and_then(Value::as_str)
@@ -192,6 +192,11 @@ pub fn translate(envelope: &Value, at: OffsetDateTime) -> Result<BridgeUpdate, D
         .filter(|s| !s.is_empty());
     let name = display.or(canonical).ok_or(DropReason::NoAgent)?;
     let kind = classify_agent(canonical.unwrap_or(name));
+
+    let status = data
+        .get("agent_status")
+        .and_then(Value::as_str)
+        .ok_or(DropReason::Malformed)?;
 
     let pane_id = format!("{PANE_ID_PREFIX}{raw_pane}");
     // herdr panes carry no tmux socket, so the synthetic session id is the
@@ -251,18 +256,27 @@ pub fn translate(envelope: &Value, at: OffsetDateTime) -> Result<BridgeUpdate, D
     })
 }
 
+/// True when a bridge row already owning `pane` (a real, hook-driven,
+/// non-synthetic occupant) must be treated as owning it authoritatively.
+///
+/// A `Stopped` occupant does NOT own the pane: GC keeps a `Stopped` row around
+/// for up to an hour, and a fresh (hook-less) agent launched in that same pane
+/// during that window would otherwise be invisible to the bridge the whole
+/// time. So only NON-`Stopped` non-synthetic occupants block a bridge update.
+fn occupant_is_authoritative(agent: &Agent) -> bool {
+    !agent.session_id.starts_with(SYNTHETIC_SESSION_PREFIX) && agent.state != AgentState::Stopped
+}
+
 /// Apply a translated update, enforcing the hook-authoritative rule: if a
-/// non-synthetic (real hook) row already owns the pane, drop the bridge update
-/// wholesale.
+/// *live* non-synthetic (real hook) row already owns the pane, drop the bridge
+/// update wholesale. A `Stopped` real row is a stale tombstone, not an owner —
+/// see [`occupant_is_authoritative`].
 async fn apply_update(store: &SharedStore, update: BridgeUpdate) {
     let occupants = store.by_pane(&update.pane_id).await;
-    if occupants
-        .iter()
-        .any(|a| !a.session_id.starts_with(SYNTHETIC_SESSION_PREFIX))
-    {
+    if occupants.iter().any(occupant_is_authoritative) {
         tracing::debug!(
             pane = %update.pane_id,
-            "herdr bridge: pane owned by a hooked agent, dropping bridge update",
+            "herdr bridge: pane owned by a live hooked agent, dropping bridge update",
         );
         return;
     }
@@ -271,15 +285,110 @@ async fn apply_update(store: &SharedStore, update: BridgeUpdate) {
     }
 }
 
+/// The muxa-namespaced pane id of an agent-less `pane.agent_status_changed`
+/// envelope (herdr reports `agent = null` when an agent exits but the pane's
+/// shell stays open). `None` if the envelope carries no usable `pane_id`.
+fn agentless_pane_id(envelope: &Value) -> Option<String> {
+    let raw = envelope
+        .get("data")
+        .and_then(|d| d.get("pane_id"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())?;
+    Some(format!("{PANE_ID_PREFIX}{raw}"))
+}
+
+/// Herdr says this pane has no agent. If a *synthetic* bridge row is still
+/// mirroring an agent there, stop it — otherwise its last state (`Working` /
+/// `WaitingInput`) would freeze forever: the pane's shell is alive (so the
+/// reconciler won't reap it) and the row isn't `Stopped` (so GC won't evict
+/// it). Emitting `SessionEnded` drives the synthetic row to `Stopped`, after
+/// which GC can reclaim it. A pane with no synthetic row is left untouched (no
+/// row is invented), and a real hook row is never disturbed by this path.
+async fn stop_agentless_synthetic(store: &SharedStore, pane_id: &str) {
+    let occupants = store.by_pane(pane_id).await;
+    for occ in occupants {
+        if !occ.session_id.starts_with(SYNTHETIC_SESSION_PREFIX) || occ.state == AgentState::Stopped
+        {
+            // Real hook rows are not ours to stop; already-`Stopped` synthetic
+            // rows need no further event.
+            continue;
+        }
+        let id = AgentId {
+            kind: occ.kind,
+            session_id: occ.session_id.clone(),
+            surface: occ.surface.clone(),
+            pane: occ.pane.clone(),
+            tmux_socket: None,
+            cwd: occ.cwd.clone(),
+        };
+        store
+            .apply(&AgentEvent::SessionEnded {
+                id,
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+        tracing::debug!(pane = %pane_id, "herdr bridge: agent gone, stopped synthetic row");
+    }
+}
+
 /// Translate a wire/seed envelope and, when it yields an update, apply it.
 async fn ingest_envelope(store: &SharedStore, envelope: &Value) {
     match translate(envelope, OffsetDateTime::now_utc()) {
         Ok(update) => apply_update(store, update).await,
-        // Unknown status / plain shells are routine — keep them off the debug
-        // stream so the log isn't swamped on a busy session.
-        Err(DropReason::StatusUnknown | DropReason::NoAgent) => {}
+        // Agent gone: herdr no longer attributes an agent to this pane. If a
+        // synthetic bridge row is still mirroring one there, stop it so it
+        // doesn't freeze; otherwise it's a plain shell and a no-op.
+        Err(DropReason::NoAgent) => {
+            if let Some(pane) = agentless_pane_id(envelope) {
+                stop_agentless_synthetic(store, &pane).await;
+            }
+        }
+        // Unknown status is routine — keep it off the debug stream so the log
+        // isn't swamped on a busy session.
+        Err(DropReason::StatusUnknown) => {}
         Err(reason) => tracing::debug!(?reason, "herdr bridge: dropped event"),
     }
+}
+
+/// A compact, comparable fingerprint of a pane's herdr-reported agent state
+/// (`agent` + `display_agent` + `agent_status`). The rescan loop keeps the
+/// last-observed signature per pane so it re-ingests a pane ONLY when its
+/// status actually drifted — re-ingesting an unchanged pane would needlessly
+/// bump the synthetic row's activity timestamp every rescan tick. The `\u{1}`
+/// separator can't appear in an agent name or status, so distinct field tuples
+/// never collide.
+fn status_signature(agent: Option<&str>, display: Option<&str>, status: &str) -> String {
+    format!(
+        "{}\u{1}{}\u{1}{}",
+        agent.unwrap_or(""),
+        display.unwrap_or(""),
+        status
+    )
+}
+
+/// The `(raw_pane_id, signature)` of a live `pane.agent_status_changed`
+/// envelope, so the rescan loop's `seen` map can be kept current from streamed
+/// deltas too (not just from `pane.list`). `None` for non-status events or an
+/// envelope with no `pane_id`.
+fn envelope_signature(envelope: &Value) -> Option<(String, String)> {
+    if envelope.get("event").and_then(Value::as_str) != Some(AGENT_STATUS_EVENT) {
+        return None;
+    }
+    let data = envelope.get("data")?;
+    let raw = data
+        .get("pane_id")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())?;
+    let status = data
+        .get("agent_status")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let sig = status_signature(
+        data.get("agent").and_then(Value::as_str),
+        data.get("display_agent").and_then(Value::as_str),
+        status,
+    );
+    Some((raw.to_owned(), sig))
 }
 
 /// One herdr pane's current agent state, as read from `pane.list`.
@@ -303,6 +412,15 @@ impl HerdrPane {
                 "agent_status": self.agent_status,
             },
         })
+    }
+
+    /// This pane's current status fingerprint (see [`status_signature`]).
+    fn signature(&self) -> String {
+        status_signature(
+            self.agent.as_deref(),
+            self.display_agent.as_deref(),
+            &self.agent_status,
+        )
     }
 }
 
@@ -430,9 +548,21 @@ async fn connect_and_stream(
         "herdr event bridge subscribed to {AGENT_STATUS_EVENT}",
     );
 
-    // Seed current state — subscribing streams only *future* changes.
+    // Seed current state — subscribing streams only *future* changes. Record
+    // each pane's signature so the rescan below can tell real drift from noise.
+    //
+    // Seed/subscribe race: the `pane.list` snapshot above was taken on a
+    // *separate* connection a moment before this subscription went live, so a
+    // status change landing in that gap is in neither the seed nor the stream.
+    // The status-aware rescan (below) is the backstop: within one
+    // `RESCAN_INTERVAL` it re-lists, notices any pane whose signature no longer
+    // matches `seen`, and re-ingests it — healing both the seed/subscribe gap
+    // *and* any single delta the stream might drop. (This is why the rescan
+    // compares per-pane status, not just the pane *set*.)
+    let mut seen: HashMap<String, String> = HashMap::new();
     for pane in &panes {
         ingest_envelope(store, &pane.as_envelope()).await;
+        seen.insert(pane.pane_id.clone(), pane.signature());
     }
 
     let known: HashSet<String> = pane_ids.into_iter().collect();
@@ -449,6 +579,11 @@ async fn connect_and_stream(
                         // Events carry `event`; the subscribe ack carries `id`.
                         if value.get("event").is_some() {
                             ingest_envelope(store, &value).await;
+                            // Keep `seen` current from the stream so the next
+                            // rescan doesn't redundantly re-ingest this pane.
+                            if let Some((pane, sig)) = envelope_signature(&value) {
+                                seen.insert(pane, sig);
+                            }
                         }
                     }
                 }
@@ -460,10 +595,24 @@ async fn connect_and_stream(
             },
             _ = rescan.tick() => {
                 if let Some(current) = list_panes(socket_path).await {
-                    let current: HashSet<String> =
-                        current.into_iter().map(|p| p.pane_id).collect();
-                    if current != known {
+                    let current_ids: HashSet<String> =
+                        current.iter().map(|p| p.pane_id.clone()).collect();
+                    if current_ids != known {
+                        // Pane set changed — reconnect so new panes get
+                        // subscribed (herdr has no wildcard subscription) and
+                        // closed panes get dropped from the seen map on the
+                        // fresh connect.
                         return ConnOutcome::StreamEnded("pane set changed");
+                    }
+                    // Same pane set: heal any status drift (a lost delta or the
+                    // seed/subscribe race) by re-ingesting only panes whose
+                    // signature changed since we last observed them.
+                    for pane in &current {
+                        let sig = pane.signature();
+                        if seen.get(&pane.pane_id) != Some(&sig) {
+                            ingest_envelope(store, &pane.as_envelope()).await;
+                            seen.insert(pane.pane_id.clone(), sig);
+                        }
                     }
                 }
             }
@@ -732,12 +881,80 @@ async fn send_report(socket_path: &Path, report: &HerdrReport, seq: u64) {
     }
 }
 
+/// Fold one just-sent decision into the running "panes muxa has reported as
+/// authoritative" set that [`resync_reports`] diffs against on a lag. A
+/// `Report` records the pane→slug; a `Release` forgets it.
+fn track_report(reported: &mut HashMap<String, String>, report: &HerdrReport) {
+    match report {
+        HerdrReport::Report { pane_id, agent, .. } => {
+            reported.insert(pane_id.clone(), agent.clone());
+        }
+        HerdrReport::Release { pane_id, .. } => {
+            reported.remove(pane_id);
+        }
+    }
+}
+
+/// Recompute the full set of reverse-path calls needed to re-assert muxa's
+/// authority after the transition stream *lagged* (a burst overran the
+/// broadcast buffer and dropped transitions). Because we don't know which
+/// edges were dropped — possibly the only `…→Stopped` edge that would have
+/// released a pane — we rebuild from a store snapshot:
+///
+/// * report every currently-reportable REAL `herdr:` row (idempotent for herdr:
+///   the monotonic `seq` and `source` make a re-report harmless), and
+/// * release any pane we *previously* reported that has no reportable row in
+///   the snapshot anymore — its agent stopped or its row was GC-evicted during
+///   the gap, so herdr is still holding muxa's last state for a pane muxa no
+///   longer tracks.
+///
+/// Pure and total over its inputs, so the decision logic is unit-testable.
+/// `previously_reported` maps a bare herdr pane id to the agent slug last
+/// reported for it. Returns `(calls to send in order, the new reported set)`.
+fn resync_reports(
+    agents: &[Agent],
+    previously_reported: &HashMap<String, String>,
+) -> (Vec<HerdrReport>, HashMap<String, String>) {
+    let mut calls = Vec::new();
+    let mut now_reported: HashMap<String, String> = HashMap::new();
+    for agent in agents {
+        let Some(report) = report_decision(agent) else {
+            continue;
+        };
+        if let HerdrReport::Report { pane_id, agent, .. } = &report {
+            now_reported.insert(pane_id.clone(), agent.clone());
+        }
+        calls.push(report);
+    }
+    // Release panes we had reported that produced no call this pass — their row
+    // is gone entirely (a Stopped row GC-evicted, or reaped mid-gap), so herdr
+    // would otherwise keep muxa-authoritative state for a dead pane forever.
+    for (pane, slug) in previously_reported {
+        let handled = now_reported.contains_key(pane)
+            || calls
+                .iter()
+                .any(|c| matches!(c, HerdrReport::Release { pane_id, .. } if pane_id == pane));
+        if !handled {
+            calls.push(HerdrReport::Release {
+                pane_id: pane.clone(),
+                agent: slug.clone(),
+            });
+        }
+    }
+    (calls, now_reported)
+}
+
 /// Subscribe to the store's transition stream and push every REAL row's state
 /// change on a `herdr:` pane into herdr. Runs until shutdown or the store's
 /// broadcast channel closes.
 async fn run_report(store: SharedStore, socket_path: PathBuf, shutdown_tx: broadcast::Sender<()>) {
     let mut rx = store.subscribe();
     let mut shutdown_rx = shutdown_tx.subscribe();
+    // Panes muxa has reported as authoritative to herdr (bare pane id -> agent
+    // slug), kept current on every send so a lag-driven resync knows which
+    // panes to release when their `…→Stopped` edge was among the dropped
+    // transitions.
+    let mut reported: HashMap<String, String> = HashMap::new();
     loop {
         tokio::select! {
             _ = shutdown_rx.recv() => {
@@ -747,15 +964,26 @@ async fn run_report(store: SharedStore, socket_path: PathBuf, shutdown_tx: broad
             msg = rx.recv() => match msg {
                 Ok(transition) => {
                     if let Some(report) = report_decision(transition.agent.as_ref()) {
+                        track_report(&mut reported, &report);
                         send_report(&socket_path, &report, next_seq()).await;
                     }
                 }
-                // A slow send while herdr was wedged let transitions pile up.
-                // Reporting is best-effort and each transition carries the full
-                // post-state, so skipping the gap is harmless — the next
-                // transition re-reports current truth.
+                // A slow send while herdr was wedged let transitions overrun the
+                // broadcast buffer. We can't skip the gap: a dropped `…→Stopped`
+                // edge would leave herdr muxa-authoritative for a dead agent
+                // forever (a Stopped row emits no further transition). Resync the
+                // whole reverse path from a store snapshot instead.
                 Err(broadcast::error::RecvError::Lagged(n)) => {
-                    tracing::warn!(dropped = n, "herdr report path lagged behind transitions");
+                    tracing::warn!(
+                        dropped = n,
+                        "herdr report path lagged; resyncing reverse path from store snapshot",
+                    );
+                    let snapshot = store.snapshot().await;
+                    let (calls, new_reported) = resync_reports(&snapshot, &reported);
+                    reported = new_reported;
+                    for report in &calls {
+                        send_report(&socket_path, report, next_seq()).await;
+                    }
                 }
                 Err(broadcast::error::RecvError::Closed) => return,
             },
@@ -993,6 +1221,116 @@ mod tests {
         assert_eq!(rows[0].state, AgentState::Idle, "unchanged by the bridge");
     }
 
+    #[tokio::test]
+    async fn stopped_real_row_does_not_block_bridge() {
+        // A real hook row that has gone `Stopped` is a stale tombstone GC keeps
+        // for up to an hour — it must NOT suppress a fresh (hook-less) agent
+        // the bridge detects in the same pane.
+        let store = Store::shared();
+        let id = AgentId {
+            kind: AgentKind::ClaudeCode,
+            session_id: "real".into(),
+            surface: None,
+            pane: Some("herdr:w1:p1".into()),
+            tmux_socket: None,
+            cwd: None,
+        };
+        store
+            .apply(&AgentEvent::Started {
+                id: id.clone(),
+                at: AT,
+            })
+            .await;
+        store.apply(&AgentEvent::SessionEnded { id, at: AT }).await;
+
+        let working = translate(&status_event("cursor", "Cursor", "working", "w1:p1"), AT).unwrap();
+        apply_update(&store, working).await;
+
+        let rows = store.by_pane("herdr:w1:p1").await;
+        assert!(
+            rows.iter()
+                .any(|r| r.session_id == "real" && r.state == AgentState::Stopped),
+            "the stale Stopped real row is left in place",
+        );
+        let synth = rows
+            .iter()
+            .find(|r| r.session_id.starts_with(SYNTHETIC_SESSION_PREFIX))
+            .expect("bridge synthetic row applied over the Stopped tombstone");
+        assert_eq!(synth.state, AgentState::Working);
+    }
+
+    #[tokio::test]
+    async fn agent_gone_stops_synthetic_row() {
+        // herdr detects an agent, then it exits while the shell stays open
+        // (agent = null). The synthetic row must be driven to Stopped, not left
+        // frozen at Working forever.
+        let store = Store::shared();
+        let working = translate(&status_event("cursor", "Cursor", "working", "w1:p1"), AT).unwrap();
+        apply_update(&store, working).await;
+        assert_eq!(
+            store.by_pane("herdr:w1:p1").await[0].state,
+            AgentState::Working
+        );
+
+        let gone = json!({
+            "event": "pane.agent_status_changed",
+            "data": { "pane_id": "w1:p1", "agent": null, "agent_status": "idle" },
+        });
+        ingest_envelope(&store, &gone).await;
+
+        let rows = store.by_pane("herdr:w1:p1").await;
+        assert_eq!(rows.len(), 1, "same row, now stopped");
+        assert_eq!(rows[0].state, AgentState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn agent_gone_on_empty_pane_is_noop() {
+        // An agent-less update for a pane muxa has no row for must not invent
+        // one (a plain shell is not an agent).
+        let store = Store::shared();
+        let gone = json!({
+            "event": "pane.agent_status_changed",
+            "data": { "pane_id": "w9:p9", "agent_status": "idle" },
+        });
+        ingest_envelope(&store, &gone).await;
+        assert!(
+            store.by_pane("herdr:w9:p9").await.is_empty(),
+            "no row invented for an agent-less shell pane",
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_gone_leaves_real_hook_row_untouched() {
+        // A real hook row on the pane is not the bridge's to stop.
+        let store = Store::shared();
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    kind: AgentKind::ClaudeCode,
+                    session_id: "real".into(),
+                    surface: None,
+                    pane: Some("herdr:w1:p1".into()),
+                    tmux_socket: None,
+                    cwd: None,
+                },
+                at: AT,
+            })
+            .await;
+        let gone = json!({
+            "event": "pane.agent_status_changed",
+            "data": { "pane_id": "w1:p1", "agent": null, "agent_status": "idle" },
+        });
+        ingest_envelope(&store, &gone).await;
+        let rows = store.by_pane("herdr:w1:p1").await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].session_id, "real");
+        assert_eq!(
+            rows[0].state,
+            AgentState::Idle,
+            "real hook row untouched by the agent-gone signal",
+        );
+    }
+
     // --- Reverse path: report_decision --------------------------------------
 
     /// Build an `Agent` for the reverse-path mapping tests. Only the fields
@@ -1203,5 +1541,107 @@ mod tests {
         assert_eq!(params["source"], json!("muxa"));
         assert_eq!(params["agent"], json!("claude"));
         assert_eq!(params["seq"], json!(7));
+    }
+
+    // --- Reverse path: resync_reports (lag recovery) ------------------------
+
+    fn reported(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(p, a)| ((*p).to_owned(), (*a).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn resync_reasserts_live_rows_and_releases_vanished() {
+        // p1 still has a live Working real row; p2 was reported before but has
+        // vanished from the snapshot entirely (its row was GC-evicted after a
+        // dropped `…→Stopped` edge). p1 must be re-reported, p2 released.
+        let prev = reported(&[("w1:p1", "claude"), ("w1:p2", "codex")]);
+        let live = agent(
+            AgentKind::ClaudeCode,
+            "s1",
+            "herdr:w1:p1",
+            AgentState::Working,
+        );
+        let (calls, now) = resync_reports(&[live], &prev);
+
+        assert!(
+            calls.iter().any(|c| matches!(
+                c,
+                HerdrReport::Report { pane_id, state, .. } if pane_id == "w1:p1" && *state == "working"
+            )),
+            "live pane re-reported",
+        );
+        assert!(
+            calls.iter().any(|c| matches!(
+                c,
+                HerdrReport::Release { pane_id, agent } if pane_id == "w1:p2" && agent == "codex"
+            )),
+            "vanished pane released with its last-known slug",
+        );
+        assert_eq!(now.get("w1:p1").map(String::as_str), Some("claude"));
+        assert!(
+            !now.contains_key("w1:p2"),
+            "vanished pane dropped from the reported set",
+        );
+    }
+
+    #[test]
+    fn resync_releases_a_stopped_row_once() {
+        // The row is still present but Stopped — report_decision already yields
+        // a Release, so the vanished-pane sweep must not add a duplicate.
+        let prev = reported(&[("w1:p1", "claude")]);
+        let stopped = agent(
+            AgentKind::ClaudeCode,
+            "s1",
+            "herdr:w1:p1",
+            AgentState::Stopped,
+        );
+        let (calls, now) = resync_reports(&[stopped], &prev);
+        assert_eq!(calls.len(), 1, "exactly one release, no duplicate");
+        assert!(matches!(
+            &calls[0],
+            HerdrReport::Release { pane_id, .. } if pane_id == "w1:p1"
+        ));
+        assert!(now.is_empty(), "released pane is not in the reported set");
+    }
+
+    #[test]
+    fn resync_ignores_synthetic_and_non_herdr_rows() {
+        let synthetic = agent(
+            AgentKind::Unknown,
+            "synthetic-herdr:w1:p1",
+            "herdr:w1:p1",
+            AgentState::Working,
+        );
+        let tmux = agent(AgentKind::ClaudeCode, "s2", "%3", AgentState::Working);
+        let (calls, now) = resync_reports(&[synthetic, tmux], &HashMap::new());
+        assert!(calls.is_empty(), "neither row is reportable");
+        assert!(now.is_empty());
+    }
+
+    #[test]
+    fn track_report_records_and_forgets() {
+        let mut set = HashMap::new();
+        track_report(
+            &mut set,
+            &HerdrReport::Report {
+                pane_id: "w1:p1".into(),
+                agent: "claude".into(),
+                state: "working",
+                message: None,
+                agent_session_id: "s1".into(),
+            },
+        );
+        assert_eq!(set.get("w1:p1").map(String::as_str), Some("claude"));
+        track_report(
+            &mut set,
+            &HerdrReport::Release {
+                pane_id: "w1:p1".into(),
+                agent: "claude".into(),
+            },
+        );
+        assert!(set.is_empty(), "release forgets the pane");
     }
 }

--- a/crates/muxad/src/herdr_bridge.rs
+++ b/crates/muxad/src/herdr_bridge.rs
@@ -1,0 +1,737 @@
+//! herdr event bridge (Phase 2).
+//!
+//! When the active pane backend is herdr, this task holds a long-lived
+//! connection to the herdr socket, subscribes to `pane.agent_status_changed`,
+//! and translates each status change into synthetic muxa [`AgentEvent`]s. That
+//! gives `muxa status` / `watch` / stats visibility into *every* agent herdr
+//! detects — cursor, amp, copilot, and the rest — even the ones muxa has no
+//! hooks for.
+//!
+//! ## Row identity and precedence
+//!
+//! Bridge rows reuse muxa's existing SYNTHETIC-row convention: the pane id is
+//! namespaced `herdr:<pane_id>` (via [`PANE_ID_PREFIX`]) and the session id is
+//! `synthetic-herdr:<pane_id>` — exactly the shape `discovery` mints for a
+//! herdr pane (whose `socket` is always `None`). Two consequences fall out for
+//! free:
+//!
+//! * When a real hook row later claims the same pane, `Store::apply`'s
+//!   synthetic-eviction pass drops the bridge row — the hook is authoritative.
+//! * Before applying any bridge event we query [`Store::by_pane`]: if a
+//!   *non-synthetic* row already owns the pane, the update is dropped. A hooked
+//!   agent owns its pane; herdr's screen-detected view must not clobber it.
+//!
+//! ## Wire
+//!
+//! newline-delimited JSON over the same socket path the query backend resolves
+//! ([`default_socket_path`]). herdr's `pane.agent_status_changed` subscription
+//! is *per pane* (each subscription item carries a `pane_id`), so on every
+//! connect the bridge:
+//!
+//! 1. enumerates panes with `pane.list` (which reports each pane's *current*
+//!    `agent` / `agent_status`),
+//! 2. subscribes to all of them in one `events.subscribe` call,
+//! 3. seeds current state from step 1 (subscribing does **not** replay the
+//!    present status — only future changes stream), then
+//! 4. streams deltas, re-listing on a timer and reconnecting whenever the pane
+//!    set changes so newly-created panes get covered.
+//!
+//! A dropped connection is retried with capped exponential backoff.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use muxa::backend::herdr::{default_socket_path, PANE_ID_PREFIX};
+use muxa::event::{AgentEvent, AgentId, AgentKind, NotificationLevel};
+use muxa::state::SYNTHETIC_SESSION_PREFIX;
+use muxa::{HostKind, SharedBackend, SharedStore};
+use serde_json::{json, Value};
+use time::OffsetDateTime;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::sync::broadcast;
+
+/// The one herdr subscription kind the bridge cares about. The other
+/// subscribable kinds (`pane.output_matched`, `pane.scroll_changed`) carry no
+/// agent-state signal.
+const AGENT_STATUS_EVENT: &str = "pane.agent_status_changed";
+
+/// First reconnect delay after a failed connect/subscribe. Kept short so a
+/// herdr server that comes up a moment after muxad is picked up quickly.
+const INITIAL_BACKOFF: Duration = Duration::from_millis(500);
+
+/// Ceiling on the reconnect delay. A herdr server that stays down settles into
+/// one probe every 30 s rather than busy-looping.
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// How often, while streaming, to re-`pane.list` and check whether the pane
+/// set changed. A change triggers a reconnect so new panes get subscribed.
+const RESCAN_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Bound on a one-shot `pane.list` round-trip, mirroring the query backend's
+/// per-call timeout so a wedged server can't stall the bridge's rescan.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Why a herdr event did not produce a muxa update. Returned by [`translate`]
+/// so the caller can log at the right level (unknown status is routine noise;
+/// a malformed envelope is worth a debug line).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DropReason {
+    /// The envelope was not a `pane.agent_status_changed` event.
+    NotAgentStatusEvent,
+    /// The event carried no usable `pane_id`.
+    MissingPaneId,
+    /// The event named no agent (`agent` and `display_agent` both absent) — a
+    /// plain shell pane, not something muxa should synthesize a row for.
+    NoAgent,
+    /// `agent_status` was `unknown` (or an unrecognized value) — herdr can't
+    /// classify the pane, so muxa shouldn't invent a state for it.
+    StatusUnknown,
+    /// The envelope was missing the `data` object or the `agent_status` field.
+    Malformed,
+}
+
+/// A translated herdr status change: the muxa-namespaced pane it targets plus
+/// the ordered events to apply once the pane is confirmed hook-free.
+///
+/// [`AgentEvent`] is not `PartialEq`, so neither is this — tests inspect the
+/// `events` vec by pattern-matching rather than comparing whole values.
+#[derive(Debug, Clone)]
+pub struct BridgeUpdate {
+    /// muxa-namespaced pane id (`herdr:<pane_id>`). The caller runs the
+    /// hook-authoritative [`Store::by_pane`] check against this.
+    pub pane_id: String,
+    /// Events to apply in order. The status-bearing event comes first (so a
+    /// fresh row transitions straight into its real state), followed by an
+    /// [`AgentEvent::Heartbeat`] that stamps the herdr agent name into the
+    /// row's `model` metadata.
+    pub events: Vec<AgentEvent>,
+}
+
+/// Map a herdr agent name to a muxa [`AgentKind`].
+///
+/// herdr's canonical agent slugs (from `server.agent_manifests`) aren't pinned
+/// in the schema dump, so matching is deliberately loose and case-insensitive:
+/// substring hits on the well-known agents muxa has a kind for, everything else
+/// (cursor, amp, copilot, …) falls through to [`AgentKind::Unknown`] and rides
+/// on the herdr name carried in `model`.
+fn classify_agent(agent: &str) -> AgentKind {
+    let agent = agent.to_ascii_lowercase();
+    if agent.contains("claude") {
+        AgentKind::ClaudeCode
+    } else if agent.contains("codex") {
+        AgentKind::Codex
+    } else if agent.contains("gemini") {
+        AgentKind::GeminiCli
+    } else if agent.contains("opencode") {
+        AgentKind::Opencode
+    } else {
+        AgentKind::Unknown
+    }
+}
+
+/// A short, human-facing label for the `working` [`AgentEvent::ToolStarted`].
+/// The tool string isn't persisted on the row (no `current_tool` field), so it
+/// only ever surfaces in the activity ledger — the herdr agent name is the
+/// most informative thing to record there.
+fn tool_label(name: &str) -> String {
+    name.to_owned()
+}
+
+/// The `last_notification` text for a `blocked` row. Prefers the herdr pane
+/// title (often "waiting for approval" style copy), else a generic line naming
+/// the agent.
+fn blocked_message(data: &Value, name: &str) -> String {
+    data.get("title")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map_or_else(|| format!("{name} is waiting"), ToOwned::to_owned)
+}
+
+/// Translate one `pane.agent_status_changed` envelope into muxa events. Pure:
+/// no I/O, no clock read (the caller supplies `at`), so the full mapping table
+/// is unit-testable.
+///
+/// Status mapping:
+///
+/// | herdr `agent_status` | muxa event          | resulting state |
+/// |----------------------|---------------------|-----------------|
+/// | `working`            | `ToolStarted`       | `Working`       |
+/// | `blocked`            | `NotificationFired` | `WaitingInput`  |
+/// | `idle` / `done`      | `TurnStopped`       | `Idle`          |
+/// | `unknown`            | — (dropped)         | —               |
+pub fn translate(envelope: &Value, at: OffsetDateTime) -> Result<BridgeUpdate, DropReason> {
+    if envelope.get("event").and_then(Value::as_str) != Some(AGENT_STATUS_EVENT) {
+        return Err(DropReason::NotAgentStatusEvent);
+    }
+    let data = envelope.get("data").ok_or(DropReason::Malformed)?;
+
+    let raw_pane = data
+        .get("pane_id")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or(DropReason::MissingPaneId)?;
+    let status = data
+        .get("agent_status")
+        .and_then(Value::as_str)
+        .ok_or(DropReason::Malformed)?;
+
+    // `agent` is herdr's canonical slug; `display_agent` is its pretty label.
+    // The name (for the visible `model` metadata) prefers the pretty label;
+    // the kind is classified from whichever is present. A pane with neither is
+    // a plain shell — nothing to synthesize.
+    let canonical = data
+        .get("agent")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty());
+    let display = data
+        .get("display_agent")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty());
+    let name = display.or(canonical).ok_or(DropReason::NoAgent)?;
+    let kind = classify_agent(canonical.unwrap_or(name));
+
+    let pane_id = format!("{PANE_ID_PREFIX}{raw_pane}");
+    // herdr panes carry no tmux socket, so the synthetic session id is the
+    // plain `synthetic-<pane_id>` shape `discovery::synthetic_session_id`
+    // produces for a socket-less pane — the two coincide by design so a
+    // discovery placeholder and a bridge row collapse onto one registry key.
+    let session_id = format!("{SYNTHETIC_SESSION_PREFIX}{pane_id}");
+    let id = AgentId {
+        kind,
+        session_id,
+        surface: None,
+        pane: Some(pane_id.clone()),
+        tmux_socket: None,
+        cwd: None,
+    };
+
+    let status_event = match status {
+        "working" => AgentEvent::ToolStarted {
+            id: id.clone(),
+            tool: tool_label(name),
+            subagent: None,
+            at,
+        },
+        "blocked" => AgentEvent::NotificationFired {
+            id: id.clone(),
+            level: NotificationLevel::NeedsInput,
+            message: blocked_message(data, name),
+            at,
+        },
+        "idle" | "done" => AgentEvent::TurnStopped {
+            id: id.clone(),
+            response: None,
+            at,
+        },
+        "unknown" => return Err(DropReason::StatusUnknown),
+        _ => return Err(DropReason::Malformed),
+    };
+
+    // Carry the herdr agent name into `model` so an Unknown-kind row (cursor,
+    // amp, …) still tells the operator *which* agent it is. Harmless for a row
+    // that later gets real hooks — the bridge row is evicted first.
+    let heartbeat = AgentEvent::Heartbeat {
+        id,
+        model: Some(name.to_owned()),
+        context_used_pct: None,
+        cost_usd: None,
+        rate_limit_5h_pct: None,
+        rate_limit_5h_resets_at: None,
+        rate_limit_7d_pct: None,
+        rate_limit_7d_resets_at: None,
+        at,
+    };
+
+    Ok(BridgeUpdate {
+        pane_id,
+        events: vec![status_event, heartbeat],
+    })
+}
+
+/// Apply a translated update, enforcing the hook-authoritative rule: if a
+/// non-synthetic (real hook) row already owns the pane, drop the bridge update
+/// wholesale.
+async fn apply_update(store: &SharedStore, update: BridgeUpdate) {
+    let occupants = store.by_pane(&update.pane_id).await;
+    if occupants
+        .iter()
+        .any(|a| !a.session_id.starts_with(SYNTHETIC_SESSION_PREFIX))
+    {
+        tracing::debug!(
+            pane = %update.pane_id,
+            "herdr bridge: pane owned by a hooked agent, dropping bridge update",
+        );
+        return;
+    }
+    for ev in &update.events {
+        store.apply(ev).await;
+    }
+}
+
+/// Translate a wire/seed envelope and, when it yields an update, apply it.
+async fn ingest_envelope(store: &SharedStore, envelope: &Value) {
+    match translate(envelope, OffsetDateTime::now_utc()) {
+        Ok(update) => apply_update(store, update).await,
+        // Unknown status / plain shells are routine — keep them off the debug
+        // stream so the log isn't swamped on a busy session.
+        Err(DropReason::StatusUnknown | DropReason::NoAgent) => {}
+        Err(reason) => tracing::debug!(?reason, "herdr bridge: dropped event"),
+    }
+}
+
+/// One herdr pane's current agent state, as read from `pane.list`.
+struct HerdrPane {
+    pane_id: String,
+    agent: Option<String>,
+    display_agent: Option<String>,
+    agent_status: String,
+}
+
+impl HerdrPane {
+    /// Rebuild the `pane.agent_status_changed` envelope shape so seeding reuses
+    /// the exact same [`translate`] path the live wire events take.
+    fn as_envelope(&self) -> Value {
+        json!({
+            "event": AGENT_STATUS_EVENT,
+            "data": {
+                "pane_id": self.pane_id,
+                "agent": self.agent,
+                "display_agent": self.display_agent,
+                "agent_status": self.agent_status,
+            },
+        })
+    }
+}
+
+/// One request/response round-trip on a fresh connection, bounded by
+/// [`REQUEST_TIMEOUT`]. Returns the `result` value on success. Used for the
+/// bridge's `pane.list` enumeration; the persistent stream stays dedicated to
+/// events.
+async fn herdr_request(socket_path: &Path, method: &str, params: Value) -> Option<Value> {
+    let stream = UnixStream::connect(socket_path).await.ok()?;
+    let (read_half, mut write_half) = stream.into_split();
+    let id = "muxa-herdr-bridge-req";
+    let mut payload = json!({ "id": id, "method": method, "params": params }).to_string();
+    payload.push('\n');
+    write_half.write_all(payload.as_bytes()).await.ok()?;
+
+    let mut lines = BufReader::new(read_half).lines();
+    tokio::time::timeout(REQUEST_TIMEOUT, async {
+        while let Ok(Some(line)) = lines.next_line().await {
+            let Ok(value) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
+            if value.get("id").and_then(Value::as_str) == Some(id) {
+                return value.get("result").cloned();
+            }
+        }
+        None
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+/// Enumerate herdr panes with their current agent state.
+async fn list_panes(socket_path: &Path) -> Option<Vec<HerdrPane>> {
+    let result = herdr_request(socket_path, "pane.list", json!({})).await?;
+    let panes = result.get("panes")?.as_array()?;
+    Some(
+        panes
+            .iter()
+            .filter_map(|p| {
+                Some(HerdrPane {
+                    pane_id: p.get("pane_id").and_then(Value::as_str)?.to_owned(),
+                    agent: p
+                        .get("agent")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned),
+                    display_agent: p
+                        .get("display_agent")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned),
+                    agent_status: p.get("agent_status").and_then(Value::as_str)?.to_owned(),
+                })
+            })
+            .collect(),
+    )
+}
+
+/// The `events.subscribe` request line (newline-terminated) for the given raw
+/// herdr pane ids, requesting only `pane.agent_status_changed` on each.
+fn subscribe_request(pane_ids: &[String]) -> String {
+    let subscriptions: Vec<Value> = pane_ids
+        .iter()
+        .map(|id| json!({ "type": AGENT_STATUS_EVENT, "pane_id": id }))
+        .collect();
+    let mut line = json!({
+        "id": "muxa-herdr-bridge",
+        "method": "events.subscribe",
+        "params": { "subscriptions": subscriptions },
+    })
+    .to_string();
+    line.push('\n');
+    line
+}
+
+/// Outcome of one connect-and-stream attempt, so the reconnect loop can pick
+/// the right backoff.
+enum ConnOutcome {
+    /// Shutdown was signalled — the task should return.
+    Shutdown,
+    /// Never established a subscription (socket absent, no panes, connect/
+    /// write/list failed). Escalate the backoff.
+    NotConnected(&'static str),
+    /// Was subscribed, then the stream ended or the pane set changed. Retry
+    /// promptly.
+    StreamEnded(&'static str),
+}
+
+/// Connect, subscribe to every current pane, seed their state, and stream
+/// deltas until shutdown, disconnect, or a pane-set change.
+async fn connect_and_stream(
+    store: &SharedStore,
+    socket_path: &Path,
+    shutdown_rx: &mut broadcast::Receiver<()>,
+) -> ConnOutcome {
+    if !socket_path.exists() {
+        return ConnOutcome::NotConnected("socket file missing");
+    }
+    let Some(panes) = list_panes(socket_path).await else {
+        return ConnOutcome::NotConnected("pane.list failed");
+    };
+    if panes.is_empty() {
+        // Nothing to watch yet; back off and re-list rather than holding an
+        // empty subscription open.
+        return ConnOutcome::NotConnected("no panes");
+    }
+    let pane_ids: Vec<String> = panes.iter().map(|p| p.pane_id.clone()).collect();
+
+    let stream = match UnixStream::connect(socket_path).await {
+        Ok(stream) => stream,
+        Err(e) => {
+            tracing::debug!(error = %e, "herdr bridge: connect failed");
+            return ConnOutcome::NotConnected("connect failed");
+        }
+    };
+    let (read_half, mut write_half) = stream.into_split();
+    if let Err(e) = write_half
+        .write_all(subscribe_request(&pane_ids).as_bytes())
+        .await
+    {
+        tracing::debug!(error = %e, "herdr bridge: subscribe write failed");
+        return ConnOutcome::NotConnected("subscribe write failed");
+    }
+    tracing::info!(
+        panes = pane_ids.len(),
+        "herdr event bridge subscribed to {AGENT_STATUS_EVENT}",
+    );
+
+    // Seed current state — subscribing streams only *future* changes.
+    for pane in &panes {
+        ingest_envelope(store, &pane.as_envelope()).await;
+    }
+
+    let known: HashSet<String> = pane_ids.into_iter().collect();
+    let mut lines = BufReader::new(read_half).lines();
+    let mut rescan = tokio::time::interval(RESCAN_INTERVAL);
+    rescan.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    rescan.tick().await; // consume the immediate first tick
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.recv() => return ConnOutcome::Shutdown,
+            line = lines.next_line() => match line {
+                Ok(Some(line)) => {
+                    if let Ok(value) = serde_json::from_str::<Value>(&line) {
+                        // Events carry `event`; the subscribe ack carries `id`.
+                        if value.get("event").is_some() {
+                            ingest_envelope(store, &value).await;
+                        }
+                    }
+                }
+                Ok(None) => return ConnOutcome::StreamEnded("connection closed"),
+                Err(e) => {
+                    tracing::debug!(error = %e, "herdr bridge: read error");
+                    return ConnOutcome::StreamEnded("read error");
+                }
+            },
+            _ = rescan.tick() => {
+                if let Some(current) = list_panes(socket_path).await {
+                    let current: HashSet<String> =
+                        current.into_iter().map(|p| p.pane_id).collect();
+                    if current != known {
+                        return ConnOutcome::StreamEnded("pane set changed");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Reconnect loop. Owns the backoff; races every wait against shutdown so a
+/// SIGTERM never leaves the process lingering on a sleep.
+async fn run(store: SharedStore, socket_path: PathBuf, shutdown_tx: broadcast::Sender<()>) {
+    let mut backoff = INITIAL_BACKOFF;
+    loop {
+        let mut shutdown_rx = shutdown_tx.subscribe();
+        match connect_and_stream(&store, &socket_path, &mut shutdown_rx).await {
+            ConnOutcome::Shutdown => {
+                tracing::debug!("herdr bridge shutting down");
+                return;
+            }
+            ConnOutcome::StreamEnded(reason) => {
+                // A healthy connection that ended — reset so we reconnect
+                // promptly rather than inheriting a stale long backoff.
+                backoff = INITIAL_BACKOFF;
+                tracing::debug!(reason, "herdr bridge: stream ended; reconnecting");
+            }
+            ConnOutcome::NotConnected(reason) => {
+                tracing::debug!(
+                    reason,
+                    backoff_secs = backoff.as_secs_f64(),
+                    "herdr bridge: not connected; backing off",
+                );
+            }
+        }
+
+        let mut shutdown_rx = shutdown_tx.subscribe();
+        tokio::select! {
+            _ = shutdown_rx.recv() => return,
+            () = tokio::time::sleep(backoff) => {}
+        }
+        backoff = (backoff * 2).min(MAX_BACKOFF);
+    }
+}
+
+/// Spawn the herdr bridge task, but only when the active backend is herdr.
+/// Returns the join handle so the daemon can drain it on shutdown; `None` on
+/// every other host.
+pub fn spawn_herdr_bridge_task(
+    backend: &SharedBackend,
+    store: SharedStore,
+    shutdown_tx: &broadcast::Sender<()>,
+) -> Option<tokio::task::JoinHandle<()>> {
+    if backend.kind() != HostKind::Herdr {
+        return None;
+    }
+    let socket_path = default_socket_path();
+    let shutdown_tx = shutdown_tx.clone();
+    tracing::info!(
+        socket = %socket_path.display(),
+        "herdr event bridge enabled",
+    );
+    Some(tokio::spawn(run(store, socket_path, shutdown_tx)))
+}
+
+#[cfg(test)]
+mod tests {
+    use muxa::event::AgentEvent;
+    use muxa::state::Store;
+    use muxa::AgentState;
+    use serde_json::json;
+    use time::macros::datetime;
+
+    use super::*;
+
+    const AT: OffsetDateTime = datetime!(2026-07-20 12:00:00 UTC);
+
+    fn status_event(agent: &str, display: &str, status: &str, pane: &str) -> Value {
+        json!({
+            "event": "pane.agent_status_changed",
+            "data": {
+                "pane_id": pane,
+                "workspace_id": "w1",
+                "agent": agent,
+                "display_agent": display,
+                "agent_status": status,
+                "state_labels": {},
+                "title": null,
+            },
+        })
+    }
+
+    fn drop_reason(ev: &Value) -> DropReason {
+        match translate(ev, AT) {
+            Err(reason) => reason,
+            Ok(_) => panic!("expected a drop, got an update"),
+        }
+    }
+
+    #[test]
+    fn working_maps_to_tool_started_plus_heartbeat() {
+        let ev = status_event("cursor", "Cursor", "working", "w1:p1");
+        let out = translate(&ev, AT).expect("working translates");
+        assert_eq!(out.pane_id, "herdr:w1:p1");
+        assert_eq!(out.events.len(), 2, "status event + name heartbeat");
+        match &out.events[0] {
+            AgentEvent::ToolStarted { id, tool, .. } => {
+                assert_eq!(id.session_id, "synthetic-herdr:w1:p1");
+                assert_eq!(id.pane.as_deref(), Some("herdr:w1:p1"));
+                assert_eq!(id.kind, AgentKind::Unknown, "cursor has no muxa kind");
+                assert_eq!(tool, "Cursor");
+            }
+            other => panic!("expected ToolStarted, got {other:?}"),
+        }
+        match &out.events[1] {
+            AgentEvent::Heartbeat { model, .. } => {
+                assert_eq!(model.as_deref(), Some("Cursor"), "name carried in model");
+            }
+            other => panic!("expected Heartbeat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn blocked_maps_to_needs_input_notification() {
+        let ev = status_event("amp", "Amp", "blocked", "w1:p2");
+        let out = translate(&ev, AT).expect("blocked translates");
+        match &out.events[0] {
+            AgentEvent::NotificationFired { level, message, .. } => {
+                assert_eq!(*level, NotificationLevel::NeedsInput);
+                assert_eq!(message, "Amp is waiting");
+            }
+            other => panic!("expected NotificationFired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn blocked_prefers_title_for_message() {
+        let mut ev = status_event("amp", "Amp", "blocked", "w1:p2");
+        ev["data"]["title"] = json!("Approve running `rm`?");
+        let out = translate(&ev, AT).unwrap();
+        match &out.events[0] {
+            AgentEvent::NotificationFired { message, .. } => {
+                assert_eq!(message, "Approve running `rm`?");
+            }
+            other => panic!("expected NotificationFired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn idle_and_done_map_to_turn_stopped() {
+        for status in ["idle", "done"] {
+            let ev = status_event("cursor", "Cursor", status, "w1:p1");
+            let out = translate(&ev, AT).unwrap();
+            assert!(
+                matches!(out.events[0], AgentEvent::TurnStopped { .. }),
+                "{status} should stop the turn",
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_status_is_dropped() {
+        let ev = status_event("cursor", "Cursor", "unknown", "w1:p1");
+        assert_eq!(drop_reason(&ev), DropReason::StatusUnknown);
+    }
+
+    #[test]
+    fn non_status_event_is_dropped() {
+        let ev = json!({ "event": "pane.scroll_changed", "data": {} });
+        assert_eq!(drop_reason(&ev), DropReason::NotAgentStatusEvent);
+    }
+
+    #[test]
+    fn missing_pane_id_is_dropped() {
+        let ev = json!({
+            "event": "pane.agent_status_changed",
+            "data": { "workspace_id": "w1", "agent": "cursor", "agent_status": "working" },
+        });
+        assert_eq!(drop_reason(&ev), DropReason::MissingPaneId);
+    }
+
+    #[test]
+    fn shell_pane_without_agent_is_dropped() {
+        let ev = json!({
+            "event": "pane.agent_status_changed",
+            "data": { "pane_id": "w1:p1", "workspace_id": "w1", "agent_status": "idle" },
+        });
+        assert_eq!(drop_reason(&ev), DropReason::NoAgent);
+    }
+
+    #[test]
+    fn missing_agent_status_is_malformed() {
+        let ev = json!({
+            "event": "pane.agent_status_changed",
+            "data": { "pane_id": "w1:p1", "workspace_id": "w1", "agent": "cursor" },
+        });
+        assert_eq!(drop_reason(&ev), DropReason::Malformed);
+    }
+
+    #[test]
+    fn known_agents_map_to_their_kinds() {
+        let cases = [
+            ("claude", AgentKind::ClaudeCode),
+            ("codex", AgentKind::Codex),
+            ("gemini", AgentKind::GeminiCli),
+            ("opencode", AgentKind::Opencode),
+            ("cursor", AgentKind::Unknown),
+            ("copilot", AgentKind::Unknown),
+        ];
+        for (agent, expected) in cases {
+            let ev = status_event(agent, agent, "working", "w1:p1");
+            let out = translate(&ev, AT).unwrap();
+            assert_eq!(out.events[0].id().kind, expected, "agent {agent}");
+        }
+    }
+
+    #[test]
+    fn name_falls_back_to_agent_when_display_absent() {
+        let mut ev = status_event("cursor", "Cursor", "working", "w1:p1");
+        ev["data"]["display_agent"] = json!(null);
+        let out = translate(&ev, AT).unwrap();
+        match &out.events[0] {
+            AgentEvent::ToolStarted { tool, .. } => assert_eq!(tool, "cursor"),
+            other => panic!("expected ToolStarted, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn bridge_row_appears_then_transitions() {
+        let store = Store::shared();
+        let working = translate(&status_event("cursor", "Cursor", "working", "w1:p1"), AT).unwrap();
+        apply_update(&store, working).await;
+
+        let rows = store.by_pane("herdr:w1:p1").await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].state, AgentState::Working);
+        assert_eq!(rows[0].kind, AgentKind::Unknown);
+        assert_eq!(rows[0].model.as_deref(), Some("Cursor"));
+
+        let blocked = translate(&status_event("cursor", "Cursor", "blocked", "w1:p1"), AT).unwrap();
+        apply_update(&store, blocked).await;
+        let rows = store.by_pane("herdr:w1:p1").await;
+        assert_eq!(rows.len(), 1, "same synthetic row, not a duplicate");
+        assert_eq!(rows[0].state, AgentState::WaitingInput);
+    }
+
+    #[tokio::test]
+    async fn hook_owned_pane_drops_bridge_update() {
+        let store = Store::shared();
+        // A real hook row (non-synthetic) claims the pane first.
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    kind: AgentKind::ClaudeCode,
+                    session_id: "real-session".into(),
+                    surface: None,
+                    pane: Some("herdr:w1:p1".into()),
+                    tmux_socket: None,
+                    cwd: None,
+                },
+                at: AT,
+            })
+            .await;
+
+        // A bridge update for the same pane must be dropped wholesale.
+        let working = translate(&status_event("cursor", "Cursor", "working", "w1:p1"), AT).unwrap();
+        apply_update(&store, working).await;
+
+        let rows = store.by_pane("herdr:w1:p1").await;
+        assert_eq!(rows.len(), 1, "only the real row remains");
+        assert_eq!(rows[0].session_id, "real-session");
+        assert_eq!(rows[0].kind, AgentKind::ClaudeCode);
+        assert_eq!(rows[0].state, AgentState::Idle, "unchanged by the bridge");
+    }
+}

--- a/crates/muxad/src/herdr_bridge.rs
+++ b/crates/muxad/src/herdr_bridge.rs
@@ -40,12 +40,13 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use muxa::backend::herdr::{default_socket_path, PANE_ID_PREFIX};
 use muxa::event::{AgentEvent, AgentId, AgentKind, NotificationLevel};
-use muxa::state::SYNTHETIC_SESSION_PREFIX;
-use muxa::{HostKind, SharedBackend, SharedStore};
+use muxa::state::{Agent, SYNTHETIC_SESSION_PREFIX};
+use muxa::{AgentState, HostKind, SharedBackend, SharedStore};
 use serde_json::{json, Value};
 use time::OffsetDateTime;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -525,6 +526,263 @@ pub fn spawn_herdr_bridge_task(
     Some(tokio::spawn(run(store, socket_path, shutdown_tx)))
 }
 
+// ============================================================================
+// Reverse path: pane.report_agent — push muxa's hook-derived state INTO herdr.
+// ============================================================================
+//
+// ## What and why
+//
+// The forward bridge above turns herdr's *own* screen detection into synthetic
+// muxa rows. This reverse path does the opposite for the rows muxa is
+// authoritative about: whenever a REAL (hook-driven, non-synthetic) agent on a
+// `herdr:` pane changes state, muxa reports that state to herdr via
+// `pane.report_agent` (source `"muxa"`). herdr treats an installed
+// integration's report as authoritative over its own screen detection, so its
+// sidebar/UI shows muxa's exact hook-derived state instead of guessing from the
+// pane's scrollback — and stops its screen-detection state flapping for that
+// pane while muxa owns it.
+//
+// ## No feedback loop (the load-bearing invariant)
+//
+// We report ONLY non-synthetic rows. Synthetic rows (`synthetic-…` session ids)
+// are the ones the forward bridge MINTS from herdr's detection — echoing them
+// back would form a loop: report → herdr adopts muxa as authority → herdr stops
+// emitting `pane.agent_status_changed` → the forward bridge sees no more deltas
+// → muxa's synthetic row goes stale. The two directions stay disjoint by pane
+// ownership:
+//
+//   * A `herdr:` pane with a real hook row → reported here; the forward bridge's
+//     `apply_update` already DROPS herdr's screen-detection updates for that
+//     same pane (hook-authoritative), so herdr's flapping is silenced from both
+//     ends and muxa is the single source of truth.
+//   * A `herdr:` pane with only a synthetic bridge row → never reported; herdr
+//     keeps its own detection and the forward bridge keeps mirroring it.
+//
+// ## Release
+//
+// When a reported row transitions to `Stopped` we send `pane.release_agent`,
+// handing authority back to herdr's own detection. `Stopped` is muxa's terminal
+// state — reached on a `SessionEnded` hook and on reconciler/GC reaping (the
+// reaper flips the row to `Stopped`, which emits a `Transition`). NOTE: a row
+// that is GC-evicted from the registry *after* it already went `Stopped` emits
+// no further transition, and there is no distinct "row removed" transition on
+// the stream to observe. Releasing on the `…→Stopped` edge is therefore both
+// necessary and sufficient — that single release is the last thing herdr hears
+// from muxa for the pane, after which its own detection resumes.
+
+/// The `source` every reverse-path call carries, so herdr attributes the
+/// authority to this integration (and its `pane.release_agent` matches).
+const REPORT_SOURCE: &str = "muxa";
+
+/// Process-global monotonic sequence for `pane.report_agent` /
+/// `pane.release_agent`. herdr uses `seq` to discard out-of-order reports, so a
+/// single ever-increasing counter across every pane keeps a late-delivered
+/// report from resurrecting stale state.
+static REPORT_SEQ: AtomicU64 = AtomicU64::new(1);
+
+fn next_seq() -> u64 {
+    REPORT_SEQ.fetch_add(1, Ordering::Relaxed)
+}
+
+/// herdr's canonical agent slug for a muxa [`AgentKind`]. Chosen to line up
+/// with herdr's own agent names (its `IntegrationTarget` uses `claude`,
+/// `codex`, …) and with the forward bridge's [`classify_agent`], so a pane muxa
+/// reports and a pane herdr detects carry the same agent label.
+fn agent_slug(kind: AgentKind) -> &'static str {
+    match kind {
+        AgentKind::ClaudeCode => "claude",
+        AgentKind::Codex => "codex",
+        AgentKind::GeminiCli => "gemini",
+        AgentKind::Opencode => "opencode",
+        AgentKind::Task => "task",
+        AgentKind::Unknown => "unknown",
+    }
+}
+
+/// A wire-ready decision for one muxa [`Transition`]: report a state to herdr,
+/// or release muxa's authority so herdr's own detection resumes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HerdrReport {
+    /// `pane.report_agent` — muxa is authoritative for this pane's state.
+    Report {
+        /// Bare herdr pane id (the `herdr:` prefix stripped for the wire).
+        pane_id: String,
+        /// herdr agent slug (see [`agent_slug`]).
+        agent: String,
+        /// One of herdr's `PaneAgentState`: `idle` | `working` | `blocked`.
+        state: &'static str,
+        /// Optional human message — blocked/error rows carry the notification.
+        message: Option<String>,
+        /// muxa's real session id, forwarded as herdr's `agent_session_id`.
+        agent_session_id: String,
+    },
+    /// `pane.release_agent` — hand authority back to herdr.
+    Release {
+        /// Bare herdr pane id (the `herdr:` prefix stripped for the wire).
+        pane_id: String,
+        /// herdr agent slug (see [`agent_slug`]).
+        agent: String,
+    },
+}
+
+impl HerdrReport {
+    /// The herdr JSON-RPC method and params for this decision, stamped with
+    /// `seq`. `source` is always [`REPORT_SOURCE`].
+    fn request(&self, seq: u64) -> (&'static str, Value) {
+        match self {
+            HerdrReport::Report {
+                pane_id,
+                agent,
+                state,
+                message,
+                agent_session_id,
+            } => (
+                "pane.report_agent",
+                json!({
+                    "pane_id": pane_id,
+                    "source": REPORT_SOURCE,
+                    "agent": agent,
+                    "state": state,
+                    "message": message,
+                    "agent_session_id": agent_session_id,
+                    "seq": seq,
+                }),
+            ),
+            HerdrReport::Release { pane_id, agent } => (
+                "pane.release_agent",
+                json!({
+                    "pane_id": pane_id,
+                    "source": REPORT_SOURCE,
+                    "agent": agent,
+                    "seq": seq,
+                }),
+            ),
+        }
+    }
+}
+
+/// Decide what (if anything) to report to herdr for a post-transition agent
+/// snapshot. Pure and total, so the full mapping is unit-testable.
+///
+/// Returns `None` — report nothing — unless the row is BOTH on a `herdr:` pane
+/// AND non-synthetic (a real hook row). See the module-level no-loop note.
+///
+/// State mapping:
+///
+/// | muxa `AgentState`              | herdr call / state      |
+/// |--------------------------------|-------------------------|
+/// | `Working`                      | report `working`        |
+/// | `WaitingInput`/`WaitingChoice` | report `blocked` (+msg) |
+/// | `Error`                        | report `blocked` (+msg) |
+/// | `Idle`                         | report `idle`           |
+/// | `Stopped`                      | release                 |
+/// | `Starting`                     | — (nothing; transient)  |
+pub fn report_decision(agent: &Agent) -> Option<HerdrReport> {
+    let pane = agent.pane.as_deref()?;
+    // Only herdr-namespaced panes; the bare id is what crosses the wire.
+    let bare = pane.strip_prefix(PANE_ID_PREFIX)?;
+    // NEVER report synthetic rows — those are minted FROM herdr's own detection
+    // and echoing them back would loop (see the module-level no-loop note).
+    if agent.session_id.starts_with(SYNTHETIC_SESSION_PREFIX) {
+        return None;
+    }
+    let pane_id = bare.to_owned();
+    let agent_name = agent_slug(agent.kind).to_owned();
+
+    let (state, message): (&'static str, Option<String>) = match agent.state {
+        AgentState::Working => ("working", None),
+        // Both "needs input" and "needs a choice" are `blocked` to herdr; carry
+        // the notification text so the sidebar shows *what* it's blocked on.
+        AgentState::WaitingInput | AgentState::WaitingChoice => {
+            ("blocked", agent.last_notification.clone())
+        }
+        // Error has no herdr equivalent; surface it as `blocked` with the error
+        // message (NotificationFired at Error level populates last_notification).
+        AgentState::Error => ("blocked", agent.last_notification.clone()),
+        AgentState::Idle => ("idle", None),
+        AgentState::Stopped => {
+            return Some(HerdrReport::Release {
+                pane_id,
+                agent: agent_name,
+            });
+        }
+        // A freshly-`Started` row is `Starting` only briefly before its first
+        // prompt/tool/turn event moves it on; reporting a transient state herdr
+        // has no equivalent for adds churn without value.
+        AgentState::Starting => return None,
+    };
+    Some(HerdrReport::Report {
+        pane_id,
+        agent: agent_name,
+        state,
+        message,
+        agent_session_id: agent.session_id.clone(),
+    })
+}
+
+/// Fire one reverse-path call at herdr. Best-effort: a failure just means herdr
+/// keeps its own detection for a beat. Bounded by [`REQUEST_TIMEOUT`] inside
+/// [`herdr_request`] so a wedged server can't stall the transition stream.
+async fn send_report(socket_path: &Path, report: &HerdrReport, seq: u64) {
+    let (method, params) = report.request(seq);
+    if herdr_request(socket_path, method, params).await.is_none() {
+        // No `result` came back (transport error, timeout, or an error
+        // response) — non-fatal, just note it and move on.
+        tracing::debug!(method, seq, "herdr report: no result (dropped)");
+    }
+}
+
+/// Subscribe to the store's transition stream and push every REAL row's state
+/// change on a `herdr:` pane into herdr. Runs until shutdown or the store's
+/// broadcast channel closes.
+async fn run_report(store: SharedStore, socket_path: PathBuf, shutdown_tx: broadcast::Sender<()>) {
+    let mut rx = store.subscribe();
+    let mut shutdown_rx = shutdown_tx.subscribe();
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.recv() => {
+                tracing::debug!("herdr report path shutting down");
+                return;
+            }
+            msg = rx.recv() => match msg {
+                Ok(transition) => {
+                    if let Some(report) = report_decision(transition.agent.as_ref()) {
+                        send_report(&socket_path, &report, next_seq()).await;
+                    }
+                }
+                // A slow send while herdr was wedged let transitions pile up.
+                // Reporting is best-effort and each transition carries the full
+                // post-state, so skipping the gap is harmless — the next
+                // transition re-reports current truth.
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(dropped = n, "herdr report path lagged behind transitions");
+                }
+                Err(broadcast::error::RecvError::Closed) => return,
+            },
+        }
+    }
+}
+
+/// Spawn the herdr reverse-path (report) task, but only when the active backend
+/// is herdr. Returns the join handle so the daemon can drain it on shutdown;
+/// `None` on every other host.
+pub fn spawn_herdr_report_task(
+    backend: &SharedBackend,
+    store: SharedStore,
+    shutdown_tx: &broadcast::Sender<()>,
+) -> Option<tokio::task::JoinHandle<()>> {
+    if backend.kind() != HostKind::Herdr {
+        return None;
+    }
+    let socket_path = default_socket_path();
+    let shutdown_tx = shutdown_tx.clone();
+    tracing::info!(
+        socket = %socket_path.display(),
+        "herdr report path enabled (pushing hook-derived state via pane.report_agent)",
+    );
+    Some(tokio::spawn(run_report(store, socket_path, shutdown_tx)))
+}
+
 #[cfg(test)]
 mod tests {
     use muxa::event::AgentEvent;
@@ -733,5 +991,217 @@ mod tests {
         assert_eq!(rows[0].session_id, "real-session");
         assert_eq!(rows[0].kind, AgentKind::ClaudeCode);
         assert_eq!(rows[0].state, AgentState::Idle, "unchanged by the bridge");
+    }
+
+    // --- Reverse path: report_decision --------------------------------------
+
+    /// Build an `Agent` for the reverse-path mapping tests. Only the fields
+    /// `report_decision` reads (`kind`, `session_id`, `pane`, `state`,
+    /// `last_notification`) carry meaning; the rest are inert.
+    fn agent(kind: AgentKind, session_id: &str, pane: &str, state: AgentState) -> Agent {
+        Agent {
+            kind,
+            session_id: session_id.to_owned(),
+            surface: None,
+            pane: Some(pane.to_owned()),
+            tmux_socket: None,
+            tmux_session: None,
+            cwd: None,
+            pid: None,
+            workload: muxa::WorkloadSummary::default(),
+            subagents: Vec::new(),
+            state,
+            last_prompt: None,
+            last_response: None,
+            last_notification: None,
+            model: None,
+            context_used_pct: None,
+            cost_usd: None,
+            rate_limit_5h_pct: None,
+            rate_limit_5h_resets_at: None,
+            rate_limit_7d_pct: None,
+            rate_limit_7d_resets_at: None,
+            rate_limited_until: None,
+            rate_limit_scope: None,
+            rate_limit_source: None,
+            started_at: AT,
+            last_activity_at: AT,
+            state_entered_at: AT,
+        }
+    }
+
+    #[test]
+    fn working_row_reports_working_with_stripped_pane() {
+        let a = agent(
+            AgentKind::ClaudeCode,
+            "sess-1",
+            "herdr:w1:p1",
+            AgentState::Working,
+        );
+        match report_decision(&a).expect("herdr working row reports") {
+            HerdrReport::Report {
+                pane_id,
+                agent,
+                state,
+                message,
+                agent_session_id,
+            } => {
+                assert_eq!(pane_id, "w1:p1", "herdr: prefix stripped for the wire");
+                assert_eq!(agent, "claude", "ClaudeCode -> herdr slug");
+                assert_eq!(state, "working");
+                assert_eq!(message, None);
+                assert_eq!(agent_session_id, "sess-1");
+            }
+            report @ HerdrReport::Release { .. } => panic!("expected Report, got {report:?}"),
+        }
+    }
+
+    #[test]
+    fn waiting_states_report_blocked_with_notification() {
+        for state in [AgentState::WaitingInput, AgentState::WaitingChoice] {
+            let mut a = agent(AgentKind::ClaudeCode, "s", "herdr:w1:p1", state);
+            a.last_notification = Some("Approve running `rm`?".into());
+            match report_decision(&a).unwrap() {
+                HerdrReport::Report { state, message, .. } => {
+                    assert_eq!(state, "blocked", "{state:?} -> blocked");
+                    assert_eq!(message.as_deref(), Some("Approve running `rm`?"));
+                }
+                report @ HerdrReport::Release { .. } => panic!("expected Report, got {report:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn error_reports_blocked_with_error_message() {
+        let mut a = agent(AgentKind::Codex, "s", "herdr:w1:p1", AgentState::Error);
+        a.last_notification = Some("StopFailure: auth".into());
+        match report_decision(&a).unwrap() {
+            HerdrReport::Report {
+                agent,
+                state,
+                message,
+                ..
+            } => {
+                assert_eq!(agent, "codex");
+                assert_eq!(state, "blocked");
+                assert_eq!(message.as_deref(), Some("StopFailure: auth"));
+            }
+            report @ HerdrReport::Release { .. } => panic!("expected Report, got {report:?}"),
+        }
+    }
+
+    #[test]
+    fn idle_reports_idle() {
+        let a = agent(AgentKind::ClaudeCode, "s", "herdr:w1:p1", AgentState::Idle);
+        match report_decision(&a).unwrap() {
+            HerdrReport::Report { state, .. } => assert_eq!(state, "idle"),
+            report @ HerdrReport::Release { .. } => panic!("expected Report, got {report:?}"),
+        }
+    }
+
+    #[test]
+    fn stopped_releases_authority() {
+        let a = agent(
+            AgentKind::ClaudeCode,
+            "s",
+            "herdr:w1:p1",
+            AgentState::Stopped,
+        );
+        match report_decision(&a).expect("stopped releases") {
+            HerdrReport::Release { pane_id, agent } => {
+                assert_eq!(pane_id, "w1:p1");
+                assert_eq!(agent, "claude");
+            }
+            report @ HerdrReport::Report { .. } => panic!("expected Release, got {report:?}"),
+        }
+    }
+
+    #[test]
+    fn starting_reports_nothing() {
+        let a = agent(
+            AgentKind::ClaudeCode,
+            "s",
+            "herdr:w1:p1",
+            AgentState::Starting,
+        );
+        assert_eq!(
+            report_decision(&a),
+            None,
+            "transient Starting is not reported"
+        );
+    }
+
+    #[test]
+    fn synthetic_row_is_never_reported_no_loop() {
+        // A synthetic (bridge-owned) row on a herdr pane must NEVER be reported
+        // back to herdr — that would close the detection loop.
+        let a = agent(
+            AgentKind::Unknown,
+            "synthetic-herdr:w1:p1",
+            "herdr:w1:p1",
+            AgentState::Working,
+        );
+        assert_eq!(
+            report_decision(&a),
+            None,
+            "synthetic rows are not echoed back"
+        );
+    }
+
+    #[test]
+    fn non_herdr_pane_is_not_reported() {
+        // A real hook row on a tmux pane is none of herdr's business.
+        let a = agent(AgentKind::ClaudeCode, "s", "%7", AgentState::Working);
+        assert_eq!(report_decision(&a), None);
+        // …and a row with no pane at all.
+        let mut paneless = agent(AgentKind::ClaudeCode, "s", "%7", AgentState::Working);
+        paneless.pane = None;
+        assert_eq!(report_decision(&paneless), None);
+    }
+
+    #[test]
+    fn agent_slug_covers_every_kind() {
+        assert_eq!(agent_slug(AgentKind::ClaudeCode), "claude");
+        assert_eq!(agent_slug(AgentKind::Codex), "codex");
+        assert_eq!(agent_slug(AgentKind::GeminiCli), "gemini");
+        assert_eq!(agent_slug(AgentKind::Opencode), "opencode");
+        assert_eq!(agent_slug(AgentKind::Task), "task");
+        assert_eq!(agent_slug(AgentKind::Unknown), "unknown");
+    }
+
+    #[test]
+    fn report_request_shape_is_wire_correct() {
+        let a = agent(
+            AgentKind::ClaudeCode,
+            "sess-1",
+            "herdr:w1:p1",
+            AgentState::Working,
+        );
+        let report = report_decision(&a).unwrap();
+        let (method, params) = report.request(42);
+        assert_eq!(method, "pane.report_agent");
+        assert_eq!(params["pane_id"], json!("w1:p1"));
+        assert_eq!(params["source"], json!("muxa"));
+        assert_eq!(params["agent"], json!("claude"));
+        assert_eq!(params["state"], json!("working"));
+        assert_eq!(params["agent_session_id"], json!("sess-1"));
+        assert_eq!(params["seq"], json!(42));
+    }
+
+    #[test]
+    fn release_request_shape_is_wire_correct() {
+        let a = agent(
+            AgentKind::ClaudeCode,
+            "s",
+            "herdr:w1:p1",
+            AgentState::Stopped,
+        );
+        let report = report_decision(&a).unwrap();
+        let (method, params) = report.request(7);
+        assert_eq!(method, "pane.release_agent");
+        assert_eq!(params["pane_id"], json!("w1:p1"));
+        assert_eq!(params["source"], json!("muxa"));
+        assert_eq!(params["agent"], json!("claude"));
+        assert_eq!(params["seq"], json!(7));
     }
 }

--- a/crates/muxad/src/herdr_bridge.rs
+++ b/crates/muxad/src/herdr_bridge.rs
@@ -229,6 +229,8 @@ pub fn translate(envelope: &Value, at: OffsetDateTime) -> Result<BridgeUpdate, D
         "idle" | "done" => AgentEvent::TurnStopped {
             id: id.clone(),
             response: None,
+            recap: None,
+            ai_title: None,
             at,
         },
         "unknown" => return Err(DropReason::StatusUnknown),
@@ -1351,6 +1353,8 @@ mod tests {
             state,
             last_prompt: None,
             last_response: None,
+            recap: None,
+            ai_title: None,
             last_notification: None,
             model: None,
             context_used_pct: None,

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -27,6 +27,8 @@ use std::sync::Arc;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::broadcast;
 
+mod herdr_bridge;
+
 /// Inactivity window before a stopped agent is evicted from the in-memory store.
 const STOPPED_AGENT_TTL_MINUTES: i64 = 60;
 /// Cadence at which the GC task scans for evictable agents.
@@ -184,6 +186,12 @@ async fn main() -> Result<()> {
     .await;
     let gc_handle = spawn_gc_task(&store, &shutdown_tx);
     let reconciler_handle = spawn_reconciler_task(&cfg, &store, &shutdown_tx, backend.clone());
+    // herdr event bridge (Phase 2): only on herdr hosts. Translates herdr's
+    // own agent-state detection into synthetic muxa rows so agents muxa has no
+    // hooks for still appear in status/watch/stats. Spawned before the IPC
+    // server takes ownership of `store` so it shares the same registry.
+    let herdr_bridge_handle =
+        herdr_bridge::spawn_herdr_bridge_task(&backend, store.clone(), &shutdown_tx);
     let session_activity_handle =
         spawn_session_activity_task(&cfg, &shutdown_tx, activity_log.clone());
     let history_compaction_handle = spawn_history_compaction_task(&cfg, &store, &shutdown_tx);
@@ -312,6 +320,7 @@ async fn main() -> Result<()> {
     let _ = shutdown_tx.send(());
     await_shutdown_task("gc", Some(gc_handle)).await;
     await_shutdown_task("reconciler", reconciler_handle).await;
+    await_shutdown_task("herdr bridge", herdr_bridge_handle).await;
     await_shutdown_task("session activity", session_activity_handle).await;
     await_shutdown_task("history compaction", history_compaction_handle).await;
     await_shutdown_task("activity compaction", activity_compaction_handle).await;

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -192,6 +192,12 @@ async fn main() -> Result<()> {
     // server takes ownership of `store` so it shares the same registry.
     let herdr_bridge_handle =
         herdr_bridge::spawn_herdr_bridge_task(&backend, store.clone(), &shutdown_tx);
+    // herdr reverse path: push muxa's authoritative hook-derived state for REAL
+    // (non-synthetic) `herdr:` rows back into herdr's UI via `pane.report_agent`,
+    // releasing authority when the row stops. Subscribes to the same store
+    // transition stream the notifier/activity tasks use. Herdr-host only.
+    let herdr_report_handle =
+        herdr_bridge::spawn_herdr_report_task(&backend, store.clone(), &shutdown_tx);
     let session_activity_handle =
         spawn_session_activity_task(&cfg, &shutdown_tx, activity_log.clone());
     let history_compaction_handle = spawn_history_compaction_task(&cfg, &store, &shutdown_tx);
@@ -321,6 +327,7 @@ async fn main() -> Result<()> {
     await_shutdown_task("gc", Some(gc_handle)).await;
     await_shutdown_task("reconciler", reconciler_handle).await;
     await_shutdown_task("herdr bridge", herdr_bridge_handle).await;
+    await_shutdown_task("herdr report", herdr_report_handle).await;
     await_shutdown_task("session activity", session_activity_handle).await;
     await_shutdown_task("history compaction", history_compaction_handle).await;
     await_shutdown_task("activity compaction", activity_compaction_handle).await;

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -254,6 +254,7 @@ async fn main() -> Result<()> {
             })
             .flatten();
         let sessions_for_dash = sessions.clone();
+        let backend_for_dash = backend.clone();
         let dashboard_runtime = muxa::dashboard::DashboardRuntimeConfig {
             activity_path: dashboard_activity_path,
             session_activity_path: dashboard_session_activity_path,
@@ -265,6 +266,7 @@ async fn main() -> Result<()> {
                 store_for_dash,
                 pane_cache,
                 sessions_for_dash,
+                backend_for_dash,
                 dashboard_runtime,
                 shutdown_rx,
             )

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -199,7 +199,7 @@ async fn main() -> Result<()> {
     let herdr_report_handle =
         herdr_bridge::spawn_herdr_report_task(&backend, store.clone(), &shutdown_tx);
     let session_activity_handle =
-        spawn_session_activity_task(&cfg, &shutdown_tx, activity_log.clone());
+        spawn_session_activity_task(&cfg, &shutdown_tx, activity_log.clone(), &backend);
     let history_compaction_handle = spawn_history_compaction_task(&cfg, &store, &shutdown_tx);
     let activity_compaction_handle =
         spawn_activity_compaction_task(&cfg, activity_log.clone(), &shutdown_tx);
@@ -798,11 +798,15 @@ fn spawn_reconciler_task(
     Some(handle)
 }
 
-/// Track cumulative tmux session attached time for `muxa watch --view session`.
+/// Track cumulative session foreground time for `muxa watch --view session`.
+/// The sampling source follows the active pane backend: tmux (and the zellij
+/// fallback) shells out to `list-clients`; herdr queries the focused
+/// workspace over its socket. All downstream accounting is shared.
 fn spawn_session_activity_task(
     cfg: &Config,
     shutdown_tx: &broadcast::Sender<()>,
     activity_log: Option<std::sync::Arc<ActivityLog>>,
+    backend: &muxa::SharedBackend,
 ) -> Option<tokio::task::JoinHandle<()>> {
     if !cfg.session_activity.enabled {
         tracing::info!("session activity tracking disabled by config");
@@ -817,16 +821,27 @@ fn spawn_session_activity_task(
         tracing::warn!("session activity tracking enabled but no path resolvable");
         return None;
     };
+    // On herdr, foreground time is credited to the focused workspace over the
+    // herdr socket (resolved the same way the query backend and event bridge
+    // do). Every other host uses the tmux sampler.
+    let source = match backend.kind() {
+        muxa::HostKind::Herdr => muxa::SessionActivitySource::Herdr {
+            socket_path: muxa::backend::herdr::default_socket_path(),
+        },
+        _ => muxa::SessionActivitySource::Tmux,
+    };
     let tracker = muxa::SessionActivityTracker::new(
         path.clone(),
         std::time::Duration::from_secs(cfg.session_activity.interval_secs),
     )
-    .with_activity_log(activity_log);
+    .with_activity_log(activity_log)
+    .with_source(source);
     let shutdown_rx = shutdown_tx.subscribe();
     let handle = tokio::spawn(tracker.run(shutdown_rx));
     tracing::info!(
         path = %path.display(),
         interval_secs = cfg.session_activity.interval_secs,
+        host = %backend.kind(),
         "session activity tracking enabled",
     );
     Some(handle)

--- a/docs/HERDR.md
+++ b/docs/HERDR.md
@@ -97,10 +97,34 @@ can tell which host governs a row (see reaping guard below).
 5. **CLI attach** (`main.rs jump_to_pane`, done): `HostKind::Herdr` arm →
    `focus_pane`, zellij-shape.
 
-Out of scope for Phase 1: `session_activity` (tmux foreground time —
-returns empty on herdr hosts; a herdr workspace-focus analog can come
-later), the web dashboard's tmux scanner panes view, `muxa status-line`
-(a tmux status-right concept; herdr has its own sidebar).
+6. **Session foreground time** (`session_activity.rs`, done): the tmux
+   foreground-time ledger has a herdr analog. On herdr hosts the sampler
+   branches (`SessionActivitySource::Herdr`) and, each poll, queries the
+   focused herdr **workspace** via `workspace.list` (the cheapest call
+   reporting each workspace's `focused` flag; `backend::herdr::herdr_focused_workspace`)
+   instead of `tmux list-clients`. The focused workspace becomes a single
+   `SessionInfo` with one "attached client", so the *same*
+   `apply_sample_report` accounting credits foreground time to it and emits
+   the same ledger intervals + `session-activity.json`. The muxa session key
+   is the raw `workspace_id` (`w1`), matching `PaneInfo.session` from
+   `HerdrBackend::list_panes` so ledger keys line up with pane rows. No
+   focused workspace, or an unreachable/absent server, yields an empty
+   sample — the tmux "no server running" analog, which closes any open
+   interval. Only the *sampling source* branches; downstream accounting is
+   shared with tmux.
+
+   **Known limitation (mitigation out of scope for now):** herdr's socket
+   API exposes no client-attach state — there is no `client.list` analog.
+   So, unlike tmux (which credits time only while an interactive client is
+   attached), herdr focus time accrues even when the server sits detached
+   with no client attached. This **inflates ACT for always-on detached
+   herdr servers**. herdr also has no per-client input/scroll signal, so no
+   `HumanInteraction` (keypress/scroll) ticks are emitted on herdr hosts —
+   only the workspace-foreground observation.
+
+Out of scope for Phase 1: the web dashboard's tmux scanner panes view,
+`muxa status-line` (a tmux status-right concept; herdr has its own
+sidebar).
 
 ## Phase 2 — herdr-native agent state (event bridge)
 

--- a/docs/HERDR.md
+++ b/docs/HERDR.md
@@ -1,0 +1,165 @@
+# herdr support
+
+Status: **Phase 1 + Phase 2 implemented.** Verified against herdr **0.7.4**
+(socket protocol **16**, schema dumped via `herdr api schema --json`).
+
+[herdr](https://herdr.dev) is an agent-native terminal multiplexer. Unlike
+zellij — where muxa's rich path needs a WASM plugin — herdr ships a full
+local socket API out of the box, so muxa gets pane enumeration, captures,
+pid maps, focus, *and* herdr's own agent-state detection without installing
+anything into herdr.
+
+## Why
+
+muxa's positioning is a multiplexer-neutral observability/analytics layer:
+tmux is the mature backend, zellij has a CLI baseline, herdr is the third
+host. On herdr, muxa keeps its unique value (activity ledger, ACT/WACT,
+stats/report/timeline, prompt history, notifications) while herdr provides
+the pane host and — in Phase 2 — agent-state detection for agents muxa has
+no hooks for.
+
+## herdr ground truth (verified locally)
+
+- Socket: `$HERDR_SOCKET_PATH`, else `~/.config/herdr/herdr.sock`.
+  Named sessions (`herdr --session <name>`) serve their API on
+  `~/.config/herdr/sessions/<name>/herdr.sock` instead — inside panes
+  `$HERDR_SOCKET_PATH` always points at the right one, so env-first
+  resolution is what makes named sessions work; the hardcoded default
+  only covers the daemon observing the default session. A daemon
+  observing a named session needs `HERDR_SOCKET_PATH` set explicitly.
+- Wire: newline-delimited JSON. Request `{"id","method","params"}`;
+  response echoes `id` with `result` (`type`-tagged) or `error`
+  (`{code,message}`).
+- Pane env vars inside panes: `HERDR_ENV=1`, `HERDR_PANE_ID`,
+  `HERDR_SOCKET_PATH`, `HERDR_WORKSPACE_ID`, `HERDR_TAB_ID`.
+- Methods muxa uses: `pane.list`, `pane.get`, `pane.read`
+  (`source: visible|recent|recent_unwrapped|detection`),
+  `pane.process_info` (shell pid, tty, foreground processes),
+  `pane.focus`, `ping`; Phase 2 adds `events.subscribe`. The subscribable
+  kinds are `pane.agent_status_changed`, `pane.output_matched`, and
+  `pane.scroll_changed` — pane create/close are *not* subscribable, so
+  pane liveness stays with the reconciler's `observe_panes` polling.
+  Optional later: `pane.report_agent` (reverse path: muxa's hook-derived
+  state shown in herdr's UI).
+- `PaneInfo` (herdr): `pane_id`, `tab_id`, `workspace_id`, `terminal_id`,
+  `cwd`, `focused`, `title`, `terminal_title`, `agent`, `agent_status`
+  (`idle|working|blocked|done|unknown`), …
+- Schema/API details: `herdr api schema --json`.
+
+## Pane-id namespace
+
+herdr pane ids are namespaced as **`herdr:<herdr_pane_id>`** everywhere
+inside muxa (registry rows, prompt-history keys, `by_pane` queries),
+following the zellij plugin's `zellij:terminal:<id>` precedent. The prefix
+(`backend::herdr::PANE_ID_PREFIX`) is stripped before ids go back over the
+herdr socket. Rationale: no collision with tmux `%N`, and cross-host code
+can tell which host governs a row (see reaping guard below).
+
+## Phase 1 — pane host parity
+
+1. **Host detection** (`backend/mod.rs`, done): `MUXA_HOST=herdr`
+   override; auto-detect `HERDR_PANE_ID`/`HERDR_ENV`, ordered
+   `ZELLIJ` → `HERDR` → `TMUX` (newer hosts win nested-env ties; the
+   override is the escape hatch). The daemon usually runs outside any
+   host env — set `MUXA_HOST=herdr` in its environment (launchd/systemd
+   or shell) to observe herdr.
+2. **`HerdrBackend`** (`backend/herdr.rs`): direct-query `PaneBackend`
+   over the socket, tmux-shape (stateless; callers already wrap calls in
+   `spawn_blocking`). Per-call connect with ~1s timeout, matching the
+   tmux command timeout.
+   - `list_panes` → `pane.list` + per-pane `pane.process_info` to fill
+     `current_command`/`pane_pid`/`tty`. Mapping into muxa `PaneInfo`:
+     `session` = herdr `workspace_id`, `window_index` = `tab_id`,
+     `pane_index` = raw herdr pane id, `current_path` = `cwd`,
+     `socket` = `None` (never reuse the tmux-socket identity channel).
+   - `observe_panes` → `complete` on a successful query; `complete(empty)`
+     when the socket file is absent (server truly down ⇒ its panes are
+     gone, tmux semantics); `incomplete` on connect/protocol errors or
+     timeout (transient ⇒ must not reap).
+   - `capture_pane` → `pane.read` (`visible`), `focus_pane` → `pane.focus`,
+     `pane_pid_map` → shell pids from `pane.process_info`,
+     `current_pane` → `$HERDR_PANE_ID` (prefixed).
+   - `caps()`: all true when reachable.
+3. **Hook correlation** (`adapters/hook.rs`): `host_pane_env()` learns
+   `HERDR_PANE_ID` and applies the `herdr:` prefix. `$TMUX` is unset
+   inside herdr, so `AgentId.tmux_socket` stays `None` and the
+   `MUXA_TMUX_SOCKET` ingest scope gate passes herdr events untouched
+   (`event_in_scope_with` treats `None` as in-scope). Do **not** stamp
+   `HERDR_SOCKET_PATH` into `tmux_socket` — the gate would canonicalize
+   and drop it.
+4. **Cross-host reaping guard** (`state.rs` reconcile): a
+   `PaneObservation` only governs rows whose pane id belongs to the
+   observing backend's host: `%…` → tmux, `zellij:…` → zellij,
+   `herdr:…` → herdr; unknown shapes stay governed by the active backend
+   (today's behavior). Without this, a tmux-backend daemon reaps live
+   herdr rows every reconcile tick (and vice versa) whenever both hosts
+   are in use during migration.
+5. **CLI attach** (`main.rs jump_to_pane`, done): `HostKind::Herdr` arm →
+   `focus_pane`, zellij-shape.
+
+Out of scope for Phase 1: `session_activity` (tmux foreground time —
+returns empty on herdr hosts; a herdr workspace-focus analog can come
+later), the web dashboard's tmux scanner panes view, `muxa status-line`
+(a tmux status-right concept; herdr has its own sidebar).
+
+## Phase 2 — herdr-native agent state (event bridge)
+
+**Implemented** (`muxad::herdr_bridge`). A muxad background task — spawned
+only when the active backend is herdr (`backend.kind() == HostKind::Herdr`)
+— holds a socket connection and translates herdr's own agent-state
+detection into synthetic muxa rows, giving muxa visibility into every
+agent herdr detects (cursor, amp, copilot, …) without muxa hooks.
+
+**Translation** (`translate`, a pure event-json → events fn, unit-tested):
+
+| herdr `agent_status` | muxa `AgentEvent`   | resulting state |
+|----------------------|---------------------|-----------------|
+| `working`            | `ToolStarted`       | `Working`       |
+| `blocked`            | `NotificationFired` (`NeedsInput`) | `WaitingInput` |
+| `idle` / `done`      | `TurnStopped`       | `Idle`          |
+| `unknown`            | — (dropped)         | —               |
+
+Rows are keyed by `herdr:<pane_id>` with the SYNTHETIC session id
+`synthetic-herdr:<pane_id>` (the same shape `discovery` mints for a
+socket-less pane), so a discovery placeholder and a bridge row collapse
+onto one registry key. herdr agent names map `claude`→`ClaudeCode`,
+`codex`→`Codex`, `gemini`→`GeminiCli`, `opencode`→`Opencode` (loose,
+lowercased substring match — herdr's exact slugs aren't pinned in the
+schema); everything else is `AgentKind::Unknown` with the herdr
+`display_agent`/`agent` name carried in the row's **`model`** field (set
+via a trailing `Heartbeat`) so an Unknown row still names its agent.
+Panes herdr attributes to no agent are dropped (a plain shell is not an
+agent row).
+
+**Precedence — hooks stay authoritative.** Before applying any bridge
+update the task queries `Store::by_pane`; if a *non-synthetic* row already
+owns the pane, the update is dropped. And because bridge rows are
+synthetic, `Store::apply`'s synthetic-eviction pass drops them the moment
+a real hook `Started`/tool/prompt event claims the pane — the
+hook-authoritative rule falls out of the existing machinery for free.
+
+**Subscription mechanics — a deviation from the original sketch.** herdr's
+`pane.agent_status_changed` subscription is *per pane* (each subscription
+item requires a `pane_id`; no wildcard), and subscribing does **not**
+replay the pane's current status — only future changes stream. So on each
+connect the bridge (1) enumerates panes via `pane.list` (which reports each
+pane's current `agent`/`agent_status`), (2) subscribes to all of them in
+one `events.subscribe` call, (3) *seeds* current state from step 1, then
+(4) streams deltas, re-listing on a 10 s timer and reconnecting whenever
+the pane set changes so newly-created panes get covered. The connection is
+tokio `UnixStream` + `BufReader` lines with a capped-exponential-backoff
+reconnect loop, wired into the daemon shutdown drain like the other
+background producers. The bridge applies directly to the in-process
+`Store` (not over IPC), matching the reconciler and other internal
+producers.
+
+Pane liveness stays with the reconciler (pane close is not a subscribable
+herdr event kind). Optional reverse path — push muxa's hook-derived state
+into herdr's UI via `pane.report_agent` — remains future work.
+
+## Risks
+
+- herdr is pre-1.0; the protocol number (16) is checked at connect time
+  and mismatches degrade to "backend unreachable" with a logged warning,
+  never a crash.
+- Nested-host auto-detection is heuristic; `MUXA_HOST` overrides.

--- a/docs/HERDR.md
+++ b/docs/HERDR.md
@@ -122,6 +122,23 @@ can tell which host governs a row (see reaping guard below).
    `HumanInteraction` (keypress/scroll) ticks are emitted on herdr hosts —
    only the workspace-foreground observation.
 
+7. **Watch session view** (`muxa-cli/src/watch.rs`, done): the session
+   view sources its "sessions" per host — tmux shells `list-sessions`,
+   herdr derives them from `workspace.list`
+   (`backend::herdr::herdr_list_workspaces`, the `list_sessions` analog).
+   Each workspace becomes a `SessionInfo` whose id is the raw `workspace_id`
+   (matching `PaneInfo.session` and the ledger key, so the DUR column
+   resolves) and whose display name is the workspace `label` (falling back
+   to the id). Rows still come from the pane inventory as on tmux; sourcing
+   the workspace list is what lights the DUR column and surfaces the human
+   label instead of the raw `w1`. The activity bridge gained a
+   session-id fallback so the herdr key (pane session == ledger key) resolves
+   directly. Attach (Enter-twice) is host-dispatched via `jump_to_pane` →
+   `focus_pane`, so a herdr session row never fires a tmux-only action. The
+   dashboard TUI already sources sessions from the daemon's own registry, so
+   it was host-agnostic and needed no change. zellij has no session concept
+   here and stays empty.
+
 Out of scope for Phase 1: the web dashboard's tmux scanner panes view,
 `muxa status-line` (a tmux status-right concept; herdr has its own
 sidebar).

--- a/docs/HERDR.md
+++ b/docs/HERDR.md
@@ -139,9 +139,31 @@ can tell which host governs a row (see reaping guard below).
    it was host-agnostic and needed no change. zellij has no session concept
    here and stays empty.
 
-Out of scope for Phase 1: the web dashboard's tmux scanner panes view,
-`muxa status-line` (a tmux status-right concept; herdr has its own
-sidebar).
+8. **Web dashboard panes view** (`dashboard/server.rs`, done): the
+   `/api/panes` route sources its rows from the tmux multi-socket scanner
+   (`tmux::scanner::scan`), which sees nothing on a herdr host. The daemon
+   now threads its active `SharedBackend` into the dashboard `AppState`;
+   the pane-cache refresh closure branches on `backend.kind() ==
+   HostKind::Herdr` and folds `HerdrBackend::list_panes()` (a blocking
+   socket call, so `spawn_blocking`) into the scanner's `ScanResult` shape
+   via `tmux::scanner::herdr_scan_result`. Both `/api/panes` and the
+   timeline handler's pane→session map go through the same refresh, so
+   they agree on herdr. Field mapping reuses the muxa `PaneInfo` the
+   backend already returns (`pane_id` `herdr:<id>`, `session` =
+   `workspace_id`, `window_index` = `tab_id`, `pane_index` = raw id,
+   `current_command`/`current_path` enriched); the two dashboard-only
+   fields the backend leaves blank are filled with a synthetic `"herdr"`
+   socket identity (the web UI's socket-filter chip splits on `/`, and the
+   daemon observes exactly one herdr server) and an empty `attach_command`
+   (herdr has no copyable shell attach line — the CLI focuses over the
+   socket). `MUXA_TMUX_SOCKET` is *not* consulted on the herdr path — it
+   scopes tmux sockets only, consistent with the ingest scope gate that
+   passes socket-less herdr events. The tmux scanner path is byte-identical
+   (`backend == None`/non-herdr → unchanged `scanner::scan`). zellij stays
+   empty (no pane-metadata surface until the WASM plugin lands).
+
+Out of scope for Phase 1: `muxa status-line` (a tmux status-right concept;
+herdr has its own sidebar).
 
 ## Phase 2 — herdr-native agent state (event bridge)
 

--- a/docs/HERDR.md
+++ b/docs/HERDR.md
@@ -39,8 +39,8 @@ no hooks for.
   kinds are `pane.agent_status_changed`, `pane.output_matched`, and
   `pane.scroll_changed` — pane create/close are *not* subscribable, so
   pane liveness stays with the reconciler's `observe_panes` polling.
-  Optional later: `pane.report_agent` (reverse path: muxa's hook-derived
-  state shown in herdr's UI).
+  Phase 2 reverse path (implemented): `pane.report_agent` /
+  `pane.release_agent` push muxa's hook-derived state into herdr's UI.
 - `PaneInfo` (herdr): `pane_id`, `tab_id`, `workspace_id`, `terminal_id`,
   `cwd`, `focused`, `title`, `terminal_title`, `agent`, `agent_status`
   (`idle|working|blocked|done|unknown`), …
@@ -154,8 +154,61 @@ background producers. The bridge applies directly to the in-process
 producers.
 
 Pane liveness stays with the reconciler (pane close is not a subscribable
-herdr event kind). Optional reverse path — push muxa's hook-derived state
-into herdr's UI via `pane.report_agent` — remains future work.
+herdr event kind).
+
+### Reverse path — muxa's hook state into herdr (`pane.report_agent`)
+
+**Implemented** (`muxad::herdr_bridge`, `report_decision` + a second
+transition-subscriber task, both herdr-host only). herdr treats an installed
+integration's report as authoritative over its *own* screen detection, so when
+muxa has real hook truth for a pane, it hands that truth to herdr's sidebar
+instead of letting herdr guess from scrollback. The task subscribes to the same
+`Store::subscribe()` transition stream the desktop notifier and activity ledger
+use; on every state change it decides via the pure `report_decision` fn and, for
+a reportable row, fires `pane.report_agent` (`source = "muxa"`) at the herdr
+socket. Failures are non-fatal (bounded request timeout, debug-logged, dropped)
+and never hold the transition channel back.
+
+**Only REAL rows on `herdr:` panes are reported.** `report_decision` returns
+nothing unless the row is *both* on a `herdr:` pane (the prefix is stripped for
+the wire `pane_id`) *and* non-synthetic. Mapping:
+
+| muxa `AgentState`              | herdr call / state                       |
+|--------------------------------|------------------------------------------|
+| `Working`                      | `pane.report_agent` `working`            |
+| `WaitingInput`/`WaitingChoice` | `pane.report_agent` `blocked` (+message) |
+| `Error`                        | `pane.report_agent` `blocked` (+message) |
+| `Idle`                         | `pane.report_agent` `idle`               |
+| `Stopped`                      | `pane.release_agent`                     |
+| `Starting`                     | — (transient; nothing reported)          |
+
+`agent` is a herdr-aligned slug (`ClaudeCode`→`claude`, `Codex`→`codex`,
+`GeminiCli`→`gemini`, `Opencode`→`opencode`, else the kind name), matching the
+forward bridge's `classify_agent` so the same pane carries the same label in
+both directions. `agent_session_id` is muxa's real session id, and a
+process-global monotonic `seq` lets herdr discard out-of-order reports. `blocked`
+rows carry `last_notification` as the `message` so herdr shows *what* the agent
+is waiting on / erroring about.
+
+**No feedback loop — the load-bearing invariant.** Synthetic rows (the ones the
+forward bridge *mints* from herdr's own detection) are NEVER reported back:
+echoing them would form a cycle — report → herdr adopts muxa as authority →
+herdr stops emitting `pane.agent_status_changed` → the forward bridge starves →
+the synthetic row goes stale. The two directions stay disjoint by pane
+ownership. A `herdr:` pane with a real hook row is reported here, and the forward
+bridge's `apply_update` already *drops* herdr's screen-detection updates for that
+same pane — so herdr's flapping is silenced from both ends and muxa is the single
+source of truth. A `herdr:` pane with only a synthetic bridge row is never
+reported; herdr keeps detecting and the forward bridge keeps mirroring it.
+
+**Release.** `Stopped` is muxa's terminal state — reached on a `SessionEnded`
+hook and on reconciler/GC reaping (the reaper flips the row to `Stopped`, which
+emits a transition) — and triggers `pane.release_agent`, returning authority to
+herdr's own detection. A row GC-evicted *after* it already went `Stopped` emits
+no further transition, and there is no distinct "row removed" transition to
+observe, so releasing on the `…→Stopped` edge is both necessary and sufficient.
+One consequence of being change-driven: a hook row rehydrated from `state.json`
+at startup isn't reported to herdr until its *next* transition.
 
 ## Risks
 

--- a/docs/HERDR.md
+++ b/docs/HERDR.md
@@ -59,23 +59,47 @@ can tell which host governs a row (see reaping guard below).
 
 1. **Host detection** (`backend/mod.rs`, done): `MUXA_HOST=herdr`
    override; auto-detect `HERDR_PANE_ID`/`HERDR_ENV`, ordered
-   `ZELLIJ` → `HERDR` → `TMUX` (newer hosts win nested-env ties; the
-   override is the escape hatch). The daemon usually runs outside any
+   `ZELLIJ` → `HERDR` → `TMUX`. The daemon usually runs outside any
    host env — set `MUXA_HOST=herdr` in its environment (launchd/systemd
    or shell) to observe herdr.
+
+   **Nested-host tie-break — one policy, both places.** Env presence
+   alone can't tell an inner host from an outer one: a herdr pane launched
+   from a tmux shell *inherits* the outer `$TMUX`/`$TMUX_PANE` (empirically
+   verified), and tmux launched inside a herdr pane inherits `$HERDR_*`. muxa
+   resolves the ambiguity **herdr-wins** — launching herdr from a tmux shell
+   is the common migration path, so on a `HERDR_* + TMUX` tie both the host
+   detector (`detect_from`) *and* the hook pane-stamper
+   (`adapters/hook.rs::host_pane_env`) pick herdr. Keeping the two in lockstep
+   is what makes the pane a hook is stamped onto and the backend that observes
+   it agree. **Caveat:** the rarer nesting — tmux running *inside* a herdr
+   pane — is misdetected by this default; set **`MUXA_HOST=tmux`** to force it
+   (the override is honored by both `detect_from` and `host_pane_env`;
+   `MUXA_HOST=herdr`/`zellij` force those hosts analogously).
 2. **`HerdrBackend`** (`backend/herdr.rs`): direct-query `PaneBackend`
    over the socket, tmux-shape (stateless; callers already wrap calls in
-   `spawn_blocking`). Per-call connect with ~1s timeout, matching the
-   tmux command timeout.
+   `spawn_blocking`). Per-call connect with ~1s per-read timeout, matching the
+   tmux command timeout, plus an aggregate ~2× read deadline over the whole
+   reply loop so a server that *streams* unrelated lines faster than the
+   per-read timeout can't loop forever and wedge a reconcile/watch refresh
+   (the per-read timeout resets on every line; only the aggregate deadline
+   bounds the total).
    - `list_panes` → `pane.list` + per-pane `pane.process_info` to fill
      `current_command`/`pane_pid`/`tty`. Mapping into muxa `PaneInfo`:
      `session` = herdr `workspace_id`, `window_index` = `tab_id`,
      `pane_index` = raw herdr pane id, `current_path` = `cwd`,
      `socket` = `None` (never reuse the tmux-socket identity channel).
+     Per-pane enrichment is bounded by a total time budget: once spent, the
+     remaining panes return with empty process fields rather than let a slow
+     server turn one `pane.list` into an N×1s stall.
    - `observe_panes` → `complete` on a successful query; `complete(empty)`
-     when the socket file is absent (server truly down ⇒ its panes are
-     gone, tmux semantics); `incomplete` on connect/protocol errors or
-     timeout (transient ⇒ must not reap).
+     **only** when the socket file is authoritatively absent
+     (`try_exists() == Ok(false)` ⇒ server truly down ⇒ its panes are gone,
+     tmux semantics); `incomplete` on connect/protocol errors, timeout, *or a
+     stat that errors* (`try_exists() == Err` — EACCES/EIO/stalled automount;
+     transient ⇒ must not reap). Using `try_exists` rather than `exists` is
+     what keeps a stat error from being swallowed as an authoritative empty
+     and triggering a mass reap.
    - `capture_pane` → `pane.read` (`visible`), `focus_pane` → `pane.focus`,
      `pane_pid_map` → shell pids from `pane.process_info`,
      `current_pane` → `$HERDR_PANE_ID` (prefixed).
@@ -94,6 +118,23 @@ can tell which host governs a row (see reaping guard below).
    (today's behavior). Without this, a tmux-backend daemon reaps live
    herdr rows every reconcile tick (and vice versa) whenever both hosts
    are in use during migration.
+
+   **Foreign-host age-out** (`Store::mark_stale_cross_host_stopped`): the
+   guard exempts a foreign-host row from *immediate* reaping, but a
+   single-backend daemon never observes those panes at all and the GC only
+   evicts `Stopped` rows — so a `herdr:` row left in `state.json` after the
+   operator switches the daemon back to tmux would ghost forever. Each
+   reconcile tick the reconciler flips foreign-host rows (pane id classifies
+   to a host *not* in the active observing set) to `Stopped` after the same
+   inactivity window the paneless orphan sweep uses
+   (`[reconciler] paneless_stale_timeout_secs`, default 86400), after which
+   the existing GC removes them. A genuinely-live remote row keeps itself
+   alive by emitting activity; a dead one ages out. The check takes a *set*
+   of observing kinds (today always the one active backend) so a future
+   multi-host daemon can pass several without changing shape. Note
+   `muxa prune` targets *paneless* orphans only — a foreign-host row still
+   carries its `herdr:`/`zellij:` pane id, so this age-out (not `prune`) is
+   what clears it.
 5. **CLI attach** (`main.rs jump_to_pane`, done): `HostKind::Herdr` arm →
    `focus_pane`, zellij-shape.
 
@@ -144,10 +185,15 @@ can tell which host governs a row (see reaping guard below).
    (`tmux::scanner::scan`), which sees nothing on a herdr host. The daemon
    now threads its active `SharedBackend` into the dashboard `AppState`;
    the pane-cache refresh closure branches on `backend.kind() ==
-   HostKind::Herdr` and folds `HerdrBackend::list_panes()` (a blocking
-   socket call, so `spawn_blocking`) into the scanner's `ScanResult` shape
-   via `tmux::scanner::herdr_scan_result`. Both `/api/panes` and the
-   timeline handler's pane→session map go through the same refresh, so
+   HostKind::Herdr` and runs **both** the tmux `scanner::scan` *and*
+   `HerdrBackend::list_panes()` (a blocking socket call, so `spawn_blocking`,
+   folded into the scanner's `ScanResult` shape via
+   `tmux::scanner::herdr_scan_result`), then concatenates them
+   (`merge_pane_scans`) — herdr panes appended onto the tmux scan, tmux
+   per-socket errors preserved in `errors`. Running only the herdr side would
+   drop live tmux panes during a mixed-host migration (they'd vanish from
+   `/api/panes` and the timeline); merging keeps both. Both `/api/panes` and
+   the timeline handler's pane→session map go through the same refresh, so
    they agree on herdr. Field mapping reuses the muxa `PaneInfo` the
    backend already returns (`pane_id` `herdr:<id>`, `session` =
    `workspace_id`, `window_index` = `tab_id`, `pane_index` = raw id,


### PR DESCRIPTION
## Summary
- **Phase 1 — pane host parity**: `HerdrBackend` implements `PaneBackend` over herdr's local NDJSON socket API (`pane.list`/`pane.read`/`pane.process_info`/`pane.focus`) — pane inventory, live captures, pid maps, and watch-attach work with no plugin. Hook correlation via `$HERDR_PANE_ID` with rows namespaced `herdr:<pane_id>`; host auto-detection plus `MUXA_HOST=herdr` daemon override.
- **Cross-host reaping guard**: an observation only governs rows whose pane-id namespace belongs to the observing host (`%…`→tmux, `zellij:…`, `herdr:…`), so a tmux-backend daemon never reaps live herdr rows (and vice versa) while both hosts are in use during migration.
- **Phase 2 — event bridge**: `muxad::herdr_bridge` subscribes to `pane.agent_status_changed` and translates herdr's own agent detection into synthetic registry rows — agents muxa has no hooks for (cursor, amp, copilot, …) appear in `muxa status`/`watch`/stats. Hooks stay authoritative: synthetic bridge rows are evicted the instant a real hook claims the pane.
- **Reverse path**: muxad reports hook-derived state into herdr's UI via `pane.report_agent` (herdr treats an installed integration as authoritative), releasing authority on Stopped. No feedback loop by construction.
- **Foreground time**: session-activity sampling branches per host — on herdr the focused workspace is credited through the unchanged accounting, so ACT/foreground stats work (documented limitation: no client-attach signal in herdr's API).
- **Watch session view** sources herdr workspaces (label + lit DUR) on herdr hosts; **web dashboard panes view** populates from the herdr backend instead of the tmux scanner.
- Design docs: `docs/HERDR.md` (verified ground truth incl. named-session sockets, wire format, subscribable event kinds) and `docs/MULTI_HOST.md` (follow-up proposal: simultaneous tmux+herdr observation).

## Test plan
- [x] `cargo test --workspace` all green (incl. HerdrBackend mock-socket tests, bridge tests, reverse-path mapping tests, session-activity source tests, watch/session + dashboard mapping tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean
- [x] Live E2E against herdr 0.7.4 (protocol 16), each feature verified against a real server: pane inventory → hook correlation → reconcile survival → recap → reap on `pane.close`; bridge synthetic rows + hook-authoritative eviction; herdr UI showing muxa-sourced state and releasing on session end; workspace foreground intervals in the ledger; watch TUI session row with label/DUR; `curl /api/panes` returning the herdr pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)