### PR TITLE
feat(multi-host): observe tmux + herdr simultaneously — watch becomes the unified console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **multi-host observation (daemon).** `muxad` now observes every backend
+  in `muxa::active_backends()` at once (tmux + herdr during a migration)
+  instead of a single env-detected backend. One reconciler runs over the
+  whole set — each tick observes every backend concurrently and reconciles
+  each observation under its own `HostKind`, so a herdr timeout can't reap
+  tmux rows (completeness stays per-host); the workload scan runs once over
+  the union of complete observations, and the cross-host age-out sweep
+  receives all observed kinds so a row on an unobserved host ages out while
+  observed hosts stay governed by their own pass. Discovery, the
+  pane-session cache, and history enrichment enumerate the set and union
+  their scans; session-activity sampling runs one tracker that polls every
+  host's foreground source (tmux clients + herdr focused workspace) into a
+  single race-free ledger; the herdr bridge/report tasks spawn whenever
+  herdr is in the set, not only when it's the sole backend. See
+  `docs/MULTI_HOST.md`.
+- **cross-multiplexer unified console (CLI).** `muxa watch` and the
+  pane-listing surfaces now aggregate across *every* active host at once
+  instead of the single env-detected backend — during a tmux→herdr
+  migration both sides show in one view. `watch`'s refresh fans
+  `list_panes()` and the per-host session sources (tmux `list-sessions`,
+  herdr `workspace.list`) across the backend set concurrently and concats
+  the rows (namespaces keep them distinct: tmux `%N` / herdr `herdr:…`).
+  When the row set spans more than one host, each row gets a subtle dim
+  host tag (`tmux`/`herdr`) on its SESSION/PANE cell; single-host users see
+  no change. Attach (Enter in `watch`, `muxa attend`) dispatches per row on
+  the pane id's namespace, so a `herdr:` row focuses via herdr even when the
+  shell is tmux-primary (and vice versa); unrecognized ids fall back to the
+  process-global backend. `muxa panes`, `stats`, and `timeline` enumerate
+  panes across the set too, and `muxa panes` prints a per-host empty hint
+  for any host in the set that contributed zero. Live pane captures
+  (`watch` preview, `dashboard`) resolve the capturing backend by namespace.
+  `current_pane`/status-line ("where am I") stay single-host by design. See
+  `docs/MULTI_HOST.md`.
 - **herdr web dashboard panes view.** The dashboard's `/api/panes` route
   (and the timeline's pane→session map) now populate on herdr hosts. The
   daemon threads its active pane backend into the dashboard; when the host

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of a single env-detected backend. One reconciler runs over the
   whole set — each tick observes every backend concurrently and reconciles
   each observation under its own `HostKind`, so a herdr timeout can't reap
-  tmux rows (completeness stays per-host); the workload scan runs once over
-  the union of complete observations, and the cross-host age-out sweep
-  receives all observed kinds so a row on an unobserved host ages out while
-  observed hosts stay governed by their own pass. Discovery, the
+  tmux rows (completeness stays per-host); the workload scan, paneless-codex
+  correlation, and cross-host age-out all key off the *complete-this-tick*
+  host set, so a row on an unobserved (or chronically-unanswerable) host ages
+  out while every host that answered stays governed by its own pass and keeps
+  its metadata. Discovery, the
   pane-session cache, and history enrichment enumerate the set and union
   their scans; session-activity sampling runs one tracker that polls every
   host's foreground source (tmux clients + herdr focused workspace) into a
@@ -133,6 +134,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scan with the herdr pane list instead of replacing it, so tmux panes no
   longer vanish from `/api/panes`/timeline during mixed-host migration. See
   `docs/HERDR.md`.
+
+- **multi-host CLI/daemon wiring (review follow-ups).** Correctness fixes to the
+  cross-multiplexer console: (1) `muxa watch` session rows are now grouped by a
+  host-namespaced key, so a tmux session and a herdr workspace that share a raw
+  id (both named `w1`) stay two distinct rows with correct per-host pane counts
+  instead of merging into one corrupted row — display names, the activity ledger
+  lookup, and DUR still key off the raw id (host id-spaces are disjoint), only
+  grouping/identity/sort-tiebreak use the composite; (2) `watch`'s initial "where
+  am I" cursor resolves `current_pane()` across the backend set in env-preference
+  order (first `Some` wins) so a herdr pane launched from tmux lands on the
+  env-preferred host; (3) daemon discovery passes and the CLI's cross-host pane
+  enumeration (`muxa panes`/`stats`/`timeline`/`attend`) now fan out
+  concurrently — a slow or unreachable host no longer serializes behind (or
+  blocks the runtime on) the others, and a failed host contributes an empty
+  result; (4) the web dashboard's single-backend scanner is documented to bind to
+  the env-preferred host (`backends[0]`), matching the pre-multi-host daemon. See
+  `docs/MULTI_HOST.md`.
+
+- **multi-host core hardening (review follow-ups).** Correctness fixes to the
+  backend set and reconciler so one permanently-unreachable or chronically-slow
+  host can't poison the others: (1) herdr auto-detect now *connects* to the
+  socket instead of `try_exists()`ing the file, so a stale socket left by a
+  crashed server no longer ghosts a dead herdr backend into a tmux-only daemon's
+  set forever; (2) the env-preferred host now leads the auto-detected set, so
+  `backends[0]` (the "primary" the dashboard and watch cursor use) is the host
+  the shell actually lives in (`MUXA_HOSTS` keeps its verbatim order); (3) the
+  workload scan/update runs over the union of *complete* observations and only
+  governs rows whose host was observed complete this tick — a chronically-
+  incomplete host's rows keep their workload metadata instead of being frozen or
+  reset for every host; (4) the cross-host ghost age-out is keyed on the
+  complete-this-tick kinds, so a host that can't answer past the inactivity
+  window ages out its rows like a host outside the set (transient incompleteness
+  is safe — the threshold is the 24h paneless window, not one tick); (5) paneless-
+  codex cwd correlation runs once per tick over the union of panes from all
+  complete hosts, so its many-to-one ambiguity guard sees candidates on every
+  host and won't mis-adopt a row whose codex lives in the other host's pane at
+  the same cwd; (6) the merged session-activity sampler now applies each source
+  independently — a failing source (e.g. tmux on a herdr-only machine with no
+  `tmux` binary) contributes nothing and no longer closes the other host's open
+  foreground intervals, only its own keyspace is left untouched. Single-host
+  behavior is unchanged throughout. See `docs/MULTI_HOST.md`.
 
 - **`code_mode_host` codex sessions now correlate to their tmux pane instead of
   splitting into two rows.** Such a session runs its turns — and fires its

--- a/crates/muxa-cli/src/attend.rs
+++ b/crates/muxa-cli/src/attend.rs
@@ -20,7 +20,7 @@ use time::OffsetDateTime;
 use muxa::ipc::Client;
 use muxa::state::Agent;
 use muxa::tmux::PaneInfo;
-use muxa::{AgentState, PaneBackend};
+use muxa::AgentState;
 
 use crate::{pane_display, state_icon, state_style, terminal_width, truncate_cell, use_colors};
 
@@ -150,11 +150,11 @@ fn next_after<'c>(
 /// Choose a pane to attend to, or print the queue / a "nothing to do"
 /// line. Returns the pane id the caller should jump to, or `None` when
 /// there's nothing to jump to (`--list`, or no agent needs attention).
-pub async fn run(client: &Client, backend: &dyn PaneBackend, args: Args) -> Result<Option<String>> {
+pub async fn run(client: &Client, panes: Vec<PaneInfo>, args: Args) -> Result<Option<String>> {
     let agents = client.snapshot().await?;
-    // Resolve panes once: spatial ordering + `pane_display` both read it,
-    // and it's empty (harmless) on backends without pane metadata.
-    let panes = backend.list_panes();
+    // Panes are enumerated by the caller across every active host (spatial
+    // ordering + `pane_display` both read them); empty is harmless on
+    // backends without pane metadata.
     let cands = candidates(&agents, &panes);
     // Agents that need a human but have no pane to focus. `candidates`
     // drops these (there's nothing to jump to), which used to make a
@@ -188,7 +188,11 @@ pub async fn run(client: &Client, backend: &dyn PaneBackend, args: Args) -> Resu
     }
 
     let chosen = if args.cycle {
-        let current = backend.current_pane().map(|p| spatial_key(&p, &panes));
+        // "Where am I" is inherently single-host — resolve the cursor's
+        // current pane via the env-preferred backend.
+        let current = muxa::default_backend()
+            .current_pane()
+            .map(|p| spatial_key(&p, &panes));
         next_after(&cands, current.as_ref())
     } else {
         longest_waiting(&cands)

--- a/crates/muxa-cli/src/dashboard_tui.rs
+++ b/crates/muxa-cli/src/dashboard_tui.rs
@@ -1832,10 +1832,15 @@ async fn refresh_capture(client: &Client, app: &mut DashboardApp) {
 
     let text = match target.clone() {
         CaptureTarget::Pane(pane_id) => {
-            tokio::task::spawn_blocking(move || muxa::default_backend().capture_pane(&pane_id))
-                .await
-                .ok()
-                .flatten()
+            // Resolve the backend by the pane id's namespace (like the jump
+            // path) so a herdr pane captures via herdr even when the
+            // process-global host is tmux, and vice versa.
+            tokio::task::spawn_blocking(move || {
+                crate::backend_for_pane(&pane_id).capture_pane(&pane_id)
+            })
+            .await
+            .ok()
+            .flatten()
         }
         CaptureTarget::PtySession(session_id) => client
             .capture_session(&session_id)

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -658,8 +658,11 @@ fn key_to_pty_input(key: crossterm::event::KeyEvent) -> Option<String> {
 /// the actual focus through `jump_to_pane`, the identical machinery the
 /// `muxa watch` Enter action uses, so a jump lands the same way from both.
 async fn cmd_attend(client: &Client, args: attend::Args) -> Result<()> {
-    let backend = muxa::default_backend();
-    if let Some(pane) = attend::run(client, backend.as_ref(), args).await? {
+    // Enumerate panes across every active host so a herdr agent that needs
+    // a human is jumpable from a tmux-primary shell (and vice versa). The
+    // jump itself dispatches per-row in `jump_to_pane`.
+    let panes = all_panes();
+    if let Some(pane) = attend::run(client, panes, args).await? {
         jump_to_pane(&pane);
     }
     Ok(())
@@ -862,12 +865,80 @@ fn tmux_interaction_target(pane_id: &str) -> Option<(Option<String>, Option<Stri
 /// switching — `select-window`/`select-pane` are plain control messages to
 /// the tmux server and don't need an attached client.
 fn jump_to_pane(pane_id: &str) {
-    let backend = muxa::default_backend();
-    match backend.kind() {
+    // Dispatch on the pane id's namespace FIRST: a `herdr:` row must jump
+    // via a herdr backend even when the process-global detected host is
+    // tmux (and vice versa) — the multi-host unified console lists rows
+    // from every host, so the row's own id is the source of truth. Only
+    // when the namespace is unrecognized (legacy/synthetic ids) do we fall
+    // back to the process-global backend's kind.
+    let fallback = muxa::default_backend();
+    let kind = dispatch_kind(pane_id, fallback.kind());
+    match kind {
+        // tmux jumps go straight through `tmux::` helpers and need no backend.
         muxa::HostKind::Tmux => jump_to_pane_tmux(pane_id),
-        muxa::HostKind::Zellij => jump_to_pane_zellij(backend.as_ref(), pane_id),
-        muxa::HostKind::Herdr => jump_to_pane_herdr(backend.as_ref(), pane_id),
+        muxa::HostKind::Zellij => {
+            let backend = backend_for_dispatch(kind, &fallback);
+            jump_to_pane_zellij(backend.as_ref(), pane_id);
+        }
+        muxa::HostKind::Herdr => {
+            let backend = backend_for_dispatch(kind, &fallback);
+            jump_to_pane_herdr(backend.as_ref(), pane_id);
+        }
     }
+}
+
+/// Effective host for a per-row action: the pane id's namespace when
+/// recognized, else the process-global `fallback`. Pure so the dispatch
+/// table is unit-testable without constructing backends.
+fn dispatch_kind(pane_id: &str, fallback: muxa::HostKind) -> muxa::HostKind {
+    muxa::backend::pane_id_host_kind(pane_id).unwrap_or(fallback)
+}
+
+/// Reuse the already-built `fallback` backend when its kind matches, else
+/// construct a fresh one for `kind` (cheap — the constructors are a unit
+/// struct for tmux/zellij and a socket path for herdr).
+fn backend_for_dispatch(
+    kind: muxa::HostKind,
+    fallback: &muxa::SharedBackend,
+) -> muxa::SharedBackend {
+    if fallback.kind() == kind {
+        fallback.clone()
+    } else {
+        backend_for_kind(kind)
+    }
+}
+
+/// Build one backend of the given kind. The CLI-side analog of the
+/// (private) `muxa::backend::backend_of`, used for per-row host dispatch
+/// where the row's host differs from the process-global one.
+pub(crate) fn backend_for_kind(kind: muxa::HostKind) -> muxa::SharedBackend {
+    match kind {
+        muxa::HostKind::Tmux => std::sync::Arc::new(muxa::TmuxBackend::new()),
+        muxa::HostKind::Zellij => std::sync::Arc::new(muxa::ZellijBackend::new()),
+        muxa::HostKind::Herdr => std::sync::Arc::new(muxa::backend::herdr::HerdrBackend::new()),
+    }
+}
+
+/// Resolve the backend that owns `pane_id` by its namespace, falling back
+/// to the process-global backend for unrecognized ids. Used by the live
+/// pane-capture paths (`watch` preview, `dashboard` capture) so a capture
+/// hits the host the pane actually lives on.
+pub(crate) fn backend_for_pane(pane_id: &str) -> muxa::SharedBackend {
+    match muxa::backend::pane_id_host_kind(pane_id) {
+        Some(kind) => backend_for_kind(kind),
+        None => muxa::default_backend(),
+    }
+}
+
+/// Aggregate pane inventories across every active backend — the multi-host
+/// enumeration used by `muxa panes`, `stats`, `timeline`, and `attend`.
+/// Rows already carry their host namespace in `pane_id`, so a plain concat
+/// keeps them distinct.
+pub(crate) fn all_panes() -> Vec<muxa::tmux::PaneInfo> {
+    muxa::active_backends()
+        .iter()
+        .flat_map(|backend| backend.list_panes())
+        .collect()
 }
 
 fn jump_to_pane_tmux(pane_id: &str) {
@@ -1339,34 +1410,57 @@ async fn cmd_recap(client: &Client, pane: Option<String>, limit: usize, all: boo
 }
 
 fn cmd_panes() {
-    let backend = muxa::default_backend();
-    let panes = backend.list_panes();
-    if panes.is_empty() {
-        // Two ways to get here: the host (tmux/zellij) has no panes,
-        // or the backend's `caps()` says metadata is plugin-only and
-        // not pushed yet. The hint differentiates so users diagnosing
-        // a misconfigured zellij plugin see something useful.
-        match backend.kind() {
-            muxa::HostKind::Tmux => println!("(no tmux panes — server may be down)"),
-            muxa::HostKind::Zellij if !backend.caps().current_command => println!(
-                "(zellij CLI baseline: pane inventory is plugin-only — install the muxa zellij plugin to populate)"
-            ),
-            muxa::HostKind::Zellij => println!("(no zellij panes)"),
-            muxa::HostKind::Herdr => {
-                println!("(no herdr panes — server may be down or socket unreachable)");
-            }
+    // Aggregate across every active host — the cross-multiplexer pane
+    // inventory. Rows carry their namespace in `pane_id`, so a concat keeps
+    // tmux `%N` and herdr `herdr:…` rows distinct. Per-host hints still fire
+    // for any host in the set that contributed zero panes, so a single-host
+    // user sees the same diagnostic as before while a multi-host user learns
+    // which side is empty.
+    let backends = muxa::active_backends();
+    let mut all: Vec<muxa::tmux::PaneInfo> = Vec::new();
+    let mut empty_hosts: Vec<&muxa::SharedBackend> = Vec::new();
+    for backend in &backends {
+        let panes = backend.list_panes();
+        if panes.is_empty() {
+            empty_hosts.push(backend);
         }
-        return;
+        all.extend(panes);
     }
+
     let terminal_width = terminal_width();
     let mut out = std::io::stdout().lock();
-    for p in panes {
+    for p in &all {
         let line = format!(
             "{:<8} {}:{}.{}  tty={}  cmd={}  title={}",
             p.pane_id, p.session, p.window_index, p.pane_index, p.tty, p.current_command, p.title
         );
         if writeln!(out, "{}", truncate_cell(&line, terminal_width)).is_err() {
             return;
+        }
+    }
+
+    // A host contributed zero: print its diagnostic. When the set is a
+    // single host and it's empty this reproduces the pre-multi-host hint;
+    // when other hosts have panes it tells the user which side came up dry.
+    for backend in empty_hosts {
+        let hint = empty_pane_hint(backend.as_ref());
+        let _ = writeln!(out, "{hint}");
+    }
+}
+
+/// The empty-state diagnostic for a host that reported no panes. Two ways
+/// to get here: the host really has no panes, or the backend's `caps()`
+/// says metadata is plugin-only and not pushed yet — the zellij branch
+/// differentiates so a misconfigured plugin is diagnosable.
+fn empty_pane_hint(backend: &dyn muxa::PaneBackend) -> &'static str {
+    match backend.kind() {
+        muxa::HostKind::Tmux => "(no tmux panes — server may be down)",
+        muxa::HostKind::Zellij if !backend.caps().current_command => {
+            "(zellij CLI baseline: pane inventory is plugin-only — install the muxa zellij plugin to populate)"
+        }
+        muxa::HostKind::Zellij => "(no zellij panes)",
+        muxa::HostKind::Herdr => {
+            "(no herdr panes — server may be down or socket unreachable)"
         }
     }
 }
@@ -1701,6 +1795,20 @@ mod tests {
     use muxa::AgentKind;
     use time::macros::datetime;
     use unicode_width::UnicodeWidthStr;
+
+    #[test]
+    fn dispatch_kind_prefers_pane_namespace_over_fallback() {
+        use muxa::HostKind;
+        // Namespaced ids dispatch to their own host regardless of the
+        // process-global fallback — a herdr row jumps via herdr even when
+        // the shell is tmux-primary, and vice versa.
+        assert_eq!(dispatch_kind("%3", HostKind::Herdr), HostKind::Tmux);
+        assert_eq!(dispatch_kind("herdr:abc", HostKind::Tmux), HostKind::Herdr);
+        assert_eq!(dispatch_kind("zellij:7", HostKind::Tmux), HostKind::Zellij);
+        // Unrecognized ids fall back to the process-global host.
+        assert_eq!(dispatch_kind("legacy-id", HostKind::Tmux), HostKind::Tmux);
+        assert_eq!(dispatch_kind("legacy-id", HostKind::Herdr), HostKind::Herdr);
+    }
 
     fn agent(session_id: &str, pane: Option<&str>, state: AgentState, prompt: &str) -> Agent {
         Agent {

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -661,7 +661,7 @@ async fn cmd_attend(client: &Client, args: attend::Args) -> Result<()> {
     // Enumerate panes across every active host so a herdr agent that needs
     // a human is jumpable from a tmux-primary shell (and vice versa). The
     // jump itself dispatches per-row in `jump_to_pane`.
-    let panes = all_panes();
+    let panes = all_panes().await;
     if let Some(pane) = attend::run(client, panes, args).await? {
         jump_to_pane(&pane);
     }
@@ -934,11 +934,25 @@ pub(crate) fn backend_for_pane(pane_id: &str) -> muxa::SharedBackend {
 /// enumeration used by `muxa panes`, `stats`, `timeline`, and `attend`.
 /// Rows already carry their host namespace in `pane_id`, so a plain concat
 /// keeps them distinct.
-pub(crate) fn all_panes() -> Vec<muxa::tmux::PaneInfo> {
-    muxa::active_backends()
-        .iter()
-        .flat_map(|backend| backend.list_panes())
-        .collect()
+///
+/// Each backend's `list_panes` blocks (tmux shells out; herdr hits a socket),
+/// so we fan the calls out onto the blocking pool up front and join them —
+/// the tick budget is one host's latency, not the sum, and a slow/failing
+/// host can't stall the runtime or the others (a join error contributes an
+/// empty list). Mirrors the concurrent fan-out `watch::compute_refresh` uses.
+pub(crate) async fn all_panes() -> Vec<muxa::tmux::PaneInfo> {
+    let tasks: Vec<_> = muxa::active_backends()
+        .into_iter()
+        .map(|backend| tokio::task::spawn_blocking(move || backend.list_panes()))
+        .collect();
+    let mut panes = Vec::new();
+    for task in tasks {
+        match task.await {
+            Ok(list) => panes.extend(list),
+            Err(e) => tracing::debug!(error = %e, "pane enumeration task failed"),
+        }
+    }
+    panes
 }
 
 fn jump_to_pane_tmux(pane_id: &str) {

--- a/crates/muxa-cli/src/stats.rs
+++ b/crates/muxa-cli/src/stats.rs
@@ -534,7 +534,7 @@ async fn load_data(
         .await
         .context("querying daemon agent snapshot")?;
     let activities = load_session_activities(cfg).await;
-    let panes = muxa::default_backend().list_panes();
+    let panes = crate::all_panes();
 
     let pane_sessions = panes
         .iter()

--- a/crates/muxa-cli/src/stats.rs
+++ b/crates/muxa-cli/src/stats.rs
@@ -534,7 +534,7 @@ async fn load_data(
         .await
         .context("querying daemon agent snapshot")?;
     let activities = load_session_activities(cfg).await;
-    let panes = crate::all_panes();
+    let panes = crate::all_panes().await;
 
     let pane_sessions = panes
         .iter()

--- a/crates/muxa-cli/src/timeline.rs
+++ b/crates/muxa-cli/src/timeline.rs
@@ -248,6 +248,7 @@ async fn load_document(client: &Client, cfg: &Config, args: &Args) -> Result<Tim
         .context("querying daemon prompt history")?;
     let session_activities = load_session_activities(cfg).await;
     let pane_sessions = crate::all_panes()
+        .await
         .into_iter()
         .map(|pane| (pane.pane_id, pane.session))
         .collect::<HashMap<_, _>>();

--- a/crates/muxa-cli/src/timeline.rs
+++ b/crates/muxa-cli/src/timeline.rs
@@ -247,8 +247,7 @@ async fn load_document(client: &Client, cfg: &Config, args: &Args) -> Result<Tim
         .await
         .context("querying daemon prompt history")?;
     let session_activities = load_session_activities(cfg).await;
-    let pane_sessions = muxa::default_backend()
-        .list_panes()
+    let pane_sessions = crate::all_panes()
         .into_iter()
         .map(|pane| (pane.pane_id, pane.session))
         .collect::<HashMap<_, _>>();

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -2117,6 +2117,62 @@ fn build_session_rows(
         .collect()
 }
 
+/// The host a row belongs to, classified by its pane id's namespace
+/// (`%…`→tmux, `herdr:…`→herdr, `zellij:…`→zellij). `None` when the row
+/// carries no classifiable pane id (a paneless agent, a legacy/synthetic
+/// id) — such rows get no host badge.
+fn row_host(row: &WatchRow) -> Option<muxa::HostKind> {
+    let pane_id = match row {
+        WatchRow::Agent(a) => a.pane.as_deref(),
+        WatchRow::BarePane(p) => Some(p.pane_id.as_str()),
+        WatchRow::Session(s) => s
+            .representative_pane
+            .as_deref()
+            .or_else(|| s.pane_ids.first().map(String::as_str)),
+    }?;
+    muxa::backend::pane_id_host_kind(pane_id)
+}
+
+/// Whether the visible row set spans more than one host — the trigger for
+/// showing per-row host badges. Single-host users (the common case) see no
+/// badge, so nothing changes for them. Rows with no classifiable host don't
+/// count toward the distinct-host tally.
+fn rows_multi_host(rows: &[WatchRow]) -> bool {
+    let mut seen: Option<muxa::HostKind> = None;
+    for row in rows {
+        if let Some(host) = row_host(row) {
+            match seen {
+                Some(prev) if prev != host => return true,
+                None => seen = Some(host),
+                Some(_) => {}
+            }
+        }
+    }
+    false
+}
+
+/// The subtle dim host tag shown before a multi-host row's SESSION/PANE
+/// cell. Mirrors the dashboard TUI's `CardHost` naming.
+fn host_badge_label(host: muxa::HostKind) -> &'static str {
+    match host {
+        muxa::HostKind::Tmux => "tmux",
+        muxa::HostKind::Zellij => "zellij",
+        muxa::HostKind::Herdr => "herdr",
+    }
+}
+
+/// Prepend the dim host tag to a cell's first line. Only called when the
+/// row set spans multiple hosts, so the badge disambiguates rather than
+/// adding noise.
+fn prepend_host_badge(text: &mut Text<'_>, host: muxa::HostKind) {
+    let style = Style::default().add_modifier(Modifier::DIM);
+    let badge = Span::styled(format!("{} ", host_badge_label(host)), style);
+    match text.lines.first_mut() {
+        Some(line) => line.spans.insert(0, badge),
+        None => text.lines.push(Line::from(badge)),
+    }
+}
+
 fn sort_panes(a: &PaneInfo, b: &PaneInfo) -> std::cmp::Ordering {
     a.session
         .cmp(&b.session)
@@ -2908,31 +2964,15 @@ fn apply_full(app: &mut App, full: FullRefresh) {
     app.set_data_with_sessions(new_agents, panes, sessions, session_activity);
 }
 
-/// Compute one refresh outcome: pane inventory from the active backend
-/// (off-runtime via `spawn_blocking` so any shell-out doesn't block the
-/// runtime) plus a daemon snapshot. Kept independent of `App` so the
-/// work can run on a worker thread without holding any UI state.
-async fn compute_refresh(
-    client: &Client,
-    backend: &muxa::SharedBackend,
-    session_activity_path: Option<PathBuf>,
-) -> RefreshOutcome {
-    // Pane inventory is independent of the daemon — fetch it even when
-    // muxad is down so `muxa watch` stays useful as a session picker.
-    // The backend's `list_panes` may shell out (tmux) or hit a cache
-    // (zellij + plugin); either way it MUST NOT run on a tokio worker.
-    let backend_for_blocking = backend.clone();
-    let panes_task = tokio::task::spawn_blocking(move || backend_for_blocking.list_panes());
-
-    // Source the "sessions" list per host. tmux shells `list-sessions`;
-    // herdr derives sessions from its workspaces over the socket (session
-    // id = raw `workspace_id`, matching `PaneInfo.session` and the
-    // session-activity ledger key so the DUR column resolves; display name =
-    // workspace label, falling back to the id). zellij has no session
-    // concept here, so it stays empty. Any host: this may shell out or hit a
-    // socket, so it MUST NOT run on a tokio worker.
-    let host = backend.kind();
-    let sessions_task = tokio::task::spawn_blocking(move || match host {
+/// The "sessions" list for one host. tmux shells `list-sessions`; herdr
+/// derives sessions from its workspaces over the socket (session id = raw
+/// `workspace_id`, matching `PaneInfo.session` and the session-activity
+/// ledger key so the DUR column resolves; display name = workspace label,
+/// falling back to the id). zellij has no session concept here, so it stays
+/// empty. May shell out or hit a socket — callers MUST run it off the tokio
+/// runtime.
+fn sessions_for_host(host: muxa::HostKind) -> Vec<SessionInfo> {
+    match host {
         muxa::HostKind::Tmux => muxa::tmux::list_sessions().unwrap_or_default(),
         muxa::HostKind::Herdr => {
             let socket = muxa::backend::herdr::default_socket_path();
@@ -2949,7 +2989,45 @@ async fn compute_refresh(
                 .collect()
         }
         muxa::HostKind::Zellij => Vec::new(),
-    });
+    }
+}
+
+/// Compute one refresh outcome: pane inventory aggregated across every
+/// active backend (off-runtime via `spawn_blocking` so any shell-out
+/// doesn't block the runtime) plus a daemon snapshot. Kept independent of
+/// `App` so the work can run on a worker thread without holding any UI
+/// state.
+async fn compute_refresh(
+    client: &Client,
+    backends: &[muxa::SharedBackend],
+    session_activity_path: Option<PathBuf>,
+) -> RefreshOutcome {
+    // Pane inventory is independent of the daemon — fetch it even when
+    // muxad is down so `muxa watch` stays useful as a session picker. This
+    // is the cross-multiplexer unified console: aggregate `list_panes` and
+    // the per-host session sources across EVERY active backend so tmux and
+    // herdr rows show side by side. Rows carry their host namespace in the
+    // pane id, so a concat keeps them distinct.
+    //
+    // Each backend's `list_panes` / session source may shell out (tmux) or
+    // hit a socket (herdr); neither may run on a tokio worker, so every one
+    // goes through `spawn_blocking`. Spawning them up front runs the whole
+    // fan-out concurrently — the tick budget is one host's latency, not the
+    // sum (see docs/MULTI_HOST.md "Startup cost").
+    let pane_tasks: Vec<_> = backends
+        .iter()
+        .map(|backend| {
+            let backend = backend.clone();
+            tokio::task::spawn_blocking(move || backend.list_panes())
+        })
+        .collect();
+    let session_tasks: Vec<_> = backends
+        .iter()
+        .map(|backend| {
+            let host = backend.kind();
+            tokio::task::spawn_blocking(move || sessions_for_host(host))
+        })
+        .collect();
 
     let session_activity_task = async move {
         match session_activity_path {
@@ -2958,14 +3036,18 @@ async fn compute_refresh(
         }
     };
 
-    let (panes, sessions, session_activity, snapshot) = tokio::join!(
-        panes_task,
-        sessions_task,
-        session_activity_task,
-        client.snapshot()
-    );
-    let panes = panes.unwrap_or_default();
-    let sessions = sessions.unwrap_or_default();
+    // The blocking tasks already run concurrently on the blocking pool;
+    // await the daemon snapshot + ledger load alongside them, then collect.
+    let (session_activity, snapshot) = tokio::join!(session_activity_task, client.snapshot());
+
+    let mut panes: Vec<PaneInfo> = Vec::new();
+    for task in pane_tasks {
+        panes.extend(task.await.unwrap_or_default());
+    }
+    let mut sessions: Vec<SessionInfo> = Vec::new();
+    for task in session_tasks {
+        sessions.extend(task.await.unwrap_or_default());
+    }
 
     let full = match snapshot {
         Ok(agents) => FullRefresh {
@@ -3123,14 +3205,15 @@ pub async fn run(
     let mut guard = TerminalGuard::new(terminal);
 
     let mut app = App::with_config(watch_cfg);
-    // Resolve the host once at startup — same Arc threads through the
-    // priming refresh, the background task, and the live capture path.
-    let backend: muxa::SharedBackend = muxa::default_backend();
+    // The unified console observes every active host. The set threads
+    // through the priming refresh and the background task; the live
+    // capture path resolves a backend per pane-id namespace instead.
+    let backends: Vec<muxa::SharedBackend> = muxa::active_backends();
 
-    // When invoked from inside a host (tmux / zellij), land the cursor
-    // on the user's current pane on first load instead of always
-    // row 0.
-    let initial_pane = backend.current_pane();
+    // "Where am I" is inherently single-host (env-based) — land the
+    // cursor on the user's current pane on first load via the
+    // env-preferred backend (first entry of the set; never empty).
+    let initial_pane = backends[0].current_pane();
     app.set_initial_pane(initial_pane.clone());
     let watch_started_at = OffsetDateTime::now_utc();
     let mut prompt_started_at: Option<(OffsetDateTime, String)> = None;
@@ -3156,7 +3239,7 @@ pub async fn run(
     // wrapper for what is effectively immutable data. The backend is
     // already an `Arc<dyn …>` so cloning it is just a refcount bump.
     let bg_client = client.clone();
-    let bg_backend = backend.clone();
+    let bg_backends = backends.clone();
     let bg_session_activity_path = session_activity_path.clone();
     let sub_client = client.clone();
     let (wake_tx, wake_rx) = mpsc::channel::<()>(WAKE_CAPACITY);
@@ -3178,9 +3261,9 @@ pub async fn run(
     let bg = tokio::spawn(refresh_task(
         move || {
             let client = bg_client.clone();
-            let backend = bg_backend.clone();
+            let backends = bg_backends.clone();
             let session_activity_path = bg_session_activity_path.clone();
-            async move { compute_refresh(&client, &backend, session_activity_path).await }
+            async move { compute_refresh(&client, &backends, session_activity_path).await }
         },
         wake_rx,
         outcome_tx,
@@ -3464,19 +3547,22 @@ pub async fn run(
         // (zellij CLI today) skip the call and the renderer shows a
         // "(not supported)" placeholder.
         if let Some(p) = &app.preview {
-            if p.content == PreviewContent::LivePane && backend.caps().capture_pane {
+            // Resolve the capturing backend by the pane id's namespace so a
+            // herdr row captures via herdr even when tmux is the primary
+            // host (and vice versa). Cheap to build per capture (bounded to
+            // ~2 Hz by the TTL below).
+            let cap_backend = crate::backend_for_pane(&p.pane_id);
+            if p.content == PreviewContent::LivePane && cap_backend.caps().capture_pane {
                 let stale = app.pane_capture.as_ref().is_none_or(|c| {
                     c.pane_id != p.pane_id || c.fetched_at.elapsed() >= Duration::from_millis(500)
                 });
                 if stale {
                     let pane_id = p.pane_id.clone();
-                    let backend_for_blocking = backend.clone();
-                    let captured = tokio::task::spawn_blocking(move || {
-                        backend_for_blocking.capture_pane(&pane_id)
-                    })
-                    .await
-                    .ok()
-                    .flatten();
+                    let captured =
+                        tokio::task::spawn_blocking(move || cap_backend.capture_pane(&pane_id))
+                            .await
+                            .ok()
+                            .flatten();
                     app.pane_capture = Some(CapturedPane {
                         pane_id: p.pane_id.clone(),
                         text: captured.unwrap_or_default(),
@@ -4885,6 +4971,8 @@ fn render_swarm(f: &mut Frame, area: Rect, app: &mut App) {
     f.render_widget(para, area);
 }
 
+#[allow(clippy::too_many_lines)] // column resolution + per-row cell/badge/pulse
+                                 // assembly reads better inline than split across helpers
 fn render_table(f: &mut Frame, area: Rect, app: &mut App) {
     let theme = watch_theme(app.watch_cfg.theme.unwrap_or_default());
 
@@ -4930,6 +5018,15 @@ fn render_table(f: &mut Frame, area: Rect, app: &mut App) {
         .columns
         .iter()
         .position(|c| matches!(c, WatchColumn::State));
+    // Host badges: only when the row set spans >1 host (the cross-
+    // multiplexer console) do we tag each row's SESSION/PANE cell, so a
+    // single-host user sees no change. The Pane column is the natural
+    // host-identifying slot in both the session and pane views.
+    let pane_col = app
+        .columns
+        .iter()
+        .position(|c| matches!(c, WatchColumn::Pane));
+    let multi_host = rows_multi_host(&app.rows);
     let row_pulses = resolve_row_pulses(app);
     let rows: Vec<Row> = app
         .rows
@@ -4953,6 +5050,13 @@ fn render_table(f: &mut Frame, area: Rect, app: &mut App) {
             // Overlay a transition pulse on the State cell.
             if let (Some(sc), Some(kind)) = (state_col, row_pulses[i]) {
                 texts[sc] = pulse_cell(kind, theme, anim_frame);
+            }
+
+            // Tag the row with its host when the console spans multiple.
+            if multi_host {
+                if let (Some(pc), Some(host)) = (pane_col, row_host(r)) {
+                    prepend_host_badge(&mut texts[pc], host);
+                }
             }
 
             let mut expanded = false;
@@ -6989,6 +7093,133 @@ mod tests {
             panic!("expected session row");
         };
         assert_eq!(row.display_name, "w1", "display name falls back to the id");
+    }
+
+    // ---- multi-host aggregation + badges ---------------------------------
+
+    #[test]
+    fn row_host_classifies_by_pane_namespace() {
+        let tmux = WatchRow::BarePane(Box::new(fake_pane("%1", "main", 0, 0, "zsh")));
+        let herdr = WatchRow::BarePane(Box::new(fake_pane("herdr:p1", "w1", 0, 0, "zsh")));
+        let zellij = WatchRow::BarePane(Box::new(fake_pane("zellij:7", "z", 0, 0, "zsh")));
+        let legacy = WatchRow::BarePane(Box::new(fake_pane("weird-id", "x", 0, 0, "zsh")));
+        assert_eq!(row_host(&tmux), Some(muxa::HostKind::Tmux));
+        assert_eq!(row_host(&herdr), Some(muxa::HostKind::Herdr));
+        assert_eq!(row_host(&zellij), Some(muxa::HostKind::Zellij));
+        assert_eq!(row_host(&legacy), None, "unrecognized ids get no badge");
+    }
+
+    #[test]
+    fn rows_multi_host_only_when_hosts_differ() {
+        let tmux_a = WatchRow::BarePane(Box::new(fake_pane("%1", "main", 0, 0, "zsh")));
+        let tmux_b = WatchRow::BarePane(Box::new(fake_pane("%2", "main", 0, 1, "zsh")));
+        let herdr = WatchRow::BarePane(Box::new(fake_pane("herdr:p1", "w1", 0, 0, "zsh")));
+        let legacy = WatchRow::BarePane(Box::new(fake_pane("weird", "x", 0, 0, "zsh")));
+
+        assert!(
+            !rows_multi_host(std::slice::from_ref(&tmux_a)),
+            "single tmux host → no badges"
+        );
+        assert!(
+            !rows_multi_host(&[
+                WatchRow::BarePane(Box::new(fake_pane("%1", "main", 0, 0, "zsh"))),
+                WatchRow::BarePane(Box::new(fake_pane("%2", "main", 0, 1, "zsh"))),
+            ]),
+            "two tmux rows are still one host"
+        );
+        assert!(
+            rows_multi_host(&[
+                WatchRow::BarePane(Box::new(fake_pane("%1", "main", 0, 0, "zsh"))),
+                WatchRow::BarePane(Box::new(fake_pane("herdr:p1", "w1", 0, 0, "zsh"))),
+            ]),
+            "tmux + herdr → badges on"
+        );
+        // Unclassifiable rows never flip the decision on their own.
+        assert!(!rows_multi_host(&[legacy]));
+        drop((tmux_a, tmux_b, herdr));
+    }
+
+    #[test]
+    fn mixed_host_panes_build_distinct_session_rows() {
+        // A tmux session and a herdr workspace with colliding-looking keys
+        // ("main" vs "w1") stay separate rows, each classified to its host.
+        let cfg = WatchConfig {
+            view: WatchView::Session,
+            ..WatchConfig::default()
+        };
+        let mut app = App::with_config(cfg);
+        app.set_data_with_sessions(
+            vec![],
+            vec![
+                fake_pane("%1", "main", 0, 0, "vim"),
+                fake_pane("herdr:p1", "w1", 0, 0, "zsh"),
+            ],
+            vec![fake_session("w1", "muxa", 0)],
+            vec![],
+        );
+        assert_eq!(app.rows.len(), 2, "one row per host session");
+        let hosts: std::collections::HashSet<_> = app.rows.iter().filter_map(row_host).collect();
+        assert!(hosts.contains(&muxa::HostKind::Tmux));
+        assert!(hosts.contains(&muxa::HostKind::Herdr));
+        assert!(rows_multi_host(&app.rows));
+    }
+
+    #[test]
+    fn host_badges_render_only_in_multi_host() {
+        fn render_to_string(app: &mut App) -> String {
+            let backend = TestBackend::new(120, 12);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal.draw(|f| render(f, app)).unwrap();
+            terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .map(ratatui::buffer::Cell::symbol)
+                .collect()
+        }
+
+        // Multi-host: the SESSION cells carry dim "tmux"/"herdr" tags. The
+        // session names ("main"/"w1") don't contain those words, so a match
+        // can only come from the badge.
+        let cfg = WatchConfig {
+            view: WatchView::Session,
+            ..WatchConfig::default()
+        };
+        let mut multi = App::with_config(cfg.clone());
+        multi.set_data_with_sessions(
+            vec![],
+            vec![
+                fake_pane("%1", "main", 0, 0, "vim"),
+                fake_pane("herdr:p1", "w1", 0, 0, "zsh"),
+            ],
+            vec![],
+            vec![],
+        );
+        let text = render_to_string(&mut multi);
+        assert!(
+            text.contains("tmux"),
+            "multi-host shows tmux badge: {text:?}"
+        );
+        assert!(
+            text.contains("herdr"),
+            "multi-host shows herdr badge: {text:?}"
+        );
+
+        // Single-host: no badge — a lone tmux session must not gain a
+        // "herdr" (or any) host tag.
+        let mut single = App::with_config(cfg);
+        single.set_data_with_sessions(
+            vec![],
+            vec![fake_pane("%1", "main", 0, 0, "vim")],
+            vec![],
+            vec![],
+        );
+        let text = render_to_string(&mut single);
+        assert!(
+            !text.contains("herdr"),
+            "single-host adds no host badge: {text:?}"
+        );
     }
 
     #[test]

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -668,9 +668,17 @@ pub(crate) enum RowIdentity {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SessionRow {
-    /// Stable group key — `PaneInfo.session` (tmux session name / herdr
-    /// `workspace_id`). Used for grouping, sorting, and the activity bridge.
+    /// Raw session id — `PaneInfo.session` (tmux session name / herdr
+    /// `workspace_id`). This is the ledger/display key: activity lookups and
+    /// `display_name` resolution key off it (host id-spaces are disjoint, so a
+    /// raw id is unambiguous for those lookups). NOT the grouping key — a tmux
+    /// session and a herdr workspace can share a raw id (both "w1"), so
+    /// grouping/identity use `group_key` instead.
     pub session: String,
+    /// Host-namespaced grouping/identity key (`"{host}:{session}"`, e.g.
+    /// `"tmux:w1"` vs `"herdr:w1"`). Keeps a tmux session and a herdr workspace
+    /// with the same raw id in distinct rows. Internal only — never displayed.
+    pub group_key: String,
     /// Human-facing name shown in the session view. Equals `session` on tmux;
     /// resolves to the workspace label on herdr.
     pub display_name: String,
@@ -790,7 +798,7 @@ impl WatchRow {
         match self {
             Self::Agent(a) => RowIdentity::Agent(a.kind, a.session_id.clone()),
             Self::BarePane(p) => RowIdentity::BarePane(p.pane_id.clone()),
-            Self::Session(s) => RowIdentity::Session(s.session.clone()),
+            Self::Session(s) => RowIdentity::Session(s.group_key.clone()),
         }
     }
 
@@ -2008,6 +2016,48 @@ fn sort_agents(
     a.pane.as_deref().cmp(&b.pane.as_deref())
 }
 
+/// Host-namespaced grouping/identity key for a session row.
+///
+/// A tmux session and a herdr workspace can share a raw session id (both
+/// named "w1"); grouping by the raw id alone merges them into one corrupted
+/// row (wrong pane counts, mixed agents). Prefixing with the host keeps them
+/// distinct. Ledger/display lookups still use the *raw* id (`session`), which
+/// is unambiguous because each host's id-space is disjoint — this composite is
+/// grouping/identity only. A row with no classifiable host (paneless agent,
+/// `(no session)`, a background task) keys on the raw id, matching the
+/// pre-multi-host grouping exactly.
+fn session_group_key(host: Option<muxa::HostKind>, session: &str) -> String {
+    match host {
+        Some(muxa::HostKind::Tmux) => format!("tmux:{session}"),
+        Some(muxa::HostKind::Herdr) => format!("herdr:{session}"),
+        Some(muxa::HostKind::Zellij) => format!("zellij:{session}"),
+        None => session.to_string(),
+    }
+}
+
+/// Resolve an agent's session group: the raw session id (display/ledger key)
+/// plus the pane's host namespace (grouping key input). Resolved from the
+/// agent's pane when it's in the inventory; a paneless / stale agent has no
+/// host, so it falls back to a raw synthetic session and `None`.
+fn agent_session_group(
+    agent: &Agent,
+    pane_lookup: impl Fn(&str) -> Option<(String, Option<muxa::HostKind>)>,
+) -> (String, Option<muxa::HostKind>) {
+    agent
+        .pane
+        .as_deref()
+        .and_then(&pane_lookup)
+        .unwrap_or_else(|| {
+            let session = match agent.pane.as_deref() {
+                Some(p) => format!("(stale {p})"),
+                // Paneless background tasks group under their own name.
+                None if agent.kind == AgentKind::Task => agent.session_id.clone(),
+                None => "(no session)".to_string(),
+            };
+            (session, None)
+        })
+}
+
 fn build_session_rows(
     agents: Vec<Agent>,
     panes: &[PaneInfo],
@@ -2017,7 +2067,10 @@ fn build_session_rows(
 ) -> Vec<WatchRow> {
     #[derive(Default)]
     struct Builder {
+        /// Raw session id (display/ledger key).
         session: String,
+        /// Host-namespaced grouping/identity key.
+        group_key: String,
         panes: Vec<PaneInfo>,
         agents: Vec<Agent>,
         activity: Option<SessionActivity>,
@@ -2026,30 +2079,33 @@ fn build_session_rows(
     let sort_context =
         SortContext::new(panes, sessions, session_activity, OffsetDateTime::now_utc());
 
+    // Keyed by the host-namespaced `group_key`, not the raw session, so a tmux
+    // session "w1" and a herdr workspace "w1" build two rows.
     let mut builders: HashMap<String, Builder> = HashMap::new();
     for p in panes {
-        let entry = builders
-            .entry(p.session.clone())
-            .or_insert_with(|| Builder {
-                session: p.session.clone(),
-                ..Builder::default()
-            });
+        let host = muxa::backend::pane_id_host_kind(&p.pane_id);
+        let key = session_group_key(host, &p.session);
+        let entry = builders.entry(key.clone()).or_insert_with(|| Builder {
+            session: p.session.clone(),
+            group_key: key,
+            ..Builder::default()
+        });
         entry.panes.push(p.clone());
     }
 
     for agent in agents {
-        let session = agent
-            .pane
-            .as_deref()
-            .and_then(|id| sort_context.pane(id).map(|p| p.session.clone()))
-            .unwrap_or_else(|| match agent.pane.as_deref() {
-                Some(p) => format!("(stale {p})"),
-                // Paneless background tasks group under their own name.
-                None if agent.kind == AgentKind::Task => agent.session_id.clone(),
-                None => "(no session)".to_string(),
-            });
-        let entry = builders.entry(session.clone()).or_insert_with(|| Builder {
+        let (session, host) = agent_session_group(&agent, |id| {
+            sort_context.pane(id).map(|p| {
+                (
+                    p.session.clone(),
+                    muxa::backend::pane_id_host_kind(&p.pane_id),
+                )
+            })
+        });
+        let key = session_group_key(host, &session);
+        let entry = builders.entry(key.clone()).or_insert_with(|| Builder {
             session,
+            group_key: key,
             ..Builder::default()
         });
         entry.agents.push(agent);
@@ -2098,6 +2154,7 @@ fn build_session_rows(
                 .collect();
             SessionRow {
                 display_name: sort_context.display_name(&b.session),
+                group_key: b.group_key,
                 session: b.session,
                 pane_ids: b.panes.iter().map(|p| p.pane_id.clone()).collect(),
                 representative_pane,
@@ -2239,7 +2296,9 @@ fn sort_sessions(
             return cmp;
         }
     }
-    a.session.cmp(&b.session)
+    // Final tiebreak on the host-namespaced key so two rows sharing a raw
+    // session id (tmux "w1" + herdr "w1") get a stable, deterministic order.
+    a.group_key.cmp(&b.group_key)
 }
 
 /// Render a `pane_id` as `session:window.pane` when we can resolve it
@@ -2844,26 +2903,34 @@ fn apply_single_agent(app: &mut App, agent: Agent) {
 }
 
 fn apply_single_agent_to_session(app: &mut App, agent: Agent) {
-    let session = agent
+    // Resolve the agent's raw session (display/ledger) and its pane host, then
+    // match rows on the host-namespaced group key — the same keying
+    // `build_session_rows` uses — so a herdr "w1" agent never merges into a
+    // tmux "w1" row.
+    let (session, host) = agent
         .pane
         .as_deref()
         .and_then(|id| {
-            app.panes
-                .iter()
-                .find(|p| p.pane_id == id)
-                .map(|p| p.session.clone())
+            app.panes.iter().find(|p| p.pane_id == id).map(|p| {
+                (
+                    p.session.clone(),
+                    muxa::backend::pane_id_host_kind(&p.pane_id),
+                )
+            })
         })
         .unwrap_or_else(|| {
-            agent
+            let session = agent
                 .pane
                 .as_deref()
-                .map_or_else(|| "(no session)".to_string(), |p| format!("(stale {p})"))
+                .map_or_else(|| "(no session)".to_string(), |p| format!("(stale {p})"));
+            (session, None)
         });
+    let group_key = session_group_key(host, &session);
     for row in &mut app.rows {
         let WatchRow::Session(s) = row else {
             continue;
         };
-        if s.session != session {
+        if s.group_key != group_key {
             continue;
         }
         let key = (agent.kind, agent.session_id.clone());
@@ -2911,6 +2978,7 @@ fn apply_single_agent_to_session(app: &mut App, agent: Agent) {
         .map_or_else(|| session.clone(), |s| s.name.clone());
     app.rows.push(WatchRow::Session(Box::new(SessionRow {
         display_name,
+        group_key,
         session,
         pane_ids: agent.pane.clone().into_iter().collect(),
         representative_pane: agent.pane.clone(),
@@ -3210,10 +3278,14 @@ pub async fn run(
     // capture path resolves a backend per pane-id namespace instead.
     let backends: Vec<muxa::SharedBackend> = muxa::active_backends();
 
-    // "Where am I" is inherently single-host (env-based) — land the
-    // cursor on the user's current pane on first load via the
-    // env-preferred backend (first entry of the set; never empty).
-    let initial_pane = backends[0].current_pane();
+    // "Where am I" is inherently single-host (env-based) — land the cursor on
+    // the user's current pane on first load. `current_pane` is env-based: the
+    // env-preferred backend answers inside its own pane, but inside e.g. a
+    // herdr pane launched from tmux BOTH backends could answer. `active_backends`
+    // is ordered by env preference (`backends[0]` = the env-preferred host), so
+    // we resolve in set order and take the first `Some` — env preference breaks
+    // the tie. Single-host: identical (the one backend answers or doesn't).
+    let initial_pane = backends.iter().find_map(|b| b.current_pane());
     app.set_initial_pane(initial_pane.clone());
     let watch_started_at = OffsetDateTime::now_utc();
     let mut prompt_started_at: Option<(OffsetDateTime, String)> = None;
@@ -7093,6 +7165,61 @@ mod tests {
             panic!("expected session row");
         };
         assert_eq!(row.display_name, "w1", "display name falls back to the id");
+    }
+
+    #[test]
+    fn same_named_tmux_session_and_herdr_workspace_stay_distinct_rows() {
+        // A tmux session named "w1" and a herdr workspace whose id is "w1"
+        // share a raw session string. Grouped by the raw id alone they'd merge
+        // into one corrupted row (panes from both hosts, wrong count); the
+        // host-namespaced group key keeps them apart.
+        let cfg = WatchConfig {
+            view: WatchView::Session,
+            ..WatchConfig::default()
+        };
+        let mut app = App::with_config(cfg);
+        app.set_data_with_sessions(
+            vec![],
+            vec![
+                // tmux "w1": two panes.
+                fake_pane("%1", "w1", 0, 0, "zsh"),
+                fake_pane("%2", "w1", 0, 1, "nvim"),
+                // herdr workspace "w1": one pane.
+                fake_pane("herdr:p1", "w1", 0, 0, "zsh"),
+            ],
+            vec![fake_session("$1", "w1", 1)],
+            vec![],
+        );
+
+        let session_rows: Vec<&SessionRow> = app
+            .rows
+            .iter()
+            .filter_map(|r| match r {
+                WatchRow::Session(s) => Some(s.as_ref()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            session_rows.len(),
+            2,
+            "tmux w1 and herdr w1 must be two distinct rows"
+        );
+
+        let tmux_row = session_rows
+            .iter()
+            .find(|s| s.group_key == "tmux:w1")
+            .expect("tmux:w1 row present");
+        let herdr_row = session_rows
+            .iter()
+            .find(|s| s.group_key == "herdr:w1")
+            .expect("herdr:w1 row present");
+
+        // Raw session id stays "w1" on both (display/ledger key), only the
+        // group key is namespaced.
+        assert_eq!(tmux_row.session, "w1");
+        assert_eq!(herdr_row.session, "w1");
+        assert_eq!(tmux_row.pane_count, 2, "tmux row keeps its two panes");
+        assert_eq!(herdr_row.pane_count, 1, "herdr row keeps its one pane");
     }
 
     // ---- multi-host aggregation + badges ---------------------------------

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -316,6 +316,44 @@ pub fn default_socket_path() -> PathBuf {
     dirs::home_dir().map_or_else(|| PathBuf::from(rel), |home| home.join(rel))
 }
 
+/// Bound on the auto-detect reachability probe. A herdr server accepts a
+/// connection instantly; a stale socket file (crashed server) refuses one
+/// instantly (`ECONNREFUSED`) and an absent path fails instantly
+/// (`ENOENT`). The only way `connect()` can linger is a wedged listener
+/// whose backlog never drains — vanishingly rare — so this timeout is a
+/// belt-and-suspenders bound that keeps daemon startup from stalling on a
+/// pathological socket. A probe that can't answer within it is treated as
+/// unreachable (conservative: better to exclude a barely-alive host than
+/// drag it into the set).
+const REACHABLE_PROBE_TIMEOUT: Duration = Duration::from_millis(250);
+
+/// Liveness probe for [`crate::backend::active_backends`] auto-detect: does a
+/// herdr server actually **answer** on `socket_path` right now?
+///
+/// A bare `try_exists()` on the socket file is not enough. A crashed herdr
+/// server leaves its socket file behind, and that stale file would otherwise
+/// drag a permanently-dead herdr backend into a tmux-only daemon's active set
+/// forever — every reconcile tick observing it incomplete (never reaping its
+/// ghost rows), every read fanning out a doomed connect. An actual
+/// `connect()` distinguishes the two: it refuses immediately on a stale
+/// socket and succeeds only when a server is listening, so the ghost is
+/// excluded. Env presence (`HERDR_PANE_ID`/`HERDR_ENV`) remains a separate
+/// inclusion signal at the call site — inside a herdr pane the server is alive
+/// by construction, so no probe is needed there.
+///
+/// The connect runs on a throwaway thread so a wedged listener can't block
+/// startup past [`REACHABLE_PROBE_TIMEOUT`]; the thread finishes on its own
+/// once `connect()` returns (its send just no-ops after we've stopped
+/// waiting).
+pub(crate) fn server_reachable(socket_path: &Path) -> bool {
+    let path = socket_path.to_path_buf();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(UnixStream::connect(&path).is_ok());
+    });
+    rx.recv_timeout(REACHABLE_PROBE_TIMEOUT).unwrap_or(false)
+}
+
 /// The focused herdr workspace, mapped to muxa's foreground-tracking keys:
 /// the stable `workspace_id` becomes the session id (matching
 /// [`to_pane_info`]'s `session` mapping so ledger keys line up) and the

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -151,12 +151,17 @@ fn backend_of(kind: HostKind) -> SharedBackend {
 /// 2. `MUXA_HOST` — the existing single-host override still means
 ///    "exactly this one"; it wins over auto-detect but loses to the
 ///    explicit set, which exists precisely to widen it.
-/// 3. Auto-detect: tmux always (its methods degrade to empty when no
-///    server is running, and it remains muxa's default market); herdr
-///    when its socket resolves to an existing path (env override or
-///    the default-session path); zellij only via env presence — the
-///    CLI baseline can't enumerate without a plugin, so a speculative
-///    zellij backend would only add an incomplete-observation source.
+/// 3. Auto-detect: the env-preferred host (whatever [`detect_host_env`]
+///    resolves the current shell to) leads so `backends[0]` is that host
+///    — consumers treat the first backend as "primary" (dashboard, watch
+///    initial cursor). tmux is always in the set (its methods degrade to
+///    empty when no server is running, and it remains muxa's default
+///    market); herdr joins when a herdr server actually **answers** on its
+///    socket (a live connect, not a stale socket file — see
+///    [`herdr::server_reachable`]) or its pane env is present; zellij only
+///    via env presence — the CLI baseline can't enumerate without a
+///    plugin, so a speculative zellij backend would only add an
+///    incomplete-observation source.
 ///
 /// Never returns an empty set — the [`default_backend`] fallback rules
 /// keep a lone tmux backend when nothing is detectable. Multiple
@@ -167,7 +172,11 @@ pub fn active_backends() -> Vec<SharedBackend> {
     active_backends_from(
         |name| std::env::var(name).ok(),
         |kind| match kind {
-            HostKind::Herdr => herdr::default_socket_path().try_exists().unwrap_or(false),
+            // Liveness probe, not file existence: a stale socket file from a
+            // crashed herdr server would otherwise ghost a dead backend into
+            // the set forever. `server_reachable` connects and only reports
+            // true when a server actually answers.
+            HostKind::Herdr => herdr::server_reachable(&herdr::default_socket_path()),
             // tmux/zellij reachability is not probed here; see the
             // resolution rules above.
             HostKind::Tmux | HostKind::Zellij => false,
@@ -190,6 +199,12 @@ fn active_kinds_from(
     read: &impl Fn(&str) -> Option<String>,
     probe: &impl Fn(HostKind) -> bool,
 ) -> Vec<HostKind> {
+    fn add(kinds: &mut Vec<HostKind>, kind: HostKind) {
+        if !kinds.contains(&kind) {
+            kinds.push(kind);
+        }
+    }
+
     // 1. Explicit set.
     if let Some(raw) = read("MUXA_HOSTS") {
         let mut kinds = Vec::new();
@@ -218,14 +233,25 @@ fn active_kinds_from(
         return vec![k];
     }
 
-    // 3. Auto-detect. tmux unconditionally; herdr on a live socket or
-    // pane env; zellij on pane env only.
-    let mut kinds = vec![HostKind::Tmux];
+    // 3. Auto-detect. The env-preferred host — whatever `detect_from`
+    // resolves the current shell to (zellij > herdr > tmux on a nested-env
+    // tie) — leads the set so `backends[0]` is the host the shell actually
+    // lives in; consumers (dashboard, watch initial cursor) treat the first
+    // backend as primary. The remaining detected hosts follow in a stable
+    // order, deduped: tmux unconditionally (its methods degrade to empty when
+    // no server runs), zellij on pane env, herdr on a live socket probe or
+    // pane env. `MUXA_HOSTS` (step 1) keeps its verbatim order — that's
+    // explicit operator intent, not auto-detect.
+    let mut kinds: Vec<HostKind> = Vec::new();
+    if let Some(env_host) = detect_from(read) {
+        add(&mut kinds, env_host);
+    }
+    add(&mut kinds, HostKind::Tmux);
     if read("ZELLIJ").is_some() {
-        kinds.push(HostKind::Zellij);
+        add(&mut kinds, HostKind::Zellij);
     }
     if read("HERDR_PANE_ID").is_some() || read("HERDR_ENV").is_some() || probe(HostKind::Herdr) {
-        kinds.push(HostKind::Herdr);
+        add(&mut kinds, HostKind::Herdr);
     }
     kinds
 }
@@ -869,7 +895,8 @@ mod tests {
     }
 
     /// Auto-detect: tmux is unconditional; herdr joins on env presence
-    /// or a live socket probe; zellij joins on env presence only.
+    /// or a live socket probe; zellij joins on env presence only. With no
+    /// host env, nothing is env-preferred so tmux simply leads.
     #[test]
     fn active_kinds_auto_detect() {
         assert_eq!(
@@ -880,11 +907,41 @@ mod tests {
             active_kinds_from(&env_reader(&[]), &|k| k == HostKind::Herdr),
             vec![HostKind::Tmux, HostKind::Herdr],
         );
+        // Both HERDR and ZELLIJ env present: zellij is the env-preferred host
+        // (nested-env tie-break), so it leads; tmux is auto-added; herdr trails
+        // on its env presence. `backends[0]` is the env-preferred host.
         assert_eq!(
             active_kinds_from(&env_reader(&[("HERDR_ENV", "1"), ("ZELLIJ", "1")]), &|_| {
                 false
             },),
-            vec![HostKind::Tmux, HostKind::Zellij, HostKind::Herdr],
+            vec![HostKind::Zellij, HostKind::Tmux, HostKind::Herdr],
+        );
+    }
+
+    /// Fix 2: the env-preferred host leads the auto-detected set so
+    /// `backends[0]` is the host the current shell lives in. A herdr shell
+    /// (`HERDR_ENV`) with tmux auto-added yields `[Herdr, Tmux]`, not
+    /// `[Tmux, Herdr]` — the migration case where the operator is *in* herdr
+    /// but the tmux server is also observed. The probe is irrelevant here
+    /// (env presence already includes herdr), and no duplicate is produced.
+    #[test]
+    fn active_kinds_env_preferred_host_leads() {
+        assert_eq!(
+            active_kinds_from(&env_reader(&[("HERDR_ENV", "1")]), &|_| false),
+            vec![HostKind::Herdr, HostKind::Tmux],
+        );
+        // A herdr pane env plus a reachable-socket probe must not double-add
+        // herdr; it still leads, tmux trails.
+        assert_eq!(
+            active_kinds_from(&env_reader(&[("HERDR_PANE_ID", "9")]), &|k| k
+                == HostKind::Herdr),
+            vec![HostKind::Herdr, HostKind::Tmux],
+        );
+        // A plain tmux shell (only `TMUX`) is already tmux-first; the env
+        // preference and the unconditional tmux add resolve to a single entry.
+        assert_eq!(
+            active_kinds_from(&env_reader(&[("TMUX", "/tmp/t,1,0")]), &|_| false),
+            vec![HostKind::Tmux],
         );
     }
 }

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -133,6 +133,116 @@ pub fn default_backend() -> SharedBackend {
     }
 }
 
+/// Build one backend of the given kind.
+fn backend_of(kind: HostKind) -> SharedBackend {
+    match kind {
+        HostKind::Tmux => Arc::new(tmux::TmuxBackend::new()),
+        HostKind::Zellij => Arc::new(zellij::ZellijBackend::new()),
+        HostKind::Herdr => Arc::new(herdr::HerdrBackend::new()),
+    }
+}
+
+/// Build every backend the daemon should observe simultaneously — the
+/// multi-host analog of [`default_backend`] (see `docs/MULTI_HOST.md`).
+///
+/// Resolution:
+/// 1. `MUXA_HOSTS` — comma-separated explicit set (`"tmux,herdr"`),
+///    unknown names ignored, order preserved, duplicates dropped.
+/// 2. `MUXA_HOST` — the existing single-host override still means
+///    "exactly this one"; it wins over auto-detect but loses to the
+///    explicit set, which exists precisely to widen it.
+/// 3. Auto-detect: tmux always (its methods degrade to empty when no
+///    server is running, and it remains muxa's default market); herdr
+///    when its socket resolves to an existing path (env override or
+///    the default-session path); zellij only via env presence — the
+///    CLI baseline can't enumerate without a plugin, so a speculative
+///    zellij backend would only add an incomplete-observation source.
+///
+/// Never returns an empty set — the [`default_backend`] fallback rules
+/// keep a lone tmux backend when nothing is detectable. Multiple
+/// observers converging one registry is safe: each observation only
+/// governs rows in its own pane-id namespace (see
+/// [`pane_id_host_kind`] and the cross-host reaping guard).
+pub fn active_backends() -> Vec<SharedBackend> {
+    active_backends_from(
+        |name| std::env::var(name).ok(),
+        |kind| match kind {
+            HostKind::Herdr => herdr::default_socket_path().try_exists().unwrap_or(false),
+            // tmux/zellij reachability is not probed here; see the
+            // resolution rules above.
+            HostKind::Tmux | HostKind::Zellij => false,
+        },
+    )
+}
+
+/// Decoupled-from-process-env variant of [`active_backends`] for tests.
+/// `probe(kind)` answers "is this host's server reachable" for hosts
+/// whose presence can't be read from env alone (currently herdr).
+fn active_backends_from(
+    read: impl Fn(&str) -> Option<String>,
+    probe: impl Fn(HostKind) -> bool,
+) -> Vec<SharedBackend> {
+    let kinds = active_kinds_from(&read, &probe);
+    kinds.into_iter().map(backend_of).collect()
+}
+
+fn active_kinds_from(
+    read: &impl Fn(&str) -> Option<String>,
+    probe: &impl Fn(HostKind) -> bool,
+) -> Vec<HostKind> {
+    // 1. Explicit set.
+    if let Some(raw) = read("MUXA_HOSTS") {
+        let mut kinds = Vec::new();
+        for name in raw.split(',') {
+            let kind = match name.trim().to_ascii_lowercase().as_str() {
+                "tmux" => Some(HostKind::Tmux),
+                "zellij" => Some(HostKind::Zellij),
+                "herdr" => Some(HostKind::Herdr),
+                _ => None,
+            };
+            if let Some(k) = kind {
+                if !kinds.contains(&k) {
+                    kinds.push(k);
+                }
+            }
+        }
+        if !kinds.is_empty() {
+            return kinds;
+        }
+        // Entirely-unparsable value falls through to the narrower rules
+        // rather than silently observing nothing.
+    }
+
+    // 2. Single-host override keeps its exact meaning.
+    if let Some(k) = detect_from_override(read) {
+        return vec![k];
+    }
+
+    // 3. Auto-detect. tmux unconditionally; herdr on a live socket or
+    // pane env; zellij on pane env only.
+    let mut kinds = vec![HostKind::Tmux];
+    if read("ZELLIJ").is_some() {
+        kinds.push(HostKind::Zellij);
+    }
+    if read("HERDR_PANE_ID").is_some() || read("HERDR_ENV").is_some() || probe(HostKind::Herdr) {
+        kinds.push(HostKind::Herdr);
+    }
+    kinds
+}
+
+/// Just the `MUXA_HOST` step of [`detect_from`], shared with
+/// [`active_kinds_from`] so the override means the same thing to both
+/// resolution paths.
+fn detect_from_override(read: &impl Fn(&str) -> Option<String>) -> Option<HostKind> {
+    let raw = read("MUXA_HOST")?;
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "tmux" => Some(HostKind::Tmux),
+        "zellij" => Some(HostKind::Zellij),
+        "herdr" => Some(HostKind::Herdr),
+        _ => None,
+    }
+}
+
 /// Identity of the pane host. Surfaced through telemetry and log lines so
 /// operators running both backends can tell which one a given event went
 /// through.
@@ -728,5 +838,53 @@ mod tests {
         assert!(caps.pane_pid_map);
         assert!(caps.capture_pane);
         assert!(caps.focus_pane);
+    }
+
+    /// `MUXA_HOSTS` is an explicit ordered set: names normalize, unknown
+    /// entries and duplicates drop, and a fully-unparsable value falls
+    /// through to auto-detect instead of observing nothing.
+    #[test]
+    fn active_kinds_explicit_set() {
+        let kinds = active_kinds_from(
+            &env_reader(&[("MUXA_HOSTS", " Herdr, tmux ,herdr,bogus")]),
+            &|_| false,
+        );
+        assert_eq!(kinds, vec![HostKind::Herdr, HostKind::Tmux]);
+
+        let fallthrough = active_kinds_from(&env_reader(&[("MUXA_HOSTS", "bogus,")]), &|_| false);
+        assert_eq!(fallthrough, vec![HostKind::Tmux]);
+    }
+
+    /// `MUXA_HOST` (singular) keeps meaning "exactly this one" even in
+    /// the set-valued resolution, and loses only to `MUXA_HOSTS`.
+    #[test]
+    fn active_kinds_single_override_stays_exact() {
+        let kinds = active_kinds_from(
+            &env_reader(&[("MUXA_HOST", "herdr"), ("TMUX", "/tmp/t,1,0")]),
+            // Even a reachable herdr socket must not widen an explicit
+            // single-host override.
+            &|_| true,
+        );
+        assert_eq!(kinds, vec![HostKind::Herdr]);
+    }
+
+    /// Auto-detect: tmux is unconditional; herdr joins on env presence
+    /// or a live socket probe; zellij joins on env presence only.
+    #[test]
+    fn active_kinds_auto_detect() {
+        assert_eq!(
+            active_kinds_from(&env_reader(&[]), &|_| false),
+            vec![HostKind::Tmux],
+        );
+        assert_eq!(
+            active_kinds_from(&env_reader(&[]), &|k| k == HostKind::Herdr),
+            vec![HostKind::Tmux, HostKind::Herdr],
+        );
+        assert_eq!(
+            active_kinds_from(&env_reader(&[("HERDR_ENV", "1"), ("ZELLIJ", "1")]), &|_| {
+                false
+            },),
+            vec![HostKind::Tmux, HostKind::Zellij, HostKind::Herdr],
+        );
     }
 }

--- a/crates/muxa/src/lib.rs
+++ b/crates/muxa/src/lib.rs
@@ -63,8 +63,8 @@ pub mod tmux;
 // ---------------------------------------------------------------------------
 
 pub use backend::{
-    default_backend, tmux::TmuxBackend, zellij::ZellijBackend, BackendCaps, HostKind, PaneBackend,
-    SharedBackend,
+    active_backends, default_backend, tmux::TmuxBackend, zellij::ZellijBackend, BackendCaps,
+    HostKind, PaneBackend, SharedBackend,
 };
 pub use config::Config;
 pub use error::CoreError as Error;

--- a/crates/muxa/src/reconcile.rs
+++ b/crates/muxa/src/reconcile.rs
@@ -161,9 +161,10 @@ impl<L: LivenessSource> Reconciler<L> {
     /// multi-host analog of [`Self::new`]. Every source is observed
     /// concurrently and reconciled under its own [`HostKind`]; the ghost
     /// age-out sweep ([`Store::mark_stale_cross_host_stopped`](crate::state::Store::mark_stale_cross_host_stopped))
-    /// naturally receives all active kinds, so a row on a host in the set is
-    /// governed by that host's reconcile pass while a row on a host NOT in the
-    /// set ages out. An empty `sources` degrades to a store-maintenance-only
+    /// receives the kinds whose observation was *complete* this tick, so a row
+    /// on a host that answered is governed by that host's reconcile pass while a
+    /// row on a host NOT in the set — or one that can't answer past the
+    /// inactivity window — ages out. An empty `sources` degrades to a store-maintenance-only
     /// loop (no observation, but the stuck/paneless/codex sweeps still run);
     /// the daemon never constructs one that way — `active_backends()` is never
     /// empty.
@@ -396,54 +397,75 @@ impl<L: LivenessSource> Reconciler<L> {
             observations.push((kind, obs));
         }
         let list_panes_us = u64::try_from(list_started.elapsed().as_micros()).unwrap_or(u64::MAX);
-        // Workload scan runs once per tick over the UNION of complete
-        // observations — process-tree scanning is store-global (it clears the
-        // workload of any pane absent from its map), so a per-backend scan would
-        // clobber the other host's rows. Gate the whole scan+update on *all*
-        // observations being complete: `update_workloads` would otherwise reset
-        // an incompletely-observed host's rows to the default workload. This
-        // generalizes the single-host rule (run only when the one observation is
-        // complete) without regressing it.
+        // The kinds whose observation was COMPLETE this tick — the hosts that
+        // actually answered. Fixes 3/4/5 all key off this set rather than "every
+        // observation is complete": one chronically-incomplete host must not
+        // freeze the others.
         let all_complete = observations.iter().all(|(_, o)| o.is_complete());
+        let complete_kinds: Vec<HostKind> = observations
+            .iter()
+            .filter(|(_, o)| o.is_complete())
+            .map(|(k, _)| *k)
+            .collect();
         let total_panes: usize = observations.iter().map(|(_, o)| o.panes.len()).sum();
-        let panes_for_workload: Vec<crate::tmux::PaneInfo> = if all_complete {
-            observations
-                .iter()
-                .flat_map(|(_, o)| o.panes.iter().cloned())
-                .collect()
-        } else {
-            Vec::new()
-        };
+        // Fix 3/5: the union of panes from COMPLETE observations only. An
+        // incompletely-observed host contributes no panes, so its rows are
+        // neither workload-reset nor used as codex-correlation candidates this
+        // tick. Empty when no host answered (a single-host daemon whose one scan
+        // failed) — then the workload scan+update is skipped entirely, keeping
+        // that host's rows untouched (the old single-host-incomplete rule).
+        let union_panes: Vec<crate::tmux::PaneInfo> = observations
+            .iter()
+            .filter(|(_, o)| o.is_complete())
+            .flat_map(|(_, o)| o.panes.iter().cloned())
+            .collect();
+        // Workload scan runs once per tick over that union — process-tree
+        // scanning is store-global (it clears the workload of any pane absent
+        // from its map), so it must see every complete host's panes at once, and
+        // `update_workloads` then governs only rows on a complete host (see
+        // `Store::update_workloads`), leaving an incomplete host's rows as-is.
         let workload_started = Instant::now();
-        let workloads = if all_complete {
-            tokio::task::spawn_blocking(move || {
-                process_tree::scan_pane_workloads(&panes_for_workload)
-            })
-            .await
-            .unwrap_or_default()
-        } else {
+        let workloads = if complete_kinds.is_empty() {
             std::collections::HashMap::new()
+        } else {
+            let panes = union_panes.clone();
+            tokio::task::spawn_blocking(move || process_tree::scan_pane_workloads(&panes))
+                .await
+                .unwrap_or_default()
         };
         let workload_scan_us =
             u64::try_from(workload_started.elapsed().as_micros()).unwrap_or(u64::MAX);
         let reconcile_started = Instant::now();
+        let mut report = ReconcileReport::default();
+        // Fix 5: correlate paneless codex ONCE over the union of complete panes,
+        // BEFORE the per-host reap/dedup passes. Running it per host would only
+        // show the ambiguity guard one host's panes, so a tmux pass could adopt a
+        // row whose codex actually lives in a herdr pane at the same cwd. Doing
+        // it here — ahead of the per-host passes — still lets this tick's dedup
+        // demote the now-redundant synthetic. Skip when nothing answered.
+        if !union_panes.is_empty() {
+            report.paneless_correlated = self
+                .store
+                .correlate_paneless_codex_union(&union_panes)
+                .await;
+        }
         // Reconcile each observation against the store sequentially, under its
         // own host kind. Completeness is enforced per host inside
         // `reconcile_observation`, so an incomplete herdr scan is a no-op that
         // leaves tmux reaping untouched. Accumulate the per-host reports so the
         // timing line and callers (tests) see the whole tick's effect.
-        let mut report = ReconcileReport::default();
         for (kind, observation) in &observations {
             let r = self.store.reconcile_observation(observation, *kind).await;
             report.stale_panes_reaped += r.stale_panes_reaped;
             report.synthetic_demoted += r.synthetic_demoted;
             report.duplicates_collapsed += r.duplicates_collapsed;
-            report.paneless_correlated += r.paneless_correlated;
         }
-        let workload_changed = if all_complete {
-            self.store.update_workloads(&workloads).await
-        } else {
+        let workload_changed = if complete_kinds.is_empty() {
             0
+        } else {
+            self.store
+                .update_workloads(&workloads, &complete_kinds)
+                .await
         };
         let store_update_us =
             u64::try_from(reconcile_started.elapsed().as_micros()).unwrap_or(u64::MAX);
@@ -481,23 +503,26 @@ impl<L: LivenessSource> Reconciler<L> {
                 "orphan-row sweep flipped {stale_paneless} paneless agent(s) to Stopped",
             );
         }
-        // Age out rows whose pane belongs to a host this daemon isn't
-        // observing (e.g. a `zellij:` row while the set is tmux + herdr, or a
-        // `herdr:` row left behind after narrowing the set back to tmux). The
-        // cross-host guard exempts them from *immediate* reaping, and no
-        // observation in the set can ever see them, so without this they'd
-        // ghost forever. Passing ALL observing kinds means a row on a host
-        // that IS in the set (even one that's down / observed incomplete this
-        // tick) is spared here and stays governed by its own reconcile pass.
-        // Same inactivity window as the paneless sweep.
+        // Age out rows whose pane belongs to a host that did NOT answer with a
+        // complete observation this tick (e.g. a `zellij:` row while the set is
+        // tmux + herdr, a `herdr:` row left behind after narrowing the set back
+        // to tmux, or a host in the set that is chronically unable to answer).
+        // The cross-host guard exempts foreign rows from *immediate* reaping,
+        // and no observation reaps them, so without this they'd ghost forever.
+        // Fix 4: pass the COMPLETE-this-tick kinds, not every kind in the set —
+        // a host that answers governs its rows via reaping and is spared here,
+        // while a host that can't answer past the inactivity window ages out
+        // exactly like a host outside the set. Transient incompleteness is safe:
+        // the threshold is the (24h-default) paneless window on last-activity,
+        // not a single tick. Same inactivity window as the paneless sweep.
         let stale_cross_host = self
             .store
-            .mark_stale_cross_host_stopped(&observing_kinds, self.paneless_stale_timeout)
+            .mark_stale_cross_host_stopped(&complete_kinds, self.paneless_stale_timeout)
             .await;
         if stale_cross_host > 0 {
             tracing::info!(
                 stale_cross_host,
-                observing = ?observing_kinds,
+                complete = ?complete_kinds,
                 "cross-host sweep flipped {stale_cross_host} foreign-host agent(s) to Stopped",
             );
         }
@@ -794,9 +819,11 @@ mod tests {
         );
     }
 
-    /// An incomplete observation from ONE backend must not clear the workload
-    /// metadata of another backend's rows: the workload scan+update is gated on
-    /// EVERY observation being complete, mirroring the single-host rule.
+    /// An incomplete observation from ONE backend must not reap or reset
+    /// another backend's rows. The complete tmux scan governs its own rows; the
+    /// incomplete herdr scan is a no-op, so `update_workloads` only touches
+    /// tmux-namespaced rows and the herdr row keeps its metadata (see the
+    /// dedicated store test `update_workloads_governs_only_complete_hosts`).
     #[tokio::test]
     async fn incomplete_one_backend_does_not_reap_or_reset_another() {
         let store = Store::shared();
@@ -816,6 +843,140 @@ mod tests {
         assert_eq!(report.stale_panes_reaped, 0);
         assert!(store.by_session("tmux-alive").await.is_some());
         assert!(store.by_session("herdr-alive").await.is_some());
+    }
+
+    /// Fix 4: the cross-host age-out keys off the COMPLETE-this-tick kinds, so a
+    /// chronically-incomplete host's stale rows age out (nothing else ever
+    /// reaps them) while a freshly-active row on the same host survives. tmux
+    /// answers complete; herdr times out (incomplete) every tick, so `Herdr` is
+    /// absent from `complete_kinds` and its rows are treated like a host outside
+    /// the set. A herdr row idle past the window flips to `Stopped`; a herdr row
+    /// with recent activity is spared by the last-activity threshold.
+    #[tokio::test]
+    async fn cross_host_ages_out_chronically_incomplete_host() {
+        let store = Store::shared();
+        let old = datetime!(2026-04-24 12:00:00 UTC);
+        let fresh = time::OffsetDateTime::now_utc();
+        store.apply(&started("herdr-stale", "herdr:p1", old)).await;
+        store
+            .apply(&started("herdr-fresh", "herdr:p2", fresh))
+            .await;
+
+        let tmux = FakeLiveness::new(vec![pane("%1")]).with_kind(HostKind::Tmux);
+        // herdr never answers — incomplete, empty, every tick.
+        let herdr = FakeLiveness::incomplete(Vec::new()).with_kind(HostKind::Herdr);
+        let r =
+            Reconciler::with_sources(store.clone(), vec![tmux, herdr], Duration::from_millis(10))
+                .with_paneless_stale_timeout(Duration::from_secs(1));
+        r.reconcile_once().await;
+
+        let snap = store.snapshot().await;
+        assert_eq!(
+            snap.iter()
+                .find(|a| a.session_id == "herdr-stale")
+                .map(|a| a.state),
+            Some(AgentState::Stopped),
+            "a chronically-incomplete host's stale row ages out",
+        );
+        assert_eq!(
+            snap.iter()
+                .find(|a| a.session_id == "herdr-fresh")
+                .map(|a| a.state),
+            Some(AgentState::Idle),
+            "a freshly-active row on the same host survives",
+        );
+    }
+
+    fn codex_paneless(sid: &str, cwd: &str, at: time::OffsetDateTime) -> AgentEvent {
+        AgentEvent::Started {
+            id: AgentId {
+                kind: AgentKind::Codex,
+                session_id: sid.into(),
+                surface: None,
+                pane: None,
+                tmux_socket: None,
+                cwd: Some(cwd.into()),
+            },
+            at,
+        }
+    }
+
+    fn codex_synthetic(sid: &str, pane_id: &str, at: time::OffsetDateTime) -> AgentEvent {
+        AgentEvent::Started {
+            id: AgentId {
+                kind: AgentKind::Codex,
+                session_id: sid.into(),
+                surface: None,
+                pane: Some(pane_id.into()),
+                tmux_socket: None,
+                cwd: None,
+            },
+            at,
+        }
+    }
+
+    /// Fix 5: paneless-codex correlation runs ONCE over the union of complete
+    /// observations, so its many-to-one cwd ambiguity guard sees candidate panes
+    /// on *both* hosts. A paneless codex row whose cwd is shared by a tmux pane
+    /// AND a herdr pane is ambiguous → NOT adopted (a per-host pass would have
+    /// seen only one candidate and mis-adopted). A paneless row whose cwd is
+    /// unique to a single host's pane still adopts as before.
+    #[tokio::test]
+    async fn codex_correlation_over_union_guards_cross_host_cwd_ambiguity() {
+        let t0 = datetime!(2026-04-24 12:00:00 UTC);
+
+        // Ambiguous: same cwd on a tmux pane and a herdr pane.
+        let store = Store::shared();
+        store
+            .apply(&codex_synthetic("synthetic-%7", "%7", t0))
+            .await;
+        store
+            .apply(&codex_synthetic("synthetic-herdr:p9", "herdr:p9", t0))
+            .await;
+        store.apply(&codex_paneless("real-amb", "/work", t0)).await;
+
+        let mut tp = pane("%7");
+        tp.current_path = "/work".into();
+        let mut hp = herdr_pane("herdr:p9");
+        hp.current_path = "/work".into();
+        let tmux = FakeLiveness::new(vec![tp]).with_kind(HostKind::Tmux);
+        let herdr = FakeLiveness::new(vec![hp]).with_kind(HostKind::Herdr);
+        let r =
+            Reconciler::with_sources(store.clone(), vec![tmux, herdr], Duration::from_millis(10));
+        let report = r.reconcile_once().await;
+
+        assert_eq!(
+            report.paneless_correlated, 0,
+            "a cwd shared across hosts is ambiguous — no adoption",
+        );
+        assert!(
+            store
+                .by_session("real-amb")
+                .await
+                .is_some_and(|a| a.pane.is_none()),
+            "the paneless row stays paneless",
+        );
+
+        // Unique: the cwd resolves to exactly one host's pane → adopt.
+        let store = Store::shared();
+        store
+            .apply(&codex_synthetic("synthetic-%8", "%8", t0))
+            .await;
+        store.apply(&codex_paneless("real-solo", "/solo", t0)).await;
+
+        let mut up = pane("%8");
+        up.current_path = "/solo".into();
+        let tmux = FakeLiveness::new(vec![up]).with_kind(HostKind::Tmux);
+        let herdr = FakeLiveness::new(Vec::new()).with_kind(HostKind::Herdr);
+        let r =
+            Reconciler::with_sources(store.clone(), vec![tmux, herdr], Duration::from_millis(10));
+        let report = r.reconcile_once().await;
+
+        assert_eq!(report.paneless_correlated, 1, "unique cwd adopts as before");
+        assert_eq!(
+            store.by_session("real-solo").await.and_then(|a| a.pane),
+            Some("%8".into()),
+        );
     }
 
     #[tokio::test]

--- a/crates/muxa/src/reconcile.rs
+++ b/crates/muxa/src/reconcile.rs
@@ -117,7 +117,13 @@ impl<B: crate::backend::PaneBackend> LivenessSource for B {
 /// knob, not a correctness requirement.
 pub struct Reconciler<L: LivenessSource> {
     store: SharedStore,
-    source: Arc<L>,
+    /// One source per backend the daemon observes. Single-host daemons (and
+    /// every test) carry exactly one; a multi-host daemon (tmux + herdr during
+    /// a migration) carries several. Each tick observes all of them
+    /// concurrently and reconciles each observation against the store under its
+    /// own [`HostKind`], so a herdr timeout can't trigger tmux reaping or vice
+    /// versa (`reconcile_observation` is completeness-gated per host).
+    sources: Vec<Arc<L>>,
     interval: Duration,
     /// Optional metrics handle. Daemon wires one in via
     /// [`Self::with_metrics`]; tests can leave it `None` to avoid
@@ -148,9 +154,23 @@ pub struct Reconciler<L: LivenessSource> {
 
 impl<L: LivenessSource> Reconciler<L> {
     pub fn new(store: SharedStore, source: L, interval: Duration) -> Self {
+        Self::with_sources(store, vec![source], interval)
+    }
+
+    /// Build a reconciler that observes several backends per tick — the
+    /// multi-host analog of [`Self::new`]. Every source is observed
+    /// concurrently and reconciled under its own [`HostKind`]; the ghost
+    /// age-out sweep ([`Store::mark_stale_cross_host_stopped`](crate::state::Store::mark_stale_cross_host_stopped))
+    /// naturally receives all active kinds, so a row on a host in the set is
+    /// governed by that host's reconcile pass while a row on a host NOT in the
+    /// set ages out. An empty `sources` degrades to a store-maintenance-only
+    /// loop (no observation, but the stuck/paneless/codex sweeps still run);
+    /// the daemon never constructs one that way — `active_backends()` is never
+    /// empty.
+    pub fn with_sources(store: SharedStore, sources: Vec<L>, interval: Duration) -> Self {
         Self {
             store,
-            source: Arc::new(source),
+            sources: sources.into_iter().map(Arc::new).collect(),
             interval,
             metrics: None,
             stuck_working_timeout: Duration::ZERO,
@@ -345,38 +365,82 @@ impl<L: LivenessSource> Reconciler<L> {
     #[allow(clippy::too_many_lines)]
     pub async fn reconcile_once(&self) -> ReconcileReport {
         let started = Instant::now();
-        // Pane observation shells out to tmux and must not block the runtime.
-        // Capture the observing host up front so the store's reaping guard can
-        // exempt rows namespaced to a *different* host (cross-host migration).
-        let observing_kind = self.source.kind();
-        let src = self.source.clone();
+        // Every backend is observed each tick. Capture each observing host so
+        // the store's reaping guard can exempt rows namespaced to a host that
+        // is *also* in the set (cross-host migration) while reaping the ones
+        // that aren't.
+        let observing_kinds: Vec<HostKind> = self.sources.iter().map(|s| s.kind()).collect();
+        // Pane observation shells out to tmux / round-trips the herdr socket and
+        // must not block the runtime. Spawn every source's blocking observation
+        // up front so they run CONCURRENTLY, then collect — a herdr timeout
+        // must not serialize behind the tmux scan (and vice versa), keeping the
+        // tick budget flat as backends are added.
         let list_started = Instant::now();
-        let observation = tokio::task::spawn_blocking(move || src.observe_panes())
-            .await
-            .unwrap_or_else(|_| PaneObservation::incomplete(Vec::new()));
+        let handles: Vec<(HostKind, tokio::task::JoinHandle<PaneObservation>)> = self
+            .sources
+            .iter()
+            .map(|src| {
+                let src = src.clone();
+                let kind = src.kind();
+                (
+                    kind,
+                    tokio::task::spawn_blocking(move || src.observe_panes()),
+                )
+            })
+            .collect();
+        let mut observations: Vec<(HostKind, PaneObservation)> = Vec::with_capacity(handles.len());
+        for (kind, handle) in handles {
+            let obs = handle
+                .await
+                .unwrap_or_else(|_| PaneObservation::incomplete(Vec::new()));
+            observations.push((kind, obs));
+        }
         let list_panes_us = u64::try_from(list_started.elapsed().as_micros()).unwrap_or(u64::MAX);
-        let pane_observation_complete = observation.is_complete();
-        let panes_for_workload = observation.panes.clone();
+        // Workload scan runs once per tick over the UNION of complete
+        // observations — process-tree scanning is store-global (it clears the
+        // workload of any pane absent from its map), so a per-backend scan would
+        // clobber the other host's rows. Gate the whole scan+update on *all*
+        // observations being complete: `update_workloads` would otherwise reset
+        // an incompletely-observed host's rows to the default workload. This
+        // generalizes the single-host rule (run only when the one observation is
+        // complete) without regressing it.
+        let all_complete = observations.iter().all(|(_, o)| o.is_complete());
+        let total_panes: usize = observations.iter().map(|(_, o)| o.panes.len()).sum();
+        let panes_for_workload: Vec<crate::tmux::PaneInfo> = if all_complete {
+            observations
+                .iter()
+                .flat_map(|(_, o)| o.panes.iter().cloned())
+                .collect()
+        } else {
+            Vec::new()
+        };
         let workload_started = Instant::now();
-        let workloads = if pane_observation_complete {
+        let workloads = if all_complete {
             tokio::task::spawn_blocking(move || {
                 process_tree::scan_pane_workloads(&panes_for_workload)
             })
             .await
             .unwrap_or_default()
         } else {
-            // Updating from a partial set would clear workload metadata for
-            // panes whose server failed observation.
             std::collections::HashMap::new()
         };
         let workload_scan_us =
             u64::try_from(workload_started.elapsed().as_micros()).unwrap_or(u64::MAX);
         let reconcile_started = Instant::now();
-        let report = self
-            .store
-            .reconcile_observation(&observation, observing_kind)
-            .await;
-        let workload_changed = if pane_observation_complete {
+        // Reconcile each observation against the store sequentially, under its
+        // own host kind. Completeness is enforced per host inside
+        // `reconcile_observation`, so an incomplete herdr scan is a no-op that
+        // leaves tmux reaping untouched. Accumulate the per-host reports so the
+        // timing line and callers (tests) see the whole tick's effect.
+        let mut report = ReconcileReport::default();
+        for (kind, observation) in &observations {
+            let r = self.store.reconcile_observation(observation, *kind).await;
+            report.stale_panes_reaped += r.stale_panes_reaped;
+            report.synthetic_demoted += r.synthetic_demoted;
+            report.duplicates_collapsed += r.duplicates_collapsed;
+            report.paneless_correlated += r.paneless_correlated;
+        }
+        let workload_changed = if all_complete {
             self.store.update_workloads(&workloads).await
         } else {
             0
@@ -418,20 +482,22 @@ impl<L: LivenessSource> Reconciler<L> {
             );
         }
         // Age out rows whose pane belongs to a host this daemon isn't
-        // observing (e.g. a `herdr:` row left behind after switching the
-        // daemon back to tmux). The cross-host guard exempts them from
-        // *immediate* reaping, but a single-backend daemon never sees them,
-        // so without this they'd ghost forever. Same inactivity window as the
-        // paneless sweep. Today the observing set is exactly the one active
-        // backend; a future multi-host daemon would pass all its live kinds.
+        // observing (e.g. a `zellij:` row while the set is tmux + herdr, or a
+        // `herdr:` row left behind after narrowing the set back to tmux). The
+        // cross-host guard exempts them from *immediate* reaping, and no
+        // observation in the set can ever see them, so without this they'd
+        // ghost forever. Passing ALL observing kinds means a row on a host
+        // that IS in the set (even one that's down / observed incomplete this
+        // tick) is spared here and stays governed by its own reconcile pass.
+        // Same inactivity window as the paneless sweep.
         let stale_cross_host = self
             .store
-            .mark_stale_cross_host_stopped(&[observing_kind], self.paneless_stale_timeout)
+            .mark_stale_cross_host_stopped(&observing_kinds, self.paneless_stale_timeout)
             .await;
         if stale_cross_host > 0 {
             tracing::info!(
                 stale_cross_host,
-                observing = %observing_kind,
+                observing = ?observing_kinds,
                 "cross-host sweep flipped {stale_cross_host} foreign-host agent(s) to Stopped",
             );
         }
@@ -470,8 +536,9 @@ impl<L: LivenessSource> Reconciler<L> {
                 list_panes_us,
                 workload_scan_us,
                 store_update_us,
-                panes = observation.panes.len(),
-                pane_observation_complete,
+                panes = total_panes,
+                pane_observation_complete = all_complete,
+                backends = observing_kinds.len(),
                 workloads = workloads.len(),
                 stale = report.stale_panes_reaped,
                 synthetic = report.synthetic_demoted,
@@ -486,8 +553,9 @@ impl<L: LivenessSource> Reconciler<L> {
                 list_panes_us,
                 workload_scan_us,
                 store_update_us,
-                panes = observation.panes.len(),
-                pane_observation_complete,
+                panes = total_panes,
+                pane_observation_complete = all_complete,
+                backends = observing_kinds.len(),
                 workloads = workloads.len(),
                 stale = report.stale_panes_reaped,
                 synthetic = report.synthetic_demoted,
@@ -556,18 +624,27 @@ mod tests {
     /// the live set between reconciliation passes.
     struct FakeLiveness {
         observation: Mutex<PaneObservation>,
+        kind: HostKind,
     }
 
     impl FakeLiveness {
         fn new(panes: Vec<PaneInfo>) -> Self {
             Self {
                 observation: Mutex::new(PaneObservation::complete(panes)),
+                kind: HostKind::Tmux,
             }
         }
         fn incomplete(panes: Vec<PaneInfo>) -> Self {
             Self {
                 observation: Mutex::new(PaneObservation::incomplete(panes)),
+                kind: HostKind::Tmux,
             }
+        }
+        /// Tag this source with a specific observing host — used by the
+        /// multi-source tests to exercise the cross-host reaping guard.
+        fn with_kind(mut self, kind: HostKind) -> Self {
+            self.kind = kind;
+            self
         }
         fn set(&self, panes: Vec<PaneInfo>) {
             *self.observation.lock().unwrap() = PaneObservation::complete(panes);
@@ -577,6 +654,9 @@ mod tests {
     impl LivenessSource for FakeLiveness {
         fn observe_panes(&self) -> PaneObservation {
             self.observation.lock().unwrap().clone()
+        }
+        fn kind(&self) -> HostKind {
+            self.kind
         }
     }
 
@@ -636,6 +716,106 @@ mod tests {
         let snap = store.snapshot().await;
         assert_eq!(snap.len(), 1);
         assert_eq!(snap[0].session_id, "a");
+    }
+
+    fn herdr_pane(id: &str) -> PaneInfo {
+        let mut p = pane(id);
+        p.session = "w1".into();
+        p
+    }
+
+    /// Multi-source reconcile: each backend governs only its own pane-id
+    /// namespace. A tmux source reaps a dead tmux `%N` row and a herdr source
+    /// reaps a dead `herdr:` row in the SAME tick, while each host's live row
+    /// is preserved and neither host's observation touches the other's rows.
+    #[tokio::test]
+    async fn reconcile_once_reaps_per_host_across_a_backend_set() {
+        let store = Store::shared();
+        let t0 = datetime!(2026-04-24 12:00:00 UTC);
+        store.apply(&started("tmux-alive", "%1", t0)).await;
+        store.apply(&started("tmux-ghost", "%2", t0)).await;
+        store.apply(&started("herdr-alive", "herdr:p1", t0)).await;
+        store.apply(&started("herdr-ghost", "herdr:p2", t0)).await;
+
+        let tmux = FakeLiveness::new(vec![pane("%1")]).with_kind(HostKind::Tmux);
+        let herdr = FakeLiveness::new(vec![herdr_pane("herdr:p1")]).with_kind(HostKind::Herdr);
+        let r =
+            Reconciler::with_sources(store.clone(), vec![tmux, herdr], Duration::from_millis(10));
+        let report = r.reconcile_once().await;
+
+        // One stale reap per host, both in the one tick.
+        assert_eq!(report.stale_panes_reaped, 2);
+        let snap = store.snapshot().await;
+        let live: std::collections::HashSet<&str> =
+            snap.iter().map(|a| a.session_id.as_str()).collect();
+        assert_eq!(live.len(), 2);
+        assert!(live.contains("tmux-alive"));
+        assert!(live.contains("herdr-alive"));
+    }
+
+    /// The cross-host age-out sweep spares rows whose host IS in the observed
+    /// set (governed by that host's own reconcile pass) and ages out rows whose
+    /// host is NOT — even when the set spans several hosts. A stale `zellij:`
+    /// row is foreign to a tmux+herdr set and must flip to `Stopped`; a stale
+    /// `herdr:` row is spared because herdr is observed (its own reconcile
+    /// governs it — here its pane is still live, so it survives).
+    #[tokio::test]
+    async fn cross_host_sweep_uses_the_whole_observed_set() {
+        let store = Store::shared();
+        let old = datetime!(2026-04-24 12:00:00 UTC);
+        store.apply(&started("herdr-live", "herdr:p1", old)).await;
+        store
+            .apply(&started("zellij-foreign", "zellij:9", old))
+            .await;
+
+        let tmux = FakeLiveness::new(vec![pane("%1")]).with_kind(HostKind::Tmux);
+        let herdr = FakeLiveness::new(vec![herdr_pane("herdr:p1")]).with_kind(HostKind::Herdr);
+        let r =
+            Reconciler::with_sources(store.clone(), vec![tmux, herdr], Duration::from_millis(10))
+                // Non-zero threshold enables the cross-host sweep; the rows are far
+                // older than the cutoff so an unobserved host's row ages out now.
+                .with_paneless_stale_timeout(Duration::from_secs(1));
+        r.reconcile_once().await;
+
+        let snap = store.snapshot().await;
+        // herdr is observed (and its pane live) → spared.
+        assert_eq!(
+            snap.iter()
+                .find(|a| a.session_id == "herdr-live")
+                .map(|a| a.state),
+            Some(AgentState::Idle),
+        );
+        // zellij is NOT observed → aged out to Stopped.
+        assert_eq!(
+            snap.iter()
+                .find(|a| a.session_id == "zellij-foreign")
+                .map(|a| a.state),
+            Some(AgentState::Stopped),
+        );
+    }
+
+    /// An incomplete observation from ONE backend must not clear the workload
+    /// metadata of another backend's rows: the workload scan+update is gated on
+    /// EVERY observation being complete, mirroring the single-host rule.
+    #[tokio::test]
+    async fn incomplete_one_backend_does_not_reap_or_reset_another() {
+        let store = Store::shared();
+        let t0 = datetime!(2026-04-24 12:00:00 UTC);
+        store.apply(&started("tmux-alive", "%1", t0)).await;
+        store.apply(&started("herdr-alive", "herdr:p1", t0)).await;
+
+        // tmux observed complete; herdr times out (incomplete, empty).
+        let tmux = FakeLiveness::new(vec![pane("%1")]).with_kind(HostKind::Tmux);
+        let herdr = FakeLiveness::incomplete(Vec::new()).with_kind(HostKind::Herdr);
+        let r =
+            Reconciler::with_sources(store.clone(), vec![tmux, herdr], Duration::from_millis(10));
+        let report = r.reconcile_once().await;
+
+        // The incomplete herdr scan reaps nothing; the tmux scan reaps nothing
+        // (its one row is live). Both rows survive.
+        assert_eq!(report.stale_panes_reaped, 0);
+        assert!(store.by_session("tmux-alive").await.is_some());
+        assert!(store.by_session("herdr-alive").await.is_some());
     }
 
     #[tokio::test]

--- a/crates/muxa/src/session_activity.rs
+++ b/crates/muxa/src/session_activity.rs
@@ -265,7 +265,15 @@ pub struct SessionActivityTracker {
     path: PathBuf,
     interval: Duration,
     activity_log: Option<Arc<ActivityLog>>,
-    source: SessionActivitySource,
+    /// One sampling source per host the daemon observes that *has* a foreground
+    /// signal (tmux and/or herdr; zellij has none). A single tracker owns one
+    /// `records` map and one `session-activity.json` writer, so polling every
+    /// source from this one task is race-free by construction — two independent
+    /// trackers writing the same file would clobber each other (each `save()`
+    /// rewrites the whole file). Merging is safe because the ledger keys are
+    /// disjoint across hosts (tmux `$N` vs herdr workspace ids), so one map
+    /// holds both hosts' sessions without collision.
+    sources: Vec<SessionActivitySource>,
 }
 
 impl SessionActivityTracker {
@@ -274,16 +282,28 @@ impl SessionActivityTracker {
             path,
             interval,
             activity_log: None,
-            source: SessionActivitySource::default(),
+            sources: vec![SessionActivitySource::default()],
         }
     }
 
-    /// Select the foreground-sampling source. Defaults to
-    /// [`SessionActivitySource::Tmux`]; the daemon sets
-    /// [`SessionActivitySource::Herdr`] on herdr hosts.
+    /// Select a single foreground-sampling source, replacing any already set.
+    /// Defaults to [`SessionActivitySource::Tmux`]; the daemon uses
+    /// [`Self::with_sources`] to sample several hosts at once.
     #[must_use]
     pub fn with_source(mut self, source: SessionActivitySource) -> Self {
-        self.source = source;
+        self.sources = vec![source];
+        self
+    }
+
+    /// Sample foreground state from several hosts each poll, merged into one
+    /// ledger. Used by the multi-host daemon (tmux + herdr during a migration).
+    /// An empty slice is treated as "no source" and leaves the default tmux
+    /// sampler in place so the tracker never silently stops sampling.
+    #[must_use]
+    pub fn with_sources(mut self, sources: Vec<SessionActivitySource>) -> Self {
+        if !sources.is_empty() {
+            self.sources = sources;
+        }
         self
     }
 
@@ -293,22 +313,42 @@ impl SessionActivityTracker {
         self
     }
 
-    /// Take one foreground sample from the configured source, off the async
-    /// runtime (both the tmux shell-out and the herdr socket round-trip
-    /// block). The two sources produce the same [`ActivitySample`] shape, so
-    /// the caller's accounting is source-agnostic.
+    /// Take one foreground sample from every configured source, off the async
+    /// runtime (both the tmux shell-out and the herdr socket round-trip block),
+    /// and merge them into a single [`ActivitySample`]. Sources sample
+    /// concurrently. All sources produce the same shape, and their session ids
+    /// don't collide across hosts, so the caller's accounting stays
+    /// source-agnostic over the merged result.
+    ///
+    /// If ANY source errors (only the tmux sampler can — the herdr sampler is
+    /// infallible, yielding an empty sample when no workspace is focused) the
+    /// whole poll is skipped rather than sampling a partial live set: passing a
+    /// host's sessions to `apply_sample_report` without the other host's would
+    /// wrongly close the missing host's foreground intervals. This matches the
+    /// single-host contract, where a failed sample skips the poll entirely.
     async fn sample(&self) -> Result<ActivitySample, String> {
-        match &self.source {
-            SessionActivitySource::Tmux => tokio::task::spawn_blocking(sample_activity)
-                .await
-                .unwrap_or_else(|e| Err(format!("join error: {e}"))),
-            SessionActivitySource::Herdr { socket_path } => {
-                let socket_path = socket_path.clone();
-                tokio::task::spawn_blocking(move || sample_herdr_activity(&socket_path))
-                    .await
-                    .map_err(|e| format!("join error: {e}"))
-            }
+        let handles: Vec<tokio::task::JoinHandle<Result<ActivitySample, String>>> = self
+            .sources
+            .iter()
+            .map(|source| match source {
+                SessionActivitySource::Tmux => tokio::task::spawn_blocking(sample_activity),
+                SessionActivitySource::Herdr { socket_path } => {
+                    let socket_path = socket_path.clone();
+                    tokio::task::spawn_blocking(move || Ok(sample_herdr_activity(&socket_path)))
+                }
+            })
+            .collect();
+
+        let mut merged = ActivitySample {
+            sessions: Vec::new(),
+            client_inputs: Vec::new(),
+        };
+        for handle in handles {
+            let sample = handle.await.map_err(|e| format!("join error: {e}"))??;
+            merged.sessions.extend(sample.sessions);
+            merged.client_inputs.extend(sample.client_inputs);
         }
+        Ok(merged)
     }
 
     pub async fn run(self, mut shutdown: broadcast::Receiver<()>) {
@@ -632,6 +672,30 @@ mod tests {
         let record = records.get("$1").unwrap();
         assert_eq!(record.attached_since, None);
         assert_eq!(record.total_attached_secs, 15);
+    }
+
+    /// A single tracker samples several hosts into one records map. The merged
+    /// live set carries both a tmux `$N` and a herdr workspace id at once;
+    /// because the keyspaces are disjoint, both accrue foreground time and
+    /// neither host's presence closes the other's interval. This is the
+    /// invariant that lets one tracker (one writer) poll both sources safely.
+    #[test]
+    fn merged_multi_host_sample_credits_both_keyspaces() {
+        let mut records = HashMap::new();
+        let t0 = datetime!(2026-05-29 00:00:00 UTC);
+        let t1 = datetime!(2026-05-29 00:00:10 UTC);
+
+        // Poll 1: a merged sample from tmux (`$1`) + herdr (`w1`).
+        let merged = [session("$1", "main", 1), session("w1", "work", 1)];
+        assert!(apply_sample(&mut records, &merged, t0));
+        assert!(records.get("$1").unwrap().is_attached());
+        assert!(records.get("w1").unwrap().is_attached());
+
+        // Poll 2: same merged set — both keep accruing, neither is closed by the
+        // other host being present in the same sample.
+        assert!(!apply_sample(&mut records, &merged, t1));
+        assert_eq!(records.get("$1").unwrap().effective_total_secs(t1), 10);
+        assert_eq!(records.get("w1").unwrap().effective_total_secs(t1), 10);
     }
 
     #[test]

--- a/crates/muxa/src/session_activity.rs
+++ b/crates/muxa/src/session_activity.rs
@@ -167,6 +167,30 @@ pub fn apply_sample_report<S: BuildHasher>(
     sessions: &[SessionInfo],
     now: OffsetDateTime,
 ) -> ApplySampleReport {
+    // A whole-ledger sample (single-source, or a pre-merged set): every record
+    // is in scope for the absence-close.
+    apply_scoped_sample_report(records, sessions, now, |_| true)
+}
+
+/// [`apply_sample_report`] scoped to one source's keyspace. The upsert of
+/// sampled sessions is unchanged (it only ever touches sessions this source
+/// reported), but the absence-close — which credits and closes an open
+/// foreground interval for a record that has *disappeared* from the live set —
+/// only fires for records this source `owns`.
+///
+/// This is what keeps multi-host sampling independent: when the tmux source
+/// fails (or is simply skipped) its sessions are absent from this poll, but a
+/// herdr apply must not read that absence as "the tmux sessions detached" and
+/// close their intervals — those records belong to the tmux keyspace, so the
+/// herdr `owns` predicate returns false for them and they're left untouched.
+/// With `owns = |_| true` this is byte-identical to the pre-partition
+/// whole-ledger behavior, so single-source callers are unaffected.
+fn apply_scoped_sample_report<S: BuildHasher>(
+    records: &mut HashMap<String, SessionActivity, S>,
+    sessions: &[SessionInfo],
+    now: OffsetDateTime,
+    owns: impl Fn(&str) -> bool,
+) -> ApplySampleReport {
     let mut changed = false;
     let mut intervals = Vec::new();
     let live_ids: HashSet<&str> = sessions.iter().map(|s| s.session_id.as_str()).collect();
@@ -218,6 +242,12 @@ pub fn apply_sample_report<S: BuildHasher>(
         if live_ids.contains(record.session_id.as_str()) {
             continue;
         }
+        // Only close intervals for records in this source's keyspace — a record
+        // absent because a *different* source produced this sample is not
+        // evidence that it detached.
+        if !owns(record.session_id.as_str()) {
+            continue;
+        }
         if let Some(since) = record.attached_since {
             intervals.push(SessionForegroundEntry::new(
                 record.session_id.clone(),
@@ -259,6 +289,30 @@ pub enum SessionActivitySource {
     Herdr {
         socket_path: PathBuf,
     },
+}
+
+impl SessionActivitySource {
+    /// Does `session_id` belong to this source's keyspace? Used to partition the
+    /// absence-close (see [`apply_scoped_sample_report`]) so one source's
+    /// failure or absence can't close another host's open foreground intervals.
+    ///
+    /// The keyspaces are disjoint by construction: tmux session ids are always
+    /// `$N`, herdr workspace ids are anything else. zellij degrades to the tmux
+    /// source with an empty sample, so it never mints ids of its own here.
+    fn owns(&self, session_id: &str) -> bool {
+        match self {
+            SessionActivitySource::Tmux => session_id.starts_with('$'),
+            SessionActivitySource::Herdr { .. } => !session_id.starts_with('$'),
+        }
+    }
+
+    /// Whether this source is the (only) producer of per-client input readings.
+    /// Reading detection prunes its `seen` set to the live clients, so it must
+    /// run only when the tmux source actually sampled — a failed tmux poll must
+    /// leave that state untouched, exactly as the single-source path did.
+    fn produces_client_inputs(&self) -> bool {
+        matches!(self, SessionActivitySource::Tmux)
+    }
 }
 
 pub struct SessionActivityTracker {
@@ -315,18 +369,17 @@ impl SessionActivityTracker {
 
     /// Take one foreground sample from every configured source, off the async
     /// runtime (both the tmux shell-out and the herdr socket round-trip block),
-    /// and merge them into a single [`ActivitySample`]. Sources sample
-    /// concurrently. All sources produce the same shape, and their session ids
-    /// don't collide across hosts, so the caller's accounting stays
-    /// source-agnostic over the merged result.
+    /// concurrently. Returns one result per source, positionally aligned with
+    /// `self.sources`, so the caller can apply each *independently*.
     ///
-    /// If ANY source errors (only the tmux sampler can — the herdr sampler is
-    /// infallible, yielding an empty sample when no workspace is focused) the
-    /// whole poll is skipped rather than sampling a partial live set: passing a
-    /// host's sessions to `apply_sample_report` without the other host's would
-    /// wrongly close the missing host's foreground intervals. This matches the
-    /// single-host contract, where a failed sample skips the poll entirely.
-    async fn sample(&self) -> Result<ActivitySample, String> {
+    /// Failures are per-source, not per-poll: only the tmux sampler can error
+    /// (the herdr sampler is infallible, yielding an empty sample when no
+    /// workspace is focused). A failed source contributes nothing and — because
+    /// [`Self::poll_once`] applies each surviving source scoped to its own
+    /// keyspace — leaves the other hosts' intervals open. A herdr-only machine
+    /// with no `tmux` binary therefore keeps accruing herdr foreground time even
+    /// though its tmux sampler errors every poll.
+    async fn sample(&self) -> Vec<Result<ActivitySample, String>> {
         let handles: Vec<tokio::task::JoinHandle<Result<ActivitySample, String>>> = self
             .sources
             .iter()
@@ -339,16 +392,14 @@ impl SessionActivityTracker {
             })
             .collect();
 
-        let mut merged = ActivitySample {
-            sessions: Vec::new(),
-            client_inputs: Vec::new(),
-        };
+        let mut results = Vec::with_capacity(handles.len());
         for handle in handles {
-            let sample = handle.await.map_err(|e| format!("join error: {e}"))??;
-            merged.sessions.extend(sample.sessions);
-            merged.client_inputs.extend(sample.client_inputs);
+            results.push(match handle.await {
+                Ok(sample) => sample,
+                Err(e) => Err(format!("join error: {e}")),
+            });
         }
-        Ok(merged)
+        results
     }
 
     pub async fn run(self, mut shutdown: broadcast::Receiver<()>) {
@@ -390,36 +441,59 @@ impl SessionActivityTracker {
         records: &mut HashMap<String, SessionActivity>,
         seen_clients: &mut HashMap<String, (i64, i64)>,
     ) {
-        let sample = self.sample().await;
-        let sample = match sample {
-            Ok(sample) => sample,
-            Err(e) => {
-                debug!(error = %e, "session activity poll skipped");
-                return;
-            }
-        };
-
+        let results = self.sample().await;
         let now = OffsetDateTime::now_utc();
-        let report = apply_sample_report(records, &sample.sessions, now);
-        for interval in report.intervals {
-            if let Some(activity_log) = &self.activity_log {
-                activity_log.append(ActivityEntry::SessionForeground(interval));
+
+        // Apply each source independently, scoped to its own keyspace. A failed
+        // source contributes nothing this poll and — because the absence-close is
+        // scoped by `owns` — does not close any other host's open intervals; only
+        // its own keyspace is left untouched. Single-source behavior is
+        // unchanged: the one source's `owns` covers the whole ledger, and a
+        // failure means no source applies (a full no-op poll, exactly as before).
+        let mut changed = false;
+        let mut client_inputs: Vec<ClientInput> = Vec::new();
+        // Reading detection prunes `seen_clients` to the live client set, so it
+        // must only run when the input-producing source (tmux) actually sampled.
+        // A failed tmux poll leaves that state untouched.
+        let mut run_input_detection = false;
+        for (source, result) in self.sources.iter().zip(results) {
+            let sample = match result {
+                Ok(sample) => sample,
+                Err(e) => {
+                    debug!(error = %e, "session activity source sample failed; its keyspace left untouched");
+                    continue;
+                }
+            };
+            let report =
+                apply_scoped_sample_report(records, &sample.sessions, now, |id| source.owns(id));
+            for interval in report.intervals {
+                if let Some(activity_log) = &self.activity_log {
+                    activity_log.append(ActivityEntry::SessionForeground(interval));
+                }
+            }
+            changed |= report.changed;
+            if source.produces_client_inputs() {
+                run_input_detection = true;
+                client_inputs.extend(sample.client_inputs);
             }
         }
 
         // Reading detection: a TmuxInput tick per session whose *already-seen*
         // client advanced its `client_activity` (a keypress or scroll). A fresh
         // client (reattach / extra client) is unseen and only seeds, so an idle
-        // attach never fabricates input.
-        for entry in detect_input_ticks(seen_clients, &sample.client_inputs) {
-            if let Some(activity_log) = &self.activity_log {
-                activity_log.append(ActivityEntry::HumanInteraction(entry));
+        // attach never fabricates input. Skipped entirely when the tmux source
+        // didn't sample, so `seen_clients` isn't pruned on a failed tmux poll.
+        if run_input_detection {
+            for entry in detect_input_ticks(seen_clients, &client_inputs) {
+                if let Some(activity_log) = &self.activity_log {
+                    activity_log.append(ActivityEntry::HumanInteraction(entry));
+                }
             }
         }
 
         // `seen_clients` is in-memory only, so input detection never forces a
         // disk write; persist only when the session foreground state changed.
-        if report.changed {
+        if changed {
             let mut sessions = records.values().cloned().collect::<Vec<_>>();
             sessions.sort_by(|a, b| {
                 a.name
@@ -729,6 +803,58 @@ mod tests {
         assert_eq!(record.attached_since, None);
         assert_eq!(record.total_attached_secs, 20);
         assert_eq!(record.attached_clients, 0);
+    }
+
+    /// Fix 6: sources apply independently, each scoped to its own keyspace, so a
+    /// failed source can't close another host's open intervals. Here the tmux
+    /// sampler "fails" (contributes nothing this poll) while the herdr sample is
+    /// applied scoped to the herdr keyspace: the tmux `$1` foreground interval
+    /// stays OPEN (not closed by tmux's absence) and herdr keeps accruing. The
+    /// herdr-scoped apply still closes its OWN interval when the workspace
+    /// detaches — the scope includes its keyspace, just not the tmux one.
+    #[test]
+    fn scoped_apply_leaves_foreign_keyspace_untouched() {
+        let tmux_owns = |id: &str| id.starts_with('$');
+        let herdr_owns = |id: &str| !id.starts_with('$');
+
+        let mut records = HashMap::new();
+        let t0 = datetime!(2026-05-29 00:00:00 UTC);
+        let t1 = datetime!(2026-05-29 00:00:10 UTC);
+        let t2 = datetime!(2026-05-29 00:00:25 UTC);
+
+        // Healthy poll: both sources attached, each applied scoped.
+        apply_scoped_sample_report(&mut records, &[session("$1", "main", 1)], t0, tmux_owns);
+        apply_scoped_sample_report(&mut records, &[session("w1", "work", 1)], t0, herdr_owns);
+        assert!(records.get("$1").unwrap().is_attached());
+        assert!(records.get("w1").unwrap().is_attached());
+
+        // Next poll: the tmux sampler errored, so only the herdr sample is
+        // applied (scoped to herdr). tmux `$1` is absent from it but must NOT be
+        // closed — it belongs to the untouched tmux keyspace.
+        let report =
+            apply_scoped_sample_report(&mut records, &[session("w1", "work", 1)], t1, herdr_owns);
+        assert!(
+            report.intervals.is_empty(),
+            "a herdr-only apply must not close the tmux interval",
+        );
+        assert!(
+            records.get("$1").unwrap().is_attached(),
+            "tmux interval stays open across a failed tmux poll",
+        );
+        assert_eq!(records.get("$1").unwrap().effective_total_secs(t1), 10);
+        assert!(records.get("w1").unwrap().is_attached());
+
+        // The herdr workspace itself detaches: the herdr-scoped apply DOES close
+        // its own interval (its keyspace is in scope), while tmux is still left
+        // untouched.
+        let report = apply_scoped_sample_report(&mut records, &[], t2, herdr_owns);
+        assert_eq!(report.intervals.len(), 1);
+        assert_eq!(report.intervals[0].session_id, "w1");
+        assert_eq!(records.get("w1").unwrap().attached_since, None);
+        assert!(
+            records.get("$1").unwrap().is_attached(),
+            "tmux keyspace remains untouched by the herdr detach",
+        );
     }
 
     // Fixed attach time for helpers whose tests don't vary it (same attach).

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -1469,11 +1469,18 @@ impl Store {
     /// [`Self::mark_stale_paneless_stopped`] lets a genuinely-live remote row
     /// keep itself alive by emitting activity, while a truly dead one ages out.
     ///
-    /// `observing_kinds` is the set of hosts that *do* have a live observation
-    /// this pass (today always exactly one — the daemon's single active
-    /// backend — but taking a slice lets a future multi-host daemon pass
-    /// several without changing the shape). A row is foreign, and therefore a
-    /// candidate, only when its pane id classifies to a known host
+    /// `observing_kinds` is the set of hosts whose observation was *complete*
+    /// this pass — the hosts that actually answered, not merely the ones in the
+    /// backend set. A host that answers governs its own rows via reaping, so it
+    /// must be spared here; a host that *can't* answer for longer than the
+    /// inactivity window is, for our purposes, indistinguishable from a host
+    /// outside the set — its rows are never reaped by any observation, so they
+    /// must age out here or they ghost forever. Passing the complete-this-tick
+    /// set (rather than every kind in the backend set) is what closes that gap:
+    /// a chronically-incomplete host's stale rows age out, while a transiently
+    /// incomplete tick is harmless because the threshold is the (24h-default)
+    /// paneless window on `last_activity_at`, not a single tick. A row is a
+    /// candidate only when its pane id classifies to a known host
     /// ([`crate::backend::pane_id_host_kind`]) that is *not* in this set.
     /// Same-host rows (governed by `reconcile`) and unclassifiable/paneless
     /// rows (governed by the normal reap / `mark_stale_paneless_stopped`
@@ -1544,12 +1551,35 @@ impl Store {
     /// touch `last_activity_at`, `state_entered_at`, or emit transitions,
     /// because a shell child appearing below an agent is not itself an
     /// agent lifecycle transition.
-    pub async fn update_workloads(&self, by_pane: &HashMap<String, WorkloadSummary>) -> usize {
+    ///
+    /// `complete_kinds` is the set of hosts whose pane observation was
+    /// *complete* this tick. Because the process-tree scan is store-global —
+    /// it clears the workload of any pane absent from its map — a row is only
+    /// governed (reset/updated) when its pane-id namespace classifies to a host
+    /// in that set. A row on a host observed *incompletely* (or not at all)
+    /// keeps its previous workload metadata rather than being wrongly reset to
+    /// the default from a scan that never covered its host. Rows whose pane id
+    /// doesn't classify to a known host (paneless / legacy) are governed as
+    /// before — they never carry a scan workload anyway, so the outcome matches
+    /// the pre-multi-host single-observation behavior byte-for-byte.
+    pub async fn update_workloads(
+        &self,
+        by_pane: &HashMap<String, WorkloadSummary>,
+        complete_kinds: &[HostKind],
+    ) -> usize {
         let mut agents = self.agents.write().await;
         let mut changed = 0_usize;
         for agent in agents.values_mut() {
             if agent.pid.is_some() {
                 continue;
+            }
+            // Skip rows namespaced to a host whose scan didn't run this tick.
+            if let Some(pane_id) = agent.pane.as_deref() {
+                if let Some(host) = crate::backend::pane_id_host_kind(pane_id) {
+                    if !complete_kinds.contains(&host) {
+                        continue;
+                    }
+                }
             }
             let next = agent
                 .pane
@@ -1761,8 +1791,45 @@ impl Store {
     /// every such caller today observes tmux, so it defaults to
     /// [`HostKind::Tmux`]. Tests exercising cross-host behavior call
     /// [`Self::reconcile_hosted`] directly.
+    ///
+    /// Composes the two halves the multi-host reconciler now runs separately —
+    /// the paneless-codex correlation ([`Self::correlate_paneless_codex_union`])
+    /// then the tmux reap/dedup pass — so a single-host caller (and every store
+    /// test) sees the exact same adopt-then-demote-in-one-pass behavior as
+    /// before the correlation was lifted out of [`Self::reconcile_hosted`].
     pub async fn reconcile(&self, live_panes: &[PaneInfo]) -> ReconcileReport {
-        self.reconcile_hosted(live_panes, HostKind::Tmux).await
+        let paneless_correlated = self.correlate_paneless_codex_union(live_panes).await;
+        let mut report = self.reconcile_hosted(live_panes, HostKind::Tmux).await;
+        report.paneless_correlated = paneless_correlated;
+        report
+    }
+
+    /// Adopt paneless codex hook rows onto the tmux/herdr pane they actually
+    /// run in, by working-directory match, across the **union** of live panes
+    /// from every complete observation this tick. Returns the number adopted.
+    ///
+    /// This is the multi-host-safe home of [`Self::correlate_paneless_codex`]:
+    /// a `code_mode_host` codex fires its hooks from a shared, detached
+    /// `app-server` (no `TMUX_PANE`), so its real row lands paneless while
+    /// discovery plants a synthetic placeholder on its pane. Correlating over
+    /// the union — rather than per host inside [`Self::reconcile_hosted`] — lets
+    /// the many-to-one cwd ambiguity guard see candidate panes on *both* hosts,
+    /// so it won't mis-adopt a row whose codex lives in a herdr pane sharing a
+    /// cwd with a tmux pane. The reconciler calls this before its per-host
+    /// reap/dedup passes so those passes still demote the redundant synthetic
+    /// in the same tick.
+    pub async fn correlate_paneless_codex_union(&self, live_panes: &[PaneInfo]) -> usize {
+        let mut agents = self.agents.write().await;
+        let mut panes_by_id: HashMap<&str, Vec<&PaneInfo>> = HashMap::new();
+        for p in live_panes {
+            panes_by_id.entry(p.pane_id.as_str()).or_default().push(p);
+        }
+        let adopted = Self::correlate_paneless_codex(&mut agents, &panes_by_id);
+        if adopted > 0 {
+            drop(agents);
+            self.dirty.notify_one();
+        }
+        adopted
     }
 
     /// Converge against a complete pane set observed by `observing_kind`.
@@ -1811,12 +1878,18 @@ impl Store {
         });
         report.stale_panes_reaped = before - agents.len();
 
-        // Adopt panes onto paneless codex hook rows via cwd match BEFORE the
-        // dedup pass, so a newly-correlated real row and the pane's synthetic
-        // placeholder land on the same (pane, socket) key and the synthetic
-        // gets demoted in the same reconcile.
-        report.paneless_correlated = Self::correlate_paneless_codex(&mut agents, &panes_by_id);
-
+        // NOTE: paneless-codex correlation is NOT done here. In a multi-host
+        // daemon each backend's observation reconciles separately, and a
+        // per-host correlation would only see one host's panes — its
+        // many-to-one cwd ambiguity guard couldn't tell that a cwd is also
+        // claimed by a pane on the *other* host, so the tmux pass could adopt a
+        // row whose codex actually lives in a herdr pane at the same cwd. The
+        // correlation runs ONCE per tick over the union of complete
+        // observations via [`Self::correlate_paneless_codex_union`], which the
+        // reconciler invokes *before* the per-host passes so this reconcile's
+        // dedup still demotes the now-redundant synthetic in the same tick.
+        // The single-host [`Self::reconcile`] entry point composes the two so
+        // its behavior is unchanged.
         Self::backfill_tmux_names(&mut agents, &panes_by_id);
 
         // Sweeps 2 & 3: per-pane dedup. Group surviving agents by pane id
@@ -2350,15 +2423,80 @@ mod tests {
             },
         );
 
-        assert_eq!(store.update_workloads(&by_pane).await, 1);
+        assert_eq!(store.update_workloads(&by_pane, &[HostKind::Tmux]).await, 1);
         let snap = store.snapshot().await;
         assert_eq!(snap[0].workload.shell_count, 1);
         assert_eq!(snap[0].workload.process_count, 2);
         assert_eq!(snap[0].last_activity_at, at);
 
-        assert_eq!(store.update_workloads(&by_pane).await, 0);
-        assert_eq!(store.update_workloads(&HashMap::new()).await, 1);
+        assert_eq!(store.update_workloads(&by_pane, &[HostKind::Tmux]).await, 0);
+        assert_eq!(
+            store
+                .update_workloads(&HashMap::new(), &[HostKind::Tmux])
+                .await,
+            1
+        );
         assert!(store.snapshot().await[0].workload.is_empty());
+    }
+
+    /// Fix 3: when only some hosts are observed complete this tick, the
+    /// workload update must govern only the complete hosts' rows. A tmux row
+    /// (complete) updates from the scan; a herdr row (incomplete this tick, so
+    /// `Herdr` absent from `complete_kinds`) keeps its previous workload
+    /// instead of being reset to the default by a scan that never covered herdr.
+    #[tokio::test]
+    async fn update_workloads_governs_only_complete_hosts() {
+        let store = Store::shared();
+        let at = datetime!(2026-05-10 12:00:00 UTC);
+        let started = |sid: &str, pane: &str| AgentEvent::Started {
+            id: AgentId {
+                tmux_socket: None,
+                kind: AgentKind::ClaudeCode,
+                session_id: sid.into(),
+                surface: None,
+                pane: Some(pane.into()),
+                cwd: None,
+            },
+            at,
+        };
+        store.apply(&started("tmux-row", "%1")).await;
+        store.apply(&started("herdr-row", "herdr:p1")).await;
+
+        let wl = |n: u16| WorkloadSummary {
+            primary_pid: Some(20),
+            process_count: n,
+            shell_count: 1,
+            subagent_count: 0,
+            helper_count: 0,
+            preview: Vec::new(),
+        };
+
+        // Seed both rows with a non-default workload (as a prior complete tick
+        // would have), so a wrongful reset is observable.
+        let mut seed = HashMap::new();
+        seed.insert("%1".to_string(), wl(2));
+        seed.insert("herdr:p1".to_string(), wl(3));
+        assert_eq!(
+            store
+                .update_workloads(&seed, &[HostKind::Tmux, HostKind::Herdr])
+                .await,
+            2
+        );
+
+        // Now only tmux is complete; the scan map covers only tmux panes.
+        let mut tmux_scan = HashMap::new();
+        tmux_scan.insert("%1".to_string(), wl(5));
+        let changed = store.update_workloads(&tmux_scan, &[HostKind::Tmux]).await;
+
+        assert_eq!(changed, 1, "only the tmux row's workload changes");
+        let snap = store.snapshot().await;
+        let tmux = snap.iter().find(|a| a.session_id == "tmux-row").unwrap();
+        let herdr = snap.iter().find(|a| a.session_id == "herdr-row").unwrap();
+        assert_eq!(tmux.workload.process_count, 5, "tmux row updated");
+        assert_eq!(
+            herdr.workload.process_count, 3,
+            "herdr row (incomplete this tick) keeps its previous workload",
+        );
     }
 
     #[tokio::test]

--- a/crates/muxad/src/herdr_bridge.rs
+++ b/crates/muxad/src/herdr_bridge.rs
@@ -657,15 +657,16 @@ async fn run(store: SharedStore, socket_path: PathBuf, shutdown_tx: broadcast::S
     }
 }
 
-/// Spawn the herdr bridge task, but only when the active backend is herdr.
-/// Returns the join handle so the daemon can drain it on shutdown; `None` on
-/// every other host.
+/// Spawn the herdr bridge task, but only when herdr is in the observed backend
+/// set (a multi-host daemon observes tmux + herdr at once during a migration).
+/// Returns the join handle so the daemon can drain it on shutdown; `None` when
+/// herdr isn't observed.
 pub fn spawn_herdr_bridge_task(
-    backend: &SharedBackend,
+    backends: &[SharedBackend],
     store: SharedStore,
     shutdown_tx: &broadcast::Sender<()>,
 ) -> Option<tokio::task::JoinHandle<()>> {
-    if backend.kind() != HostKind::Herdr {
+    if !backends.iter().any(|b| b.kind() == HostKind::Herdr) {
         return None;
     }
     let socket_path = default_socket_path();
@@ -993,15 +994,15 @@ async fn run_report(store: SharedStore, socket_path: PathBuf, shutdown_tx: broad
     }
 }
 
-/// Spawn the herdr reverse-path (report) task, but only when the active backend
-/// is herdr. Returns the join handle so the daemon can drain it on shutdown;
-/// `None` on every other host.
+/// Spawn the herdr reverse-path (report) task, but only when herdr is in the
+/// observed backend set. Returns the join handle so the daemon can drain it on
+/// shutdown; `None` when herdr isn't observed.
 pub fn spawn_herdr_report_task(
-    backend: &SharedBackend,
+    backends: &[SharedBackend],
     store: SharedStore,
     shutdown_tx: &broadcast::Sender<()>,
 ) -> Option<tokio::task::JoinHandle<()>> {
-    if backend.kind() != HostKind::Herdr {
+    if !backends.iter().any(|b| b.kind() == HostKind::Herdr) {
         return None;
     }
     let socket_path = default_socket_path();
@@ -1647,5 +1648,46 @@ mod tests {
             },
         );
         assert!(set.is_empty(), "release forgets the pane");
+    }
+
+    // --- Spawn conditions over a backend set --------------------------------
+
+    fn tmux_backend() -> SharedBackend {
+        std::sync::Arc::new(muxa::backend::tmux::TmuxBackend::new())
+    }
+
+    fn herdr_backend() -> SharedBackend {
+        std::sync::Arc::new(muxa::backend::herdr::HerdrBackend::new())
+    }
+
+    /// Neither herdr task spawns when herdr is absent from the observed set.
+    #[tokio::test]
+    async fn herdr_tasks_skip_when_herdr_not_in_set() {
+        let store = Store::shared();
+        let (tx, _) = broadcast::channel::<()>(1);
+        let backends = vec![tmux_backend()];
+        assert!(spawn_herdr_bridge_task(&backends, store.clone(), &tx).is_none());
+        assert!(spawn_herdr_report_task(&backends, store, &tx).is_none());
+    }
+
+    /// Both herdr tasks spawn when herdr is present in a multi-host set
+    /// (tmux + herdr during a migration), not only when it's the sole backend.
+    #[tokio::test]
+    async fn herdr_tasks_spawn_when_herdr_in_multi_host_set() {
+        let store = Store::shared();
+        let (tx, _) = broadcast::channel::<()>(1);
+        let backends = vec![tmux_backend(), herdr_backend()];
+        let bridge = spawn_herdr_bridge_task(&backends, store.clone(), &tx);
+        let report = spawn_herdr_report_task(&backends, store, &tx);
+        assert!(bridge.is_some(), "bridge spawns when herdr ∈ set");
+        assert!(report.is_some(), "report spawns when herdr ∈ set");
+        // Drain the spawned tasks so they don't linger past the test runtime.
+        let _ = tx.send(());
+        if let Some(h) = bridge {
+            let _ = tokio::time::timeout(Duration::from_secs(1), h).await;
+        }
+        if let Some(h) = report {
+            let _ = tokio::time::timeout(Duration::from_secs(1), h).await;
+        }
     }
 }

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -142,17 +142,23 @@ async fn main() -> Result<()> {
         build_history(&cfg, &writer_shutdown_tx, pane_session_cache.clone()).await;
     let store = Store::shared_with_history(history.clone());
 
-    // One backend, shared across every consumer that previously spoke
-    // to tmux directly. Resolution honors `MUXA_HOST` then auto-detects
-    // from `ZELLIJ` / `TMUX`, falling back to `TmuxBackend` when no host
-    // is detectable. Cheap to clone — the underlying `Arc` lets the
-    // reconciler, discovery, enrichment, and snapshotter each hold a
-    // handle without contention.
-    let backend: muxa::SharedBackend = muxa::default_backend();
+    // The set of backends this daemon observes simultaneously — tmux + herdr
+    // during a migration (see `docs/MULTI_HOST.md`). Resolution honors
+    // `MUXA_HOSTS` > `MUXA_HOST` > auto-detect and is never empty. Each element
+    // is a cheap-to-clone `Arc`, so enumeration-shaped consumers (reconciler,
+    // discovery, pane-session cache, history enrichment) iterate the whole set,
+    // while the few consumers that genuinely need a single handle take the
+    // `primary` (first) backend — or, for a host-specific consumer, the
+    // matching backend from the set.
+    let backends: Vec<muxa::SharedBackend> = muxa::active_backends();
+    // Never empty (see `active_backends`); `primary` is the conventional
+    // single-backend handle for consumers a namespace can't disambiguate.
+    let primary: muxa::SharedBackend = backends[0].clone();
     let sessions = muxa::PtySessionBackend::shared();
-    tracing::info!(host = %backend.kind(), "pane backend selected");
-    refresh_pane_session_cache(&pane_session_cache, backend.clone()).await;
-    spawn_pane_session_cache_task(pane_session_cache.clone(), backend.clone(), &shutdown_tx);
+    let observing_kinds: Vec<muxa::HostKind> = backends.iter().map(|b| b.kind()).collect();
+    tracing::info!(hosts = ?observing_kinds, "pane backends selected");
+    refresh_pane_session_cache(&pane_session_cache, &backends).await;
+    spawn_pane_session_cache_task(pane_session_cache.clone(), backends.clone(), &shutdown_tx);
 
     // Rehydrate the agent registry from the previous run's snapshot, if
     // any. Done before the IPC server starts accepting events so no
@@ -173,7 +179,7 @@ async fn main() -> Result<()> {
     // real `session_id` + `last_prompt` from prompts.ndjson, so the
     // operator sees rich rows for those panes immediately on restart
     // instead of `synthetic-%X` placeholders.
-    enrich_from_history(&store, &history, &backend).await;
+    enrich_from_history(&store, &history, &backends).await;
 
     let (activity_log, activity_writer_handle) =
         build_activity_log(&cfg, &writer_shutdown_tx).await;
@@ -185,21 +191,22 @@ async fn main() -> Result<()> {
     )
     .await;
     let gc_handle = spawn_gc_task(&store, &shutdown_tx);
-    let reconciler_handle = spawn_reconciler_task(&cfg, &store, &shutdown_tx, backend.clone());
-    // herdr event bridge (Phase 2): only on herdr hosts. Translates herdr's
-    // own agent-state detection into synthetic muxa rows so agents muxa has no
-    // hooks for still appear in status/watch/stats. Spawned before the IPC
-    // server takes ownership of `store` so it shares the same registry.
+    let reconciler_handle = spawn_reconciler_task(&cfg, &store, &shutdown_tx, backends.clone());
+    // herdr event bridge (Phase 2): spawned when herdr ∈ the observed set.
+    // Translates herdr's own agent-state detection into synthetic muxa rows so
+    // agents muxa has no hooks for still appear in status/watch/stats. Spawned
+    // before the IPC server takes ownership of `store` so it shares the same
+    // registry.
     let herdr_bridge_handle =
-        herdr_bridge::spawn_herdr_bridge_task(&backend, store.clone(), &shutdown_tx);
+        herdr_bridge::spawn_herdr_bridge_task(&backends, store.clone(), &shutdown_tx);
     // herdr reverse path: push muxa's authoritative hook-derived state for REAL
     // (non-synthetic) `herdr:` rows back into herdr's UI via `pane.report_agent`,
     // releasing authority when the row stops. Subscribes to the same store
-    // transition stream the notifier/activity tasks use. Herdr-host only.
+    // transition stream the notifier/activity tasks use. Spawned when herdr ∈ set.
     let herdr_report_handle =
-        herdr_bridge::spawn_herdr_report_task(&backend, store.clone(), &shutdown_tx);
+        herdr_bridge::spawn_herdr_report_task(&backends, store.clone(), &shutdown_tx);
     let session_activity_handle =
-        spawn_session_activity_task(&cfg, &shutdown_tx, activity_log.clone(), &backend);
+        spawn_session_activity_task(&cfg, &shutdown_tx, activity_log.clone(), &backends);
     let history_compaction_handle = spawn_history_compaction_task(&cfg, &store, &shutdown_tx);
     let activity_compaction_handle =
         spawn_activity_compaction_task(&cfg, activity_log.clone(), &shutdown_tx);
@@ -254,7 +261,13 @@ async fn main() -> Result<()> {
             })
             .flatten();
         let sessions_for_dash = sessions.clone();
-        let backend_for_dash = backend.clone();
+        // The web dashboard's pane scanner stays single-backend (the `primary`)
+        // this pass — merging it with the backend set is an explicit non-goal in
+        // `docs/MULTI_HOST.md` (the scanner is dashboard-only plumbing, tracked
+        // as a follow-up). On a single-host daemon `primary` is that host, so
+        // behavior is unchanged; on a multi-host daemon the dashboard shows the
+        // primary host only until that follow-up lands.
+        let backend_for_dash = primary.clone();
         let dashboard_runtime = muxa::dashboard::DashboardRuntimeConfig {
             activity_path: dashboard_activity_path,
             session_activity_path: dashboard_session_activity_path,
@@ -281,8 +294,20 @@ async fn main() -> Result<()> {
     spawn_oh_my_prompt_sink(&cfg, &store, &shutdown_tx)?;
     spawn_webhook_sink(&cfg, &store, &shutdown_tx)?;
 
+    // The IPC server's backend is consumed for exactly one thing: routing an
+    // inbound `BackendPaneSnapshot` push into `PaneBackend::ingest_pane_snapshot`
+    // — a no-op on every backend except zellij (whose WASM plugin is the only
+    // external snapshot source). Route those pushes to the zellij backend in the
+    // set so they land in the same instance discovery/reconciler read from;
+    // fall back to `primary` when zellij isn't observed (the ingest is then an
+    // inert no-op anyway).
+    let ipc_backend = backends
+        .iter()
+        .find(|b| b.kind() == muxa::HostKind::Zellij)
+        .cloned()
+        .unwrap_or_else(|| primary.clone());
     let server = Server::new(socket.clone(), store)
-        .with_backend(backend.clone())
+        .with_backend(ipc_backend)
         .with_sessions(sessions);
     let handle = tokio::spawn(server.run(shutdown_tx.subscribe()));
 
@@ -309,8 +334,8 @@ async fn main() -> Result<()> {
     // `muxa init` after every daemon or tmux server restart.
     if listener_ready {
         maybe_heal_tmux_socket_env(&socket, cfg.socket.as_deref());
-        spawn_startup_discovery(&cfg, socket.clone(), backend.clone(), &shutdown_tx);
-        spawn_periodic_discovery(&cfg, socket.clone(), backend.clone(), &shutdown_tx);
+        spawn_startup_discovery(&cfg, socket.clone(), backends.clone(), &shutdown_tx);
+        spawn_periodic_discovery(&cfg, socket.clone(), backends.clone(), &shutdown_tx);
     }
 
     // Shutdown sequence (each step depends on the previous):
@@ -535,16 +560,29 @@ async fn build_activity_log(
     }
 }
 
-async fn refresh_pane_session_cache(cache: &PaneSessionCache, backend: muxa::SharedBackend) {
-    let panes = tokio::task::spawn_blocking(move || backend.list_panes())
-        .await
-        .unwrap_or_default();
-    cache.replace(panes.into_iter().map(|pane| (pane.pane_id, pane.session)));
+/// Refresh the pane→session cache from the UNION of every observed backend's
+/// pane list. Pane-id namespaces are disjoint across hosts (`%N` vs `herdr:…`
+/// vs `zellij:…`), so concatenating the per-backend lists into one map can't
+/// collide. Backends are enumerated concurrently off the runtime.
+async fn refresh_pane_session_cache(cache: &PaneSessionCache, backends: &[muxa::SharedBackend]) {
+    let handles: Vec<_> = backends
+        .iter()
+        .map(|backend| {
+            let backend = backend.clone();
+            tokio::task::spawn_blocking(move || backend.list_panes())
+        })
+        .collect();
+    let mut entries = Vec::new();
+    for handle in handles {
+        let panes = handle.await.unwrap_or_default();
+        entries.extend(panes.into_iter().map(|pane| (pane.pane_id, pane.session)));
+    }
+    cache.replace(entries);
 }
 
 fn spawn_pane_session_cache_task(
     cache: PaneSessionCache,
-    backend: muxa::SharedBackend,
+    backends: Vec<muxa::SharedBackend>,
     shutdown_tx: &broadcast::Sender<()>,
 ) {
     let mut shutdown_rx = shutdown_tx.subscribe();
@@ -557,7 +595,7 @@ fn spawn_pane_session_cache_task(
         loop {
             tokio::select! {
                 _ = tick.tick() => {
-                    refresh_pane_session_cache(&cache, backend.clone()).await;
+                    refresh_pane_session_cache(&cache, &backends).await;
                 }
                 _ = shutdown_rx.recv() => {
                     tracing::debug!("pane session cache task shutting down");
@@ -752,17 +790,19 @@ fn spawn_reconciler_task(
     cfg: &Config,
     store: &muxa::SharedStore,
     shutdown_tx: &broadcast::Sender<()>,
-    backend: muxa::SharedBackend,
+    backends: Vec<muxa::SharedBackend>,
 ) -> Option<tokio::task::JoinHandle<()>> {
     if !cfg.reconciler.enabled {
         tracing::info!("reconciler disabled by config");
         return None;
     }
-    // The shared backend is what the rest of the daemon uses too —
-    // everyone agreeing on one host means the reconciler reaps panes
-    // by the same definition the watch loop, hook ancestry, and
-    // discovery do. `LivenessSource` reaches the reconciler via the
-    // blanket impl on `PaneBackend`.
+    // One reconciler over the whole observed set: each tick observes every
+    // backend concurrently and reconciles each observation under its own host
+    // kind, so a herdr timeout can't reap tmux rows (completeness is gated
+    // per host). The ghost age-out sweep receives all these kinds, so a row on
+    // a host NOT in the set ages out while rows on observed hosts stay governed
+    // by their own reconcile pass. `LivenessSource` reaches the reconciler via
+    // the blanket impl on `PaneBackend`.
     // Codex has no rate-limit hook; the reconciler learns codex usage caps
     // by polling the on-disk session rollouts. Resolve the tree once here so
     // the per-tick poll just reads files.
@@ -771,9 +811,9 @@ fn spawn_reconciler_task(
     } else {
         None
     };
-    let runner = Reconciler::new(
+    let runner = Reconciler::with_sources(
         store.clone(),
-        backend,
+        backends,
         std::time::Duration::from_secs(cfg.reconciler.interval_secs),
     )
     .with_metrics(store.metrics())
@@ -808,7 +848,7 @@ fn spawn_session_activity_task(
     cfg: &Config,
     shutdown_tx: &broadcast::Sender<()>,
     activity_log: Option<std::sync::Arc<ActivityLog>>,
-    backend: &muxa::SharedBackend,
+    backends: &[muxa::SharedBackend],
 ) -> Option<tokio::task::JoinHandle<()>> {
     if !cfg.session_activity.enabled {
         tracing::info!("session activity tracking disabled by config");
@@ -823,27 +863,41 @@ fn spawn_session_activity_task(
         tracing::warn!("session activity tracking enabled but no path resolvable");
         return None;
     };
-    // On herdr, foreground time is credited to the focused workspace over the
-    // herdr socket (resolved the same way the query backend and event bridge
-    // do). Every other host uses the tmux sampler.
-    let source = match backend.kind() {
-        muxa::HostKind::Herdr => muxa::SessionActivitySource::Herdr {
-            socket_path: muxa::backend::herdr::default_socket_path(),
-        },
-        _ => muxa::SessionActivitySource::Tmux,
-    };
+    // One sampling source per host in the set that HAS a foreground signal:
+    // tmux (`list-clients`) and herdr (focused workspace over its socket).
+    // zellij has no client-attach signal, so it contributes no source. A single
+    // tracker polls them all into one ledger — two independent trackers writing
+    // `session-activity.json` would clobber each other (each `save()` rewrites
+    // the whole file); merging is safe because the session-id keyspaces are
+    // disjoint across hosts. Fall back to the default tmux sampler if the set
+    // somehow yields no source (e.g. zellij-only), preserving prior behavior.
+    let mut sources = Vec::new();
+    for backend in backends {
+        match backend.kind() {
+            muxa::HostKind::Tmux => sources.push(muxa::SessionActivitySource::Tmux),
+            muxa::HostKind::Herdr => sources.push(muxa::SessionActivitySource::Herdr {
+                socket_path: muxa::backend::herdr::default_socket_path(),
+            }),
+            muxa::HostKind::Zellij => {}
+        }
+    }
+    let source_kinds: Vec<muxa::HostKind> = backends
+        .iter()
+        .map(|b| b.kind())
+        .filter(|k| *k != muxa::HostKind::Zellij)
+        .collect();
     let tracker = muxa::SessionActivityTracker::new(
         path.clone(),
         std::time::Duration::from_secs(cfg.session_activity.interval_secs),
     )
     .with_activity_log(activity_log)
-    .with_source(source);
+    .with_sources(sources);
     let shutdown_rx = shutdown_tx.subscribe();
     let handle = tokio::spawn(tracker.run(shutdown_rx));
     tracing::info!(
         path = %path.display(),
         interval_secs = cfg.session_activity.interval_secs,
-        host = %backend.kind(),
+        hosts = ?source_kinds,
         "session activity tracking enabled",
     );
     Some(handle)
@@ -916,20 +970,30 @@ async fn hydrate_state(cfg: &Config, store: &muxa::SharedStore) {
 async fn enrich_from_history(
     store: &muxa::SharedStore,
     history: &Arc<PromptHistory>,
-    backend: &muxa::SharedBackend,
+    backends: &[muxa::SharedBackend],
 ) {
     if history.is_empty().await {
         return;
     }
-    // Wrap the (potentially blocking) backend call so the runtime
-    // doesn't stall while tmux shells out. Cloning the `Arc` is the
-    // cheapest way to give `spawn_blocking`'s closure the `'static`
-    // handle it needs.
-    let backend_for_blocking = backend.clone();
-    let Ok(panes) = tokio::task::spawn_blocking(move || backend_for_blocking.list_panes()).await
-    else {
-        return;
-    };
+    // Wrap each (potentially blocking) backend call so the runtime doesn't
+    // stall while tmux shells out / the herdr socket round-trips; enumerate the
+    // whole set concurrently and union the results. Cloning the `Arc`s is the
+    // cheapest way to give each `spawn_blocking` closure the `'static` handle it
+    // needs. Pane namespaces are disjoint across hosts, so the union can't
+    // conflate panes from different backends.
+    let handles: Vec<_> = backends
+        .iter()
+        .map(|backend| {
+            let backend = backend.clone();
+            tokio::task::spawn_blocking(move || backend.list_panes())
+        })
+        .collect();
+    let mut panes = Vec::new();
+    for handle in handles {
+        if let Ok(list) = handle.await {
+            panes.extend(list);
+        }
+    }
     if panes.is_empty() {
         return;
     }
@@ -1190,7 +1254,7 @@ fn should_heal_tmux_socket_env(
 fn spawn_startup_discovery(
     cfg: &Config,
     socket: PathBuf,
-    backend: muxa::SharedBackend,
+    backends: Vec<muxa::SharedBackend>,
     shutdown_tx: &broadcast::Sender<()>,
 ) -> bool {
     if !cfg.discovery.enabled {
@@ -1220,22 +1284,45 @@ fn spawn_startup_discovery(
             _ = shutdown_rx.recv() => {
                 tracing::debug!("startup discovery cancelled mid-pass (shutdown)");
             }
-            result = discovery::run_discovery(&client, backend.as_ref()) => match result {
-                Ok(report) => {
-                    tracing::info!(
-                        claude_code = report.claude_code,
-                        codex = report.codex,
-                        gemini_cli = report.gemini_cli,
-                        skipped_known = report.skipped_known,
-                        failed = report.failed,
-                        "startup discovery complete",
-                    );
-                }
-                Err(e) => tracing::warn!(error = %e, "startup discovery failed"),
-            },
+            report = run_discovery_all(&client, &backends) => {
+                tracing::info!(
+                    claude_code = report.claude_code,
+                    codex = report.codex,
+                    gemini_cli = report.gemini_cli,
+                    skipped_known = report.skipped_known,
+                    failed = report.failed,
+                    "startup discovery complete",
+                );
+            }
         }
     });
     true
+}
+
+/// Run one discovery pass over every observed backend and sum the reports.
+/// Pane namespaces are disjoint per host, so each backend's scan contributes
+/// independently; a whole-pass failure for one backend is logged and the others
+/// still run (best-effort, matching the rest of the daemon's surface).
+async fn run_discovery_all(
+    client: &Client,
+    backends: &[muxa::SharedBackend],
+) -> discovery::DiscoveryReport {
+    let mut total = discovery::DiscoveryReport::default();
+    for backend in backends {
+        match discovery::run_discovery(client, backend.as_ref()).await {
+            Ok(report) => {
+                total.claude_code += report.claude_code;
+                total.codex += report.codex;
+                total.gemini_cli += report.gemini_cli;
+                total.skipped_known += report.skipped_known;
+                total.failed += report.failed;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, host = %backend.kind(), "discovery pass failed");
+            }
+        }
+    }
+    total
 }
 
 /// Spawn the periodic discovery rescan. Startup discovery covers t=0; this
@@ -1247,7 +1334,7 @@ fn spawn_startup_discovery(
 fn spawn_periodic_discovery(
     cfg: &Config,
     socket: PathBuf,
-    backend: muxa::SharedBackend,
+    backends: Vec<muxa::SharedBackend>,
     shutdown_tx: &broadcast::Sender<()>,
 ) {
     if !cfg.discovery.enabled || cfg.discovery.interval_secs == 0 {
@@ -1264,16 +1351,14 @@ fn spawn_periodic_discovery(
         loop {
             tokio::select! {
                 _ = tick.tick() => {
-                    match discovery::run_discovery(&client, backend.as_ref()).await {
-                        Ok(report) => tracing::debug!(
-                            claude_code = report.claude_code,
-                            codex = report.codex,
-                            gemini_cli = report.gemini_cli,
-                            skipped_known = report.skipped_known,
-                            "periodic discovery pass",
-                        ),
-                        Err(e) => tracing::warn!(error = %e, "periodic discovery failed"),
-                    }
+                    let report = run_discovery_all(&client, &backends).await;
+                    tracing::debug!(
+                        claude_code = report.claude_code,
+                        codex = report.codex,
+                        gemini_cli = report.gemini_cli,
+                        skipped_known = report.skipped_known,
+                        "periodic discovery pass",
+                    );
                 }
                 _ = shutdown_rx.recv() => {
                     tracing::debug!("periodic discovery shutting down");
@@ -1334,7 +1419,7 @@ mod tests {
         let spawned = spawn_startup_discovery(
             &cfg,
             PathBuf::from("/tmp/never-bound.sock"),
-            muxa::default_backend(),
+            muxa::active_backends(),
             &shutdown_tx,
         );
         assert!(spawned, "discovery should spawn when enabled");
@@ -1353,7 +1438,7 @@ mod tests {
         let spawned = spawn_startup_discovery(
             &cfg,
             PathBuf::from("/tmp/never-bound.sock"),
-            muxa::default_backend(),
+            muxa::active_backends(),
             &shutdown_tx,
         );
         assert!(!spawned, "discovery must not spawn when disabled");

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -153,6 +153,11 @@ async fn main() -> Result<()> {
     let backends: Vec<muxa::SharedBackend> = muxa::active_backends();
     // Never empty (see `active_backends`); `primary` is the conventional
     // single-backend handle for consumers a namespace can't disambiguate.
+    // `active_backends` orders the set by env preference, so `backends[0]` is
+    // the env-preferred host (e.g. herdr when running herdr-inside-herdr) — the
+    // same host the old single-backend daemon detected. Consumers that must
+    // match that legacy single-host behavior (the web dashboard scanner) take
+    // `primary`.
     let primary: muxa::SharedBackend = backends[0].clone();
     let sessions = muxa::PtySessionBackend::shared();
     let observing_kinds: Vec<muxa::HostKind> = backends.iter().map(|b| b.kind()).collect();
@@ -261,12 +266,16 @@ async fn main() -> Result<()> {
             })
             .flatten();
         let sessions_for_dash = sessions.clone();
-        // The web dashboard's pane scanner stays single-backend (the `primary`)
-        // this pass — merging it with the backend set is an explicit non-goal in
+        // The web dashboard's pane scanner stays single-backend this pass —
+        // merging it with the backend set is an explicit non-goal in
         // `docs/MULTI_HOST.md` (the scanner is dashboard-only plumbing, tracked
-        // as a follow-up). On a single-host daemon `primary` is that host, so
-        // behavior is unchanged; on a multi-host daemon the dashboard shows the
-        // primary host only until that follow-up lands.
+        // as a follow-up). It must observe the *env-preferred* host — exactly
+        // what the old single-backend daemon detected from env. `active_backends`
+        // is ordered by env preference (`backends[0]` = the env-preferred host,
+        // e.g. herdr-inside-herdr), so `primary` IS that backend and the
+        // dashboard behaves identically to the pre-multi-host daemon. On a
+        // multi-host daemon the dashboard shows the env-preferred host only
+        // until the scanner-set merge follow-up lands.
         let backend_for_dash = primary.clone();
         let dashboard_runtime = muxa::dashboard::DashboardRuntimeConfig {
             activity_path: dashboard_activity_path,
@@ -1301,24 +1310,51 @@ fn spawn_startup_discovery(
 
 /// Run one discovery pass over every observed backend and sum the reports.
 /// Pane namespaces are disjoint per host, so each backend's scan contributes
-/// independently; a whole-pass failure for one backend is logged and the others
-/// still run (best-effort, matching the rest of the daemon's surface).
+/// independently.
+///
+/// The passes fan out **concurrently** — each does its own blocking pane scan
+/// (`block_in_place` inside `run_discovery`) plus async IPC, so we drive each
+/// on its own task and join. A slow or unreachable host can't serialize behind
+/// (or block) the others, and a failed pass (discovery error *or* join error)
+/// contributes nothing while the rest still land — best-effort, matching the
+/// rest of the daemon's surface, and mirroring `watch::compute_refresh`'s
+/// concurrent inventory fan-out. `run_discovery` is async (does IPC), so we
+/// use `tokio::spawn` rather than `spawn_blocking`; both the daemon and CLI run
+/// on the multi-threaded runtime `block_in_place` requires.
 async fn run_discovery_all(
     client: &Client,
     backends: &[muxa::SharedBackend],
 ) -> discovery::DiscoveryReport {
+    let handles: Vec<_> = backends
+        .iter()
+        .map(|backend| {
+            let client = client.clone();
+            let backend = backend.clone();
+            tokio::spawn(async move {
+                let kind = backend.kind();
+                (
+                    kind,
+                    discovery::run_discovery(&client, backend.as_ref()).await,
+                )
+            })
+        })
+        .collect();
+
     let mut total = discovery::DiscoveryReport::default();
-    for backend in backends {
-        match discovery::run_discovery(client, backend.as_ref()).await {
-            Ok(report) => {
+    for handle in handles {
+        match handle.await {
+            Ok((_, Ok(report))) => {
                 total.claude_code += report.claude_code;
                 total.codex += report.codex;
                 total.gemini_cli += report.gemini_cli;
                 total.skipped_known += report.skipped_known;
                 total.failed += report.failed;
             }
+            Ok((kind, Err(e))) => {
+                tracing::warn!(error = %e, host = %kind, "discovery pass failed");
+            }
             Err(e) => {
-                tracing::warn!(error = %e, host = %backend.kind(), "discovery pass failed");
+                tracing::debug!(error = %e, "discovery task join failed");
             }
         }
     }

--- a/docs/MULTI_HOST.md
+++ b/docs/MULTI_HOST.md
@@ -1,8 +1,13 @@
-# Multi-host observation (design proposal)
+# Multi-host observation
 
-Status: **proposal — not implemented.** Prerequisite for repositioning
-`muxa watch` as the cross-multiplexer unified console (tmux + herdr +
-zellij in one view), which no single multiplexer can offer.
+Status: **daemon + CLI implemented.** `muxad` observes every backend in
+`muxa::active_backends()` simultaneously (tmux + herdr during a
+migration) — the reconciler, discovery, session-activity sampling,
+pane-session cache, history enrichment, and the herdr bridge/report
+tasks all iterate the set. The CLI reads now aggregate across the same
+set: `muxa watch` is the cross-multiplexer unified console (tmux + herdr
+in one view, with per-row host badges), which no single multiplexer can
+offer, and attach dispatches per row. See the CLI section below.
 
 ## Why
 
@@ -41,29 +46,69 @@ The herdr work landed the key enablers:
   if its socket exists, zellij per current detection. Config override:
   `MUXA_HOSTS=tmux,herdr` (env) / `hosts = ["tmux", "herdr"]` (config);
   `MUXA_HOST=<one>` keeps meaning "exactly this one" for compatibility.
-- The daemon threads the set. Single-backend consumers change shape:
-  - **Reconciler**: one pass per backend per tick (or one task per
-    backend). Each `observe_panes()` feeds
-    `reconcile_observation(obs, backend.kind())` — the existing
-    signature; completeness stays per-host so a herdr timeout can't
-    trigger tmux reaping or vice versa.
-  - **Discovery**: iterate the set, concat pane scans.
-  - **Session activity**: spawn one sampler per host that has a source
-    (tmux, herdr).
-  - **herdr bridge + report task**: spawn when herdr ∈ set (today:
-    when kind == herdr).
-- **CLI reads stay aggregated**: watch/`muxa panes` list from every
-  active backend (concat; rows already carry their namespace).
-  `current_pane`/`focus_pane` resolve per pane-id namespace.
+- The daemon threads the set. Single-backend consumers changed shape
+  (all **implemented** in `crates/muxad/src/main.rs` unless noted):
+  - **Reconciler**: one `Reconciler` over the whole set
+    (`Reconciler::with_sources`). Each tick observes every backend
+    **concurrently** (`spawn_blocking` fan-out, joined) and reconciles
+    each observation under its own `HostKind` via
+    `reconcile_observation(obs, kind)` — completeness stays per-host so
+    a herdr timeout can't trigger tmux reaping or vice versa. The
+    workload scan runs **once** over the union of complete observations
+    and is gated on *every* observation being complete (so an
+    incompletely-observed host's rows aren't reset). The cross-host
+    age-out (`mark_stale_cross_host_stopped`) receives **all** observed
+    kinds, so a row on a host in the set is governed by that host's
+    reconcile pass while a row on a host *not* in the set ages out.
+  - **Discovery**: startup + periodic passes iterate the set and concat
+    pane scans (`run_discovery` per backend, reports summed).
+  - **Session activity**: a **single** tracker samples one source per
+    host that has a foreground signal (tmux, herdr) and merges them into
+    one ledger. One tracker = one writer, so the two sources can't
+    clobber `session-activity.json` (each `save()` rewrites the whole
+    file); merging is safe because the session-id keyspaces are disjoint
+    across hosts (tmux `$N` vs herdr workspace ids).
+  - **herdr bridge + report task**: spawned when herdr ∈ set (previously:
+    when the single backend's kind == herdr).
+  - **pane-session cache / `enrich_from_history`**: enumerate the set and
+    union the per-backend `list_panes` (namespaces are disjoint, so the
+    union can't conflate panes).
+  - **IPC server backend**: consumed only for routing an inbound
+    `BackendPaneSnapshot` push into `ingest_pane_snapshot` (a no-op on
+    every backend except zellij). Routed to the zellij backend in the set
+    if present, else the primary — so pushes land in the same instance
+    discovery/reconciler read.
+- **CLI reads stay aggregated** (presentation follow-up): watch/`muxa
+  panes` list from every active backend (concat; rows already carry their
+  namespace). `current_pane`/`focus_pane` resolve per pane-id namespace.
 
-### Watch as the unified console
+### Watch as the unified console (implemented)
 
-With the set in place, watch's remaining work is presentation:
+With the set in place, the CLI reads aggregate across it:
 
-- Session view lists tmux sessions *and* herdr workspaces (both sources
-  exist today, gated to one at a time) with a host badge per row —
-  reuse the dashboard TUI's `CardHost` labels.
-- Pane view concatenates hosts; attach already dispatches per row.
+- **`compute_refresh`** fans `list_panes()` and the per-host session
+  source (`sessions_for_host`: tmux `list-sessions`, herdr
+  `workspace.list`, zellij empty) across every active backend inside
+  `spawn_blocking`, concurrently, then concats. Namespaces keep rows
+  distinct (tmux `%N` / herdr `herdr:…`), so a tmux session named `w1`
+  and a herdr workspace `w1` remain separate rows.
+- **Host badges**: when the visible row set spans more than one host
+  (`rows_multi_host`), each row's SESSION/PANE cell gets a subtle dim
+  host tag via `prepend_host_badge` (`row_host` classifies by pane-id
+  namespace; labels mirror the dashboard TUI's `CardHost`). Single-host
+  users see no change — the badge only disambiguates a mixed view.
+- **Attach dispatch**: `jump_to_pane` (shared by `watch` Enter and
+  `muxa attend`) resolves the host from `pane_id_host_kind(pane_id)`
+  *first* — a `herdr:` row focuses via a herdr backend even when the
+  process-global host is tmux — falling back to the process-global
+  backend's kind for unrecognized ids (`dispatch_kind`).
+- **Other surfaces**: `muxa panes`, `stats`, and `timeline` enumerate
+  via `all_panes()` (concat across the set); `muxa panes` prints a
+  per-host empty hint for any host in the set that contributed zero.
+  Live pane captures (`watch` preview, `dashboard`) resolve the backend
+  by pane-id namespace (`backend_for_pane`). `current_pane`/status-line
+  ("where am I") stay single-host — env-based location is inherently one
+  host.
 - Inline time data (ACT/DUR from the ledger) needs nothing new — keys
   are already host-scoped.
 

--- a/docs/MULTI_HOST.md
+++ b/docs/MULTI_HOST.md
@@ -1,0 +1,97 @@
+# Multi-host observation (design proposal)
+
+Status: **proposal — not implemented.** Prerequisite for repositioning
+`muxa watch` as the cross-multiplexer unified console (tmux + herdr +
+zellij in one view), which no single multiplexer can offer.
+
+## Why
+
+Today muxad runs exactly one `PaneBackend`, chosen from env at startup
+(`detect_host_env`). During a tmux→herdr migration — the exact situation
+muxa's herdr support targets — agents live on both hosts at once, and a
+single-backend daemon only observes one side. The other side's rows
+still ingest via hooks (env-based pane ids are host-agnostic) but get no
+liveness/discovery/foreground coverage, and `muxa watch` shows panes
+from only one host.
+
+## What already works in our favor
+
+The herdr work landed the key enablers:
+
+- **Cross-host reaping guard**: `Store::reconcile_observation(obs, kind)`
+  already scopes an observation to rows whose pane-id namespace matches
+  the observing host (`%…`/`zellij:…`/`herdr:…` via `pane_id_host_kind`).
+  Multiple observers converging the same store is safe *by construction*
+  — each governs only its own namespace.
+- **Hook ingest is host-agnostic**: `host_pane_env` resolves whichever
+  host env var is present; no daemon backend involvement.
+- **Per-host session activity**: `SessionActivitySource` already branches
+  per host; tmux clients and herdr focused-workspace sampling can run
+  side by side (ledger keys don't collide: tmux `$N` vs herdr workspace
+  ids).
+- **CLI attach dispatches per row**: `jump_to_pane` can switch on
+  `pane_id_host_kind(pane_id)` instead of the process-global backend.
+
+## Design
+
+### Backend set, not backend
+
+- `active_backends() -> Vec<SharedBackend>`: tmux if a server is
+  reachable (or unconditionally — its methods degrade to empty), herdr
+  if its socket exists, zellij per current detection. Config override:
+  `MUXA_HOSTS=tmux,herdr` (env) / `hosts = ["tmux", "herdr"]` (config);
+  `MUXA_HOST=<one>` keeps meaning "exactly this one" for compatibility.
+- The daemon threads the set. Single-backend consumers change shape:
+  - **Reconciler**: one pass per backend per tick (or one task per
+    backend). Each `observe_panes()` feeds
+    `reconcile_observation(obs, backend.kind())` — the existing
+    signature; completeness stays per-host so a herdr timeout can't
+    trigger tmux reaping or vice versa.
+  - **Discovery**: iterate the set, concat pane scans.
+  - **Session activity**: spawn one sampler per host that has a source
+    (tmux, herdr).
+  - **herdr bridge + report task**: spawn when herdr ∈ set (today:
+    when kind == herdr).
+- **CLI reads stay aggregated**: watch/`muxa panes` list from every
+  active backend (concat; rows already carry their namespace).
+  `current_pane`/`focus_pane` resolve per pane-id namespace.
+
+### Watch as the unified console
+
+With the set in place, watch's remaining work is presentation:
+
+- Session view lists tmux sessions *and* herdr workspaces (both sources
+  exist today, gated to one at a time) with a host badge per row —
+  reuse the dashboard TUI's `CardHost` labels.
+- Pane view concatenates hosts; attach already dispatches per row.
+- Inline time data (ACT/DUR from the ledger) needs nothing new — keys
+  are already host-scoped.
+
+### Non-goals (this phase)
+
+- Remote/multi-machine aggregation (a different transport problem).
+- zellij enumeration improvements (still plugin-gated).
+- Merging the web dashboard's tmux scanner with the backend set (the
+  scanner is dashboard-only plumbing; follow-up).
+
+## Risks / open questions
+
+- **Startup cost**: probing both hosts each tick is cheap (a unix
+  connect + a `tmux list-panes`), but the reconciler's spawn_blocking
+  fan-out should run backends concurrently, not serially, to keep the
+  tick budget.
+- **Row identity collisions**: none known — namespaces are disjoint by
+  the pane-id prefix design.
+- **`MUXA_TMUX_SOCKET` scoping**: stays tmux-only; herdr has no
+  multi-instance scoping (single socket per session; named sessions are
+  explicit paths). A `MUXA_HERDR_SOCKET`-style scope can follow if
+  needed.
+- **Watch session-view sorting** across heterogeneous hosts (tmux
+  attached_clients vs herdr's always-1) — pick "activity recency" as the
+  cross-host sort key.
+
+## Estimated shape
+
+Moderate: daemon startup + reconciler/discovery/session-activity
+iteration (~the size of the Phase 2 bridge), watch aggregation +
+badges (~the size of the session-view change). No store/schema changes.

--- a/docs/MULTI_HOST.md
+++ b/docs/MULTI_HOST.md
@@ -41,11 +41,17 @@ The herdr work landed the key enablers:
 
 ### Backend set, not backend
 
-- `active_backends() -> Vec<SharedBackend>`: tmux if a server is
-  reachable (or unconditionally — its methods degrade to empty), herdr
-  if its socket exists, zellij per current detection. Config override:
-  `MUXA_HOSTS=tmux,herdr` (env) / `hosts = ["tmux", "herdr"]` (config);
-  `MUXA_HOST=<one>` keeps meaning "exactly this one" for compatibility.
+- `active_backends() -> Vec<SharedBackend>`: tmux unconditionally (its
+  methods degrade to empty), herdr if its server actually **answers** on
+  the socket (a live `connect`, not a stale socket file — a crashed
+  server's leftover socket must not ghost a dead backend into the set),
+  zellij per current detection. The **env-preferred host** (whatever the
+  current shell resolves to via `detect_host_env`) leads the auto-detected
+  set, so `backends[0]` is that host — consumers treat the first backend as
+  primary (dashboard, watch initial cursor). Config override:
+  `MUXA_HOSTS=tmux,herdr` (env, verbatim order) / `hosts = ["tmux", "herdr"]`
+  (config); `MUXA_HOST=<one>` keeps meaning "exactly this one" for
+  compatibility.
 - The daemon threads the set. Single-backend consumers changed shape
   (all **implemented** in `crates/muxad/src/main.rs` unless noted):
   - **Reconciler**: one `Reconciler` over the whole set
@@ -53,13 +59,29 @@ The herdr work landed the key enablers:
     **concurrently** (`spawn_blocking` fan-out, joined) and reconciles
     each observation under its own `HostKind` via
     `reconcile_observation(obs, kind)` — completeness stays per-host so
-    a herdr timeout can't trigger tmux reaping or vice versa. The
-    workload scan runs **once** over the union of complete observations
-    and is gated on *every* observation being complete (so an
-    incompletely-observed host's rows aren't reset). The cross-host
-    age-out (`mark_stale_cross_host_stopped`) receives **all** observed
-    kinds, so a row on a host in the set is governed by that host's
-    reconcile pass while a row on a host *not* in the set ages out.
+    a herdr timeout can't trigger tmux reaping or vice versa. Everything
+    that spans hosts keys off the **complete-this-tick** kind set (the
+    hosts that actually answered), never "every observation is complete",
+    so one chronically-incomplete host can't freeze the others:
+    - The **workload scan** runs once over the union of *complete*
+      observations, and `update_workloads` governs (resets/updates) only
+      rows whose pane-id namespace belongs to a complete host — an
+      incompletely-observed host's rows keep their previous workload
+      rather than being reset to the default. When no host answers, the
+      scan+update is skipped entirely (the single-host "incomplete → skip"
+      rule).
+    - **Paneless-codex correlation** (`correlate_paneless_codex_union`)
+      runs once over the union of complete panes, *before* the per-host
+      passes, so the many-to-one cwd ambiguity guard sees candidate panes
+      on every host at once (a per-host pass could otherwise adopt a row
+      whose codex actually lives in the other host's pane at the same cwd)
+      while this tick's dedup still demotes the redundant synthetic.
+    - The cross-host age-out (`mark_stale_cross_host_stopped`) receives the
+      **complete-this-tick** kinds, so a row on a host that answered is
+      governed by that host's reconcile pass, while a row on a host *not*
+      in the set — or one that can't answer past the (24h-default)
+      inactivity window — ages out. A single incomplete tick is harmless
+      because the threshold is a last-activity window, not one tick.
   - **Discovery**: startup + periodic passes iterate the set and concat
     pane scans (`run_discovery` per backend, reports summed).
   - **Session activity**: a **single** tracker samples one source per


### PR DESCRIPTION
## Summary
- **Backend set seam**: `muxa::active_backends()` resolves the hosts to observe — `MUXA_HOSTS=tmux,herdr` explicit set > `MUXA_HOST` exact single host (unchanged meaning) > auto-detect (tmux unconditionally; herdr on pane env or a live default-session socket; zellij on pane env). Multiple observers converging one registry are safe by construction: each observation governs only its own pane-id namespace via the cross-host reaping guard from #68.
- **Daemon**: the reconciler holds a source set — every tick observes all backends concurrently and reconciles each observation under its own `HostKind` (per-host completeness; the workload scan runs once over the union and only when every observation is complete; the cross-host age-out receives all active kinds). Discovery, the pane-session cache, and history enrichment iterate the set; session activity samples tmux clients and the herdr focused workspace in one tracker (one writer, disjoint keys); the herdr bridge/report tasks spawn when herdr ∈ set.
- **CLI**: `muxa watch` is now the cross-multiplexer unified console — panes and sessions aggregate across the set (tmux sessions + herdr workspaces in one view) with a dim per-row host badge shown only in mixed views; `muxa panes`/`stats`/`timeline`/`attend` enumerate the union; attach and live captures resolve the backend from the pane-id namespace first (`herdr:` rows focus over the herdr socket even when the process-global host is tmux).
- Design doc: `docs/MULTI_HOST.md` (updated to implemented).

## Test plan
- [x] `cargo test --workspace` green (new: backend-set resolution, per-host reconcile/reap, incomplete-host isolation, merged session-activity keyspaces, spawn-condition, dispatch/badge/aggregation tests) — sole exception is the pre-existing flaky `tmux::scanner::tests::socket_is_live_distinguishes_listening_from_orphan`, which passes isolated
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean
- [x] Live multi-host smoke: one daemon with `MUXA_HOSTS=tmux,herdr` held a tmux-pane agent (`%1`) and a herdr-pane agent (`herdr:w1:p1`) in one registry; `muxa watch` showed both sessions with `tmux`/`herdr` badges, DUR/ACT populated; killing the tmux pane reaped only the tmux row while the herdr row stayed `working`; the ingest scope gate correctly rejected a hook from an out-of-scope tmux server

🤖 Generated with [Claude Code](https://claude.com/claude-code)