### PR TITLE
chore(release): prepare v0.8.21; add Homebrew tap auto-bump

### DIFF
--- a/.github/workflows/tap-bump.yml
+++ b/.github/workflows/tap-bump.yml
@@ -1,0 +1,135 @@
+name: tap-bump
+
+# Keep Open330/homebrew-tap's Formula/muxa.rb pointing at the newest
+# published release. Runs on `release: published` (NOT on tag push) so
+# the formula's download URLs are live by the time it lands — the
+# release workflow creates a *draft* whose asset URLs 404 until a
+# maintainer publishes it.
+#
+# Requires the `TAP_GITHUB_TOKEN` repo secret: a fine-grained PAT with
+# Contents read/write on Open330/homebrew-tap (the default
+# GITHUB_TOKEN cannot push to a sibling repo). When the secret is
+# absent the job exits early with a notice instead of failing, so
+# releases stay green while the tap is bumped by hand.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to sync the formula to (e.g. v0.8.21)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  bump-formula:
+    name: bump homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${{ github.event.release.tag_name }}"
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Collect release asset checksums
+        id: sums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.ref.outputs.tag }}"
+          mkdir sums && cd sums
+          gh release download "$tag" --repo "$GITHUB_REPOSITORY" --pattern '*.sha256'
+          sum_for() {
+            # Sidecar format: "<sha256>  <archive name>" (first field).
+            awk '{print $1; exit}' "muxa-${tag}-$1.sha256"
+          }
+          {
+            echo "mac_arm=$(sum_for aarch64-apple-darwin)"
+            echo "mac_x86=$(sum_for x86_64-apple-darwin)"
+            echo "linux_arm=$(sum_for aarch64-unknown-linux-gnu)"
+            echo "linux_x86=$(sum_for x86_64-unknown-linux-gnu)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Render and push formula
+        env:
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          VERSION: ${{ steps.ref.outputs.version }}
+          MAC_ARM: ${{ steps.sums.outputs.mac_arm }}
+          MAC_X86: ${{ steps.sums.outputs.mac_x86 }}
+          LINUX_ARM: ${{ steps.sums.outputs.linux_arm }}
+          LINUX_X86: ${{ steps.sums.outputs.linux_x86 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TAP_GITHUB_TOKEN}" ]; then
+            echo "::notice::TAP_GITHUB_TOKEN is not configured — skipping the tap bump. Update Open330/homebrew-tap manually or add the secret."
+            exit 0
+          fi
+          git clone --depth 1 \
+            "https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/Open330/homebrew-tap.git" tap
+          cat > tap/Formula/muxa.rb <<EOF
+          class Muxa < Formula
+            desc "Agent CLI observability and orchestration layer for terminal multiplexers"
+            homepage "https://github.com/Open330/muxa"
+            version "${VERSION}"
+            license "MIT OR Apache-2.0"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "https://github.com/Open330/muxa/releases/download/v#{version}/muxa-v#{version}-aarch64-apple-darwin.tar.gz"
+                sha256 "${MAC_ARM}"
+              else
+                url "https://github.com/Open330/muxa/releases/download/v#{version}/muxa-v#{version}-x86_64-apple-darwin.tar.gz"
+                sha256 "${MAC_X86}"
+              end
+            end
+
+            on_linux do
+              if Hardware::CPU.arm?
+                url "https://github.com/Open330/muxa/releases/download/v#{version}/muxa-v#{version}-aarch64-unknown-linux-gnu.tar.gz"
+                sha256 "${LINUX_ARM}"
+              else
+                url "https://github.com/Open330/muxa/releases/download/v#{version}/muxa-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
+                sha256 "${LINUX_X86}"
+              end
+            end
+
+            def install
+              bin.install "muxa"
+              bin.install "muxad"
+            end
+
+            service do
+              run [opt_bin/"muxad"]
+              keep_alive true
+              log_path var/"log/muxad.log"
+              error_log_path var/"log/muxad.err.log"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/muxa --version")
+            end
+          end
+          EOF
+          cd tap
+          if git diff --quiet; then
+            echo "formula already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/muxa.rb
+          git commit -m "muxa ${VERSION}"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.21] - 2026-07-21
+
 ### Added
 
+- **Homebrew tap.** `brew install open330/tap/muxa` installs pre-built
+  `muxa`/`muxad` binaries (macOS + Linux, arm64 + x86_64) with a
+  `brew services`-compatible `muxad` service. A new `tap-bump` workflow
+  rewrites the formula in Open330/homebrew-tap whenever a release is
+  published (requires the `TAP_GITHUB_TOKEN` secret; skips with a notice
+  otherwise).
 - **multi-host observation (daemon).** `muxad` now observes every backend
   in `muxa::active_backends()` at once (tmux + herdr during a migration)
   instead of a single env-detected backend. One reconciler runs over the
@@ -1461,7 +1469,8 @@ and opt-in desktop notifications. 92 tests green.
 - Hook ingest is best-effort — adapter or daemon hiccups never block
   the agent CLI's actual command from running.
 
-[Unreleased]: https://github.com/Open330/muxa/compare/v0.8.15...HEAD
+[Unreleased]: https://github.com/Open330/muxa/compare/v0.8.21...HEAD
+[0.8.21]: https://github.com/Open330/muxa/releases/tag/v0.8.21
 [0.8.15]: https://github.com/Open330/muxa/compare/v0.8.14...v0.8.15
 [0.8.14]: https://github.com/Open330/muxa/compare/v0.8.13...v0.8.14
 [0.8.13]: https://github.com/Open330/muxa/compare/v0.8.12...v0.8.13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,7 +2284,7 @@ checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
 name = "muxa"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "axum",
  "dirs",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "muxa-cli"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "muxa-zellij-plugin"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "serde",
  "serde_json",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "muxad"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "clap 4.6.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/muxa", "crates/muxa-cli", "crates/muxad", "crates/muxa-zellij-plugin"]
 
 [workspace.package]
-version = "0.8.20"
+version = "0.8.21"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,16 @@ planned richer plugin path.
 
 ## Quick Start
 
-Requires Rust 1.88+, tmux 3.x, and a Unix-like OS.
+Requires tmux 3.x (or herdr) and a Unix-like OS.
+
+Homebrew (pre-built binaries, no Rust toolchain needed):
+
+```bash
+brew install open330/tap/muxa
+muxa init
+```
+
+Or the one-shot installer (builds from source, requires Rust 1.88+):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/install.sh | sh

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -37,6 +37,25 @@ muxa init
 `cargo install` writes to `~/.cargo/bin`; make sure that directory is on
 your `PATH`.
 
+## Homebrew
+
+```bash
+brew install open330/tap/muxa
+muxa init
+```
+
+Installs pre-built `muxa` and `muxad` binaries from
+[Open330/homebrew-tap](https://github.com/Open330/homebrew-tap)
+(macOS arm64/x86_64 and Linux arm64/x86_64). The formula ships a
+`brew services`-compatible service for `muxad`:
+
+```bash
+brew services start muxa   # or run `muxad` yourself / via muxa init
+```
+
+The formula tracks the latest release automatically (the `tap-bump`
+workflow rewrites it whenever a release is published).
+
 ## Pre-Built Binaries
 
 Download an archive from the


### PR DESCRIPTION
## Summary
- Bump workspace version to 0.8.21 and cut the CHANGELOG section (full herdr integration #68 + multi-host observation #69).
- New `tap-bump` workflow: on `release: published` it collects the four target checksums from the release's `.sha256` sidecars, renders `Formula/muxa.rb`, and pushes to Open330/homebrew-tap via a `TAP_GITHUB_TOKEN` fine-grained PAT secret (Contents read/write on the tap). Missing secret ⇒ notice + graceful skip. Runs on publish (not tag push) because the release workflow creates a draft whose asset URLs 404 until published.
- README/INSTALL document `brew install open330/tap/muxa` as the no-Rust-toolchain install path (the tap's current formula is a v0.1.0 placeholder — the first real formula lands with the v0.8.21 release).

## Test plan
- [x] Workflow YAML parses; embedded shell passes `bash -n`
- [x] `cargo check` green after version bump
- [ ] After merge: tag v0.8.21 → release workflow builds assets → publish → formula updated (manually this first time; workflow takes over once the secret is configured) → `brew install open330/tap/muxa` verified live

🤖 Generated with [Claude Code](https://claude.com/claude-code)