### PR TITLE
feat(mcp): control IPC + MCP server — agents can orchestrate muxa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Control plane + MCP server (`muxa mcp`).** muxa can now *drive* agents,
+  not only observe them. A new `muxa mcp` subcommand runs a Model Context
+  Protocol stdio server so a coding agent can orchestrate the others — wire it
+  into Claude Code with `claude mcp add muxa -- muxa mcp` (see
+  [docs/MCP.md](docs/MCP.md)). Tools: `muxa_status`, `muxa_recent_prompts`,
+  `muxa_send_prompt`, `muxa_capture_pane`, and `muxa_wait_for_change`. It is a
+  hand-rolled, tools-only JSON-RPC 2.0 server (no new dependencies; not the
+  `rmcp` SDK) and refuses to start when the daemon socket is unreachable.
+- **Control IPC methods** (`PROTOCOL.md`): `send_prompt { pane, text, submit }`
+  injects keystrokes into a pane (resolving the backend by pane-id namespace,
+  and committing the line with a trailing Enter when `submit`), `capture
+  { pane }` returns a pane's visible contents, and the existing `subscribe`
+  stream now emits a `{"event":"lagged"}` marker after a broadcast overflow so
+  clients can reconcile. `send_prompt` refuses backends without the new
+  `send_text` capability with a structured error. The daemon threads its full
+  multi-host backend set into the IPC server (`Server::with_backends`) for
+  namespace-scoped routing. The socket stays owner-only (`0600`).
+- **`PaneBackend::send_text`** capability: tmux (`send-keys -l`, scoped to
+  `MUXA_TMUX_SOCKET` when set) and herdr (`pane.send_text`) support keystroke
+  injection; zellij does not (`write-chars` only reaches the focused pane).
+
 ## [0.8.21] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `rmcp` SDK) and refuses to start when the daemon socket is unreachable.
 - **Control IPC methods** (`PROTOCOL.md`): `send_prompt { pane, text, submit }`
   injects keystrokes into a pane (resolving the backend by pane-id namespace,
-  and committing the line with a trailing Enter when `submit`), `capture
-  { pane }` returns a pane's visible contents, and the existing `subscribe`
-  stream now emits a `{"event":"lagged"}` marker after a broadcast overflow so
-  clients can reconcile. `send_prompt` refuses backends without the new
-  `send_text` capability with a structured error. The daemon threads its full
-  multi-host backend set into the IPC server (`Server::with_backends`) for
-  namespace-scoped routing. The socket stays owner-only (`0600`).
-- **`PaneBackend::send_text`** capability: tmux (`send-keys -l`, scoped to
-  `MUXA_TMUX_SOCKET` when set) and herdr (`pane.send_text`) support keystroke
-  injection; zellij does not (`write-chars` only reaches the focused pane).
+  and committing the line with a trailing Enter when `submit`) and `capture
+  { pane }` returns a pane's visible contents. `send_prompt` refuses backends
+  without the new `send_text` capability with a structured error. The daemon
+  threads its full multi-host backend set into the IPC server
+  (`Server::with_backends`) for namespace-scoped routing. The socket stays
+  owner-only (`0600`).
+  - **Wrong-target keystroke hardening.** Control ops are pinned to the
+    **specific tmux server** the pane's agent row was recorded on (`tmux -S
+    <socket>`), not an env-global socket — a pane id like `%5` exists on every
+    server, so an unpinned send/capture could hit the wrong one. A pane in a
+    KNOWN-but-unobserved namespace (e.g. `herdr:` on a tmux-only daemon) is
+    refused with a `namespace unavailable` error instead of falling through to
+    the primary backend. The plain (watch preview / dashboard) `capture_pane`
+    stays on the default server; only the control path targets a recorded
+    socket.
+  - **`send_prompt` reports `{ sent, submitted }`** so the text-send and the
+    submit-CR outcomes are distinct: a caller that sees `sent:true,
+    submitted:false` knows the text already landed and must retry only the
+    submit, never the whole prompt (which would double-inject). The submit CR
+    is attempted only after the text lands.
+  - **Argument-injection & multi-line hardening.** tmux `send-keys` uses `--`
+    so text starting with `-` isn't parsed as a flag; text with an embedded
+    newline or a trailing `;` is injected via a bracketed paste
+    (`load-buffer` + `paste-buffer -p`) so newlines don't submit line-by-line
+    and a trailing `;` (which tmux would eat as a command separator) survives.
+  - **`subscribe` lagged marker is now opt-in** (`subscribe { lagged_markers:
+    true }`). It defaults off so a pre-marker client isn't broken by the
+    `{"event":"lagged"}` frame; the server silently continues past an overflow
+    for un-opted clients. muxa's own `watch` / `mcp` client opts in.
+- **`PaneBackend::send_text`** capability (and its server-pinned
+  `send_text_on` / `capture_pane_on` variants): tmux (`send-keys -l --`, or a
+  bracketed paste for multi-line / trailing-`;` text) and herdr
+  (`pane.send_text`) support keystroke injection; zellij does not
+  (`write-chars` only reaches the focused pane).
 
 ## [0.8.21] - 2026-07-21
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -207,33 +207,80 @@ shape between minor releases; pin a muxa version if you build on them.
 
 Inject `text` into `pane` as literal keystrokes. The daemon resolves the
 backend from the pane-id namespace (`%…` → tmux, `herdr:…` → herdr, …),
-falling back to the primary backend for unclassifiable ids. When `submit`
-is true a trailing carriage return is sent as a second injection so the
-agent's current line is committed (byte-identical to tmux `send-keys Enter`
-and to writing a CR to a herdr pane's pty).
+falling back to the primary backend **only for ids it can't classify**. When
+`submit` is true a trailing carriage return is sent as a **second, separate**
+injection so the agent's current line is committed (byte-identical to tmux
+`send-keys Enter` and to writing a CR to a herdr pane's pty).
+
+**Server targeting.** A tmux pane id like `%5` exists on *every* running tmux
+server, so the daemon pins the injection to the specific server the pane's
+agent row was recorded on (its `tmux_socket`), passing `tmux -S <socket>`. An
+untracked pane, or a host without a per-server socket concept (herdr), falls
+back to the env-scoped default. This is what makes `send_prompt` land on the
+right pane in a multi-server setup.
 
 ```json
 { "protocol": 3, "kind": "send_prompt", "pane": "%12", "text": "run the tests", "submit": true }
 ```
 
-Response: `{ "ok": true, "protocol": 3 }`.
+Response (text landed): `{ "ok": true, "protocol": 3, "sent": true, "submitted": true }`.
 
-Refused with a **structured error** (never a panic) when the resolving
-backend lacks the `send_text` capability — e.g. zellij, whose CLI
-`write-chars` only reaches the focused pane and so can't safely target an
-arbitrary pane id:
+The text-send and the submit CR are two **non-atomic** injections, reported
+distinctly so a caller can act on a partial failure without double-injecting:
 
-```json
-{ "ok": false, "protocol": 3, "error": "backend zellij does not support send_text (pane zellij:3)" }
-```
+- `sent` — the text landed. When `ok` is `true`, `sent` is `true`; a caller
+  **MUST NOT resend the text** even if `submitted` is `false`.
+- `submitted` — the submit CR landed and committed the line. `false` when
+  `submit:false` was requested (nothing to submit), or — with `submit:true` —
+  a **partial failure**: the text is typed but not committed, so retry the
+  *submit alone* (never the whole prompt).
 
-`text` is sent literally (`send-keys -l` on tmux), so it is never
-reinterpreted as a key name. Text that *begins* with `-` can be misparsed by
-tmux's option scanner; muxa never generates such prompts.
+The submit CR is attempted **only** when the text send succeeded — a text-send
+failure never masquerades as a submit failure, and a submit failure never
+looks like a total failure (which would drive a double-inject retry). A total
+text-send failure is an `ok:false` error (`"send_text failed: …"`); nothing
+landed, so the whole send is safe to retry.
+
+Refused with a **structured error** (never a panic), and with no injection
+attempted, in two cases:
+
+- The pane classifies to a KNOWN namespace whose backend is **not observed**
+  by this daemon — routing it to another host would inject into the wrong
+  pane, so it is refused rather than falling back:
+
+  ```json
+  { "ok": false, "protocol": 3, "error": "namespace unavailable: no active herdr backend for pane herdr:3" }
+  ```
+
+- The resolving backend lacks the `send_text` capability — e.g. zellij, whose
+  CLI `write-chars` only reaches the focused pane and so can't safely target
+  an arbitrary pane id:
+
+  ```json
+  { "ok": false, "protocol": 3, "error": "backend zellij does not support send_text (pane zellij:3)" }
+  ```
+
+`text` is sent literally, so it is never reinterpreted as a key name. On tmux,
+simple single-line text uses `send-keys -l -- <text>` (the `--` keeps text
+that *begins* with `-` from being parsed as a flag — MCP forwards arbitrary
+model text). Text with an embedded **newline** or a **trailing `;`** is sent
+via a bracketed paste (`load-buffer` + `paste-buffer -p`) instead: a raw
+`send-keys -l` would replay each newline as an Enter (submitting a multi-line
+prompt line-by-line) and tmux would eat a trailing `;` as a command separator.
+The paste path is best-effort for submit semantics — a paste-aware target
+(Claude Code, a modern readline shell) inserts the block without executing
+intermediate newlines, but a non-paste-aware target may still run them
+line-by-line. On herdr, `pane.send_text` delivers the whole block (newlines
+included) literally over the socket, with no per-line submit.
 
 #### `capture`
 
 Capture the visible contents of `pane` via the namespace-resolved backend.
+Like `send_prompt`, the capture is pinned to the specific server the pane's
+agent row was recorded on (its `tmux_socket`) so a shared pane id reads the
+right screen, and it is refused with the same `namespace unavailable` error
+when the pane classifies to a known-but-unobserved namespace (capturing via
+the wrong backend would read a different host's screen).
 
 ```json
 { "protocol": 3, "kind": "capture", "pane": "%12" }
@@ -241,7 +288,8 @@ Capture the visible contents of `pane` via the namespace-resolved backend.
 
 Response: `{ "ok": true, "protocol": 3, "capture": "<visible pane text>" }`.
 `capture` is `null` when the pane is gone or the backend can't capture
-(best-effort — never an error).
+(best-effort — never an error). A `namespace unavailable` refusal is an
+`ok:false` error, distinct from a `null` capture.
 
 #### `subscribe`
 
@@ -252,19 +300,29 @@ stream is the same broadcast the daemon's notifier and activity ledger
 consume, so subscribers see every committed transition.
 
 ```json
-{ "protocol": 3, "kind": "subscribe" }
+{ "protocol": 3, "kind": "subscribe", "lagged_markers": true }
 ```
+
+`lagged_markers` (optional, default `false`) opts the connection into the
+lagged-marker control frame described below. It defaults **off** so a
+pre-marker client — whose `Transition` parser would choke on the frame and
+abandon push mode — keeps the historical behavior: on overflow the server
+silently continues and the client reconciles via its fallback `snapshot` poll.
+muxa's own client (used by `muxa watch` and `muxa mcp`) sends
+`lagged_markers: true`, because its `TransitionStream` reader understands the
+frame.
 
 Two non-`Transition` control frames are interleaved on the stream and MUST be
 tolerated by readers:
 
 - **Keepalive** — a bare empty line the daemon writes on an idle stream to
-  detect a dead client (broken pipe). Skip it.
+  detect a dead client (broken pipe). Skip it. Always emitted.
 - **Lagged marker** — `{"event":"lagged","dropped":N}` when the client
   consumed too slowly and the broadcast buffer overflowed, dropping `N`
-  transitions. The stream continues; the client should reconcile the gap
-  with a fresh `snapshot`. muxa's own `TransitionStream` reader skips this
-  frame automatically.
+  transitions. **Emitted only to connections that sent
+  `lagged_markers: true`.** The stream continues; the client should reconcile
+  the gap with a fresh `snapshot`. muxa's own `TransitionStream` reader skips
+  this frame automatically.
 
 Used by `muxa watch` (to replace 500 ms polling with push updates) and by
 `muxa mcp`'s `muxa_wait_for_change` tool.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -186,6 +186,104 @@ unchanged).
 
 ---
 
+## Control methods
+
+These methods let a client **drive** agents rather than only observe them.
+They back muxa's control plane — the `muxa mcp` MCP server exposes each as a
+tool so a coding agent can orchestrate the others (see `docs/MCP.md`).
+
+**Safety.** `send_prompt` injects keystrokes into another agent's pane — a
+control action, not a read. The IPC socket is already owner-only (`0600`,
+chmod'd after bind — see [Transport](#transport)), so only the daemon's own
+user can invoke it; there is no network exposure and no additional
+authentication layer. Treat socket access as equivalent to shell access for
+that user.
+
+**Pre-1.0 evolution.** These methods are additive (they do not bump
+`PROTOCOL_VERSION`). Like the rest of the pre-1.0 surface they may change
+shape between minor releases; pin a muxa version if you build on them.
+
+#### `send_prompt`
+
+Inject `text` into `pane` as literal keystrokes. The daemon resolves the
+backend from the pane-id namespace (`%…` → tmux, `herdr:…` → herdr, …),
+falling back to the primary backend for unclassifiable ids. When `submit`
+is true a trailing carriage return is sent as a second injection so the
+agent's current line is committed (byte-identical to tmux `send-keys Enter`
+and to writing a CR to a herdr pane's pty).
+
+```json
+{ "protocol": 3, "kind": "send_prompt", "pane": "%12", "text": "run the tests", "submit": true }
+```
+
+Response: `{ "ok": true, "protocol": 3 }`.
+
+Refused with a **structured error** (never a panic) when the resolving
+backend lacks the `send_text` capability — e.g. zellij, whose CLI
+`write-chars` only reaches the focused pane and so can't safely target an
+arbitrary pane id:
+
+```json
+{ "ok": false, "protocol": 3, "error": "backend zellij does not support send_text (pane zellij:3)" }
+```
+
+`text` is sent literally (`send-keys -l` on tmux), so it is never
+reinterpreted as a key name. Text that *begins* with `-` can be misparsed by
+tmux's option scanner; muxa never generates such prompts.
+
+#### `capture`
+
+Capture the visible contents of `pane` via the namespace-resolved backend.
+
+```json
+{ "protocol": 3, "kind": "capture", "pane": "%12" }
+```
+
+Response: `{ "ok": true, "protocol": 3, "capture": "<visible pane text>" }`.
+`capture` is `null` when the pane is gone or the backend can't capture
+(best-effort — never an error).
+
+#### `subscribe`
+
+Long-lived push stream. The server replies with a one-shot `ok` ack, then
+writes one JSON-encoded [`Transition`](#transition-schema-in-subscribe-stream)
+per state change (newline-delimited) until the client closes the socket. The
+stream is the same broadcast the daemon's notifier and activity ledger
+consume, so subscribers see every committed transition.
+
+```json
+{ "protocol": 3, "kind": "subscribe" }
+```
+
+Two non-`Transition` control frames are interleaved on the stream and MUST be
+tolerated by readers:
+
+- **Keepalive** — a bare empty line the daemon writes on an idle stream to
+  detect a dead client (broken pipe). Skip it.
+- **Lagged marker** — `{"event":"lagged","dropped":N}` when the client
+  consumed too slowly and the broadcast buffer overflowed, dropping `N`
+  transitions. The stream continues; the client should reconcile the gap
+  with a fresh `snapshot`. muxa's own `TransitionStream` reader skips this
+  frame automatically.
+
+Used by `muxa watch` (to replace 500 ms polling with push updates) and by
+`muxa mcp`'s `muxa_wait_for_change` tool.
+
+##### `Transition` schema (in `subscribe` stream)
+
+```json
+{
+  "from": "idle",
+  "to": "working",
+  "agent": { <Agent>, ... }
+}
+```
+
+`from`/`to` are `AgentState` values; `agent` is the post-transition
+[`Agent`](#agent-schema-in-responses) row.
+
+---
+
 ## `AgentEvent` schema
 
 Tagged union. `type` field is the discriminant.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ rollback details, see [docs/INSTALL.md](docs/INSTALL.md).
 | `muxa sync` | Backfill the registry by scanning tmux panes. |
 | `muxa register --name X [--pid N]` | Surface an arbitrary background process (script, game, automation loop) as a pid-tracked row in `muxa status`. |
 | `muxa run --detach --name X -- <cmd>` | Run a command in a muxa-owned PTY; it also appears in `muxa status` as a task. |
+| `muxa mcp` | MCP stdio server so a coding agent can orchestrate muxa — inspect agents, send prompts, capture panes, wait for changes (`claude mcp add muxa -- muxa mcp`, see [docs/MCP.md](docs/MCP.md)). |
 | `muxa init` | Interactive install/uninstall wizard. |
 | `muxad` | Daemon process. |
 
@@ -151,6 +152,7 @@ Patterns are case-sensitive and support `*` and `?`, e.g.
 | Topic | Doc |
 | --- | --- |
 | Install and wiring | [docs/INSTALL.md](docs/INSTALL.md) |
+| MCP control plane (`muxa mcp`) | [docs/MCP.md](docs/MCP.md) |
 | Live TUI and prompt composer | [docs/WATCH.md](docs/WATCH.md) |
 | CLI dashboard | [docs/DASHBOARD_CLI.md](docs/DASHBOARD_CLI.md) |
 | Stats, reports, activity ledger | [docs/ACTIVITY.md](docs/ACTIVITY.md) |

--- a/crates/muxa-cli/Cargo.toml
+++ b/crates/muxa-cli/Cargo.toml
@@ -21,7 +21,9 @@ dirs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 time = { workspace = true }
-tokio = { workspace = true }
+# `io-std` (on top of the workspace feature set) gives `muxa mcp` async
+# stdin/stdout for its JSON-RPC stdio loop.
+tokio = { workspace = true, features = ["io-std"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -6,6 +6,7 @@ mod dashboard_tui;
 mod doctor;
 mod init;
 mod logs;
+mod mcp;
 mod stats;
 mod theme;
 mod time_range;
@@ -192,6 +193,12 @@ enum Cmd {
     Init(init::Args),
     /// Run end-to-end diagnostics and report any setup issues.
     Doctor,
+    /// Run a Model Context Protocol (MCP) stdio server so a coding agent
+    /// can orchestrate muxa — inspect other agents, send them prompts,
+    /// capture panes, and wait for state changes. Wire it into Claude Code
+    /// with `claude mcp add muxa -- muxa mcp`. Refuses to start if the
+    /// daemon socket is unreachable. See docs/MCP.md.
+    Mcp,
     /// Tail muxad's stdout/stderr logs without remembering paths.
     /// Falls back to `journalctl --user -u muxad` on Linux when the
     /// systemd unit is the source of truth.
@@ -372,6 +379,7 @@ async fn main() -> Result<()> {
         Cmd::Sync => cmd_sync(&client).await,
         Cmd::Init(init_args) => init::run(init_args, socket).await,
         Cmd::Doctor => doctor::run(socket).await,
+        Cmd::Mcp => mcp::run(client).await,
         Cmd::Logs(logs_args) => logs::run(logs_args).await,
         Cmd::Upgrade(upgrade_args) => upgrade::run(upgrade_args, socket).await,
         Cmd::Prune {

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -24,10 +24,16 @@
 //! control plane.
 
 use anyhow::{bail, Result};
+use muxa::event::AgentState;
 use muxa::ipc::Client;
+use muxa::state::{Agent, Transition};
 use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::sync::Mutex;
+use tokio::task::JoinSet;
 
 /// MCP protocol revision we speak. `2024-11-05` is the widely-deployed
 /// revision Claude Code and other hosts negotiate; a tools-only server is
@@ -43,6 +49,17 @@ const DEFAULT_WAIT_SECS: u64 = 30;
 /// loop forever on a typo'd huge timeout.
 const MAX_WAIT_SECS: u64 = 600;
 
+/// How often `muxa_wait_for_change` reconciles against a fresh daemon
+/// snapshot while blocking on the transition stream. A broadcast lag on the
+/// daemon can silently drop the exact transition we're waiting for (the
+/// daemon emits a `{"event":"lagged"}` marker, but the shared
+/// `TransitionStream` consumer skips it and this consumer has no other lag
+/// signal), so we poll on this cadence and compare the target pane's current
+/// state against a baseline captured at entry. Small enough to stay
+/// responsive, large enough that even a 600 s wait costs only a few hundred
+/// cheap snapshot round-trips.
+const RECONCILE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
 /// Run the MCP stdio server until stdin closes. Refuses to start if the
 /// daemon socket is unreachable.
 pub async fn run(client: Client) -> Result<()> {
@@ -55,49 +72,152 @@ pub async fn run(client: Client) -> Result<()> {
         );
     }
 
-    let stdin = BufReader::new(tokio::io::stdin());
-    let mut lines = stdin.lines();
-    let mut stdout = tokio::io::stdout();
+    serve(
+        client,
+        BufReader::new(tokio::io::stdin()),
+        tokio::io::stdout(),
+    )
+    .await
+}
+
+/// Read newline-delimited JSON-RPC requests from `reader` and write one
+/// response line per request to `writer`, **dispatching each request on its
+/// own task**. This is the crux of the non-blocking transport: a
+/// long-running tool (`muxa_wait_for_change`, up to 600 s) must never wedge
+/// unrelated traffic, so a `ping` / `tools/list` issued while a wait is
+/// outstanding is answered immediately rather than queued behind it.
+///
+/// Responses may therefore interleave in time; that is expected for
+/// concurrent JSON-RPC requests, and the `id` echoed on each response lets
+/// the client correlate. Line framing is still strict: the shared `writer`
+/// mutex is held across the whole `write_all` + newline, so two concurrent
+/// responses can never splice mid-line.
+///
+/// `Client` is a cheap handle (a socket path) and every tool opens its own
+/// short-lived daemon connection per call, so cloning it per task shares no
+/// serial connection between dispatches.
+///
+/// Generic over the transport so tests can drive it through an in-memory
+/// duplex pipe instead of the real stdio handles.
+async fn serve<R, W>(client: Client, reader: R, writer: W) -> Result<()>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    let mut lines = reader.lines();
+    let writer = Arc::new(Mutex::new(writer));
+    // In-flight dispatch tasks, tracked so we can drain them when stdin
+    // closes rather than dropping a response mid-flight.
+    let mut tasks: JoinSet<()> = JoinSet::new();
 
     while let Some(line) = lines.next_line().await? {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
+        if line.trim().is_empty() {
             continue;
         }
-        let response = match serde_json::from_str::<Value>(trimmed) {
-            Ok(req) => dispatch(&client, &req).await,
-            Err(e) => Some(error_response(
-                &Value::Null,
-                -32700,
-                &format!("parse error: {e}"),
-            )),
-        };
-        // Notifications (and parse-error-on-a-notification) produce no
-        // response; only write when there is one.
-        if let Some(resp) = response {
-            let mut bytes = serde_json::to_vec(&resp)?;
-            bytes.push(b'\n');
-            stdout.write_all(&bytes).await?;
-            stdout.flush().await?;
-        }
+        let client = client.clone();
+        let writer = Arc::clone(&writer);
+        tasks.spawn(async move {
+            let response = match serde_json::from_str::<Value>(&line) {
+                Ok(req) => dispatch(&client, &req).await,
+                // A line that isn't valid JSON at all: -32700, id unknown.
+                Err(e) => Some(error_response(
+                    &Value::Null,
+                    -32700,
+                    &format!("parse error: {e}"),
+                )),
+            };
+            // Notifications (and a parse error on what was meant to be a
+            // notification) produce no response; only write when there is one.
+            if let Some(resp) = response {
+                if let Err(e) = write_response(&writer, &resp).await {
+                    // stdout is gone (host closed the pipe): nothing left to do
+                    // for this response. The read loop will see EOF and exit.
+                    tracing::debug!(error = %e, "mcp: failed to write response");
+                }
+            }
+        });
+        // Reap finished tasks opportunistically so the set can't grow without
+        // bound under steady traffic.
+        while tasks.try_join_next().is_some() {}
     }
+
+    // stdin closed: let any in-flight dispatches finish writing before exit.
+    while tasks.join_next().await.is_some() {}
     Ok(())
 }
 
-/// Handle one JSON-RPC message. Returns `Some(response)` for requests and
-/// `None` for notifications (messages without an `id`).
+/// Write one response object followed by a newline, holding the shared
+/// writer lock across the entire write so concurrent responses never
+/// interleave mid-line.
+async fn write_response<W>(writer: &Arc<Mutex<W>>, resp: &Value) -> std::io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut bytes = serde_json::to_vec(resp).unwrap_or_else(|_| b"{}".to_vec());
+    bytes.push(b'\n');
+    let mut guard = writer.lock().await;
+    guard.write_all(&bytes).await?;
+    guard.flush().await
+}
+
+/// Handle one parsed JSON-RPC message. Returns `Some(response)` for
+/// anything that warrants a reply and `None` for notifications (a request
+/// object with no `id`), which JSON-RPC forbids answering.
+///
+/// Framing robustness (JSON-RPC 2.0 + MCP `2024-11-05`) — no valid JSON is
+/// ever silently dropped:
+/// - a **batch array** is rejected with a single `-32600` error (muxa does
+///   not implement batching; documented in `docs/MCP.md`);
+/// - a **bare value** (number / string / bool / null) is not a request
+///   object and carries no `id`, so `-32600` with `id: null`;
+/// - an **object** is routed by [`dispatch_object`], which still returns a
+///   proper error for a missing/invalid `jsonrpc` or `method` whenever an
+///   `id` is present to address the reply to.
 async fn dispatch(client: &Client, req: &Value) -> Option<Value> {
-    let method = req
-        .get("method")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
+    match req {
+        Value::Object(_) => dispatch_object(client, req).await,
+        Value::Array(_) => Some(error_response(
+            &Value::Null,
+            -32600,
+            "batch requests are not supported; send one JSON-RPC object per line",
+        )),
+        // Valid JSON, but not a JSON-RPC request object — and no id to
+        // address a reply to.
+        _ => Some(error_response(
+            &Value::Null,
+            -32600,
+            "invalid request: expected a JSON-RPC object",
+        )),
+    }
+}
+
+/// Route a JSON-RPC **object**: split notifications (no `id`) from requests,
+/// validate the envelope, then dispatch by `method`.
+async fn dispatch_object(client: &Client, req: &Value) -> Option<Value> {
     let id = req.get("id").cloned();
 
-    // A message without an `id` is a notification: never answered.
+    // No `id` key at all → notification: never answered (even if malformed,
+    // there's nothing to address a reply to). The only one we expect is
+    // `notifications/initialized`.
     let Some(id) = id else {
-        // The only notification we expect is `notifications/initialized`;
-        // anything else is harmlessly ignored.
         return None;
+    };
+
+    // From here the message has an `id`, so any envelope problem yields a
+    // proper error response addressed to it rather than a silent drop.
+    if req.get("jsonrpc").and_then(Value::as_str) != Some("2.0") {
+        return Some(error_response(
+            &id,
+            -32600,
+            "invalid request: \"jsonrpc\" must be \"2.0\"",
+        ));
+    }
+    let Some(method) = req.get("method").and_then(Value::as_str) else {
+        return Some(error_response(
+            &id,
+            -32600,
+            "invalid request: missing or non-string \"method\"",
+        ));
     };
 
     let response = match method {
@@ -244,11 +364,13 @@ async fn call_tool(client: &Client, params: Option<&Value>) -> Result<Value> {
             // Submit defaults to true — the common case is "prompt and run".
             let submit = args.get("submit").and_then(Value::as_bool).unwrap_or(true);
             Ok(match client.send_prompt(pane, text, submit).await {
-                Ok(()) => text_result(&format!(
-                    "sent {} chars to {pane}{}",
-                    text.len(),
-                    if submit { " and submitted" } else { "" },
-                )),
+                // The daemon distinguishes "text injected" (`sent`) from
+                // "Enter delivered" (`submitted`); surface the latter so a
+                // caller whose submit was requested but not delivered learns
+                // the text already landed and must not blindly resend it.
+                Ok(outcome) => {
+                    render_send_result(text.len(), pane, submit, Some(outcome.submitted))
+                }
                 Err(e) => error_result(&format!("send_prompt failed: {e}")),
             })
         }
@@ -269,8 +391,64 @@ async fn call_tool(client: &Client, params: Option<&Value>) -> Result<Value> {
     }
 }
 
-/// `muxa_wait_for_change`: stream transitions from the daemon until one
-/// matches (optionally scoped to a pane) or the timeout elapses.
+/// Render the `muxa_send_prompt` result, defensively tolerating both the
+/// legacy contract (success = text sent, and Enter pressed if requested) and
+/// the newer daemon shape that reports Enter delivery separately.
+///
+/// `submitted` is what the daemon actually reported about the Enter keystroke:
+/// - `None` — the daemon didn't say (older client method that returns `()`):
+///   fall back to the caller's `submit` intent.
+/// - `Some(true)` — Enter was delivered; the line is committed.
+/// - `Some(false)` — the text landed but Enter did **not**; surfaced plainly
+///   so the caller doesn't assume the line was committed.
+fn render_send_result(text_len: usize, pane: &str, submit: bool, submitted: Option<bool>) -> Value {
+    match submitted {
+        Some(false) if submit => text_result(&format!(
+            "sent {text_len} chars to {pane}, but the line was NOT submitted \
+             (Enter not delivered) — the text is typed but not yet committed",
+        )),
+        _ => {
+            // No daemon signal → trust the requested `submit`; an explicit
+            // `Some(true)` confirms it.
+            let committed = submitted.unwrap_or(submit);
+            text_result(&format!(
+                "sent {text_len} chars to {pane}{}",
+                if committed { " and submitted" } else { "" },
+            ))
+        }
+    }
+}
+
+/// Terminal outcome of a `muxa_wait_for_change` race, before it's rendered
+/// into a tool result.
+enum WaitOutcome {
+    /// A live transition arrived on the stream and matched the pane filter.
+    Observed(Transition),
+    /// A reconcile poll (or a post-lag / post-timeout reconcile) detected the
+    /// target pane's state had moved. Carries the ready-made result value.
+    Reconciled(Value),
+    /// The daemon closed the stream before any matching change, and a
+    /// reconcile found nothing.
+    Closed,
+}
+
+/// `muxa_wait_for_change`: block until a matching state transition is
+/// observed, or a reconciled post-lag state match is detected, or the
+/// timeout elapses. **Returns on the first observed change OR a reconciled
+/// post-lag state match.**
+///
+/// Two signals race under one deadline:
+/// 1. the daemon's transition **stream** (push, ~1 ms latency); and
+/// 2. a periodic snapshot **reconcile** ([`RECONCILE_POLL_INTERVAL`]) that
+///    compares the target pane's current state against a baseline captured
+///    at entry.
+///
+/// The reconcile exists because a broadcast **lag** on the daemon can drop
+/// the exact transition we're waiting for: the daemon emits a
+/// `{"event":"lagged"}` marker, but the shared `TransitionStream` consumer
+/// skips it, so a matching change dropped during lag would otherwise be
+/// misreported as a timeout. Polling the snapshot closes that hole without
+/// depending on the stream surfacing the lag to this consumer.
 async fn wait_for_change(client: &Client, args: &Value) -> Value {
     let pane = args.get("pane").and_then(Value::as_str);
     let timeout_secs = args
@@ -279,45 +457,125 @@ async fn wait_for_change(client: &Client, args: &Value) -> Value {
         .unwrap_or(DEFAULT_WAIT_SECS)
         .clamp(1, MAX_WAIT_SECS);
 
+    // Baseline pane→state map so a reconcile can tell whether the target moved
+    // even if the stream never delivered the transition.
+    let baseline = pane_states(client, pane).await;
+
     let mut stream = match client.subscribe().await {
         Ok(s) => s,
         Err(e) => return error_result(&format!("subscribe failed: {e}")),
     };
 
+    let mut poll = tokio::time::interval(RECONCILE_POLL_INTERVAL);
+    poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    poll.tick().await; // consume the immediate first tick
+
     let deadline = Duration::from_secs(timeout_secs);
     let outcome = tokio::time::timeout(deadline, async {
         loop {
-            match stream.recv().await {
-                Ok(Some(t)) => {
-                    if pane.is_none_or(|p| t.agent.pane.as_deref() == Some(p)) {
-                        return Some(t);
+            tokio::select! {
+                recv = stream.recv() => match recv {
+                    Ok(Some(t)) => {
+                        if pane.is_none_or(|p| t.agent.pane.as_deref() == Some(p)) {
+                            return WaitOutcome::Observed(t);
+                        }
+                    }
+                    // Stream closed (daemon shutdown) or a read error. Try one
+                    // reconcile before giving up — the change may already have
+                    // landed — otherwise report the closed stream.
+                    Ok(None) | Err(_) => {
+                        return match reconcile(client, pane, &baseline).await {
+                            Some(v) => WaitOutcome::Reconciled(v),
+                            None => WaitOutcome::Closed,
+                        };
+                    }
+                },
+                _ = poll.tick() => {
+                    if let Some(v) = reconcile(client, pane, &baseline).await {
+                        return WaitOutcome::Reconciled(v);
                     }
                 }
-                // Daemon closed the stream (shutdown) or a read error —
-                // either way, stop waiting.
-                Ok(None) | Err(_) => return None,
             }
         }
     })
     .await;
 
     match outcome {
-        Ok(Some(t)) => json_result(&json!({
+        Ok(WaitOutcome::Observed(t)) => json_result(&json!({
             "changed": true,
             "from": t.from,
             "to": t.to,
             "agent": &*t.agent,
         })),
-        Ok(None) => json_result(&json!({
+        Ok(WaitOutcome::Reconciled(v)) => v,
+        Ok(WaitOutcome::Closed) => json_result(&json!({
             "changed": false,
             "reason": "stream closed before a matching change",
         })),
-        Err(_) => json_result(&json!({
-            "changed": false,
-            "reason": "timeout",
-            "timeout_secs": timeout_secs,
-        })),
+        // Deadline hit. One last reconcile guards the narrow window where a
+        // transition was dropped between the final poll tick and the timeout.
+        Err(_) => reconcile(client, pane, &baseline).await.unwrap_or_else(|| {
+            json_result(&json!({
+                "changed": false,
+                "reason": "timeout",
+                "timeout_secs": timeout_secs,
+            }))
+        }),
     }
+}
+
+/// Snapshot the current `pane → state` map for the reconcile baseline and
+/// polls, scoped to one pane when the caller asked for one, else the whole
+/// fleet. A daemon error yields an empty map — the reconcile then simply
+/// can't detect a change, degrading to the stream/timeout path.
+async fn pane_states(client: &Client, pane: Option<&str>) -> HashMap<String, AgentState> {
+    fetch_agents(client, pane)
+        .await
+        .into_iter()
+        .filter_map(|a| a.pane.clone().map(|p| (p, a.state)))
+        .collect()
+}
+
+/// Compare the target pane(s)' current state against `baseline`; if any has
+/// moved — or a matching pane appeared that wasn't there before — return a
+/// synthetic transition result flagged `reconciled` so the caller can tell it
+/// came from a snapshot rather than the live stream. `None` when nothing
+/// changed.
+async fn reconcile(
+    client: &Client,
+    pane: Option<&str>,
+    baseline: &HashMap<String, AgentState>,
+) -> Option<Value> {
+    for agent in fetch_agents(client, pane).await {
+        let Some(p) = agent.pane.clone() else {
+            continue;
+        };
+        if pane.is_some_and(|want| want != p) {
+            continue;
+        }
+        let previous = baseline.get(&p).copied();
+        if previous != Some(agent.state) {
+            return Some(json_result(&json!({
+                "changed": true,
+                "reconciled": true,
+                // `null` when the pane is newly observed (no baseline entry).
+                "from": previous,
+                "to": agent.state,
+                "agent": agent,
+            })));
+        }
+    }
+    None
+}
+
+/// Fetch the agents relevant to a wait: just the target pane's rows when
+/// scoped, else the whole snapshot. Daemon errors degrade to an empty list.
+async fn fetch_agents(client: &Client, pane: Option<&str>) -> Vec<Agent> {
+    match pane {
+        Some(p) => client.by_pane(p).await,
+        None => client.snapshot().await,
+    }
+    .unwrap_or_default()
 }
 
 // --- JSON-RPC / MCP result helpers --------------------------------------
@@ -356,11 +614,13 @@ fn error_result(message: &str) -> Value {
 mod tests {
     use super::*;
     use muxa::backend::{BackendCaps, HostKind, PaneBackend, SharedBackend};
+    use muxa::event::AgentEvent;
     use muxa::ipc::Server;
     use muxa::state::Store;
     use muxa::tmux::PaneInfo;
     use std::path::Path;
     use std::sync::{Arc, Mutex};
+    use std::time::Instant;
     use tokio::sync::broadcast;
 
     /// Fake backend that always accepts `send_text` and records the calls,
@@ -592,5 +852,198 @@ mod tests {
 
         tx.send(()).unwrap();
         handle.await.unwrap();
+    }
+
+    /// Ingest one synthetic hook event so a pane appears in the store with a
+    /// derived state (`prompt_submitted` → Working, `turn_stopped` → Idle).
+    async fn ingest(client: &Client, pane: &str, ty: &str, extra: Value) {
+        let mut ev = json!({
+            "type": ty,
+            "id": { "kind": "claude_code", "session_id": pane, "pane": pane, "cwd": null },
+            "at": "2026-07-20T00:00:00Z",
+        });
+        let (Value::Object(fields), Value::Object(more)) = (&mut ev, extra) else {
+            unreachable!("event and extra are objects");
+        };
+        for (k, v) in more {
+            fields.insert(k, v);
+        }
+        let event: AgentEvent = serde_json::from_value(ev).unwrap();
+        client.ingest(&event).await.unwrap();
+    }
+
+    /// `render_send_result` tolerates the unknown/legacy shape and the newer
+    /// `{sent, submitted}` daemon signal, surfacing "not submitted" plainly.
+    #[test]
+    fn render_send_result_covers_all_submit_shapes() {
+        let text = |v: &Value| v["content"][0]["text"].as_str().unwrap().to_string();
+
+        // Unknown submit status (client returns `()` today) → trust intent.
+        assert!(text(&render_send_result(5, "%1", true, None)).contains("and submitted"));
+        assert!(!text(&render_send_result(5, "%1", false, None)).contains("submitted"));
+        // Daemon confirms Enter landed.
+        assert!(text(&render_send_result(5, "%1", true, Some(true))).contains("and submitted"));
+        // Daemon says text landed but Enter did NOT — surfaced to the caller.
+        let not_submitted = text(&render_send_result(5, "%1", true, Some(false)));
+        assert!(not_submitted.contains("NOT submitted"), "{not_submitted}");
+    }
+
+    /// Framing robustness: batch arrays, bare values, and malformed envelopes
+    /// all yield a proper error (or a silent drop only for a true
+    /// notification) instead of vanishing.
+    #[tokio::test]
+    async fn framing_rejects_non_object_and_bad_envelope() {
+        let client = Client::new(std::path::PathBuf::from("/nonexistent/muxa.sock"));
+
+        // Batch array → single -32600, id null (batching unsupported).
+        let batch = dispatch(&client, &json!([{"jsonrpc":"2.0","id":1,"method":"ping"}]))
+            .await
+            .unwrap();
+        assert_eq!(batch["error"]["code"], -32600);
+        assert!(batch["id"].is_null());
+
+        // Bare value → -32600, id null.
+        let bare = dispatch(&client, &json!(42)).await.unwrap();
+        assert_eq!(bare["error"]["code"], -32600);
+        assert!(bare["id"].is_null());
+
+        // Object with an id but a bad `jsonrpc` → -32600 addressed to the id.
+        let bad = dispatch(&client, &json!({"id":7,"method":"ping"}))
+            .await
+            .unwrap();
+        assert_eq!(bad["error"]["code"], -32600);
+        assert_eq!(bad["id"], 7);
+
+        // Object with an id but no method → -32600 addressed to the id.
+        let no_method = dispatch(&client, &json!({"jsonrpc":"2.0","id":8}))
+            .await
+            .unwrap();
+        assert_eq!(no_method["error"]["code"], -32600);
+        assert_eq!(no_method["id"], 8);
+
+        // Object with no id → notification: no response even though malformed.
+        assert!(dispatch(&client, &json!({"foo":"bar"})).await.is_none());
+    }
+
+    /// A raw line that isn't JSON at all yields a `-32700` parse error with a
+    /// null id, and never crashes the server loop.
+    #[tokio::test]
+    async fn serve_reports_parse_error_for_garbage_line() {
+        let client = Client::new(std::path::PathBuf::from("/nonexistent/muxa.sock"));
+        let (mut client_in, server_in) = tokio::io::duplex(4096);
+        let (server_out, client_out) = tokio::io::duplex(4096);
+        let handle = tokio::spawn(async move {
+            serve(client, BufReader::new(server_in), server_out)
+                .await
+                .unwrap();
+        });
+        let mut client_out = BufReader::new(client_out);
+
+        client_in.write_all(b"this is not json\n").await.unwrap();
+        client_in.flush().await.unwrap();
+
+        let mut line = String::new();
+        client_out.read_line(&mut line).await.unwrap();
+        let resp: Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(resp["error"]["code"], -32700);
+        assert!(resp["id"].is_null());
+
+        drop(client_in);
+        handle.await.unwrap();
+    }
+
+    /// The core non-blocking property: a slow `muxa_wait_for_change` in flight
+    /// must not delay an unrelated `ping` — the ping response comes back
+    /// promptly, well before the wait's timeout.
+    #[tokio::test]
+    async fn slow_wait_does_not_block_ping() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("mcp-concurrent.sock");
+        let (client, _sends, tx, daemon) = spawn_daemon(&sock).await;
+
+        let (mut client_in, server_in) = tokio::io::duplex(8192);
+        let (server_out, client_out) = tokio::io::duplex(8192);
+        let serve_handle = tokio::spawn(async move {
+            serve(client, BufReader::new(server_in), server_out)
+                .await
+                .unwrap();
+        });
+        let mut client_out = BufReader::new(client_out);
+
+        // Slow wait (2 s, empty fleet → will time out) then an immediate ping.
+        client_in
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":\
+                  {\"name\":\"muxa_wait_for_change\",\"arguments\":{\"timeout_secs\":2}}}\n",
+            )
+            .await
+            .unwrap();
+        client_in
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"ping\"}\n")
+            .await
+            .unwrap();
+        client_in.flush().await.unwrap();
+
+        // First response back must be the ping (id 2), and quickly.
+        let start = Instant::now();
+        let mut first = String::new();
+        client_out.read_line(&mut first).await.unwrap();
+        let first: Value = serde_json::from_str(first.trim()).unwrap();
+        assert_eq!(
+            first["id"], 2,
+            "ping should return before the slow wait; got {first}"
+        );
+        assert!(
+            start.elapsed() < Duration::from_millis(1500),
+            "ping was blocked by the outstanding wait ({:?})",
+            start.elapsed(),
+        );
+
+        // The wait's own response (id 1) lands later, timing out.
+        let mut second = String::new();
+        client_out.read_line(&mut second).await.unwrap();
+        let second: Value = serde_json::from_str(second.trim()).unwrap();
+        assert_eq!(second["id"], 1);
+        assert!(second["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("timeout"));
+
+        drop(client_in);
+        serve_handle.await.unwrap();
+        tx.send(()).unwrap();
+        daemon.await.unwrap();
+    }
+
+    /// `wait_for_change`'s reconcile catches a state move that the transition
+    /// stream might have dropped during a broadcast lag: baseline is captured,
+    /// the pane moves, and a snapshot comparison surfaces the change.
+    #[tokio::test]
+    async fn reconcile_detects_state_change_missed_by_stream() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("mcp-reconcile.sock");
+        let (client, _sends, tx, daemon) = spawn_daemon(&sock).await;
+
+        // Put %1 into Working via a prompt, then baseline it.
+        ingest(&client, "%1", "prompt_submitted", json!({ "prompt": "go" })).await;
+        let baseline = pane_states(&client, Some("%1")).await;
+        assert_eq!(baseline.get("%1").copied(), Some(AgentState::Working));
+
+        // No movement yet → reconcile reports nothing.
+        assert!(reconcile(&client, Some("%1"), &baseline).await.is_none());
+
+        // End the turn → Idle. Even if the stream had dropped this transition,
+        // the reconcile compares against the baseline and catches it.
+        ingest(&client, "%1", "turn_stopped", json!({})).await;
+        let v = reconcile(&client, Some("%1"), &baseline)
+            .await
+            .expect("reconcile should detect the state move");
+        let text = v["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("\"reconciled\": true"), "{text}");
+        assert!(text.contains("\"from\": \"working\""), "{text}");
+        assert!(text.contains("\"to\": \"idle\""), "{text}");
+
+        tx.send(()).unwrap();
+        daemon.await.unwrap();
     }
 }

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -199,9 +199,7 @@ async fn dispatch_object(client: &Client, req: &Value) -> Option<Value> {
     // No `id` key at all → notification: never answered (even if malformed,
     // there's nothing to address a reply to). The only one we expect is
     // `notifications/initialized`.
-    let Some(id) = id else {
-        return None;
-    };
+    let id = id?;
 
     // From here the message has an `id`, so any envelope problem yields a
     // proper error response addressed to it rather than a silent drop.

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -1,0 +1,596 @@
+//! `muxa mcp` — a Model Context Protocol stdio server that lets a coding
+//! agent orchestrate muxa: ask what other agents are doing, send them
+//! prompts, capture their panes, and block until an agent changes state.
+//!
+//! ## Why hand-rolled, not `rmcp`
+//!
+//! The official Rust MCP SDK (`rmcp`) pulls a substantial dependency tree
+//! (schemars, an async runtime layer, proc-macro codegen) that has to clear
+//! MSRV 1.88 *and* the workspace's `cargo-deny` license/advisory policy. A
+//! **tools-only** server needs just three request methods — `initialize`,
+//! `tools/list`, `tools/call` — plus `ping` and the `initialized`
+//! notification. That subset of the JSON-RPC 2.0 wire protocol is tiny and
+//! stable, so we implement it directly over the crate's existing
+//! `serde_json` + `tokio`, adding **no new dependencies**. If the tool
+//! surface ever grows to need resources/prompts/sampling, revisit `rmcp`.
+//!
+//! ## Transport
+//!
+//! Newline-delimited JSON-RPC 2.0 over stdio: read one request object per
+//! line from stdin, write one response object per line to stdout. Every
+//! tool proxies the daemon over the existing unix-socket [`Client`]. The
+//! server refuses to start when the daemon socket is unreachable (a clear
+//! stderr message + non-zero exit) so an agent never talks to a dead
+//! control plane.
+
+use anyhow::{bail, Result};
+use muxa::ipc::Client;
+use serde_json::{json, Value};
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+/// MCP protocol revision we speak. `2024-11-05` is the widely-deployed
+/// revision Claude Code and other hosts negotiate; a tools-only server is
+/// wire-compatible across the later revisions too.
+const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
+
+/// Deadline for the startup liveness probe against the daemon socket.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(750);
+
+/// Default `muxa_wait_for_change` timeout when the caller omits one.
+const DEFAULT_WAIT_SECS: u64 = 30;
+/// Hard ceiling on `muxa_wait_for_change` so a caller can't pin the stdio
+/// loop forever on a typo'd huge timeout.
+const MAX_WAIT_SECS: u64 = 600;
+
+/// Run the MCP stdio server until stdin closes. Refuses to start if the
+/// daemon socket is unreachable.
+pub async fn run(client: Client) -> Result<()> {
+    // Refuse to start against an absent/dead daemon: a control plane the
+    // tools can't reach is worse than a clear failure.
+    if let Err(e) = client.snapshot_with_timeout(PROBE_TIMEOUT).await {
+        bail!(
+            "muxa daemon is not reachable ({e}). Start `muxad` (or check MUXA_SOCKET) \
+             before launching `muxa mcp`.",
+        );
+    }
+
+    let stdin = BufReader::new(tokio::io::stdin());
+    let mut lines = stdin.lines();
+    let mut stdout = tokio::io::stdout();
+
+    while let Some(line) = lines.next_line().await? {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let response = match serde_json::from_str::<Value>(trimmed) {
+            Ok(req) => dispatch(&client, &req).await,
+            Err(e) => Some(error_response(
+                &Value::Null,
+                -32700,
+                &format!("parse error: {e}"),
+            )),
+        };
+        // Notifications (and parse-error-on-a-notification) produce no
+        // response; only write when there is one.
+        if let Some(resp) = response {
+            let mut bytes = serde_json::to_vec(&resp)?;
+            bytes.push(b'\n');
+            stdout.write_all(&bytes).await?;
+            stdout.flush().await?;
+        }
+    }
+    Ok(())
+}
+
+/// Handle one JSON-RPC message. Returns `Some(response)` for requests and
+/// `None` for notifications (messages without an `id`).
+async fn dispatch(client: &Client, req: &Value) -> Option<Value> {
+    let method = req
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let id = req.get("id").cloned();
+
+    // A message without an `id` is a notification: never answered.
+    let Some(id) = id else {
+        // The only notification we expect is `notifications/initialized`;
+        // anything else is harmlessly ignored.
+        return None;
+    };
+
+    let response = match method {
+        "initialize" => success(&id, initialize_result()),
+        "ping" => success(&id, json!({})),
+        "tools/list" => success(&id, json!({ "tools": tool_definitions() })),
+        "tools/call" => match call_tool(client, req.get("params")).await {
+            Ok(result) => success(&id, result),
+            // A malformed `tools/call` (missing name / bad args) is a
+            // protocol error; a tool that *ran* but failed reports
+            // `isError` inside a normal result (see `call_tool`).
+            Err(e) => error_response(&id, -32602, &format!("invalid tool call: {e}")),
+        },
+        other => error_response(&id, -32601, &format!("method not found: {other}")),
+    };
+    Some(response)
+}
+
+fn initialize_result() -> Value {
+    json!({
+        "protocolVersion": MCP_PROTOCOL_VERSION,
+        "capabilities": { "tools": {} },
+        "serverInfo": {
+            "name": "muxa",
+            "version": env!("CARGO_PKG_VERSION"),
+        },
+        "instructions": "muxa control plane. Use muxa_status to see what agents \
+            are doing, muxa_send_prompt to drive one, muxa_capture_pane to read \
+            its screen, and muxa_wait_for_change to block until an agent changes \
+            state.",
+    })
+}
+
+/// The five tools this server exposes, with JSON-Schema `inputSchema`s.
+fn tool_definitions() -> Vec<Value> {
+    vec![
+        json!({
+            "name": "muxa_status",
+            "description": "Snapshot of every agent muxa tracks: state \
+                (working/idle/waiting_input/…), pane id, session, model, last \
+                prompt, and last notification. Call this first to see what other \
+                agents are doing.",
+            "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false },
+        }),
+        json!({
+            "name": "muxa_recent_prompts",
+            "description": "Recent prompt-history entries (newest first) from the \
+                daemon's audit log. Optionally filter to one pane and cap the count.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "pane": { "type": "string", "description": "Pane id to filter to (e.g. %12 or herdr:p1). Omit for all panes." },
+                    "limit": { "type": "integer", "minimum": 0, "description": "Max entries. 0 or omitted = all retained." },
+                },
+                "additionalProperties": false,
+            },
+        }),
+        json!({
+            "name": "muxa_send_prompt",
+            "description": "Inject text into an agent's pane as keystrokes. With \
+                submit=true (the default), a trailing Enter commits the line so the \
+                agent starts working. This is a control action against another \
+                agent — use deliberately.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "pane": { "type": "string", "description": "Target pane id (e.g. %12 or herdr:p1)." },
+                    "text": { "type": "string", "description": "Literal text to type into the pane." },
+                    "submit": { "type": "boolean", "description": "Press Enter after the text. Default true." },
+                },
+                "required": ["pane", "text"],
+                "additionalProperties": false,
+            },
+        }),
+        json!({
+            "name": "muxa_capture_pane",
+            "description": "Capture the visible contents of a pane so you can read \
+                what an agent is showing right now.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "pane": { "type": "string", "description": "Pane id to capture (e.g. %12 or herdr:p1)." },
+                },
+                "required": ["pane"],
+                "additionalProperties": false,
+            },
+        }),
+        json!({
+            "name": "muxa_wait_for_change",
+            "description": "Block until an agent's state changes (or a timeout), \
+                then return the transition (from/to state, agent, pane). Optionally \
+                wait only for changes on a specific pane. Use after muxa_send_prompt \
+                to know when the agent finished or needs input.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "timeout_secs": { "type": "integer", "minimum": 1, "description": "Max seconds to wait. Default 30, max 600." },
+                    "pane": { "type": "string", "description": "Only report changes on this pane id. Omit for any pane." },
+                },
+                "additionalProperties": false,
+            },
+        }),
+    ]
+}
+
+/// Execute a `tools/call`. Returns `Err` only for protocol-level problems
+/// (missing tool name, malformed params); a tool that runs but fails to do
+/// its job returns an `isError` result so the calling model sees the
+/// message rather than a transport fault.
+async fn call_tool(client: &Client, params: Option<&Value>) -> Result<Value> {
+    let params = params.ok_or_else(|| anyhow::anyhow!("missing params"))?;
+    let name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("missing tool name"))?;
+    let args = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+
+    match name {
+        "muxa_status" => Ok(match client.snapshot().await {
+            Ok(agents) => json_result(&json!({ "agents": agents })),
+            Err(e) => error_result(&format!("status failed: {e}")),
+        }),
+        "muxa_recent_prompts" => {
+            let pane = args.get("pane").and_then(Value::as_str);
+            let limit = args
+                .get("limit")
+                .and_then(Value::as_u64)
+                .and_then(|n| usize::try_from(n).ok());
+            Ok(match client.recent_prompts(pane, limit).await {
+                Ok(prompts) => json_result(&json!({ "prompts": prompts })),
+                Err(e) => error_result(&format!("recent_prompts failed: {e}")),
+            })
+        }
+        "muxa_send_prompt" => {
+            let Some(pane) = args.get("pane").and_then(Value::as_str) else {
+                return Ok(error_result("send_prompt requires a `pane` argument"));
+            };
+            let Some(text) = args.get("text").and_then(Value::as_str) else {
+                return Ok(error_result("send_prompt requires a `text` argument"));
+            };
+            // Submit defaults to true — the common case is "prompt and run".
+            let submit = args.get("submit").and_then(Value::as_bool).unwrap_or(true);
+            Ok(match client.send_prompt(pane, text, submit).await {
+                Ok(()) => text_result(&format!(
+                    "sent {} chars to {pane}{}",
+                    text.len(),
+                    if submit { " and submitted" } else { "" },
+                )),
+                Err(e) => error_result(&format!("send_prompt failed: {e}")),
+            })
+        }
+        "muxa_capture_pane" => {
+            let Some(pane) = args.get("pane").and_then(Value::as_str) else {
+                return Ok(error_result("capture_pane requires a `pane` argument"));
+            };
+            Ok(match client.capture(pane).await {
+                Ok(Some(text)) => text_result(&text),
+                Ok(None) => error_result(&format!(
+                    "no capture for {pane} (pane gone or backend can't capture)",
+                )),
+                Err(e) => error_result(&format!("capture failed: {e}")),
+            })
+        }
+        "muxa_wait_for_change" => Ok(wait_for_change(client, &args).await),
+        other => Ok(error_result(&format!("unknown tool: {other}"))),
+    }
+}
+
+/// `muxa_wait_for_change`: stream transitions from the daemon until one
+/// matches (optionally scoped to a pane) or the timeout elapses.
+async fn wait_for_change(client: &Client, args: &Value) -> Value {
+    let pane = args.get("pane").and_then(Value::as_str);
+    let timeout_secs = args
+        .get("timeout_secs")
+        .and_then(Value::as_u64)
+        .unwrap_or(DEFAULT_WAIT_SECS)
+        .clamp(1, MAX_WAIT_SECS);
+
+    let mut stream = match client.subscribe().await {
+        Ok(s) => s,
+        Err(e) => return error_result(&format!("subscribe failed: {e}")),
+    };
+
+    let deadline = Duration::from_secs(timeout_secs);
+    let outcome = tokio::time::timeout(deadline, async {
+        loop {
+            match stream.recv().await {
+                Ok(Some(t)) => {
+                    if pane.is_none_or(|p| t.agent.pane.as_deref() == Some(p)) {
+                        return Some(t);
+                    }
+                }
+                // Daemon closed the stream (shutdown) or a read error —
+                // either way, stop waiting.
+                Ok(None) | Err(_) => return None,
+            }
+        }
+    })
+    .await;
+
+    match outcome {
+        Ok(Some(t)) => json_result(&json!({
+            "changed": true,
+            "from": t.from,
+            "to": t.to,
+            "agent": &*t.agent,
+        })),
+        Ok(None) => json_result(&json!({
+            "changed": false,
+            "reason": "stream closed before a matching change",
+        })),
+        Err(_) => json_result(&json!({
+            "changed": false,
+            "reason": "timeout",
+            "timeout_secs": timeout_secs,
+        })),
+    }
+}
+
+// --- JSON-RPC / MCP result helpers --------------------------------------
+
+fn success(id: &Value, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn error_response(id: &Value, code: i64, message: &str) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}
+
+/// A tools/call result wrapping plain text.
+fn text_result(text: &str) -> Value {
+    json!({ "content": [ { "type": "text", "text": text } ] })
+}
+
+/// A tools/call result wrapping a JSON value, serialized as pretty text
+/// (MCP content is text; the model reads the JSON).
+fn json_result(value: &Value) -> Value {
+    let text = serde_json::to_string_pretty(value)
+        .unwrap_or_else(|_| "{\"error\":\"serialize failed\"}".to_string());
+    text_result(&text)
+}
+
+/// A tools/call result flagged `isError` so the model sees the failure
+/// message instead of a silent empty result.
+fn error_result(message: &str) -> Value {
+    json!({
+        "content": [ { "type": "text", "text": message } ],
+        "isError": true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use muxa::backend::{BackendCaps, HostKind, PaneBackend, SharedBackend};
+    use muxa::ipc::Server;
+    use muxa::state::Store;
+    use muxa::tmux::PaneInfo;
+    use std::path::Path;
+    use std::sync::{Arc, Mutex};
+    use tokio::sync::broadcast;
+
+    /// Fake backend that always accepts `send_text` and records the calls,
+    /// so the MCP → IPC → backend path can be exercised in-process.
+    struct FakeBackend {
+        sends: Arc<Mutex<Vec<(String, String)>>>,
+    }
+
+    impl PaneBackend for FakeBackend {
+        fn kind(&self) -> HostKind {
+            HostKind::Tmux
+        }
+        fn list_panes(&self) -> Vec<PaneInfo> {
+            Vec::new()
+        }
+        fn resolve_pane(&self, _: &str) -> Option<PaneInfo> {
+            None
+        }
+        fn capture_pane(&self, pane_id: &str) -> Option<String> {
+            Some(format!("screen of {pane_id}"))
+        }
+        fn pane_pid_map(&self) -> std::collections::HashMap<u32, String> {
+            std::collections::HashMap::new()
+        }
+        fn current_pane(&self) -> Option<String> {
+            None
+        }
+        fn focus_pane(&self, _: &str) -> bool {
+            false
+        }
+        fn send_text(&self, pane_id: &str, text: &str) -> bool {
+            self.sends
+                .lock()
+                .unwrap()
+                .push((pane_id.to_string(), text.to_string()));
+            true
+        }
+        fn caps(&self) -> BackendCaps {
+            BackendCaps::default()
+        }
+    }
+
+    async fn wait_for_socket(sock: &Path) {
+        for _ in 0..50 {
+            if sock.exists() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    /// Spin an in-process daemon with a recording backend; returns the
+    /// client, the send-log, and a shutdown handle.
+    async fn spawn_daemon(
+        sock: &Path,
+    ) -> (
+        Client,
+        Arc<Mutex<Vec<(String, String)>>>,
+        broadcast::Sender<()>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let sends = Arc::new(Mutex::new(Vec::new()));
+        let backend: SharedBackend = Arc::new(FakeBackend {
+            sends: sends.clone(),
+        });
+        let server = Server::new(sock.to_path_buf(), Store::shared()).with_backends(vec![backend]);
+        let (tx, rx) = broadcast::channel(1);
+        let handle = tokio::spawn(async move { server.run(rx).await.unwrap() });
+        wait_for_socket(sock).await;
+        (Client::new(sock.to_path_buf()), sends, tx, handle)
+    }
+
+    #[tokio::test]
+    async fn initialize_and_tools_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("mcp-init.sock");
+        let (client, _sends, tx, handle) = spawn_daemon(&sock).await;
+
+        let init = dispatch(
+            &client,
+            &json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(init["result"]["serverInfo"]["name"], "muxa");
+        assert_eq!(init["result"]["protocolVersion"], MCP_PROTOCOL_VERSION);
+        assert!(init["result"]["capabilities"]["tools"].is_object());
+
+        let list = dispatch(
+            &client,
+            &json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" }),
+        )
+        .await
+        .unwrap();
+        let tools = list["result"]["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "muxa_status",
+                "muxa_recent_prompts",
+                "muxa_send_prompt",
+                "muxa_capture_pane",
+                "muxa_wait_for_change",
+            ],
+        );
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    /// A notification (no `id`) yields no response.
+    #[tokio::test]
+    async fn notification_produces_no_response() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("mcp-notif.sock");
+        let (client, _sends, tx, handle) = spawn_daemon(&sock).await;
+
+        let resp = dispatch(
+            &client,
+            &json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
+        )
+        .await;
+        assert!(resp.is_none());
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn tools_call_status_and_send_prompt() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("mcp-call.sock");
+        let (client, sends, tx, handle) = spawn_daemon(&sock).await;
+
+        // muxa_status returns a (possibly empty) agents payload as text.
+        let status = dispatch(
+            &client,
+            &json!({
+                "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                "params": { "name": "muxa_status", "arguments": {} },
+            }),
+        )
+        .await
+        .unwrap();
+        let text = status["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("\"agents\""), "status text: {text}");
+
+        // muxa_send_prompt routes through to the backend with a submit CR.
+        let send = dispatch(
+            &client,
+            &json!({
+                "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+                "params": {
+                    "name": "muxa_send_prompt",
+                    "arguments": { "pane": "%1", "text": "hello", "submit": true },
+                },
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(send["result"]["isError"].as_bool() != Some(true), "{send}");
+        assert_eq!(
+            sends.lock().unwrap().clone(),
+            vec![
+                ("%1".to_string(), "hello".to_string()),
+                ("%1".to_string(), "\r".to_string()),
+            ],
+        );
+
+        // muxa_capture_pane returns the backend's screen text.
+        let cap = dispatch(
+            &client,
+            &json!({
+                "jsonrpc": "2.0", "id": 5, "method": "tools/call",
+                "params": { "name": "muxa_capture_pane", "arguments": { "pane": "%1" } },
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            cap["result"]["content"][0]["text"].as_str().unwrap(),
+            "screen of %1",
+        );
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unknown_method_is_jsonrpc_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("mcp-unknown.sock");
+        let (client, _sends, tx, handle) = spawn_daemon(&sock).await;
+
+        let resp = dispatch(
+            &client,
+            &json!({ "jsonrpc": "2.0", "id": 9, "method": "does/not/exist" }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp["error"]["code"], -32601);
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn wait_for_change_times_out_cleanly() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("mcp-wait.sock");
+        let (client, _sends, tx, handle) = spawn_daemon(&sock).await;
+
+        let resp = dispatch(
+            &client,
+            &json!({
+                "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+                "params": {
+                    "name": "muxa_wait_for_change",
+                    "arguments": { "timeout_secs": 1 },
+                },
+            }),
+        )
+        .await
+        .unwrap();
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("\"changed\": false"), "{text}");
+        assert!(text.contains("timeout"), "{text}");
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+}

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -291,11 +291,17 @@ impl PaneBackend for HerdrBackend {
 
     fn send_text(&self, pane_id: &str, text: &str) -> bool {
         let raw = strip_prefix(pane_id);
-        // `pane.send_text` writes the text into the pane's pty. The daemon
-        // sends a bare `"\r"` as a follow-up call to submit — a CR through
-        // the pty is Enter for both cooked-mode shells (ICRNL → NL) and
-        // raw-mode TUIs (crossterm reads CR as Enter), so no separate
-        // key-name call is needed. Any non-error reply means it landed.
+        // `pane.send_text` writes the text into the pane's pty as one literal
+        // block — including any embedded newlines, which are delivered as raw
+        // bytes, NOT as per-line Enter presses (unlike tmux `send-keys -l`).
+        // So a multi-line prompt lands intact here with no special paste path;
+        // the daemon's `submit:false` semantics hold, and `submit:true` sends a
+        // separate bare `"\r"` to commit. A CR through the pty is Enter for both
+        // cooked-mode shells (ICRNL → NL) and raw-mode TUIs (crossterm reads CR
+        // as Enter), so no separate key-name call is needed. herdr has no
+        // per-server socket concept, so `send_text_on` inherits the trait
+        // default (ignores `socket`, delegates here). Any non-error reply means
+        // it landed.
         self.request("pane.send_text", json!({ "pane_id": raw, "text": text }))
             .is_ok()
     }

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -289,9 +289,21 @@ impl PaneBackend for HerdrBackend {
             .is_ok()
     }
 
+    fn send_text(&self, pane_id: &str, text: &str) -> bool {
+        let raw = strip_prefix(pane_id);
+        // `pane.send_text` writes the text into the pane's pty. The daemon
+        // sends a bare `"\r"` as a follow-up call to submit — a CR through
+        // the pty is Enter for both cooked-mode shells (ICRNL → NL) and
+        // raw-mode TUIs (crossterm reads CR as Enter), so no separate
+        // key-name call is needed. Any non-error reply means it landed.
+        self.request("pane.send_text", json!({ "pane_id": raw, "text": text }))
+            .is_ok()
+    }
+
     fn caps(&self) -> BackendCaps {
-        // The socket API covers every capability directly; nothing is
-        // plugin-gated the way zellij is.
+        // The socket API covers every capability directly (including
+        // `send_text` via `pane.send_text`); nothing is plugin-gated the
+        // way zellij is.
         BackendCaps::default()
     }
 }
@@ -964,6 +976,24 @@ mod tests {
         assert!(backend.capture_pane("herdr:p1").is_none());
         assert!(backend.pane_pid_map().is_empty());
         assert!(!backend.focus_pane("herdr:p1"));
+        assert!(!backend.send_text("herdr:p1", "hi"));
+    }
+
+    #[test]
+    fn send_text_true_on_ok_reply() {
+        let (socket, _dir) = spawn_server(|method| match method {
+            "pane.send_text" => Reply::Result(json!({ "type": "ok" })),
+            _ => Reply::Error,
+        });
+        assert!(backend_at(&socket).send_text("herdr:p1", "echo hi"));
+        // The submit form (bare CR) uses the same call.
+        assert!(backend_at(&socket).send_text("herdr:p1", "\r"));
+    }
+
+    #[test]
+    fn send_text_false_on_error_reply() {
+        let (socket, _dir) = spawn_server(|_| Reply::Error);
+        assert!(!backend_at(&socket).send_text("herdr:p1", "echo hi"));
     }
 
     /// A herdr `workspace_list` result: `w1` focused, `w2` not.

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -434,6 +434,30 @@ pub trait PaneBackend: Send + Sync + 'static {
         false
     }
 
+    /// Like [`Self::send_text`] but targeting the pane on a specific host
+    /// *server* named by `socket`. This is the control-plane entry point: a
+    /// tmux pane id like `%5` exists on every running tmux server, so the
+    /// daemon threads the agent row's recorded `tmux_socket` here to inject
+    /// into the RIGHT server rather than whichever one answers first.
+    ///
+    /// `socket` is the pane row's recorded short socket name (`default` /
+    /// `amux`), or `None` when the row has no recorded socket. The default
+    /// impl ignores `socket` and delegates to [`Self::send_text`] — correct
+    /// for hosts without a per-server socket concept (herdr, zellij); tmux
+    /// overrides it to pin the server.
+    fn send_text_on(&self, _socket: Option<&str>, pane_id: &str, text: &str) -> bool {
+        self.send_text(pane_id, text)
+    }
+
+    /// Like [`Self::capture_pane`] but targeting the pane on the specific host
+    /// server named by `socket` — the control-plane `capture` counterpart to
+    /// [`Self::send_text_on`]. The default impl ignores `socket` and delegates
+    /// to [`Self::capture_pane`]; tmux overrides it to pin the server so a
+    /// shared pane id can't capture the wrong screen.
+    fn capture_pane_on(&self, _socket: Option<&str>, pane_id: &str) -> Option<String> {
+        self.capture_pane(pane_id)
+    }
+
     /// Static capability descriptor. Default impl returns "everything
     /// supported" because that's the tmux shape and most backends
     /// model their gaps as exceptions to that baseline.
@@ -491,6 +515,12 @@ impl<T: PaneBackend + ?Sized> PaneBackend for Arc<T> {
     }
     fn send_text(&self, pane_id: &str, text: &str) -> bool {
         (**self).send_text(pane_id, text)
+    }
+    fn send_text_on(&self, socket: Option<&str>, pane_id: &str, text: &str) -> bool {
+        (**self).send_text_on(socket, pane_id, text)
+    }
+    fn capture_pane_on(&self, socket: Option<&str>, pane_id: &str) -> Option<String> {
+        (**self).capture_pane_on(socket, pane_id)
     }
     fn caps(&self) -> BackendCaps {
         (**self).caps()

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -292,11 +292,19 @@ pub enum HostKind {
 /// capability table — only backends with gaps zero out the relevant
 /// flag.
 ///
-/// The four-bool shape trips clippy's `struct_excessive_bools` lint;
+/// The multi-bool shape trips clippy's `struct_excessive_bools` lint;
 /// allowed here because each flag really is an independent capability
 /// (no state-machine ordering between them) and a `bitflags!` macro
-/// would be overkill at this scale. Add an enum if a fifth flag lands
-/// — until then, named bools are the most grep-able shape.
+/// would be overkill at this scale.
+///
+/// A prior version of this comment said "add an enum if a fifth flag
+/// lands". The fifth flag has now landed (`send_text`, added for the
+/// control-plane `send_prompt` path), and we **consciously supersede**
+/// that guidance: an enum/bitflags representation would force every
+/// call site that reads a single field (e.g. `caps().capture_pane`) to
+/// go through a lookup and lose the grep-ability that makes the current
+/// shape easy to audit. Named bools remain the clearest form; revisit
+/// only if the set grows past a handful.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BackendCaps {
@@ -319,6 +327,15 @@ pub struct BackendCaps {
     /// return false here and the watch picker hides the "Enter to
     /// jump" hint accordingly.
     pub focus_pane: bool,
+    /// Whether `send_text()` can inject keystrokes into a pane. This is
+    /// the control-plane capability the daemon's `send_prompt` IPC (and
+    /// the `muxa mcp` server on top of it) gates on: a backend that
+    /// returns `false` here is refused with a structured error rather
+    /// than silently dropping the prompt. tmux (`send-keys`) and herdr
+    /// (`pane.send_text`) support it; zellij does not — `zellij action
+    /// write-chars` only reaches the *focused* pane, so it can't safely
+    /// target an arbitrary pane id.
+    pub send_text: bool,
 }
 
 impl Default for BackendCaps {
@@ -328,6 +345,7 @@ impl Default for BackendCaps {
             pane_pid_map: true,
             capture_pane: true,
             focus_pane: true,
+            send_text: true,
         }
     }
 }
@@ -394,6 +412,28 @@ pub trait PaneBackend: Send + Sync + 'static {
     /// host couldn't action the request.
     fn focus_pane(&self, pane_id: &str) -> bool;
 
+    /// Inject `text` into the pane as if typed. This is a **control
+    /// action** — the entry point for the daemon's `send_prompt` IPC
+    /// (see `docs/PROTOCOL.md`) and the `muxa mcp` server that proxies
+    /// it — so callers MUST gate on [`BackendCaps::send_text`] and refuse
+    /// (structured error) rather than call a backend that can't honor it.
+    ///
+    /// The text is sent *literally*: no key-name interpretation, no
+    /// implicit submit. To submit the pane's current line, send a
+    /// carriage return as a separate call — `send_text(pane, "\r")` — which
+    /// is byte-identical to tmux's `send-keys Enter` and to writing a CR to
+    /// a herdr pane's pty (the daemon does exactly this for `submit: true`).
+    /// Splitting text from submit keeps the primitive minimal and lets one
+    /// trait method + one capability flag cover both hosts.
+    ///
+    /// Returns `true` when the host accepted the injection; `false`
+    /// (best-effort) when the pane is gone, the host errored, or the
+    /// backend doesn't support injection at all. The default impl returns
+    /// `false` so a backend that never overrides it is safely inert.
+    fn send_text(&self, _pane_id: &str, _text: &str) -> bool {
+        false
+    }
+
     /// Static capability descriptor. Default impl returns "everything
     /// supported" because that's the tmux shape and most backends
     /// model their gaps as exceptions to that baseline.
@@ -448,6 +488,9 @@ impl<T: PaneBackend + ?Sized> PaneBackend for Arc<T> {
     }
     fn focus_pane(&self, pane_id: &str) -> bool {
         (**self).focus_pane(pane_id)
+    }
+    fn send_text(&self, pane_id: &str, text: &str) -> bool {
+        (**self).send_text(pane_id, text)
     }
     fn caps(&self) -> BackendCaps {
         (**self).caps()
@@ -864,6 +907,7 @@ mod tests {
         assert!(caps.pane_pid_map);
         assert!(caps.capture_pane);
         assert!(caps.focus_pane);
+        assert!(caps.send_text);
     }
 
     /// `MUXA_HOSTS` is an explicit ordered set: names normalize, unknown

--- a/crates/muxa/src/backend/tmux.rs
+++ b/crates/muxa/src/backend/tmux.rs
@@ -80,10 +80,24 @@ impl PaneBackend for TmuxBackend {
 
     fn send_text(&self, pane_id: &str, text: &str) -> bool {
         // `send-keys -l` (literal) so prompt text can't be reinterpreted as
-        // a tmux key. Scoped to `MUXA_TMUX_SOCKET` when set so the injection
-        // reaches the right server. Best-effort: a non-zero exit (pane gone)
-        // collapses to `false`, which the daemon surfaces as a send failure.
+        // a tmux key; env-scoped default server. Best-effort: a non-zero exit
+        // (pane gone) collapses to `false`, which the daemon surfaces as a
+        // send failure.
         crate::tmux::send_text(pane_id, text)
+    }
+
+    fn send_text_on(&self, socket: Option<&str>, pane_id: &str, text: &str) -> bool {
+        // Control-plane injection pinned to the pane's recorded server via
+        // `-S <socket>` — `%5` exists on every tmux server, so this targets
+        // the right one. Handles leading-dash / trailing-`;` / multi-line text
+        // (see `crate::tmux::send_text_on`).
+        crate::tmux::send_text_on(socket, pane_id, text)
+    }
+
+    fn capture_pane_on(&self, socket: Option<&str>, pane_id: &str) -> Option<String> {
+        // Control-plane capture pinned to the pane's recorded server, so a
+        // shared pane id can't read the wrong screen. Best-effort → `None`.
+        crate::tmux::capture_pane_on(socket, pane_id).ok()
     }
 
     // `caps()` uses the default impl from the trait — tmux supports

--- a/crates/muxa/src/backend/tmux.rs
+++ b/crates/muxa/src/backend/tmux.rs
@@ -78,9 +78,17 @@ impl PaneBackend for TmuxBackend {
             .is_ok_and(|s| s.success())
     }
 
+    fn send_text(&self, pane_id: &str, text: &str) -> bool {
+        // `send-keys -l` (literal) so prompt text can't be reinterpreted as
+        // a tmux key. Scoped to `MUXA_TMUX_SOCKET` when set so the injection
+        // reaches the right server. Best-effort: a non-zero exit (pane gone)
+        // collapses to `false`, which the daemon surfaces as a send failure.
+        crate::tmux::send_text(pane_id, text)
+    }
+
     // `caps()` uses the default impl from the trait — tmux supports
-    // every method the trait exposes, so spelling out the table here
-    // would just be noise.
+    // every method the trait exposes (including `send_text`), so spelling
+    // out the table here would just be noise.
 }
 
 #[cfg(test)]

--- a/crates/muxa/src/backend/zellij.rs
+++ b/crates/muxa/src/backend/zellij.rs
@@ -205,6 +205,11 @@ impl PaneBackend for ZellijBackend {
             capture_pane: false,
             // Always works.
             focus_pane: true,
+            // `zellij action write-chars` only reaches the *focused* pane —
+            // there's no per-pane-id targeting — so injecting into an
+            // arbitrary pane id would type into the wrong place. Unsupported;
+            // `send_text` inherits the trait default (`false`).
+            send_text: false,
         }
     }
 }

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -19,7 +19,7 @@
 //! can call `Store::apply` afterwards, so the daemon's final flush
 //! captures every state change the user actually triggered.
 
-use crate::backend::{default_backend, SharedBackend};
+use crate::backend::{default_backend, HostKind, SharedBackend};
 use crate::event::{AgentEvent, PROTOCOL_VERSION};
 use crate::session::{
     PtySessionBackend, SessionBackend, SessionOutput, SessionRef, SharedSessionBackend,
@@ -149,7 +149,18 @@ enum RequestBody {
     /// socket. Used by `muxa watch` to switch from 500 ms polling to
     /// push-based updates, and by the `muxa mcp` server's
     /// `muxa_wait_for_change` tool.
-    Subscribe,
+    ///
+    /// `lagged_markers` (default `false`) opts the connection into receiving
+    /// the `{"event":"lagged","dropped":N}` control frame after a broadcast
+    /// overflow. It defaults OFF so a pre-marker client (whose `Transition`
+    /// parser would choke on the frame and abandon push mode) keeps the
+    /// historical behavior — the server silently continues after a lag, and the
+    /// client reconciles the gap via its fallback snapshot poll. muxa's own
+    /// `TransitionStream` reader understands the frame and opts in.
+    Subscribe {
+        #[serde(default)]
+        lagged_markers: bool,
+    },
 
     /// Control action: inject `text` into `pane` as literal keystrokes,
     /// resolving the backend from the pane-id namespace. When `submit`,
@@ -297,6 +308,19 @@ pub struct Response {
     /// response kind, or a `capture` whose backend returned nothing).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capture: Option<String>,
+    /// Whether a `send_prompt`'s text injection landed. Present only on a
+    /// `send_prompt` response. `true` means the text is already in the pane
+    /// — a caller MUST NOT resend it, even if `submitted` is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sent: Option<bool>,
+    /// Whether a `send_prompt`'s submit CR landed. Present only on a
+    /// `send_prompt` response. `false` with `sent:true` and a requested
+    /// `submit:true` is a PARTIAL success: the text is in the pane but the
+    /// Enter didn't commit — retry the submit alone (e.g. `send_prompt` with
+    /// empty text + submit), never the whole prompt. `false` is also the
+    /// normal value when `submit:false` was requested (nothing to submit).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub submitted: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -323,6 +347,8 @@ impl Response {
             output: None,
             pruned: None,
             capture: None,
+            sent: None,
+            submitted: None,
         }
     }
     fn err(msg: impl Into<String>) -> Self {
@@ -377,6 +403,16 @@ impl Response {
     fn with_capture(capture: Option<String>) -> Self {
         let mut r = Self::ok();
         r.capture = capture;
+        r
+    }
+    /// A `send_prompt` success carrying the two non-atomic outcomes distinctly
+    /// (Fix: honest partial-failure signal). Only built when the text landed
+    /// (`sent = true`), so `ok = true`; `submitted` reflects whether the
+    /// follow-up submit CR also landed.
+    fn with_send_result(sent: bool, submitted: bool) -> Self {
+        let mut r = Self::ok();
+        r.sent = Some(sent);
+        r.submitted = Some(submitted);
         r
     }
     fn hello() -> Self {
@@ -700,6 +736,27 @@ where
     Ok(line.len())
 }
 
+/// Encode the `{"event":"lagged","dropped":N}` overflow control frame — but
+/// only for a subscriber that opted in (`emit = true`, from
+/// `subscribe { lagged_markers: true }`).
+///
+/// Returns `Ok(None)` when the connection did NOT opt in, so the caller writes
+/// nothing and the stream silently continues past the lag — the pre-marker
+/// behavior a legacy client's `Transition` parser needs (it would otherwise
+/// choke on the marker and abandon push mode). Split out so the opt-in gate is
+/// unit-testable without forcing a real broadcast overflow.
+fn lagged_marker_bytes(
+    emit: bool,
+    dropped: u64,
+    protocol: u32,
+) -> Result<Option<Vec<u8>>, serde_json::Error> {
+    if !emit {
+        return Ok(None);
+    }
+    let marker = serde_json::json!({ "event": "lagged", "dropped": dropped });
+    encode_line(&marker, protocol).map(Some)
+}
+
 /// Pump every state transition from `store` to `writer` as a JSON
 /// line. Runs until the broadcast channel closes (daemon shutting
 /// down) or the client closes its half of the socket — the first
@@ -714,6 +771,7 @@ async fn stream_transitions(
     mut writer: tokio::net::unix::OwnedWriteHalf,
     store: SharedStore,
     protocol: u32,
+    emit_lagged: bool,
 ) -> Result<(), RuntimeError> {
     let mut rx = store.subscribe();
     // Periodic keepalive so a watch client that dies without a clean close is
@@ -742,18 +800,21 @@ async fn stream_transitions(
                         dropped = n,
                         "subscribe lagged; client will reconcile via fallback poll"
                     );
-                    // Emit a lagged marker so a streaming client knows it
-                    // dropped `n` transitions and should reconcile via a
-                    // snapshot. It's a distinct object shape (`event` tag, no
-                    // `from`/`to`), so `TransitionStream::recv` skips it rather
-                    // than mis-parsing it as a `Transition`.
-                    let marker = serde_json::json!({ "event": "lagged", "dropped": n });
-                    let bytes = encode_line(&marker, protocol)?;
-                    if writer.write_all(&bytes).await.is_err() {
-                        return Ok(());
-                    }
-                    if writer.flush().await.is_err() {
-                        return Ok(());
+                    // Emit a lagged marker ONLY for clients that opted in
+                    // (`subscribe { lagged_markers: true }`). It's a distinct
+                    // object shape (`event` tag, no `from`/`to`), which an
+                    // opted-in reader (`TransitionStream::recv`) skips — but a
+                    // pre-marker client's `Transition` parser would choke on it
+                    // and abandon push mode, so an un-opted client gets the
+                    // historical behavior: silently continue after the lag and
+                    // let its fallback snapshot poll reconcile the gap.
+                    if let Some(bytes) = lagged_marker_bytes(emit_lagged, n, protocol)? {
+                        if writer.write_all(&bytes).await.is_err() {
+                            return Ok(());
+                        }
+                        if writer.flush().await.is_err() {
+                            return Ok(());
+                        }
                     }
                 }
             },
@@ -774,17 +835,26 @@ async fn stream_transitions(
 }
 
 /// Resolve the backend that governs `pane`'s id namespace (`%…` → tmux,
-/// `herdr:…` → herdr, `zellij:…` → zellij), falling back to the primary
-/// (`backends[0]`) for ids muxa doesn't classify. `backends` is never
-/// empty (the `Server` builder guarantees it), so the fallback is always
-/// valid.
-fn resolve_backend<'a>(backends: &'a [SharedBackend], pane: &str) -> &'a SharedBackend {
-    if let Some(kind) = crate::backend::pane_id_host_kind(pane) {
-        if let Some(b) = backends.iter().find(|b| b.kind() == kind) {
-            return b;
-        }
+/// `herdr:…` → herdr, `zellij:…` → zellij).
+///
+/// - A pane id that classifies to a KNOWN namespace whose backend is in the
+///   active set → `Ok(backend)`.
+/// - A pane id that classifies to a known namespace whose backend is NOT
+///   observed → `Err(kind)`: a **structured refusal**. We must NOT fall back
+///   to the primary here — routing e.g. a `herdr:` keystroke onto the tmux
+///   backend would inject into the wrong host entirely. The caller turns this
+///   into a `namespace-unavailable` error.
+/// - An UNCLASSIFIED pane id (legacy/synthetic/unknown shape) → `Ok(primary)`:
+///   only these fall back to `backends[0]`, which is never empty (the `Server`
+///   builder guarantees it), preserving pre-guard behavior.
+fn resolve_backend<'a>(
+    backends: &'a [SharedBackend],
+    pane: &str,
+) -> Result<&'a SharedBackend, HostKind> {
+    match crate::backend::pane_id_host_kind(pane) {
+        Some(kind) => backends.iter().find(|b| b.kind() == kind).ok_or(kind),
+        None => Ok(&backends[0]),
     }
-    &backends[0]
 }
 
 #[tracing::instrument(level = "debug", skip(stream, store, backend, backends, sessions))]
@@ -977,44 +1047,90 @@ async fn handle(
                 }
                 RequestBody::SendPrompt { pane, text, submit } => {
                     kind = "send_prompt";
-                    let target = resolve_backend(&backends, &pane).clone();
-                    if target.caps().send_text {
-                        // `send_text` is a blocking shell-out / socket call, so
-                        // run it off the async worker. Text first, then the
-                        // submit CR as a separate injection (byte-identical to
-                        // `send-keys Enter` / a CR to a herdr pty).
-                        let sent = tokio::task::spawn_blocking(move || {
-                            let ok = target.send_text(&pane, &text);
-                            if ok && submit {
-                                target.send_text(&pane, "\r")
-                            } else {
-                                ok
-                            }
-                        })
-                        .await
-                        .unwrap_or(false);
-                        if sent {
-                            tracing::debug!(submit, "send_prompt");
-                            Response::ok()
-                        } else {
-                            Response::err("send_text failed: pane gone or host unreachable")
-                        }
-                    } else {
+                    match resolve_backend(&backends, &pane) {
+                        // Known namespace, but no active backend observes it —
+                        // refuse rather than mis-route keystrokes to another
+                        // host (routing `herdr:` onto tmux would type into the
+                        // wrong pane entirely).
+                        Err(missing) => Response::err(format!(
+                            "namespace unavailable: no active {missing} backend for pane {pane}",
+                        )),
                         // Structured refusal, not a panic: the backend that
-                        // owns this pane's namespace can't inject keystrokes.
-                        Response::err(format!(
+                        // owns this pane's namespace can't inject keystrokes
+                        // (e.g. zellij).
+                        Ok(target) if !target.caps().send_text => Response::err(format!(
                             "backend {} does not support send_text (pane {pane})",
                             target.kind(),
-                        ))
+                        )),
+                        Ok(target) => {
+                            let target = target.clone();
+                            // Pin the injection to the specific server this
+                            // pane's agent row was recorded on — `%5` exists on
+                            // every tmux server, so an env-scoped send could hit
+                            // the wrong one. `None` for hosts without a server
+                            // concept (herdr) or an untracked pane, which falls
+                            // back to the env-scoped default.
+                            let socket = store
+                                .by_pane(&pane)
+                                .await
+                                .into_iter()
+                                .find_map(|a| a.tmux_socket);
+                            // `send_text_on` is a blocking shell-out / socket
+                            // call, so run it off the async worker. The text and
+                            // the submit CR are TWO non-atomic injections, so
+                            // report the outcomes distinctly (`sent` /
+                            // `submitted`): a caller that sees `sent:true,
+                            // submitted:false` knows the text already landed and
+                            // must NOT resend it. The submit CR is attempted only
+                            // when the text landed — never commit a half-sent
+                            // line, and never let a CR failure masquerade as a
+                            // text failure (which would drive a double-inject
+                            // retry).
+                            let (sent, submitted) = tokio::task::spawn_blocking(move || {
+                                let s = socket.as_deref();
+                                let sent = target.send_text_on(s, &pane, &text);
+                                let submitted =
+                                    sent && submit && target.send_text_on(s, &pane, "\r");
+                                (sent, submitted)
+                            })
+                            .await
+                            .unwrap_or((false, false));
+                            if sent {
+                                tracing::debug!(submit, submitted, "send_prompt");
+                                Response::with_send_result(sent, submitted)
+                            } else {
+                                // Nothing landed — safe for the caller to retry
+                                // the whole send.
+                                Response::err("send_text failed: pane gone or host unreachable")
+                            }
+                        }
                     }
                 }
                 RequestBody::Capture { pane } => {
                     kind = "capture";
-                    let target = resolve_backend(&backends, &pane).clone();
-                    let text = tokio::task::spawn_blocking(move || target.capture_pane(&pane))
-                        .await
-                        .unwrap_or(None);
-                    Response::with_capture(text)
+                    match resolve_backend(&backends, &pane) {
+                        // Same structured refusal as send_prompt: capturing via
+                        // the wrong backend would read a different host's screen.
+                        Err(missing) => Response::err(format!(
+                            "namespace unavailable: no active {missing} backend for pane {pane}",
+                        )),
+                        Ok(target) => {
+                            let target = target.clone();
+                            // Capture the RIGHT `%5` by pinning to the pane's
+                            // recorded server (see send_prompt above).
+                            let socket = store
+                                .by_pane(&pane)
+                                .await
+                                .into_iter()
+                                .find_map(|a| a.tmux_socket);
+                            let text = tokio::task::spawn_blocking(move || {
+                                target.capture_pane_on(socket.as_deref(), &pane)
+                            })
+                            .await
+                            .unwrap_or(None);
+                            Response::with_capture(text)
+                        }
+                    }
                 }
                 RequestBody::SpawnSession {
                     command,
@@ -1110,7 +1226,7 @@ async fn handle(
                         Err(e) => Response::err(e.to_string()),
                     }
                 }
-                RequestBody::Subscribe => {
+                RequestBody::Subscribe { lagged_markers } => {
                     kind = "subscribe";
                     let stream_proto = negotiated.unwrap_or(PROTOCOL_VERSION);
                     // Stream takeover. Send ack, then write transitions
@@ -1128,7 +1244,7 @@ async fn handle(
                         kind,
                         "ipc.handle (stream takeover)",
                     );
-                    return stream_transitions(writer, store, stream_proto).await;
+                    return stream_transitions(writer, store, stream_proto, lagged_markers).await;
                 }
             },
             Err(e) => {
@@ -1174,6 +1290,23 @@ pub fn harden_permissions(socket_path: &Path) -> std::io::Result<()> {
 #[derive(Debug, Clone)]
 pub struct Client {
     socket_path: PathBuf,
+}
+
+/// The result of a [`Client::send_prompt`]: the two non-atomic keystroke
+/// injections (the text, then the optional submit CR) reported distinctly.
+///
+/// Only produced on `Ok`, i.e. when the text landed. `submitted` is `false`
+/// either because `submit:false` was requested (nothing to submit) or because
+/// a requested submit CR failed after the text landed — a **partial failure**
+/// the caller distinguishes using its own `submit` intent. Either way, when
+/// this value exists the text is already in the pane and MUST NOT be resent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SendPromptOutcome {
+    /// The text injection landed. Always `true` here (a failed text send is an
+    /// `Err`); carried explicitly for symmetry and forward-compatibility.
+    pub sent: bool,
+    /// The submit carriage return landed and committed the line.
+    pub submitted: bool,
 }
 
 /// Long-lived handle returned by [`Client::subscribe`]. Calls to
@@ -1297,14 +1430,20 @@ impl Client {
     /// Inject `text` into `pane` via the daemon, resolving the backend
     /// from the pane-id namespace. When `submit`, the daemon follows the
     /// text with a carriage return so the agent's line is committed.
-    /// Errors when the backend can't inject (structured refusal from the
-    /// daemon) or the send fails. Backs `muxa mcp`'s `muxa_send_prompt`.
+    ///
+    /// `Ok` means the **text landed** — the returned [`SendPromptOutcome`]
+    /// reports the two non-atomic injections distinctly (`sent` / `submitted`)
+    /// so a caller can tell a partial failure (text in, Enter not) from a total
+    /// one and must NOT resend the text on the former. `Err` means nothing
+    /// landed (structured refusal — unavailable namespace / unsupported backend
+    /// — or a failed text send), so the whole send is safe to retry. Backs
+    /// `muxa mcp`'s `muxa_send_prompt`.
     pub async fn send_prompt(
         &self,
         pane: &str,
         text: &str,
         submit: bool,
-    ) -> Result<(), RuntimeError> {
+    ) -> Result<SendPromptOutcome, RuntimeError> {
         let req = serde_json::json!({
             "protocol": PROTOCOL_VERSION,
             "kind": "send_prompt",
@@ -1312,8 +1451,14 @@ impl Client {
             "text": text,
             "submit": submit,
         });
-        let _ = self.call_checked(&req).await?;
-        Ok(())
+        let resp = self.call_checked(&req).await?;
+        Ok(SendPromptOutcome {
+            // On `Ok` the text landed; default to `true` for forward-compat
+            // with a daemon that predates the explicit field.
+            sent: resp["sent"].as_bool().unwrap_or(true),
+            // Absent field (older daemon) → fall back to the requested intent.
+            submitted: resp["submitted"].as_bool().unwrap_or(submit),
+        })
     }
 
     /// Capture the visible contents of `pane` through the daemon's
@@ -1435,6 +1580,11 @@ impl Client {
         let mut req = serde_json::to_vec(&serde_json::json!({
             "protocol": PROTOCOL_VERSION,
             "kind": "subscribe",
+            // muxa's `TransitionStream::recv` understands the lagged marker
+            // frame, so opt in — `muxa watch` and `muxa mcp`'s
+            // `muxa_wait_for_change` both consume the stream through this
+            // client and want the explicit overflow signal.
+            "lagged_markers": true,
         }))?;
         req.push(b'\n');
         if req.len() > MAX_IPC_LINE_BYTES {
@@ -2390,32 +2540,62 @@ mod tests {
 
     // --- Control-plane routing tests (send_prompt / capture) -------------
 
-    use crate::backend::{BackendCaps, HostKind, PaneBackend};
+    // `HostKind` comes in via `use super::*` (it's imported at module top).
+    use crate::backend::{BackendCaps, PaneBackend};
     use std::sync::Arc;
     use std::sync::Mutex;
 
     /// Recorded `(pane_id, text)` injections from a `RecordingBackend`.
     type SendLog = Arc<Mutex<Vec<(String, String)>>>;
+    /// Recorded per-injection `socket` argument threaded into `send_text_on`
+    /// (the pane row's recorded server, or `None`).
+    type SocketLog = Arc<Mutex<Vec<Option<String>>>>;
 
-    /// A fake backend that records every `send_text` call and answers
-    /// `capture_pane` with a canned string. Its `kind` and `send_text`
-    /// capability are configurable so routing + refusal can be exercised
-    /// without a real tmux/herdr host.
+    /// A fake backend that records every `send_text_on` call — both the
+    /// `(pane_id, text)` and the pinned `socket` — and answers `capture_pane`
+    /// with a canned string. `has_cap` (advertised `caps().send_text`) and
+    /// `send_ok` (the runtime injection result) are decoupled so we can model
+    /// "backend can't inject" (refusal) separately from "backend accepted the
+    /// call but the pane is gone" (runtime failure). `fail_on_cr` makes just
+    /// the submit CR (`"\r"`) fail while the text send still succeeds, to
+    /// exercise the partial-failure signal.
     struct RecordingBackend {
         kind: HostKind,
-        can_send: bool,
+        has_cap: bool,
+        send_ok: bool,
+        fail_on_cr: bool,
         sends: SendLog,
+        sockets: SocketLog,
     }
 
     impl RecordingBackend {
+        /// The common case: a backend whose `send_text` capability and runtime
+        /// result are the same bool (`true` = injects fine; `false` = no cap,
+        /// so it's refused before any injection is attempted).
         fn new(kind: HostKind, can_send: bool) -> (Arc<Self>, SendLog) {
+            let (backend, sends, _sockets) = Self::new_full(kind, can_send, can_send, false);
+            (backend, sends)
+        }
+
+        /// Full constructor exposing the socket log and decoupled cap / runtime
+        /// / CR-failure toggles.
+        fn new_full(
+            kind: HostKind,
+            has_cap: bool,
+            send_ok: bool,
+            fail_on_cr: bool,
+        ) -> (Arc<Self>, SendLog, SocketLog) {
             let sends = Arc::new(Mutex::new(Vec::new()));
+            let sockets = Arc::new(Mutex::new(Vec::new()));
             let backend = Arc::new(Self {
                 kind,
-                can_send,
+                has_cap,
+                send_ok,
+                fail_on_cr,
                 sends: sends.clone(),
+                sockets: sockets.clone(),
             });
-            (backend, sends)
+            (backend, sends, sockets)
         }
     }
 
@@ -2446,11 +2626,18 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push((pane_id.to_string(), text.to_string()));
-            self.can_send
+            if self.fail_on_cr && text == "\r" {
+                return false;
+            }
+            self.send_ok
+        }
+        fn send_text_on(&self, socket: Option<&str>, pane_id: &str, text: &str) -> bool {
+            self.sockets.lock().unwrap().push(socket.map(str::to_owned));
+            self.send_text(pane_id, text)
         }
         fn caps(&self) -> BackendCaps {
             BackendCaps {
-                send_text: self.can_send,
+                send_text: self.has_cap,
                 ..BackendCaps::default()
             }
         }
@@ -2596,6 +2783,228 @@ mod tests {
 
         tx.send(()).unwrap();
         handle.await.unwrap();
+    }
+
+    /// Fix 3 — routing: a pane whose namespace classifies to a KNOWN host
+    /// (`herdr:`) but whose backend is NOT in the active set is a structured
+    /// refusal (`Err(kind)`), never a silent fall-through to the primary. An
+    /// unclassified id still falls back to `backends[0]`.
+    #[test]
+    fn resolve_backend_refuses_known_but_absent_namespace() {
+        let (tmux, _s) = RecordingBackend::new(HostKind::Tmux, true);
+        let backends: Vec<SharedBackend> = vec![tmux as SharedBackend];
+
+        // Known + present → the tmux backend.
+        assert!(matches!(
+            resolve_backend(&backends, "%5"),
+            Ok(b) if b.kind() == HostKind::Tmux
+        ));
+        // Known (herdr:) + absent from the set → refusal carrying the kind.
+        assert!(matches!(
+            resolve_backend(&backends, "herdr:p1"),
+            Err(HostKind::Herdr)
+        ));
+        // Unclassified id → fall back to the primary (backends[0]).
+        assert!(matches!(
+            resolve_backend(&backends, "weird-legacy-id"),
+            Ok(b) if b.kind() == HostKind::Tmux
+        ));
+    }
+
+    /// Fix 3 — end to end: `send_prompt` to a pane in an unobserved namespace
+    /// is refused with a `namespace unavailable` error and injects nothing —
+    /// it must NOT type into the tmux (primary) backend.
+    #[tokio::test]
+    async fn send_prompt_refused_for_unavailable_namespace() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-send-ns-absent.sock");
+        let (tmux, sends) = RecordingBackend::new(HostKind::Tmux, true);
+        let (tx, handle) = serve(&sock, Store::shared(), vec![tmux]).await;
+
+        let err = Client::new(sock.clone())
+            .send_prompt("herdr:p1", "hi", true)
+            .await
+            .expect_err("must refuse an unobserved namespace");
+        assert!(
+            format!("{err}").contains("namespace unavailable"),
+            "unexpected error: {err}",
+        );
+        assert!(
+            sends.lock().unwrap().is_empty(),
+            "no injection when the namespace is unavailable",
+        );
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    /// Fix 1 — the control op is pinned to the pane's RECORDED server: the
+    /// daemon looks the agent row up by pane and threads its `tmux_socket`
+    /// into `send_text_on` (both the text and the submit CR), so a shared
+    /// pane id like `%5` reaches the right tmux server.
+    #[tokio::test]
+    async fn send_prompt_threads_recorded_socket() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-send-socket.sock");
+        let store = Store::shared();
+        // Seed an agent on pane %5 recorded against the `amux` server.
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    tmux_socket: Some("amux".into()),
+                    kind: AgentKind::ClaudeCode,
+                    session_id: "sock-sess".into(),
+                    surface: None,
+                    pane: Some("%5".into()),
+                    cwd: None,
+                },
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+
+        let (backend, _sends, sockets) =
+            RecordingBackend::new_full(HostKind::Tmux, true, true, false);
+        let (tx, handle) = serve(&sock, store, vec![backend]).await;
+
+        Client::new(sock.clone())
+            .send_prompt("%5", "go", true)
+            .await
+            .expect("send_prompt ok");
+
+        // Both injections (text + CR) were pinned to the recorded socket.
+        assert_eq!(
+            sockets.lock().unwrap().clone(),
+            vec![Some("amux".to_string()), Some("amux".to_string())],
+        );
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    /// Fix 1 — with no recorded agent row for the pane, the threaded socket is
+    /// `None` (the tmux backend then falls back to the env-scoped default).
+    #[tokio::test]
+    async fn send_prompt_threads_none_socket_when_untracked() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-send-nosock.sock");
+        let (backend, _sends, sockets) =
+            RecordingBackend::new_full(HostKind::Tmux, true, true, false);
+        let (tx, handle) = serve(&sock, Store::shared(), vec![backend]).await;
+
+        Client::new(sock.clone())
+            .send_prompt("%9", "hi", false)
+            .await
+            .expect("send_prompt ok");
+
+        assert_eq!(sockets.lock().unwrap().clone(), vec![None]);
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    /// Fix 6 — honest partial-failure signal: when the text lands but the
+    /// submit CR fails, the response is `ok:true` with `sent:true,
+    /// submitted:false` (NOT a total failure), so a caller knows the text is
+    /// already in the pane and must not resend it.
+    #[tokio::test]
+    async fn send_prompt_reports_partial_failure_when_cr_fails() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-send-partial.sock");
+        // Text send succeeds; the `\r` submit fails.
+        let (backend, sends, _sockets) =
+            RecordingBackend::new_full(HostKind::Tmux, true, true, true);
+        let (tx, handle) = serve(&sock, Store::shared(), vec![backend]).await;
+
+        let outcome = Client::new(sock.clone())
+            .send_prompt("%1", "hello", true)
+            .await
+            .expect("text landed → Ok, not a total failure");
+        assert!(outcome.sent, "text landed");
+        assert!(!outcome.submitted, "submit CR failed");
+
+        // The CR WAS attempted (text-send succeeded first), and the text was
+        // sent exactly once — no double-inject.
+        assert_eq!(
+            sends.lock().unwrap().clone(),
+            vec![
+                ("%1".to_string(), "hello".to_string()),
+                ("%1".to_string(), "\r".to_string()),
+            ],
+        );
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    /// Fix 6 — a total text-send failure is an `Err` (nothing landed, safe to
+    /// retry the whole send), and the submit CR is NOT attempted.
+    #[tokio::test]
+    async fn send_prompt_total_failure_skips_cr() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-send-total-fail.sock");
+        // Every send fails.
+        let (backend, sends, _sockets) =
+            RecordingBackend::new_full(HostKind::Tmux, true, false, false);
+        let (tx, handle) = serve(&sock, Store::shared(), vec![backend]).await;
+
+        let err = Client::new(sock.clone())
+            .send_prompt("%1", "hello", true)
+            .await
+            .expect_err("nothing landed → Err");
+        assert!(format!("{err}").contains("send_text failed"), "err: {err}");
+        // Only the text was attempted; the CR is skipped when the text fails.
+        assert_eq!(
+            sends.lock().unwrap().clone(),
+            vec![("%1".to_string(), "hello".to_string())],
+        );
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    /// Fix 7 — the lagged marker is gated on the connection's opt-in: an
+    /// un-opted subscriber gets `None` (silently continue, pre-marker
+    /// behavior), an opted-in one gets the encoded `{"event":"lagged",…}` frame.
+    #[test]
+    fn lagged_marker_bytes_gated_on_opt_in() {
+        // Not opted in → nothing on the wire.
+        assert!(lagged_marker_bytes(false, 7, PROTOCOL_VERSION)
+            .unwrap()
+            .is_none());
+        // Opted in → a newline-terminated lagged frame carrying the drop count.
+        let bytes = lagged_marker_bytes(true, 7, PROTOCOL_VERSION)
+            .unwrap()
+            .expect("opted-in subscriber gets the marker");
+        let line = String::from_utf8(bytes).unwrap();
+        assert!(line.ends_with('\n'));
+        let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(v["event"], "lagged");
+        assert_eq!(v["dropped"], 7);
+    }
+
+    /// Fix 7 — muxa's own client opts in: the `subscribe` request it sends
+    /// carries `lagged_markers: true` so `muxa watch` / `muxa mcp` receive the
+    /// overflow signal their `TransitionStream` reader knows how to skip.
+    #[test]
+    fn subscribe_request_defaults_and_opt_in_parse() {
+        // Absent field → default false (a pre-marker client stays legacy).
+        let req: Request = serde_json::from_str(r#"{"protocol":3,"kind":"subscribe"}"#).unwrap();
+        assert!(matches!(
+            req.body,
+            RequestBody::Subscribe {
+                lagged_markers: false
+            }
+        ));
+        // Explicit opt-in parses through.
+        let req: Request =
+            serde_json::from_str(r#"{"protocol":3,"kind":"subscribe","lagged_markers":true}"#)
+                .unwrap();
+        assert!(matches!(
+            req.body,
+            RequestBody::Subscribe {
+                lagged_markers: true
+            }
+        ));
     }
 
     /// `is_lagged_marker` recognizes the daemon's overflow marker and

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -147,8 +147,31 @@ enum RequestBody {
     /// `ok` ack, then writes one JSON-encoded `Transition` per
     /// state change (newline-delimited) until the client closes the
     /// socket. Used by `muxa watch` to switch from 500 ms polling to
-    /// push-based updates.
+    /// push-based updates, and by the `muxa mcp` server's
+    /// `muxa_wait_for_change` tool.
     Subscribe,
+
+    /// Control action: inject `text` into `pane` as literal keystrokes,
+    /// resolving the backend from the pane-id namespace. When `submit`,
+    /// a trailing carriage return is sent as a second injection so the
+    /// agent's current line is committed. Refused with a structured
+    /// error (never a panic) when the target backend lacks the
+    /// `send_text` capability (e.g. zellij). Backs `muxa mcp`'s
+    /// `muxa_send_prompt` tool.
+    SendPrompt {
+        pane: String,
+        text: String,
+        #[serde(default)]
+        submit: bool,
+    },
+
+    /// Control/observation: capture the visible contents of `pane` via
+    /// the namespace-resolved backend. Backs `muxa mcp`'s
+    /// `muxa_capture_pane` tool. Returns `capture = null` when the pane
+    /// is gone or the backend can't capture (best-effort).
+    Capture {
+        pane: String,
+    },
 
     /// Wholesale pane-metadata snapshot pushed by an out-of-process
     /// backend source — today the zellij WASM plugin forwarding
@@ -269,6 +292,11 @@ pub struct Response {
     pub output: Option<SessionOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pruned: Option<usize>,
+    /// Visible pane contents for a `capture` request. `Some("")` is a
+    /// real empty capture; `None` means the field is absent (any other
+    /// response kind, or a `capture` whose backend returned nothing).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capture: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -294,6 +322,7 @@ impl Response {
             terminal: None,
             output: None,
             pruned: None,
+            capture: None,
         }
     }
     fn err(msg: impl Into<String>) -> Self {
@@ -345,6 +374,11 @@ impl Response {
         r.pruned = Some(pruned);
         r
     }
+    fn with_capture(capture: Option<String>) -> Self {
+        let mut r = Self::ok();
+        r.capture = capture;
+        r
+    }
     fn hello() -> Self {
         let mut r = Self::ok();
         r.min_protocol = Some(MIN_PROTOCOL_VERSION);
@@ -358,17 +392,26 @@ impl Response {
 pub struct Server {
     socket_path: PathBuf,
     store: SharedStore,
+    /// Backend the server forwards `BackendPaneSnapshot` pushes to (the
+    /// zellij backend in a multi-host daemon; see `with_backend`).
     backend: SharedBackend,
+    /// The full set of backends the daemon observes, for namespace-scoped
+    /// control routing (`send_prompt` / `capture`). Never empty:
+    /// `backends[0]` is the primary/env-preferred host, used as the
+    /// fallback when a pane id doesn't classify to a known namespace.
+    backends: Vec<SharedBackend>,
     sessions: SharedSessionBackend,
     handler_limit: usize,
 }
 
 impl Server {
     pub fn new(socket_path: PathBuf, store: SharedStore) -> Self {
+        let backend = default_backend();
         Self {
             socket_path,
             store,
-            backend: default_backend(),
+            backend: backend.clone(),
+            backends: vec![backend],
             sessions: PtySessionBackend::shared(),
             handler_limit: MAX_INFLIGHT_HANDLERS,
         }
@@ -382,6 +425,21 @@ impl Server {
     #[must_use]
     pub fn with_backend(mut self, backend: SharedBackend) -> Self {
         self.backend = backend;
+        self
+    }
+
+    /// Thread the daemon's full backend set into the server so control
+    /// methods (`send_prompt`, `capture`) can resolve the backend that
+    /// governs a given pane id's namespace (`%…` → tmux, `herdr:…` →
+    /// herdr, …), falling back to the primary (`backends[0]`) for
+    /// unclassifiable ids. An empty set is ignored (keeps the
+    /// [`Self::new`] default) so the invariant "`backends` is never
+    /// empty" holds for the resolver.
+    #[must_use]
+    pub fn with_backends(mut self, backends: Vec<SharedBackend>) -> Self {
+        if !backends.is_empty() {
+            self.backends = backends;
+        }
         self
     }
 
@@ -477,11 +535,12 @@ impl Server {
                     };
                     let store = self.store.clone();
                     let backend = self.backend.clone();
+                    let backends = self.backends.clone();
                     let sessions = self.sessions.clone();
                     handlers.spawn(async move {
                         // Held for the handler's lifetime; released here on exit.
                         let _permit = permit;
-                        if let Err(e) = handle(stream, store, backend, sessions).await {
+                        if let Err(e) = handle(stream, store, backend, backends, sessions).await {
                             if e.is_client_disconnect() {
                                 tracing::debug!(error = %e, "client disconnected");
                                 return;
@@ -683,6 +742,19 @@ async fn stream_transitions(
                         dropped = n,
                         "subscribe lagged; client will reconcile via fallback poll"
                     );
+                    // Emit a lagged marker so a streaming client knows it
+                    // dropped `n` transitions and should reconcile via a
+                    // snapshot. It's a distinct object shape (`event` tag, no
+                    // `from`/`to`), so `TransitionStream::recv` skips it rather
+                    // than mis-parsing it as a `Transition`.
+                    let marker = serde_json::json!({ "event": "lagged", "dropped": n });
+                    let bytes = encode_line(&marker, protocol)?;
+                    if writer.write_all(&bytes).await.is_err() {
+                        return Ok(());
+                    }
+                    if writer.flush().await.is_err() {
+                        return Ok(());
+                    }
                 }
             },
             _ = keepalive.tick() => {
@@ -701,12 +773,27 @@ async fn stream_transitions(
     }
 }
 
-#[tracing::instrument(level = "debug", skip(stream, store, backend, sessions))]
+/// Resolve the backend that governs `pane`'s id namespace (`%…` → tmux,
+/// `herdr:…` → herdr, `zellij:…` → zellij), falling back to the primary
+/// (`backends[0]`) for ids muxa doesn't classify. `backends` is never
+/// empty (the `Server` builder guarantees it), so the fallback is always
+/// valid.
+fn resolve_backend<'a>(backends: &'a [SharedBackend], pane: &str) -> &'a SharedBackend {
+    if let Some(kind) = crate::backend::pane_id_host_kind(pane) {
+        if let Some(b) = backends.iter().find(|b| b.kind() == kind) {
+            return b;
+        }
+    }
+    &backends[0]
+}
+
+#[tracing::instrument(level = "debug", skip(stream, store, backend, backends, sessions))]
 #[allow(clippy::too_many_lines)] // dispatch table — splitting would only spread the match across files
 async fn handle(
     stream: UnixStream,
     store: SharedStore,
     backend: SharedBackend,
+    backends: Vec<SharedBackend>,
     sessions: SharedSessionBackend,
 ) -> Result<(), RuntimeError> {
     let (reader, mut writer) = stream.into_split();
@@ -888,6 +975,47 @@ async fn handle(
                     tracing::debug!(panes = count, "backend_pane_snapshot");
                     Response::ok()
                 }
+                RequestBody::SendPrompt { pane, text, submit } => {
+                    kind = "send_prompt";
+                    let target = resolve_backend(&backends, &pane).clone();
+                    if target.caps().send_text {
+                        // `send_text` is a blocking shell-out / socket call, so
+                        // run it off the async worker. Text first, then the
+                        // submit CR as a separate injection (byte-identical to
+                        // `send-keys Enter` / a CR to a herdr pty).
+                        let sent = tokio::task::spawn_blocking(move || {
+                            let ok = target.send_text(&pane, &text);
+                            if ok && submit {
+                                target.send_text(&pane, "\r")
+                            } else {
+                                ok
+                            }
+                        })
+                        .await
+                        .unwrap_or(false);
+                        if sent {
+                            tracing::debug!(submit, "send_prompt");
+                            Response::ok()
+                        } else {
+                            Response::err("send_text failed: pane gone or host unreachable")
+                        }
+                    } else {
+                        // Structured refusal, not a panic: the backend that
+                        // owns this pane's namespace can't inject keystrokes.
+                        Response::err(format!(
+                            "backend {} does not support send_text (pane {pane})",
+                            target.kind(),
+                        ))
+                    }
+                }
+                RequestBody::Capture { pane } => {
+                    kind = "capture";
+                    let target = resolve_backend(&backends, &pane).clone();
+                    let text = tokio::task::spawn_blocking(move || target.capture_pane(&pane))
+                        .await
+                        .unwrap_or(None);
+                    Response::with_capture(text)
+                }
                 RequestBody::SpawnSession {
                     command,
                     args,
@@ -1058,6 +1186,22 @@ pub struct TransitionStream {
     line: String,
 }
 
+/// Whether a subscribe-stream line is the daemon's `lagged` control marker
+/// (`{"event":"lagged",…}`) rather than a `Transition`. Kept cheap: a real
+/// `Transition` is tagged by `from`/`to`, never an `event` field, so a
+/// single parse-and-check disambiguates without a speculative `Transition`
+/// deserialize.
+fn is_lagged_marker(line: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(line)
+        .ok()
+        .and_then(|v| {
+            v.get("event")
+                .and_then(serde_json::Value::as_str)
+                .map(|e| e == "lagged")
+        })
+        .unwrap_or(false)
+}
+
 fn decode_agents(resp: &serde_json::Value) -> Vec<Agent> {
     resp["agents"]
         .as_array()
@@ -1081,6 +1225,16 @@ impl TransitionStream {
             }
             let trimmed = self.line.trim();
             if trimmed.is_empty() {
+                continue;
+            }
+            // The daemon interleaves non-transition control frames on this
+            // stream: a bare newline keepalive (handled above) and a lagged
+            // marker (`{"event":"lagged","dropped":N}`) after a broadcast
+            // overflow. Skip the lagged marker — the caller reconciles holes
+            // via its fallback snapshot poll — so it never reaches the
+            // `Transition` deserializer below.
+            if is_lagged_marker(trimmed) {
+                tracing::debug!("subscribe stream lagged; skipping marker");
                 continue;
             }
             let t: crate::state::Transition = serde_json::from_str(trimmed)?;
@@ -1138,6 +1292,41 @@ impl Client {
         });
         let resp = self.call(&req).await?;
         Ok(usize::try_from(resp["pruned"].as_u64().unwrap_or(0)).unwrap_or(usize::MAX))
+    }
+
+    /// Inject `text` into `pane` via the daemon, resolving the backend
+    /// from the pane-id namespace. When `submit`, the daemon follows the
+    /// text with a carriage return so the agent's line is committed.
+    /// Errors when the backend can't inject (structured refusal from the
+    /// daemon) or the send fails. Backs `muxa mcp`'s `muxa_send_prompt`.
+    pub async fn send_prompt(
+        &self,
+        pane: &str,
+        text: &str,
+        submit: bool,
+    ) -> Result<(), RuntimeError> {
+        let req = serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "send_prompt",
+            "pane": pane,
+            "text": text,
+            "submit": submit,
+        });
+        let _ = self.call_checked(&req).await?;
+        Ok(())
+    }
+
+    /// Capture the visible contents of `pane` through the daemon's
+    /// namespace-resolved backend. Returns `None` when the pane is gone or
+    /// the backend can't capture. Backs `muxa mcp`'s `muxa_capture_pane`.
+    pub async fn capture(&self, pane: &str) -> Result<Option<String>, RuntimeError> {
+        let req = serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "capture",
+            "pane": pane,
+        });
+        let resp = self.call_checked(&req).await?;
+        Ok(resp["capture"].as_str().map(str::to_owned))
     }
 
     pub async fn snapshot_with_timeout(
@@ -1766,6 +1955,7 @@ mod tests {
             server_stream,
             store,
             default_backend(),
+            vec![default_backend()],
             PtySessionBackend::shared(),
         ));
 
@@ -2196,5 +2386,276 @@ mod tests {
 
         tx.send(()).unwrap();
         handle.await.unwrap();
+    }
+
+    // --- Control-plane routing tests (send_prompt / capture) -------------
+
+    use crate::backend::{BackendCaps, HostKind, PaneBackend};
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    /// Recorded `(pane_id, text)` injections from a `RecordingBackend`.
+    type SendLog = Arc<Mutex<Vec<(String, String)>>>;
+
+    /// A fake backend that records every `send_text` call and answers
+    /// `capture_pane` with a canned string. Its `kind` and `send_text`
+    /// capability are configurable so routing + refusal can be exercised
+    /// without a real tmux/herdr host.
+    struct RecordingBackend {
+        kind: HostKind,
+        can_send: bool,
+        sends: SendLog,
+    }
+
+    impl RecordingBackend {
+        fn new(kind: HostKind, can_send: bool) -> (Arc<Self>, SendLog) {
+            let sends = Arc::new(Mutex::new(Vec::new()));
+            let backend = Arc::new(Self {
+                kind,
+                can_send,
+                sends: sends.clone(),
+            });
+            (backend, sends)
+        }
+    }
+
+    impl PaneBackend for RecordingBackend {
+        fn kind(&self) -> HostKind {
+            self.kind
+        }
+        fn list_panes(&self) -> Vec<PaneInfo> {
+            Vec::new()
+        }
+        fn resolve_pane(&self, _: &str) -> Option<PaneInfo> {
+            None
+        }
+        fn capture_pane(&self, pane_id: &str) -> Option<String> {
+            Some(format!("captured:{pane_id}"))
+        }
+        fn pane_pid_map(&self) -> std::collections::HashMap<u32, String> {
+            std::collections::HashMap::new()
+        }
+        fn current_pane(&self) -> Option<String> {
+            None
+        }
+        fn focus_pane(&self, _: &str) -> bool {
+            false
+        }
+        fn send_text(&self, pane_id: &str, text: &str) -> bool {
+            self.sends
+                .lock()
+                .unwrap()
+                .push((pane_id.to_string(), text.to_string()));
+            self.can_send
+        }
+        fn caps(&self) -> BackendCaps {
+            BackendCaps {
+                send_text: self.can_send,
+                ..BackendCaps::default()
+            }
+        }
+    }
+
+    async fn serve<B: PaneBackend>(
+        sock: &Path,
+        store: SharedStore,
+        backends: Vec<Arc<B>>,
+    ) -> (broadcast::Sender<()>, tokio::task::JoinHandle<()>) {
+        let backends: Vec<SharedBackend> =
+            backends.into_iter().map(|b| b as SharedBackend).collect();
+        let server = Server::new(sock.to_path_buf(), store).with_backends(backends);
+        let (tx, rx) = broadcast::channel(1);
+        let handle = tokio::spawn(async move { server.run(rx).await.unwrap() });
+        wait_for_socket(sock).await;
+        (tx, handle)
+    }
+
+    /// `send_prompt` routes to the backend that governs the pane's
+    /// namespace and, with `submit`, follows the text with a carriage
+    /// return as a second injection.
+    #[tokio::test]
+    async fn send_prompt_injects_text_then_submit_cr() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-send.sock");
+        let (backend, sends) = RecordingBackend::new(HostKind::Tmux, true);
+        let (tx, handle) = serve(&sock, Store::shared(), vec![backend]).await;
+
+        Client::new(sock.clone())
+            .send_prompt("%1", "fix the bug", true)
+            .await
+            .expect("send_prompt ok");
+
+        let recorded = sends.lock().unwrap().clone();
+        assert_eq!(
+            recorded,
+            vec![
+                ("%1".to_string(), "fix the bug".to_string()),
+                ("%1".to_string(), "\r".to_string()),
+            ],
+        );
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    /// Without `submit`, only the text is injected — no trailing CR.
+    #[tokio::test]
+    async fn send_prompt_without_submit_omits_cr() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-send-nosub.sock");
+        let (backend, sends) = RecordingBackend::new(HostKind::Tmux, true);
+        let (tx, handle) = serve(&sock, Store::shared(), vec![backend]).await;
+
+        Client::new(sock.clone())
+            .send_prompt("%1", "note", false)
+            .await
+            .expect("send_prompt ok");
+
+        assert_eq!(
+            sends.lock().unwrap().clone(),
+            vec![("%1".to_string(), "note".to_string())],
+        );
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    /// A backend that lacks the `send_text` capability is refused with a
+    /// structured error — never a panic, and no injection is attempted.
+    #[tokio::test]
+    async fn send_prompt_refused_when_backend_lacks_cap() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-send-refuse.sock");
+        let (backend, sends) = RecordingBackend::new(HostKind::Zellij, false);
+        let (tx, handle) = serve(&sock, Store::shared(), vec![backend]).await;
+
+        let err = Client::new(sock.clone())
+            .send_prompt("zellij:3", "hi", true)
+            .await
+            .expect_err("must refuse without send_text cap");
+        assert!(
+            format!("{err}").contains("does not support send_text"),
+            "unexpected error: {err}",
+        );
+        assert!(
+            sends.lock().unwrap().is_empty(),
+            "no injection when the cap is absent",
+        );
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    /// With a mixed backend set, `send_prompt` resolves the target by the
+    /// pane-id namespace: a `herdr:` pane routes to the herdr backend even
+    /// though tmux is primary (`backends[0]`).
+    #[tokio::test]
+    async fn send_prompt_resolves_by_pane_namespace() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-send-ns.sock");
+        let (tmux, tmux_sends) = RecordingBackend::new(HostKind::Tmux, true);
+        let (herdr, herdr_sends) = RecordingBackend::new(HostKind::Herdr, true);
+        // tmux leads (primary); herdr trails.
+        let backends: Vec<SharedBackend> = vec![tmux as SharedBackend, herdr as SharedBackend];
+        let server = Server::new(sock.clone(), Store::shared()).with_backends(backends);
+        let (tx, rx) = broadcast::channel(1);
+        let handle = tokio::spawn(async move { server.run(rx).await.unwrap() });
+        wait_for_socket(&sock).await;
+
+        Client::new(sock.clone())
+            .send_prompt("herdr:p9", "hey", false)
+            .await
+            .expect("send_prompt ok");
+
+        assert!(
+            tmux_sends.lock().unwrap().is_empty(),
+            "tmux must not receive"
+        );
+        assert_eq!(
+            herdr_sends.lock().unwrap().clone(),
+            vec![("herdr:p9".to_string(), "hey".to_string())],
+        );
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    /// `capture` routes to the namespace backend and returns its screen text.
+    #[tokio::test]
+    async fn capture_returns_backend_screen_text() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-capture.sock");
+        let (backend, _sends) = RecordingBackend::new(HostKind::Tmux, true);
+        let (tx, handle) = serve(&sock, Store::shared(), vec![backend]).await;
+
+        let text = Client::new(sock.clone())
+            .capture("%7")
+            .await
+            .expect("capture ok");
+        assert_eq!(text.as_deref(), Some("captured:%7"));
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    /// `is_lagged_marker` recognizes the daemon's overflow marker and
+    /// rejects a normal transition line.
+    #[test]
+    fn lagged_marker_is_recognized() {
+        assert!(is_lagged_marker(r#"{"event":"lagged","dropped":5}"#));
+        assert!(!is_lagged_marker(
+            r#"{"from":"idle","to":"working","agent":{}}"#
+        ));
+        assert!(!is_lagged_marker("not json"));
+    }
+
+    /// `TransitionStream::recv` skips a lagged marker frame and returns the
+    /// next real `Transition`.
+    #[tokio::test]
+    async fn transition_stream_skips_lagged_marker() {
+        use crate::event::{AgentEvent, AgentId, AgentKind};
+        use time::OffsetDateTime;
+
+        // Produce a real serialized Transition via a store.
+        let store = Store::shared();
+        let mut rx = store.subscribe();
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    tmux_socket: None,
+                    kind: AgentKind::ClaudeCode,
+                    session_id: "lag".into(),
+                    surface: None,
+                    pane: Some("%1".into()),
+                    cwd: None,
+                },
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+        let transition = rx.recv().await.unwrap();
+        let transition_json = serde_json::to_string(&transition).unwrap();
+
+        // Wire the marker + transition into a TransitionStream's reader.
+        let (client_side, server_side) = UnixStream::pair().unwrap();
+        let (cr, _cw) = client_side.into_split();
+        let mut ts = TransitionStream {
+            reader: BufReader::new(cr),
+            line: String::new(),
+        };
+        let (_sr, mut sw) = server_side.into_split();
+        let mut payload = String::from(r#"{"event":"lagged","dropped":3}"#);
+        payload.push('\n');
+        payload.push_str(&transition_json);
+        payload.push('\n');
+        sw.write_all(payload.as_bytes()).await.unwrap();
+        sw.flush().await.unwrap();
+
+        let got = ts
+            .recv()
+            .await
+            .expect("recv ok")
+            .expect("a transition after the skipped marker");
+        assert_eq!(got.to, transition.to);
+        assert_eq!(got.agent.session_id, "lag");
     }
 }

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -124,11 +124,12 @@ fn tmux_output(args: &[&str]) -> Result<Output, TmuxError> {
 /// names a specific server socket.
 ///
 /// The other single-socket helpers target whatever the default socket /
-/// `$TMUX_TMPDIR` resolves to. Control actions ([`send_text`]) instead have
-/// to reach the *particular* server the target pane lives on. When the daemon
-/// is scoped to one server (`MUXA_TMUX_SOCKET`, as in an isolated or test
-/// context) we pass `-S <socket>` so `send-keys` lands on that server rather
-/// than the default one. Unset ⇒ no `-S`, byte-identical to `tmux_command()`.
+/// `$TMUX_TMPDIR` resolves to. When the daemon is scoped to one server
+/// (`MUXA_TMUX_SOCKET`, as in an isolated or test context) we pass
+/// `-S <socket>` so the command lands on that server rather than the default
+/// one. Unset ⇒ no `-S`, byte-identical to `tmux_command()`. This is the
+/// *env-scoped* fallback; a control op that knows the pane's server prefers
+/// [`tmux_command_targeting`], which pins the exact server the pane lives on.
 fn tmux_command_scoped() -> Command {
     let mut cmd = tmux_command();
     if let Ok(sock) = std::env::var("MUXA_TMUX_SOCKET") {
@@ -140,28 +141,207 @@ fn tmux_command_scoped() -> Command {
     cmd
 }
 
+/// Resolve a short tmux socket name (a pane row's recorded `tmux_socket`, e.g.
+/// `default` / `amux` — the socket file's basename) to the full socket *path*
+/// of a live server, by matching the basename against the scanner's socket
+/// enumeration. `None` when no enumerated socket matches (server gone, or the
+/// name came from a non-standard socket dir the scanner doesn't walk).
+///
+/// This is what lets a control op target the *specific* server a pane lives
+/// on: pane id `%5` exists on every tmux server, so `send-keys` / `capture-pane`
+/// must be pinned to the right one via `-S <full-path>`. Matching against
+/// [`scanner::enumerate_sockets`] (which already honors `MUXA_TMUX_SOCKET`
+/// scoping and the macOS `/tmp`↔`/private/tmp` split) keeps the targeting
+/// byte-identical to how the pane was discovered in the first place.
+fn resolve_socket_path(short_name: &str) -> Option<PathBuf> {
+    let short_name = short_name.trim();
+    if short_name.is_empty() {
+        return None;
+    }
+    scanner::enumerate_sockets()
+        .into_iter()
+        .find(|p| p.file_name().and_then(|n| n.to_str()) == Some(short_name))
+}
+
+/// Build a tmux `Command` pinned to the specific server named by `socket` (a
+/// pane row's recorded short socket name). Resolves the name to the live
+/// server's full socket path and passes `-S <path>` so the command can't leak
+/// onto a different server that happens to share the pane id.
+///
+/// Falls back to [`tmux_command_scoped`] (the `MUXA_TMUX_SOCKET`-or-default
+/// behavior) when `socket` is `None`/empty or doesn't resolve to a live
+/// server — i.e. when the agent row has no recorded socket — preserving the
+/// pre-control-plane single-server behavior.
+fn tmux_command_targeting(socket: Option<&str>) -> Command {
+    if let Some(path) = socket.and_then(resolve_socket_path) {
+        let mut cmd = tmux_command();
+        cmd.arg("-S").arg(path);
+        return cmd;
+    }
+    tmux_command_scoped()
+}
+
 /// The `send-keys` argv (after any server-scope flags) for a literal text
-/// injection. Split out from [`send_text`] so the argument construction is
+/// injection. Split out from [`send_text_on`] so the argument construction is
 /// unit-testable without a running tmux server.
 ///
 /// `-l` sends the text literally — no key-name lookup — so arbitrary prompt
-/// text can't be misread as a tmux key (`Enter`, `C-c`, …). A bare `"\r"`
-/// submits the pane's current line (byte-identical to `send-keys Enter`).
-fn send_keys_argv<'a>(pane_id: &'a str, text: &'a str) -> [&'a str; 5] {
-    ["send-keys", "-t", pane_id, "-l", text]
+/// text can't be misread as a tmux key (`Enter`, `C-c`, …). The `--` marks the
+/// end of options so text that *starts* with `-` (e.g. `-rf`) is taken as the
+/// literal argument, not a flag — MCP forwards arbitrary model text, so this
+/// path must survive hostile leading characters.
+///
+/// The `--` does NOT rescue a *trailing* `;`: tmux consumes a trailing
+/// unescaped `;` as a command separator at its command-parse layer, before this
+/// command's own option scanner runs. Text ending in `;` (and multi-line text)
+/// is routed through the paste path instead — see [`needs_paste`].
+fn send_keys_argv<'a>(pane_id: &'a str, text: &'a str) -> [&'a str; 6] {
+    ["send-keys", "-t", pane_id, "-l", "--", text]
 }
 
-/// Inject `text` into `pane_id` as literal keystrokes. Backs the tmux
-/// [`crate::backend::PaneBackend::send_text`] capability and, through it, the
-/// daemon's `send_prompt` IPC. Returns `true` on a zero exit; `false` when
-/// the pane is gone, tmux errors, or the shell-out times out (best-effort,
-/// matching the rest of this module).
+/// Whether literal `text` must be injected via the paste-buffer path rather
+/// than a single `send-keys -l -- …` call.
 ///
-/// Known limitation: text that *starts* with `-` can be misparsed by tmux's
-/// `send-keys` option scanner; muxa never generates such prompts and callers
-/// should avoid leading dashes.
+/// Two hazards can't be sent verbatim through `send-keys` and are NOT fixed by
+/// the `--` terminator (both are resolved by tmux *before* send-keys' own
+/// option scanner runs):
+///   - **embedded newline** — `send-keys -l` replays each `\n` as an Enter, so
+///     a multi-line prompt is submitted line-by-line even with `submit:false`.
+///   - **trailing `;`** — tmux eats a trailing unescaped `;` as a command
+///     separator, silently dropping it (verified on tmux 3.x: `-l -- ';'` types
+///     nothing, while `-l -- 'a;b'` is fine — only a *trailing* `;` is lost).
+///
+/// Feeding the text on stdin via `load-buffer` and replaying it with a
+/// bracketed `paste-buffer` sidesteps argv parsing entirely, so both land
+/// literally. The lone submit CR (`"\r"`) has neither hazard, so it stays on
+/// the fast `send-keys` path.
+fn needs_paste(text: &str) -> bool {
+    text.contains('\n') || text.ends_with(';')
+}
+
+/// A process-unique scratch tmux buffer name for one paste injection. Unique
+/// (pid + monotonic counter) so concurrent control ops can't clobber each
+/// other's buffer between `load-buffer` and `paste-buffer`.
+fn paste_buffer_name() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    format!("muxa-send-{}-{n}", std::process::id())
+}
+
+/// Like [`command_output_with_timeout`] but writes `input` to the child's
+/// stdin (then closes it) before waiting — for `load-buffer -b <buf> -`, which
+/// reads the paste payload from stdin so it never passes through argv.
+fn feed_stdin_with_timeout(
+    mut cmd: Command,
+    timeout: Duration,
+    command: String,
+    input: &[u8],
+) -> Result<Output, TmuxError> {
+    use std::io::Write;
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn()?;
+    // Write the payload and drop the handle so tmux sees EOF. Best-effort: a
+    // failed write (child already died) falls through to the wait/timeout
+    // below, which surfaces the real failure via the exit status.
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(input);
+    }
+    let started = Instant::now();
+    loop {
+        if child.try_wait()?.is_some() {
+            return child.wait_with_output().map_err(TmuxError::Spawn);
+        }
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(TmuxError::Timeout { command, timeout });
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+/// Inject `text` into `pane_id` via tmux's paste buffer instead of
+/// `send-keys`, so multi-line text lands as one bracketed paste (not an
+/// Enter-per-newline submit) and a trailing `;` survives. Used by
+/// [`send_text_on`] for text that [`needs_paste`] flags.
+///
+/// Sequence: `load-buffer -b <buf> -` (payload on stdin, never in argv) →
+/// `paste-buffer -p -b <buf> -t <pane>` (`-p` = bracketed paste) →
+/// `delete-buffer -b <buf>` (best-effort scratch cleanup).
+///
+/// Bracketed paste is best-effort by nature: a paste-aware target (Claude
+/// Code's input, a modern readline shell with bracketed-paste on) inserts the
+/// whole block without executing intermediate newlines; a target that doesn't
+/// honor bracketed paste still sees the raw newlines and may run them
+/// line-by-line. This is strictly better than `send-keys -l` (which ALWAYS
+/// submits per newline), so it's the least-surprising default for multi-line
+/// submit semantics. The trailing submit CR (`submit:true`) is sent separately
+/// as a `send-keys` Enter and is unaffected.
+fn paste_text_on(socket: Option<&str>, pane_id: &str, text: &str) -> bool {
+    let buf = paste_buffer_name();
+
+    let mut load = tmux_command_targeting(socket);
+    load.args(["load-buffer", "-b", &buf, "-"]);
+    let loaded = feed_stdin_with_timeout(
+        load,
+        TMUX_COMMAND_TIMEOUT,
+        format!("tmux load-buffer -b {buf}"),
+        text.as_bytes(),
+    )
+    .is_ok_and(|o| o.status.success());
+    if !loaded {
+        return false;
+    }
+
+    let mut paste = tmux_command_targeting(socket);
+    paste.args(["paste-buffer", "-p", "-b", &buf, "-t", pane_id]);
+    let pasted = command_output_with_timeout(
+        paste,
+        TMUX_COMMAND_TIMEOUT,
+        format!("tmux paste-buffer -t {pane_id}"),
+    )
+    .is_ok_and(|o| o.status.success());
+
+    // `paste-buffer` without `-d` leaves the named buffer behind; delete it so
+    // scratch buffers don't accumulate. A leaked buffer is harmless, so the
+    // result is ignored — the paste's success is what we report.
+    let mut del = tmux_command_targeting(socket);
+    del.args(["delete-buffer", "-b", &buf]);
+    let _ = command_output_with_timeout(
+        del,
+        TMUX_COMMAND_TIMEOUT,
+        format!("tmux delete-buffer -b {buf}"),
+    );
+
+    pasted
+}
+
+/// Inject `text` into `pane_id` as literal keystrokes on the env-scoped
+/// default server. Thin wrapper over [`send_text_on`] with no pinned socket —
+/// kept for callers/tests that don't carry a recorded socket. The control
+/// plane uses [`send_text_on`] with the agent row's recorded socket.
 pub fn send_text(pane_id: &str, text: &str) -> bool {
-    let mut cmd = tmux_command_scoped();
+    send_text_on(None, pane_id, text)
+}
+
+/// Inject `text` into `pane_id` on the specific tmux server named by `socket`
+/// (a pane row's recorded short socket name; `None` ⇒ env-scoped default).
+/// Backs the tmux [`crate::backend::PaneBackend::send_text_on`] capability
+/// and, through it, the daemon's `send_prompt` IPC.
+///
+/// Simple single-line text goes through a fast `send-keys -l -- <text>`; text
+/// with an embedded newline or a trailing `;` is routed through the paste
+/// buffer instead (see [`needs_paste`] / [`paste_text_on`]) so it lands
+/// verbatim. Returns `true` on success; `false` when the pane is gone, tmux
+/// errors, or the shell-out times out (best-effort, matching this module).
+pub fn send_text_on(socket: Option<&str>, pane_id: &str, text: &str) -> bool {
+    if needs_paste(text) {
+        return paste_text_on(socket, pane_id, text);
+    }
+    let mut cmd = tmux_command_targeting(socket);
     cmd.args(send_keys_argv(pane_id, text));
     command_output_with_timeout(
         cmd,
@@ -541,11 +721,33 @@ pub fn inside_tmux() -> bool {
 /// status is non-zero, the stderr is short — so callers should treat
 /// `NonZero` as "ephemeral, retry next tick" rather than fatal.
 pub fn capture_pane(pane_id: &str) -> Result<String, TmuxError> {
-    // Scope to `MUXA_TMUX_SOCKET` (via `-S`) when set so a capture reaches the
-    // specific server the pane lives on — the same targeting `send_text` uses,
-    // which is what makes the control-plane `capture` IPC work in an isolated
-    // single-server context. Unset ⇒ default socket, unchanged.
-    let mut cmd = tmux_command_scoped();
+    // DEFAULT-SERVER capture. This is the `muxa watch` preview + web dashboard
+    // path, which must always hit the default tmux server (whatever the user's
+    // interactive `$TMUX_TMPDIR` / `default` socket resolves to) — NOT a
+    // pane-row-recorded socket. Kept on `tmux_output` (no `-S`): a PR that
+    // scoped this to `MUXA_TMUX_SOCKET` regressed the preview/dashboard when a
+    // stale env socket was set in the daemon.
+    //
+    // The control-plane `capture` IPC uses [`capture_pane_on`] instead, which
+    // pins the specific server a pane lives on. The two paths are deliberately
+    // distinct — see that function.
+    let out = tmux_output(&["capture-pane", "-ep", "-t", pane_id])?;
+    if !out.status.success() {
+        return Err(TmuxError::NonZero(
+            String::from_utf8_lossy(&out.stderr).into(),
+        ));
+    }
+    String::from_utf8(out.stdout).map_err(|e| TmuxError::BadOutput(e.to_string()))
+}
+
+/// Capture the visible contents of a pane on the specific tmux server named by
+/// `socket` (a pane row's recorded short socket name; `None` ⇒ env-scoped
+/// default). Backs the tmux [`crate::backend::PaneBackend::capture_pane_on`]
+/// capability and the control-plane `capture` IPC, whose whole point is to read
+/// the RIGHT `%5` when the pane id exists on several servers. Same `-ep`
+/// flags / error mapping as [`capture_pane`]; only the server targeting differs.
+pub fn capture_pane_on(socket: Option<&str>, pane_id: &str) -> Result<String, TmuxError> {
+    let mut cmd = tmux_command_targeting(socket);
     cmd.args(["capture-pane", "-ep", "-t", pane_id]);
     let out = command_output_with_timeout(
         cmd,
@@ -657,19 +859,62 @@ mod tests {
     use super::*;
 
     /// Locks the `send-keys` argv shape: literal (`-l`) injection targeting
-    /// the pane id, with the text passed verbatim as the final arg. `-l`
-    /// keeps prompt text from being reinterpreted as a tmux key name.
+    /// the pane id, with `--` terminating options and the text passed verbatim
+    /// as the final arg. `-l` keeps prompt text from being reinterpreted as a
+    /// tmux key name; `--` keeps a leading `-` from being parsed as a flag.
     #[test]
     fn send_keys_argv_is_literal_and_targeted() {
         assert_eq!(
             send_keys_argv("%12", "fix the bug"),
-            ["send-keys", "-t", "%12", "-l", "fix the bug"],
+            ["send-keys", "-t", "%12", "-l", "--", "fix the bug"],
         );
         // A bare carriage return is the submit form (send-keys Enter equiv).
         assert_eq!(
             send_keys_argv("%3", "\r"),
-            ["send-keys", "-t", "%3", "-l", "\r"],
+            ["send-keys", "-t", "%3", "-l", "--", "\r"],
         );
+    }
+
+    /// Hostile argv shapes the `--` terminator must neutralize: text that
+    /// *begins* with a dash (would otherwise be read as a send-keys flag),
+    /// a bare semicolon, and the empty string. MCP forwards arbitrary model
+    /// text, so these are real inputs — the argv always keeps `--` in front
+    /// of the payload so the text is positional, never optional.
+    #[test]
+    fn send_keys_argv_terminates_options_for_hostile_text() {
+        // Leading dash: `--` makes `-rf x` the literal text, not flags.
+        assert_eq!(
+            send_keys_argv("%1", "-rf x"),
+            ["send-keys", "-t", "%1", "-l", "--", "-rf x"],
+        );
+        // Bare semicolon: still placed after `--` (runtime routing sends it
+        // via the paste path — see `needs_paste` — because a *trailing* `;`
+        // is eaten by tmux's command splitter regardless of `--`).
+        assert_eq!(
+            send_keys_argv("%1", ";"),
+            ["send-keys", "-t", "%1", "-l", "--", ";"],
+        );
+        // Empty string: a harmless no-op injection, shape unchanged.
+        assert_eq!(
+            send_keys_argv("%1", ""),
+            ["send-keys", "-t", "%1", "-l", "--", ""],
+        );
+    }
+
+    /// The paste-vs-send-keys routing predicate: multi-line text and text with
+    /// a trailing `;` must take the paste path (both are corrupted by
+    /// `send-keys -l`); everything else — including an embedded `;`, a leading
+    /// dash, the empty string, and the lone submit CR — stays on the fast path.
+    #[test]
+    fn needs_paste_flags_newline_and_trailing_semicolon() {
+        assert!(needs_paste("line one\nline two"));
+        assert!(needs_paste("run this;"));
+        assert!(needs_paste(";")); // lone `;` ends with `;`
+        assert!(!needs_paste("a;b")); // embedded `;` is safe
+        assert!(!needs_paste("-rf x")); // leading dash handled by `--`
+        assert!(!needs_paste("")); // empty is a no-op, not hazardous
+        assert!(!needs_paste("\r")); // lone submit CR stays on send-keys
+        assert!(!needs_paste("plain text"));
     }
 
     #[test]

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -120,6 +120,57 @@ fn tmux_output(args: &[&str]) -> Result<Output, TmuxError> {
     )
 }
 
+/// Build a tmux `Command` scoped to `MUXA_TMUX_SOCKET` when that env var
+/// names a specific server socket.
+///
+/// The other single-socket helpers target whatever the default socket /
+/// `$TMUX_TMPDIR` resolves to. Control actions ([`send_text`]) instead have
+/// to reach the *particular* server the target pane lives on. When the daemon
+/// is scoped to one server (`MUXA_TMUX_SOCKET`, as in an isolated or test
+/// context) we pass `-S <socket>` so `send-keys` lands on that server rather
+/// than the default one. Unset ⇒ no `-S`, byte-identical to `tmux_command()`.
+fn tmux_command_scoped() -> Command {
+    let mut cmd = tmux_command();
+    if let Ok(sock) = std::env::var("MUXA_TMUX_SOCKET") {
+        let trimmed = sock.trim();
+        if !trimmed.is_empty() {
+            cmd.arg("-S").arg(trimmed);
+        }
+    }
+    cmd
+}
+
+/// The `send-keys` argv (after any server-scope flags) for a literal text
+/// injection. Split out from [`send_text`] so the argument construction is
+/// unit-testable without a running tmux server.
+///
+/// `-l` sends the text literally — no key-name lookup — so arbitrary prompt
+/// text can't be misread as a tmux key (`Enter`, `C-c`, …). A bare `"\r"`
+/// submits the pane's current line (byte-identical to `send-keys Enter`).
+fn send_keys_argv<'a>(pane_id: &'a str, text: &'a str) -> [&'a str; 5] {
+    ["send-keys", "-t", pane_id, "-l", text]
+}
+
+/// Inject `text` into `pane_id` as literal keystrokes. Backs the tmux
+/// [`crate::backend::PaneBackend::send_text`] capability and, through it, the
+/// daemon's `send_prompt` IPC. Returns `true` on a zero exit; `false` when
+/// the pane is gone, tmux errors, or the shell-out times out (best-effort,
+/// matching the rest of this module).
+///
+/// Known limitation: text that *starts* with `-` can be misparsed by tmux's
+/// `send-keys` option scanner; muxa never generates such prompts and callers
+/// should avoid leading dashes.
+pub fn send_text(pane_id: &str, text: &str) -> bool {
+    let mut cmd = tmux_command_scoped();
+    cmd.args(send_keys_argv(pane_id, text));
+    command_output_with_timeout(
+        cmd,
+        TMUX_COMMAND_TIMEOUT,
+        format!("tmux send-keys -t {pane_id}"),
+    )
+    .is_ok_and(|o| o.status.success())
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PaneInfo {
     pub pane_id: String,
@@ -490,7 +541,17 @@ pub fn inside_tmux() -> bool {
 /// status is non-zero, the stderr is short — so callers should treat
 /// `NonZero` as "ephemeral, retry next tick" rather than fatal.
 pub fn capture_pane(pane_id: &str) -> Result<String, TmuxError> {
-    let out = tmux_output(&["capture-pane", "-ep", "-t", pane_id])?;
+    // Scope to `MUXA_TMUX_SOCKET` (via `-S`) when set so a capture reaches the
+    // specific server the pane lives on — the same targeting `send_text` uses,
+    // which is what makes the control-plane `capture` IPC work in an isolated
+    // single-server context. Unset ⇒ default socket, unchanged.
+    let mut cmd = tmux_command_scoped();
+    cmd.args(["capture-pane", "-ep", "-t", pane_id]);
+    let out = command_output_with_timeout(
+        cmd,
+        TMUX_COMMAND_TIMEOUT,
+        format!("tmux capture-pane -t {pane_id}"),
+    )?;
     if !out.status.success() {
         return Err(TmuxError::NonZero(
             String::from_utf8_lossy(&out.stderr).into(),
@@ -594,6 +655,22 @@ pub(crate) fn parse_pane_pid_map(stdout: &str) -> std::collections::HashMap<u32,
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Locks the `send-keys` argv shape: literal (`-l`) injection targeting
+    /// the pane id, with the text passed verbatim as the final arg. `-l`
+    /// keeps prompt text from being reinterpreted as a tmux key name.
+    #[test]
+    fn send_keys_argv_is_literal_and_targeted() {
+        assert_eq!(
+            send_keys_argv("%12", "fix the bug"),
+            ["send-keys", "-t", "%12", "-l", "fix the bug"],
+        );
+        // A bare carriage return is the submit form (send-keys Enter equiv).
+        assert_eq!(
+            send_keys_argv("%3", "\r"),
+            ["send-keys", "-t", "%3", "-l", "\r"],
+        );
+    }
 
     #[test]
     fn bounded_command_returns_fast_output() {

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -326,6 +326,11 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|| primary.clone());
     let server = Server::new(socket.clone(), store)
         .with_backend(ipc_backend)
+        // The full observed set, so control methods (`send_prompt`,
+        // `capture`) resolve the backend per pane-id namespace. `backends`
+        // is ordered by env preference, so `backends[0]` is the primary
+        // fallback for unclassifiable ids.
+        .with_backends(backends.clone())
         .with_sessions(sessions);
     let handle = tokio::spawn(server.run(shutdown_tx.subscribe()));
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -43,6 +43,30 @@ on its existing `serde_json`/`tokio` deps rather than pulling the `rmcp` SDK's
 dependency tree (which would have to clear MSRV 1.88 and the workspace's
 cargo-deny policy). No new dependencies. Protocol revision: `2024-11-05`.
 
+### Concurrency and framing
+
+Requests are read line-by-line from stdin and **each is dispatched on its own
+task**, so a long-running tool (`muxa_wait_for_change`, up to 600 s) never
+blocks unrelated traffic — a `ping` or `tools/list` issued while a wait is
+outstanding is answered immediately. Responses may therefore interleave in
+time; that is expected for concurrent JSON-RPC, and the `id` echoed on each
+response lets the client correlate. Output framing stays strict: the shared
+stdout writer is locked across each whole `write` + newline, so two
+concurrent responses never splice mid-line (one JSON object per line).
+
+Framing is robust against non-conforming input rather than silently dropping
+it:
+
+- A line that isn't valid JSON → `-32700` parse error, `id: null`.
+- A **batch array** → a single `-32600` error (`"batch requests are not
+  supported"`). muxa **does not implement JSON-RPC batching**; MCP hosts in
+  practice send one request per line, so batches are rejected explicitly.
+- A **bare value** (number/string/bool/null) → `-32600`, `id: null`.
+- An **object with an `id`** but a missing/invalid `jsonrpc` or `method` →
+  `-32600` addressed to that `id`; an unknown method → `-32601`.
+- An **object with no `id`** is a notification and draws no response (per
+  JSON-RPC), even if otherwise malformed — there is no `id` to reply to.
+
 ## Tools
 
 | Tool | Arguments | Does |
@@ -88,6 +112,23 @@ muxa_capture_pane  { "pane": "%18" }        # read the result on screen
 `muxa_wait_for_change` returns `{ "changed": false, "reason": "timeout" }`
 when nothing matching happened in the window, so a polling loop stays cheap and
 bounded (default 30 s, max 600 s).
+
+**Semantics:** it returns on the **first observed change OR a reconciled
+post-lag state match.** Two signals race under the deadline: the daemon's
+push transition stream, and a periodic snapshot **reconcile** (every 2 s) that
+compares the target pane's current state against a baseline captured when the
+wait began. The reconcile is a backstop for a daemon-side broadcast *lag*: a
+lag can drop the very transition being waited for, which would otherwise be
+misreported as a timeout. A change surfaced by the reconcile (rather than the
+live stream) carries `"reconciled": true`, and its `from` may be `null` when
+the pane wasn't present at baseline. This poll backstop is deliberately
+self-contained in the MCP server, so it holds regardless of whether the
+subscribe stream ever exposes the lag marker to this consumer.
+
+`muxa_send_prompt` reports whether the line was committed. When the underlying
+control path can confirm that the text was injected but the submitting Enter
+was **not** delivered, the result says so explicitly ("text sent but not
+submitted") so the caller doesn't assume the agent started working.
 
 ## Safety
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,99 @@
+# muxa MCP server
+
+`muxa mcp` is a [Model Context Protocol](https://modelcontextprotocol.io)
+stdio server that turns muxa into a **control plane** for coding agents. An
+agent that speaks MCP (Claude Code, and any other MCP host) can ask muxa what
+the *other* agents are doing, send one of them a prompt, read its screen, and
+block until it changes state — the orchestration primitives that close the gap
+with agent-native multiplexers whose socket API agents can drive.
+
+Every tool proxies the daemon over its existing owner-only unix socket, so the
+MCP server adds no new surface area: it can only do what a shell on the same
+machine could already do through `muxa`.
+
+## Wire it into Claude Code
+
+Start the daemon (`muxad`) first — the MCP server **refuses to start** when
+the socket is unreachable, with a clear error, so an agent never talks to a
+dead control plane. Then register it:
+
+```bash
+claude mcp add muxa -- muxa mcp
+```
+
+That runs `muxa mcp` as a stdio MCP server. Point it at a non-default socket
+with the global flag or env var if you run an isolated daemon:
+
+```bash
+claude mcp add muxa -- muxa --socket /run/user/1000/muxa.sock mcp
+# or
+MUXA_SOCKET=/run/user/1000/muxa.sock claude mcp add muxa -- muxa mcp
+```
+
+Verify from Claude Code with `/mcp` (the `muxa` server should list five
+tools). Other MCP hosts: run `muxa mcp` as a stdio server command in their
+config.
+
+## Implementation
+
+Hand-rolled JSON-RPC 2.0 over stdio — a **tools-only** server implementing
+`initialize`, `tools/list`, `tools/call`, `ping`, and the `initialized`
+notification. That subset is small and stable, so muxa implements it directly
+on its existing `serde_json`/`tokio` deps rather than pulling the `rmcp` SDK's
+dependency tree (which would have to clear MSRV 1.88 and the workspace's
+cargo-deny policy). No new dependencies. Protocol revision: `2024-11-05`.
+
+## Tools
+
+| Tool | Arguments | Does |
+| --- | --- | --- |
+| `muxa_status` | — | Snapshot of every tracked agent: state, pane, session, model, last prompt, last notification. |
+| `muxa_recent_prompts` | `pane?`, `limit?` | Recent prompt-history entries (newest first), optionally scoped to one pane. |
+| `muxa_send_prompt` | `pane`, `text`, `submit?` | Inject `text` into a pane; `submit` (default `true`) presses Enter to commit the line. |
+| `muxa_capture_pane` | `pane` | Capture the visible contents of a pane. |
+| `muxa_wait_for_change` | `timeout_secs?`, `pane?` | Block until an agent's state changes (or timeout); returns the transition. |
+
+`muxa_send_prompt` is refused (surfaced to the model as a tool error) when the
+pane's backend can't inject keystrokes — e.g. zellij, where CLI `write-chars`
+only reaches the focused pane. tmux and herdr support it.
+
+Pane ids carry their host namespace: tmux `%12`, herdr `herdr:p1`. Use the
+`pane` field from `muxa_status` verbatim.
+
+## Orchestration examples
+
+**"What is everyone doing?"**
+
+```
+muxa_status
+→ [{ "pane": "%12", "state": "waiting_input", "last_prompt": "refactor auth", ... },
+   { "pane": "%18", "state": "working", ... }]
+```
+
+**Unblock an agent that's waiting on input**
+
+```
+muxa_send_prompt { "pane": "%12", "text": "yes, proceed", "submit": true }
+```
+
+**Hand off a task and wait for it to land**
+
+```
+muxa_send_prompt   { "pane": "%18", "text": "run the test suite", "submit": true }
+muxa_wait_for_change { "pane": "%18", "timeout_secs": 120 }
+→ { "changed": true, "from": "working", "to": "waiting_input", "agent": { ... } }
+muxa_capture_pane  { "pane": "%18" }        # read the result on screen
+```
+
+`muxa_wait_for_change` returns `{ "changed": false, "reason": "timeout" }`
+when nothing matching happened in the window, so a polling loop stays cheap and
+bounded (default 30 s, max 600 s).
+
+## Safety
+
+`muxa_send_prompt` is a **control action** — it types into another agent's
+pane. The IPC socket is owner-only (`0600`), so only your user can reach it and
+there is no network exposure; treat socket access as equivalent to shell
+access. The server never starts against an absent daemon. See `PROTOCOL.md`
+(Control methods) for the underlying `send_prompt` / `capture` / `subscribe`
+IPC.


### PR DESCRIPTION
## Summary
- **`PaneBackend::send_text`** + `send_text` capability: tmux `send-keys -l` (now `MUXA_TMUX_SOCKET`-scoped, as is capture), herdr `pane.send_text`; zellij opts out (`write-chars` only reaches the focused pane). Submit = a second `"\r"` send — byte-identical to `send-keys Enter` and a CR on a herdr pty, so one primitive covers both hosts.
- **Control IPC** (PROTOCOL.md): `send_prompt {pane,text,submit}` and `capture {pane}` resolve the backend per pane-id namespace across the daemon's multi-host set (`Server::with_backends`), refusing with a structured error when the target lacks the cap; `subscribe` emits a `{"event":"lagged","dropped":N}` marker on broadcast overflow instead of dropping silently.
- **`muxa mcp`**: hand-rolled tools-only MCP stdio server (JSON-RPC 2.0 `initialize`/`tools/list`/`tools/call`; `rmcp` skipped to keep MSRV 1.88 + cargo-deny clean — zero new crates) proxying the daemon socket: `muxa_status`, `muxa_recent_prompts`, `muxa_send_prompt`, `muxa_capture_pane`, `muxa_wait_for_change`. Wire into Claude Code with `claude mcp add muxa -- muxa mcp` (docs/MCP.md).
- Socket stays owner-only 0600; the MCP server refuses to start without a reachable daemon.

## Test plan
- [x] `cargo test --workspace` green (new: tmux argv construction, herdr mock-listener send, IPC routing/refusal/lagged, 5 MCP protocol tests); known-flaky scanner test passes isolated
- [x] clippy `-D warnings` / fmt / `cargo deny check` all clean, no new dependencies
- [x] Live stdio smoke: initialize → tools/list → status → `muxa_send_prompt` (text executed in a scratch tmux pane, verified via capture) → `muxa_capture_pane` round-trip; full teardown, real daemon untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)