### PR TITLE
feat(detect): screen-manifest fallback detection for hook-less agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,6 +2292,7 @@ dependencies = [
  "http-body-util",
  "notify-rust",
  "portable-pty",
+ "regex",
  "reqwest",
  "rust-embed",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = "2"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 toml = "0.8"
+regex = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "signal", "fs", "time", "process"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/config.example.toml
+++ b/config.example.toml
@@ -45,6 +45,21 @@
 #                                      # stop on their own. Only the registry row is removed; the tmux session
 #                                      # (if any) is untouched. `muxa prune` does this on demand. Set 0 to disable.
 
+# Screen-manifest fallback detection: for agent CLIs muxa has NO hooks for
+# (cursor-agent, amp, copilot, aider, goose, and any you declare), the daemon
+# periodically captures the pane and matches TOML manifest rules against the
+# visible tail to infer Working / WaitingInput / Idle. Last-resort only: hooks
+# stay authoritative, herdr hosts are covered by herdr's own detection, and the
+# synthetic rows are evicted the instant a real hook claims the pane. Bundled
+# manifests ship in the binary; drop overrides at
+# $XDG_CONFIG_HOME/muxa/agents/<name>.toml (same name replaces a bundled one).
+# See docs/SCREEN_DETECTION.md.
+[screen_detect]
+# enabled       = true
+# interval_secs = 3                 # 3s default — capture/classify cadence; a tick is skipped
+#                                   # if the previous is still running, and no captures run when
+#                                   # no pane matches a manifest (idle cost ≈ one pane list).
+
 # Prompt audit log: every PromptSubmitted event is appended to a bounded
 # NDJSON file plus an in-memory ring per pane. Powers `muxa recap --all`
 # even after the live agent record has been reaped (daemon restart, pane

--- a/crates/muxa/Cargo.toml
+++ b/crates/muxa/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 toml = { workspace = true }
+regex = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 dirs = { workspace = true }

--- a/crates/muxa/benches/store_apply.rs
+++ b/crates/muxa/benches/store_apply.rs
@@ -194,6 +194,7 @@ async fn bench_one(n_subscribers: usize, iters: u64) -> (Duration, Duration, u64
         response: Some("r".repeat(4096)),
         recap: None,
         ai_title: None,
+        idle_confirmed: false,
         at: now,
     };
 

--- a/crates/muxa/src/adapters/claude.rs
+++ b/crates/muxa/src/adapters/claude.rs
@@ -188,6 +188,7 @@ impl HookAdapter for ClaudeAdapter {
                         response: Some(truncate(text, 4_000)),
                         recap,
                         ai_title,
+                        idle_confirmed: false,
                         at,
                     },
                     None => AgentEvent::TurnStopped {
@@ -195,6 +196,7 @@ impl HookAdapter for ClaudeAdapter {
                         response: None,
                         recap,
                         ai_title,
+                        idle_confirmed: false,
                         at,
                     },
                 }

--- a/crates/muxa/src/adapters/codex.rs
+++ b/crates/muxa/src/adapters/codex.rs
@@ -105,6 +105,10 @@ impl HookAdapter for CodexAdapter {
                 response: None,
                 recap: None,
                 ai_title: None,
+                // Real hook: never a synthetic idle observation. A response-less
+                // Codex `Stop` can fire while a permission prompt is still on
+                // screen, so it must NOT clear a waiting row (see state.rs).
+                idle_confirmed: false,
                 at,
             },
         }

--- a/crates/muxa/src/adapters/gemini.rs
+++ b/crates/muxa/src/adapters/gemini.rs
@@ -113,6 +113,7 @@ impl HookAdapter for GeminiAdapter {
                 response: None,
                 recap: None,
                 ai_title: None,
+                idle_confirmed: false,
                 at,
             },
             Event::SessionEnd => AgentEvent::SessionEnded { id, at },

--- a/crates/muxa/src/adapters/opencode.rs
+++ b/crates/muxa/src/adapters/opencode.rs
@@ -54,6 +54,7 @@ pub fn normalize_event(input: Value, pane: Option<String>) -> AgentEvent {
             response: response_text(&input),
             recap: None,
             ai_title: None,
+            idle_confirmed: false,
             at,
         },
         "session.error" => AgentEvent::NotificationFired {

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -107,6 +107,7 @@ pub struct Config {
     pub dashboard: DashboardTomlConfig,
     pub discovery: DiscoveryConfig,
     pub reconciler: ReconcilerConfig,
+    pub screen_detect: ScreenDetectConfig,
     pub history: HistoryConfig,
     pub activity: ActivityConfig,
     pub state: StateConfig,
@@ -450,6 +451,45 @@ impl Default for ReconcilerConfig {
 
 fn default_reconciler_interval_secs() -> u64 {
     30
+}
+
+/// `[screen_detect]` config — the screen-manifest fallback detector.
+///
+/// For agent CLIs muxa has **no hooks** for (cursor-agent, amp, copilot, aider,
+/// goose, plus any user-declared agent), the daemon periodically captures the
+/// pane and matches TOML manifest rules against the visible tail to infer
+/// `Working` / `WaitingInput` / `Idle`. This is the *last-resort* fallback:
+/// hooks stay authoritative when present, herdr hosts are covered by herdr's
+/// own detection + bridge (and are skipped here), and the synthetic rows this
+/// task mints are evicted the instant a real hook claims the pane. See
+/// `docs/SCREEN_DETECTION.md`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ScreenDetectConfig {
+    /// Master switch. Default `true` — the detector only does real work when a
+    /// pane's foreground command matches a manifest AND no authoritative row
+    /// owns the pane, so its idle cost is ~one pane list per tick.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Cadence of the capture/classify pass, in seconds. Default 3 — brisk
+    /// enough to feel live, slow enough that the per-candidate `capture-pane`
+    /// shell-outs (each bounded by tmux's 1s timeout) stay negligible. A tick is
+    /// skipped if the previous one is still running.
+    #[serde(default = "default_screen_detect_interval_secs")]
+    pub interval_secs: u64,
+}
+
+impl Default for ScreenDetectConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            interval_secs: default_screen_detect_interval_secs(),
+        }
+    }
+}
+
+fn default_screen_detect_interval_secs() -> u64 {
+    3
 }
 
 fn default_paneless_stale_secs() -> u64 {
@@ -1231,6 +1271,25 @@ mod tests {
     fn discovery_can_be_disabled() {
         let cfg: Config = toml::from_str("[discovery]\nenabled = false\n").unwrap();
         assert!(!cfg.discovery.enabled);
+    }
+
+    #[test]
+    fn screen_detect_defaults_on_at_3s() {
+        let cfg = Config::default();
+        assert!(cfg.screen_detect.enabled);
+        assert_eq!(cfg.screen_detect.interval_secs, 3);
+        // Parsed from an empty document, the defaults still apply.
+        let empty: Config = toml::from_str("").unwrap();
+        assert!(empty.screen_detect.enabled);
+        assert_eq!(empty.screen_detect.interval_secs, 3);
+    }
+
+    #[test]
+    fn screen_detect_can_be_configured() {
+        let cfg: Config =
+            toml::from_str("[screen_detect]\nenabled = false\ninterval_secs = 10\n").unwrap();
+        assert!(!cfg.screen_detect.enabled);
+        assert_eq!(cfg.screen_detect.interval_secs, 10);
     }
 
     #[test]

--- a/crates/muxa/src/discovery.rs
+++ b/crates/muxa/src/discovery.rs
@@ -240,7 +240,14 @@ pub fn scan_panes(backend: &dyn PaneBackend) -> Vec<Discovered> {
     discover_from_panes(&backend.list_panes())
 }
 
-fn synthetic_session_id(pane: &PaneInfo) -> String {
+/// The synthetic session id muxa mints for a pane that has no real hook-derived
+/// session yet — `synthetic-<pane_id>` for a socket-less pane, or
+/// `synthetic-<len>:<socket>:<pane_id>` when the pane carries a tmux socket
+/// identity. Exposed so other synthetic-row producers (the herdr bridge, screen
+/// detection) mint the SAME key, letting a discovery placeholder and a
+/// synthetic row collapse onto one registry entry and share the same
+/// hook-eviction precedence.
+pub fn synthetic_session_id(pane: &PaneInfo) -> String {
     match pane.socket.as_deref() {
         // Length-prefix the socket so the identity stays unambiguous even if
         // a custom socket name contains the separator.

--- a/crates/muxa/src/discovery.rs
+++ b/crates/muxa/src/discovery.rs
@@ -60,7 +60,12 @@ pub fn classify_command(cmd: &str) -> Option<AgentKind> {
     }
 }
 
-fn command_name(cmd: &str) -> &str {
+/// The bare command basename: `/usr/local/bin/Cursor-Agent` → `Cursor-Agent`
+/// (case preserved). The single source of the basename rule — `classify_command`
+/// lowercases the result, and `screen`'s manifest matcher reuses this so the two
+/// agree on what "the command" is by construction.
+#[must_use]
+pub fn command_name(cmd: &str) -> &str {
     cmd.trim().rsplit('/').next().unwrap_or(cmd).trim()
 }
 

--- a/crates/muxa/src/event.rs
+++ b/crates/muxa/src/event.rs
@@ -215,6 +215,21 @@ pub enum AgentEvent {
         /// recap, so it's the practical steady-state summary.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         ai_title: Option<String>,
+        /// Marker set ONLY by the SYNTHETIC detection producers (screen
+        /// inference / the herdr bridge) when they have OBSERVED the pane go
+        /// idle — the approval prompt / spinner is gone from the screen. A real
+        /// hook's turn-boundary `Stop` always leaves this `false`.
+        ///
+        /// It exists to distinguish "a stop that is positive evidence the agent
+        /// is now idle" (set it) from "a bare response-less stop that proves
+        /// nothing about a pending wait" (leave it). The latter is the Codex
+        /// quirk — Codex fires a response-less `Stop` while a permission prompt
+        /// is still on screen — so a *markerless* response-less stop keeps a
+        /// `WaitingInput`/`WaitingChoice` row waiting, while a marked one clears
+        /// it to `Idle`. See `mutate_for_event`'s `TurnStopped` arm.
+        /// `#[serde(default)]` keeps the field additive for older wire peers.
+        #[serde(default)]
+        idle_confirmed: bool,
         #[serde(with = "time::serde::rfc3339")]
         at: OffsetDateTime,
     },
@@ -382,6 +397,7 @@ mod tests {
             response: None,
             recap: None,
             ai_title: None,
+            idle_confirmed: false,
             at: datetime!(2026-04-24 12:00:00 UTC),
         };
         let json = serde_json::to_string(&ev).unwrap();

--- a/crates/muxa/src/lib.rs
+++ b/crates/muxa/src/lib.rs
@@ -50,6 +50,7 @@ mod process_snapshot;
 pub mod process_tree;
 pub mod reconcile;
 pub mod scope_filter;
+pub mod screen;
 pub mod session;
 pub mod session_activity;
 pub mod sinks;
@@ -100,7 +101,7 @@ pub use activity::{
     ACTIVITY_SCHEMA_VERSION,
 };
 #[doc(hidden)]
-pub use discovery::{run_discovery, scan_panes, Discovered, DiscoveryReport};
+pub use discovery::{run_discovery, scan_panes, synthetic_session_id, Discovered, DiscoveryReport};
 #[doc(hidden)]
 pub use error::{CoreError, Result};
 #[doc(hidden)]
@@ -111,6 +112,8 @@ pub use metrics::{Metrics, MetricsSnapshot};
 pub use reconcile::{LivenessSource, Reconciler};
 #[doc(hidden)]
 pub use scope_filter::ScopeExclusions;
+#[doc(hidden)]
+pub use screen::{load_manifests, AgentManifest, ManifestSet, ScreenState};
 #[doc(hidden)]
 pub use session::{
     PtySessionBackend, SessionBackend, SessionBackendCaps, SessionBackendKind, SessionError,

--- a/crates/muxa/src/screen.rs
+++ b/crates/muxa/src/screen.rs
@@ -1,0 +1,628 @@
+//! Screen-manifest fallback detection.
+//!
+//! For agent CLIs muxa has **no hooks** for (cursor-agent, amp, copilot, aider,
+//! goose, …) there is no authoritative event stream to drive a registry row.
+//! This module implements the *screen-inference* fallback herdr validated:
+//! match a set of TOML-declared regex rules against a pane's captured tail to
+//! infer whether the agent is `Working`, `Blocked` (waiting on the operator),
+//! or `Idle`.
+//!
+//! The daemon side (candidate selection, pane capture, synthetic-row ingest)
+//! lives in `muxad::screen_detect`; this module is the pure, unit-testable core:
+//! manifest parsing, bundled + user-override loading, capture preparation
+//! (ANSI-strip + tail), and the classifier.
+//!
+//! ## Precedence (documented in full in `docs/SCREEN_DETECTION.md`)
+//!
+//! Hooks are authoritative when present; herdr's own detection covers herdr
+//! hosts; screen inference is the *last* resort. The daemon enforces this by
+//! only synthesizing rows for panes no authoritative row owns, and by minting
+//! those rows SYNTHETIC so a real hook evicts them the instant it fires.
+//!
+//! ## Classifier contract (STRICT-blocked, unknown-keeps-previous)
+//!
+//! [`AgentManifest::classify`] tests rule categories **in a fixed order**:
+//!
+//! 1. `blocked` — tested FIRST and STRICT: only clear approval/permission UI
+//!    should ever match here. A false `blocked` is the worst outcome (a working
+//!    agent shown as "needs input"), so the bundled patterns require an
+//!    unambiguous yes/no affordance or explicit permission wording.
+//! 2. `working` — spinner glyphs / interrupt hints.
+//! 3. `idle` — a bare prompt marker.
+//!
+//! If NOTHING matches, `classify` returns `None` — the caller keeps the pane's
+//! previous state. An unrecognized screen never *transitions* a row; only a
+//! positive match to a *different* category does. This is the "unknown
+//! transitions are dropped" rule that stops screen noise from flapping a row.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use regex::{Regex, RegexSet};
+use serde::Deserialize;
+
+/// The inferred agent state for one pane capture. A deliberately small set:
+/// screen inference can reliably tell "busy" from "waiting on me" from "idle
+/// prompt", but not the richer states hooks provide.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScreenState {
+    /// An approval/permission prompt is on screen — the agent needs operator
+    /// input. Maps to muxa `WaitingInput`.
+    Blocked,
+    /// The agent is actively generating (spinner / interrupt hint). Maps to
+    /// muxa `Working`.
+    Working,
+    /// A bare input prompt is waiting for the next instruction. Maps to muxa
+    /// `Idle`.
+    Idle,
+}
+
+/// Why a manifest failed to load. Parse failures are logged and the offending
+/// file skipped — never fatal (see [`load_manifests`]).
+#[derive(Debug, thiserror::Error)]
+pub enum ManifestError {
+    #[error("TOML parse error: {0}")]
+    Toml(#[from] toml::de::Error),
+    #[error("invalid regex in [rules].{category}: {source}")]
+    Regex {
+        category: &'static str,
+        #[source]
+        source: regex::Error,
+    },
+    #[error("[agent].name must not be empty")]
+    EmptyName,
+    #[error("[agent].command must list at least one non-empty command")]
+    EmptyCommand,
+}
+
+/// Raw TOML shape. Unknown fields are *tolerated* (not `deny_unknown_fields`):
+/// a manifest written for a newer muxa should still load its known rules rather
+/// than being dropped wholesale over one unrecognized key.
+#[derive(Debug, Deserialize)]
+struct RawManifest {
+    agent: RawAgent,
+    #[serde(default)]
+    rules: RawRules,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawAgent {
+    name: String,
+    command: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawRules {
+    #[serde(default)]
+    blocked: Vec<String>,
+    #[serde(default)]
+    working: Vec<String>,
+    #[serde(default)]
+    idle: Vec<String>,
+}
+
+/// One agent's screen-detection manifest: its identity, the process names that
+/// select it, and the compiled regex rule sets.
+#[derive(Debug, Clone)]
+pub struct AgentManifest {
+    /// Display name — carried into the synthetic row's `model` field (the kind
+    /// stays `Unknown`). Also the override key: a user file with the same name
+    /// replaces the bundled manifest.
+    pub name: String,
+    /// Lowercased command *basenames* that select this manifest against a
+    /// pane's `current_command` (tmux reports the basename only).
+    commands: Vec<String>,
+    blocked: RegexSet,
+    working: RegexSet,
+    idle: RegexSet,
+}
+
+impl AgentManifest {
+    /// Does this manifest govern a pane whose foreground command is `cmd`?
+    /// Matching is on the command basename, case-insensitive — mirroring
+    /// `discovery::classify_command`.
+    #[must_use]
+    pub fn matches_command(&self, cmd: &str) -> bool {
+        let base = command_basename(cmd);
+        self.commands.iter().any(|c| c == &base)
+    }
+
+    /// Classify a *prepared* capture (see [`prepare_capture`]). Returns `None`
+    /// when no rule matches — the caller keeps the pane's previous state. See
+    /// the module-level classifier contract for the STRICT-blocked ordering.
+    #[must_use]
+    pub fn classify(&self, text: &str) -> Option<ScreenState> {
+        if self.blocked.is_match(text) {
+            Some(ScreenState::Blocked)
+        } else if self.working.is_match(text) {
+            Some(ScreenState::Working)
+        } else if self.idle.is_match(text) {
+            Some(ScreenState::Idle)
+        } else {
+            None
+        }
+    }
+}
+
+/// The full set of loaded manifests, indexed for command lookup.
+#[derive(Debug, Clone, Default)]
+pub struct ManifestSet {
+    manifests: Vec<AgentManifest>,
+}
+
+impl ManifestSet {
+    /// The first manifest that governs `current_command`, if any. First-match
+    /// wins; with the bundled set every `command` list is disjoint, and a user
+    /// override *replaces* (not appends) its bundled peer, so there is at most
+    /// one match in practice.
+    #[must_use]
+    pub fn manifest_for_command(&self, current_command: &str) -> Option<&AgentManifest> {
+        self.manifests
+            .iter()
+            .find(|m| m.matches_command(current_command))
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.manifests.is_empty()
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.manifests.len()
+    }
+
+    /// Names of the loaded manifests, for startup logging.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.manifests.iter().map(|m| m.name.as_str())
+    }
+}
+
+/// Compile one raw regex list into a [`RegexSet`], tagging the category on
+/// failure so the log line points at the offending `[rules]` key.
+fn compile(patterns: &[String], category: &'static str) -> Result<RegexSet, ManifestError> {
+    RegexSet::new(patterns).map_err(|source| ManifestError::Regex { category, source })
+}
+
+/// Parse and compile one manifest from TOML text. Returns an error (never
+/// panics) for malformed TOML, an empty name/command, or an uncompilable regex.
+pub fn parse_manifest(toml_str: &str) -> Result<AgentManifest, ManifestError> {
+    let raw: RawManifest = toml::from_str(toml_str)?;
+    if raw.agent.name.trim().is_empty() {
+        return Err(ManifestError::EmptyName);
+    }
+    let commands: Vec<String> = raw
+        .agent
+        .command
+        .iter()
+        .map(|c| command_basename(c))
+        .filter(|c| !c.is_empty())
+        .collect();
+    if commands.is_empty() {
+        return Err(ManifestError::EmptyCommand);
+    }
+    Ok(AgentManifest {
+        name: raw.agent.name.trim().to_owned(),
+        commands,
+        blocked: compile(&raw.rules.blocked, "blocked")?,
+        working: compile(&raw.rules.working, "working")?,
+        idle: compile(&raw.rules.idle, "idle")?,
+    })
+}
+
+/// Lowercase command basename: `/usr/local/bin/Cursor-Agent` → `cursor-agent`.
+fn command_basename(cmd: &str) -> String {
+    cmd.trim()
+        .rsplit('/')
+        .next()
+        .unwrap_or(cmd)
+        .trim()
+        .to_ascii_lowercase()
+}
+
+/// The bundled manifest sources, shipped in the binary via `include_str!`.
+/// These are muxa-authored and MUST parse — a parse failure is a build-time
+/// bug caught by [`tests::every_bundled_manifest_parses`].
+fn bundled_sources() -> [(&'static str, &'static str); 5] {
+    [
+        ("cursor", include_str!("screen/agents/cursor.toml")),
+        ("amp", include_str!("screen/agents/amp.toml")),
+        ("copilot", include_str!("screen/agents/copilot.toml")),
+        ("aider", include_str!("screen/agents/aider.toml")),
+        ("goose", include_str!("screen/agents/goose.toml")),
+    ]
+}
+
+/// The bundled manifests, parsed. Panics with a pointed message if a *bundled*
+/// manifest fails to parse (that's a muxa bug, not a user error).
+#[must_use]
+pub fn bundled_manifests() -> Vec<AgentManifest> {
+    bundled_sources()
+        .into_iter()
+        .map(|(file, src)| {
+            parse_manifest(src)
+                .unwrap_or_else(|e| panic!("bundled manifest {file}.toml failed to parse: {e}"))
+        })
+        .collect()
+}
+
+/// `$XDG_CONFIG_HOME/muxa/agents`, falling back to the platform config dir's
+/// `muxa/agents`. `XDG_CONFIG_HOME` is honored FIRST and explicitly so the path
+/// documented in `docs/SCREEN_DETECTION.md` works cross-platform — on macOS
+/// `dirs::config_dir()` returns `~/Library/Application Support` and ignores
+/// `XDG_CONFIG_HOME`, which would otherwise silently miss user overrides.
+fn user_agents_dir() -> Option<PathBuf> {
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        if !xdg.is_empty() {
+            return Some(PathBuf::from(xdg).join("muxa").join("agents"));
+        }
+    }
+    dirs::config_dir().map(|d| d.join("muxa").join("agents"))
+}
+
+/// Load every manifest: the bundled set, then user overrides from
+/// `$XDG_CONFIG_HOME/muxa/agents/*.toml`. A user file whose `[agent].name`
+/// matches a bundled manifest **replaces** it; a new name is appended. Parse
+/// errors are logged (`warn`) and the file skipped — never fatal.
+#[must_use]
+pub fn load_manifests() -> ManifestSet {
+    let mut manifests = bundled_manifests();
+    if let Some(dir) = user_agents_dir() {
+        load_user_overrides(&dir, &mut manifests);
+    }
+    ManifestSet { manifests }
+}
+
+/// Read `*.toml` files from `dir` and fold them into `manifests`, replacing any
+/// bundled manifest of the same name. Deterministic order (files sorted) so a
+/// later-sorted file with a duplicate name wins predictably. Missing dir is a
+/// no-op; unreadable/malformed files warn and are skipped.
+fn load_user_overrides(dir: &std::path::Path, manifests: &mut Vec<AgentManifest>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        // Missing/unreadable directory is the common case (no overrides) — not
+        // worth a warning.
+        return;
+    };
+    let mut files: Vec<PathBuf> = entries
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"))
+        })
+        .collect();
+    files.sort();
+    for path in files {
+        let text = match std::fs::read_to_string(&path) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(file = %path.display(), error = %e, "screen manifest: read failed, skipping");
+                continue;
+            }
+        };
+        match parse_manifest(&text) {
+            Ok(manifest) => {
+                if let Some(existing) = manifests.iter_mut().find(|m| m.name == manifest.name) {
+                    tracing::info!(name = %manifest.name, file = %path.display(), "screen manifest: user override replaces bundled");
+                    *existing = manifest;
+                } else {
+                    tracing::info!(name = %manifest.name, file = %path.display(), "screen manifest: user manifest loaded");
+                    manifests.push(manifest);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(file = %path.display(), error = %e, "screen manifest: parse failed, skipping");
+            }
+        }
+    }
+}
+
+/// Prepare a raw pane capture for classification: strip ANSI escape sequences
+/// (so color codes don't defeat the regexes) and keep only the bottom
+/// `max_lines` lines (the active prompt/spinner region, and a bound on regex
+/// work). Spinner glyphs and box-drawing characters are Unicode, not ANSI, so
+/// they survive the strip.
+#[must_use]
+pub fn prepare_capture(raw: &str, max_lines: usize) -> String {
+    let stripped = strip_ansi(raw);
+    let lines: Vec<&str> = stripped.lines().collect();
+    let start = lines.len().saturating_sub(max_lines);
+    lines[start..].join("\n")
+}
+
+/// Remove the ANSI control sequences a `tmux capture-pane -e` emits: CSI
+/// (`ESC [ … final`), OSC (`ESC ] … BEL`), and stray two-byte escapes. Not a
+/// full terminal parser — just enough that the text rules match on the visible
+/// characters.
+fn strip_ansi(s: &str) -> String {
+    static ANSI: OnceLock<Regex> = OnceLock::new();
+    let re = ANSI.get_or_init(|| {
+        // CSI: ESC [ params intermediates final | OSC: ESC ] ... BEL |
+        // two-byte: ESC <single char>.
+        Regex::new(r"\x1b\[[0-9;:?]*[ -/]*[@-~]|\x1b\][^\x07]*\x07|\x1b[@-Z\\-_]")
+            .expect("static ANSI strip regex is valid")
+    });
+    re.replace_all(s, "").into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cursor() -> AgentManifest {
+        parse_manifest(include_str!("screen/agents/cursor.toml")).unwrap()
+    }
+
+    // --- parsing ------------------------------------------------------------
+
+    #[test]
+    fn parses_a_good_manifest() {
+        let m = parse_manifest(
+            r#"
+[agent]
+name = "demo"
+command = ["/usr/bin/Demo-Agent", "demo2"]
+[rules]
+blocked = ['\[y/n\]']
+working = ['thinking']
+idle = ['^> $']
+"#,
+        )
+        .expect("valid manifest parses");
+        assert_eq!(m.name, "demo");
+        // command basenames are lowercased.
+        assert!(m.matches_command("Demo-Agent"));
+        assert!(m.matches_command("/opt/x/demo-agent"));
+        assert!(m.matches_command("demo2"));
+        assert!(!m.matches_command("other"));
+    }
+
+    #[test]
+    fn empty_name_is_rejected() {
+        let err = parse_manifest("[agent]\nname = \"\"\ncommand = [\"x\"]\n").unwrap_err();
+        assert!(matches!(err, ManifestError::EmptyName));
+    }
+
+    #[test]
+    fn empty_command_is_rejected() {
+        let err = parse_manifest("[agent]\nname = \"x\"\ncommand = []\n").unwrap_err();
+        assert!(matches!(err, ManifestError::EmptyCommand));
+    }
+
+    #[test]
+    fn bad_toml_is_rejected() {
+        let err = parse_manifest("this is not toml {{{").unwrap_err();
+        assert!(matches!(err, ManifestError::Toml(_)));
+    }
+
+    #[test]
+    fn bad_regex_is_rejected_with_category() {
+        let err = parse_manifest(
+            "[agent]\nname = \"x\"\ncommand = [\"x\"]\n[rules]\nworking = ['(unclosed']\n",
+        )
+        .unwrap_err();
+        match err {
+            ManifestError::Regex { category, .. } => assert_eq!(category, "working"),
+            other => panic!("expected a Regex error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_rules_section_is_ok_and_matches_nothing() {
+        let m = parse_manifest("[agent]\nname = \"x\"\ncommand = [\"x\"]\n").unwrap();
+        assert_eq!(m.classify("anything at all"), None);
+    }
+
+    // --- classifier semantics ----------------------------------------------
+
+    #[test]
+    fn blocked_wins_over_working_and_idle_strict_ordering() {
+        // A screen that carries BOTH a spinner glyph and an approval prompt and
+        // an idle marker must classify as Blocked — blocked is tested first.
+        let m = parse_manifest(
+            r#"
+[agent]
+name = "x"
+command = ["x"]
+[rules]
+blocked = ['\[y/n\]']
+working = ['thinking']
+idle = ['^> $']
+"#,
+        )
+        .unwrap();
+        let screen = "thinking...\nProceed? [y/n]\n> ";
+        assert_eq!(m.classify(screen), Some(ScreenState::Blocked));
+    }
+
+    #[test]
+    fn working_wins_over_idle() {
+        let m = cursor();
+        // spinner glyph present with a trailing prompt-ish line.
+        assert_eq!(m.classify("⠹ Generating\n"), Some(ScreenState::Working));
+    }
+
+    #[test]
+    fn unknown_screen_keeps_previous_returns_none() {
+        let m = cursor();
+        assert_eq!(m.classify("just some ordinary output text\n"), None);
+    }
+
+    #[test]
+    fn idle_matches_bare_prompt() {
+        let m = cursor();
+        assert_eq!(
+            m.classify("some earlier output\n> "),
+            Some(ScreenState::Idle)
+        );
+    }
+
+    // --- per-bundled-agent fixtures ----------------------------------------
+
+    #[test]
+    fn every_bundled_manifest_parses() {
+        let set = bundled_manifests();
+        assert_eq!(set.len(), 5);
+        for m in &set {
+            assert!(!m.name.is_empty());
+        }
+    }
+
+    #[test]
+    fn cursor_fixtures() {
+        let m = cursor();
+        assert_eq!(
+            m.classify("⠋ Thinking\nesc to interrupt"),
+            Some(ScreenState::Working)
+        );
+        assert_eq!(
+            m.classify("Do you want to allow this command? [y/n]"),
+            Some(ScreenState::Blocked)
+        );
+        assert_eq!(m.classify("\n> "), Some(ScreenState::Idle));
+    }
+
+    #[test]
+    fn amp_fixtures() {
+        let m = parse_manifest(include_str!("screen/agents/amp.toml")).unwrap();
+        assert!(m.matches_command("amp"));
+        assert_eq!(m.classify("⠸ Working"), Some(ScreenState::Working));
+        assert_eq!(
+            m.classify("Allow this command? (y/n)"),
+            Some(ScreenState::Blocked)
+        );
+        assert_eq!(m.classify("> "), Some(ScreenState::Idle));
+    }
+
+    #[test]
+    fn copilot_fixtures() {
+        let m = parse_manifest(include_str!("screen/agents/copilot.toml")).unwrap();
+        assert!(m.matches_command("copilot"));
+        assert_eq!(m.classify("⠴ generating"), Some(ScreenState::Working));
+        assert_eq!(
+            m.classify("Do you want to run this? [y/n]"),
+            Some(ScreenState::Blocked)
+        );
+    }
+
+    #[test]
+    fn aider_fixtures() {
+        let m = parse_manifest(include_str!("screen/agents/aider.toml")).unwrap();
+        assert!(m.matches_command("aider"));
+        // Aider's distinctive (Y)es/(N)o confirm.
+        assert_eq!(
+            m.classify("Add main.py to the chat? (Y)es/(N)o [Yes]:"),
+            Some(ScreenState::Blocked)
+        );
+        assert_eq!(m.classify("architect> "), Some(ScreenState::Idle));
+    }
+
+    #[test]
+    fn goose_fixtures() {
+        let m = parse_manifest(include_str!("screen/agents/goose.toml")).unwrap();
+        assert!(m.matches_command("goose"));
+        assert_eq!(m.classify("⠧ thinking"), Some(ScreenState::Working));
+        assert_eq!(
+            m.classify("Goose would like to call the shell tool. Allow? [y/n]"),
+            Some(ScreenState::Blocked)
+        );
+    }
+
+    // --- capture preparation -----------------------------------------------
+
+    #[test]
+    fn strip_ansi_removes_color_codes_keeps_glyphs() {
+        let raw = "\x1b[1;32m⠋ Thinking\x1b[0m\x1b]0;title\x07";
+        let out = strip_ansi(raw);
+        assert_eq!(out, "⠋ Thinking");
+    }
+
+    #[test]
+    fn prepare_capture_keeps_only_the_tail() {
+        use std::fmt::Write as _;
+        let mut raw = String::new();
+        for i in 0..100 {
+            let _ = writeln!(raw, "line {i}");
+        }
+        let out = prepare_capture(&raw, 5);
+        assert_eq!(out.lines().count(), 5);
+        assert!(out.starts_with("line 95"));
+        assert!(out.ends_with("line 99"));
+    }
+
+    #[test]
+    fn prepare_capture_classifies_through_ansi() {
+        // A colored spinner line must still classify as Working after prep.
+        let m = cursor();
+        let raw = "\x1b[2K\x1b[36m⠙ Generating…\x1b[0m\n";
+        let prepared = prepare_capture(raw, 40);
+        assert_eq!(m.classify(&prepared), Some(ScreenState::Working));
+    }
+
+    // --- loading / overrides -----------------------------------------------
+
+    #[test]
+    fn user_override_replaces_bundled_by_name() {
+        let mut manifests = bundled_manifests();
+        let before = manifests.len();
+        let override_src = r#"
+[agent]
+name = "cursor"
+command = ["cursor-agent", "cursor"]
+[rules]
+working = ['CUSTOM-SPINNER']
+"#;
+        // Simulate load_user_overrides' replace-by-name step directly.
+        let parsed = parse_manifest(override_src).unwrap();
+        if let Some(existing) = manifests.iter_mut().find(|m| m.name == parsed.name) {
+            *existing = parsed;
+        } else {
+            manifests.push(parsed);
+        }
+        assert_eq!(manifests.len(), before, "override replaces, not appends");
+        let set = ManifestSet { manifests };
+        let cursor = set.manifest_for_command("cursor-agent").unwrap();
+        assert_eq!(
+            cursor.classify("CUSTOM-SPINNER"),
+            Some(ScreenState::Working)
+        );
+        // The bundled cursor spinner glyphs are gone (replaced wholesale).
+        assert_eq!(cursor.classify("⠋ Thinking"), None);
+    }
+
+    #[test]
+    fn load_user_overrides_from_a_temp_dir() {
+        let dir = std::env::temp_dir().join(format!("muxa-screen-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // A valid new agent + a malformed file that must be skipped, not fatal.
+        std::fs::write(
+            dir.join("newbie.toml"),
+            "[agent]\nname = \"newbie\"\ncommand = [\"newbie\"]\n[rules]\nworking = ['spin']\n",
+        )
+        .unwrap();
+        std::fs::write(dir.join("broken.toml"), "not valid ][ toml").unwrap();
+
+        let mut manifests = bundled_manifests();
+        let before = manifests.len();
+        load_user_overrides(&dir, &mut manifests);
+        assert_eq!(manifests.len(), before + 1, "one new agent, broken skipped");
+        assert!(manifests.iter().any(|m| m.name == "newbie"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn manifest_for_command_matches_basename() {
+        let set = ManifestSet {
+            manifests: bundled_manifests(),
+        };
+        assert_eq!(
+            set.manifest_for_command("/usr/local/bin/cursor-agent")
+                .map(|m| m.name.as_str()),
+            Some("cursor"),
+        );
+        assert!(set.manifest_for_command("bash").is_none());
+        assert!(set.manifest_for_command("claude").is_none());
+    }
+}

--- a/crates/muxa/src/screen.rs
+++ b/crates/muxa/src/screen.rs
@@ -211,13 +211,12 @@ pub fn parse_manifest(toml_str: &str) -> Result<AgentManifest, ManifestError> {
 }
 
 /// Lowercase command basename: `/usr/local/bin/Cursor-Agent` → `cursor-agent`.
+/// Delegates the basename extraction to [`crate::discovery::command_name`] (the
+/// same rule `discovery::classify_command` uses) and only adds the lowercasing
+/// the manifest matcher wants, so the screen matcher and `classify_command`
+/// agree on "the command" by construction.
 fn command_basename(cmd: &str) -> String {
-    cmd.trim()
-        .rsplit('/')
-        .next()
-        .unwrap_or(cmd)
-        .trim()
-        .to_ascii_lowercase()
+    crate::discovery::command_name(cmd).to_ascii_lowercase()
 }
 
 /// The bundled manifest sources, shipped in the binary via `include_str!`.
@@ -486,7 +485,14 @@ idle = ['^> $']
     fn amp_fixtures() {
         let m = parse_manifest(include_str!("screen/agents/amp.toml")).unwrap();
         assert!(m.matches_command("amp"));
-        assert_eq!(m.classify("⠸ Working"), Some(ScreenState::Working));
+        // A spinner glyph is busy; the bare word "working" alone is NOT (it
+        // shows up in ordinary output like "working tree clean").
+        assert_eq!(m.classify("⠸ generating"), Some(ScreenState::Working));
+        assert_eq!(
+            m.classify("nothing to commit, working tree clean"),
+            None,
+            "the word `working` in prose must not read as busy",
+        );
         assert_eq!(
             m.classify("Allow this command? (y/n)"),
             Some(ScreenState::Blocked)
@@ -500,8 +506,26 @@ idle = ['^> $']
         assert!(m.matches_command("copilot"));
         assert_eq!(m.classify("⠴ generating"), Some(ScreenState::Working));
         assert_eq!(
+            m.classify("working tree clean"),
+            None,
+            "the word `working` in prose must not read as busy",
+        );
+        assert_eq!(
             m.classify("Do you want to run this? [y/n]"),
             Some(ScreenState::Blocked)
+        );
+        // A real yes/no selection widget (highlighted `❯ Yes` row) reads as
+        // blocked...
+        assert_eq!(
+            m.classify("  Run this command?\n❯ Yes\n  No"),
+            Some(ScreenState::Blocked),
+        );
+        // ...but an ordinary sentence containing yes / no / ? does NOT (the old
+        // `\byes\b.*\bno\b.*\?` pattern wrongly matched this).
+        assert_eq!(
+            m.classify("Yes, we can do that, but no rush — right?"),
+            None,
+            "prose with yes/no/? must not read as an approval prompt",
         );
     }
 
@@ -523,8 +547,22 @@ idle = ['^> $']
         assert!(m.matches_command("goose"));
         assert_eq!(m.classify("⠧ thinking"), Some(ScreenState::Working));
         assert_eq!(
+            m.classify("working tree clean"),
+            None,
+            "the word `working` in prose must not read as busy",
+        );
+        assert_eq!(
             m.classify("Goose would like to call the shell tool. Allow? [y/n]"),
             Some(ScreenState::Blocked)
+        );
+        // The literal `Allow?` affordance on its own reads as blocked...
+        assert_eq!(m.classify("Allow?"), Some(ScreenState::Blocked));
+        // ...but the bare word "allow" in prose does NOT (the old pattern made
+        // every token after "allow" optional, matching a lone "allow ").
+        assert_eq!(
+            m.classify("These settings allow faster incremental rebuilds."),
+            None,
+            "the word `allow` in prose must not read as an approval prompt",
         );
     }
 

--- a/crates/muxa/src/screen/agents/aider.toml
+++ b/crates/muxa/src/screen/agents/aider.toml
@@ -1,0 +1,37 @@
+# Bundled screen-detection manifest — Aider (`aider`).
+#
+# BEST-EFFORT / CONSERVATIVE. Written WITHOUT running aider. Aider's confirm
+# prompts use a distinctive `(Y)es/(N)o` affordance, which is a stronger signal
+# than the generic phrasing the other manifests fall back on. Still: when unsure,
+# match nothing. See docs/SCREEN_DETECTION.md. Override at
+# $XDG_CONFIG_HOME/muxa/agents/aider.toml.
+#
+# NOTE: aider often runs as a `python` process, so its tmux foreground command
+# may be `python`/`python3` rather than `aider`. muxa's screen detection matches
+# the foreground command name only (no process-tree walk), so panes where aider
+# is not the direct foreground command won't be picked up. Add `python` to
+# `command` in a user override ONLY if you accept that every python pane becomes
+# a candidate.
+
+[agent]
+name = "aider"
+command = ["aider"]
+
+[rules]
+blocked = [
+    '(?i)\(y\)es/\(n\)o',
+    '(?i)\[y/n\]',
+    '(?i)\(y/n\)',
+    '(?i)add .* to the chat\?',
+    '(?i)run shell command\?',
+    '(?i)do you want to (allow|proceed|run|continue)',
+    '(?i)allow (edits|command)\??',
+]
+working = [
+    '[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⣾⣽⣻⢿⡿⣟⣯⣷]',
+    '(?i)\b(thinking|generating)\b',
+]
+idle = [
+    '(?m)^\s*>\s*$',
+    '(?m)^\s*(architect|ask|code)?\s*>\s*$',
+]

--- a/crates/muxa/src/screen/agents/amp.toml
+++ b/crates/muxa/src/screen/agents/amp.toml
@@ -1,0 +1,27 @@
+# Bundled screen-detection manifest — Amp CLI (`amp`, Sourcegraph).
+#
+# BEST-EFFORT / CONSERVATIVE. Written WITHOUT running amp. See the notes in
+# cursor.toml and docs/SCREEN_DETECTION.md. Override at
+# $XDG_CONFIG_HOME/muxa/agents/amp.toml.
+
+[agent]
+name = "amp"
+command = ["amp"]
+
+[rules]
+blocked = [
+    '(?i)\[y/n\]',
+    '(?i)\(y/n\)',
+    '(?i)do you want to (allow|proceed|run|continue)',
+    '(?i)allow (this|the) (command|tool|edit)\??',
+    '(?i)permission (to run|required|request)',
+    '(?i)approve (this|the) (command|edit|change|tool)',
+]
+working = [
+    '[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⣾⣽⣻⢿⡿⣟⣯⣷]',
+    '(?i)\b(thinking|generating|working)\b',
+    '(?i)esc to interrupt',
+]
+idle = [
+    '(?m)^\s*>\s*$',
+]

--- a/crates/muxa/src/screen/agents/amp.toml
+++ b/crates/muxa/src/screen/agents/amp.toml
@@ -19,7 +19,7 @@ blocked = [
 ]
 working = [
     '[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⣾⣽⣻⢿⡿⣟⣯⣷]',
-    '(?i)\b(thinking|generating|working)\b',
+    '(?i)\b(thinking|generating)\b',
     '(?i)esc to interrupt',
 ]
 idle = [

--- a/crates/muxa/src/screen/agents/copilot.toml
+++ b/crates/muxa/src/screen/agents/copilot.toml
@@ -1,0 +1,28 @@
+# Bundled screen-detection manifest — GitHub Copilot CLI (`copilot`).
+#
+# BEST-EFFORT / CONSERVATIVE. Written WITHOUT running the Copilot CLI. See the
+# notes in cursor.toml and docs/SCREEN_DETECTION.md. Override at
+# $XDG_CONFIG_HOME/muxa/agents/copilot.toml.
+
+[agent]
+name = "copilot"
+command = ["copilot"]
+
+[rules]
+blocked = [
+    '(?i)\[y/n\]',
+    '(?i)\(y/n\)',
+    '(?i)allow (command|tool|this)\??',
+    '(?i)do you want to (allow|proceed|run|continue)',
+    '(?i)permission (to run|required|request)',
+    '(?i)approve (this|the) (command|edit|change|tool)',
+    '(?i)\byes\b.*\bno\b.*\?',
+]
+working = [
+    '[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⣾⣽⣻⢿⡿⣟⣯⣷]',
+    '(?i)\b(thinking|generating|working)\b',
+    '(?i)esc to interrupt',
+]
+idle = [
+    '(?m)^\s*>\s*$',
+]

--- a/crates/muxa/src/screen/agents/copilot.toml
+++ b/crates/muxa/src/screen/agents/copilot.toml
@@ -16,11 +16,14 @@ blocked = [
     '(?i)do you want to (allow|proceed|run|continue)',
     '(?i)permission (to run|required|request)',
     '(?i)approve (this|the) (command|edit|change|tool)',
-    '(?i)\byes\b.*\bno\b.*\?',
+    # An actual yes/no selection widget (the highlighted `❯ Yes` row), NOT any
+    # prose sentence that happens to contain "yes … no … ?". The previous
+    # pattern matched ordinary text.
+    '(?i)❯\s*yes\b',
 ]
 working = [
     '[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⣾⣽⣻⢿⡿⣟⣯⣷]',
-    '(?i)\b(thinking|generating|working)\b',
+    '(?i)\b(thinking|generating)\b',
     '(?i)esc to interrupt',
 ]
 idle = [

--- a/crates/muxa/src/screen/agents/cursor.toml
+++ b/crates/muxa/src/screen/agents/cursor.toml
@@ -1,0 +1,34 @@
+# Bundled screen-detection manifest — Cursor CLI (`cursor-agent`).
+#
+# BEST-EFFORT / CONSERVATIVE. Written WITHOUT running cursor-agent (muxa's CI
+# can't drive these CLIs). Patterns lean on braille spinner glyphs and generic
+# approval phrasing; when unsure they match NOTHING so an unrecognized screen
+# keeps the row's previous state rather than mislabeling it. See
+# docs/SCREEN_DETECTION.md. Override at $XDG_CONFIG_HOME/muxa/agents/cursor.toml.
+
+[agent]
+name = "cursor"
+command = ["cursor-agent"]
+
+[rules]
+# STRICT — only unambiguous approval / permission UI. An over-broad blocked
+# pattern is the worst failure (a working agent shown as "needs input"), so
+# these require a clear yes/no affordance or explicit permission wording.
+blocked = [
+    '(?i)\[y/n\]',
+    '(?i)\(y/n\)',
+    '(?i)do you want to (allow|proceed|run|continue|apply)',
+    '(?i)permission (to run|required|request)',
+    '(?i)approve (this|the) (command|edit|change|tool)',
+    '(?i)press\s+y\s+to\s+(confirm|approve|continue|run)',
+]
+# Active generation: spinner glyphs or an explicit interrupt hint.
+working = [
+    '[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⣾⣽⣻⢿⡿⣟⣯⣷]',
+    '(?i)\b(thinking|generating|reasoning)\b',
+    '(?i)esc to interrupt',
+]
+# Idle: a bare prompt line waiting for the next instruction.
+idle = [
+    '(?m)^\s*>\s*$',
+]

--- a/crates/muxa/src/screen/agents/goose.toml
+++ b/crates/muxa/src/screen/agents/goose.toml
@@ -13,13 +13,17 @@ blocked = [
     '(?i)\[y/n\]',
     '(?i)\(y/n\)',
     '(?i)would like to call',
-    '(?i)allow (this|the)? ?(tool|command)?\s*(call|execution)?\??',
+    # Only an actual approval prompt — the literal "Allow?" affordance
+    # ("… Allow? [y/n]"), NOT the bare word "allow" in prose. The previous
+    # pattern made every token after "allow" optional, so it matched a lone
+    # "allow ".
+    '(?i)\ballow\?',
     '(?i)do you want to (allow|proceed|run|continue)',
     '(?i)approve (this|the) (command|tool|action)',
 ]
 working = [
     '[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⣾⣽⣻⢿⡿⣟⣯⣷]',
-    '(?i)\b(thinking|generating|working)\b',
+    '(?i)\b(thinking|generating)\b',
     '(?i)esc to interrupt',
 ]
 idle = [

--- a/crates/muxa/src/screen/agents/goose.toml
+++ b/crates/muxa/src/screen/agents/goose.toml
@@ -1,0 +1,28 @@
+# Bundled screen-detection manifest — Goose CLI (`goose`, Block).
+#
+# BEST-EFFORT / CONSERVATIVE. Written WITHOUT running goose. See the notes in
+# cursor.toml and docs/SCREEN_DETECTION.md. Override at
+# $XDG_CONFIG_HOME/muxa/agents/goose.toml.
+
+[agent]
+name = "goose"
+command = ["goose"]
+
+[rules]
+blocked = [
+    '(?i)\[y/n\]',
+    '(?i)\(y/n\)',
+    '(?i)would like to call',
+    '(?i)allow (this|the)? ?(tool|command)?\s*(call|execution)?\??',
+    '(?i)do you want to (allow|proceed|run|continue)',
+    '(?i)approve (this|the) (command|tool|action)',
+]
+working = [
+    '[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⣾⣽⣻⢿⡿⣟⣯⣷]',
+    '(?i)\b(thinking|generating|working)\b',
+    '(?i)esc to interrupt',
+]
+idle = [
+    '(?m)^\s*>\s*$',
+    '(?i)\bgoose\b\s*>\s*$',
+]

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -751,12 +751,19 @@ fn mutate_for_event(
             } else if matches!(
                 agent.state,
                 AgentState::WaitingInput | AgentState::WaitingChoice
-            ) {
+            ) && !is_synthetic(&agent.session_id)
+            {
                 // Codex can emit `Stop` while a permission request is still
                 // sitting in the terminal. A response-less stop is not proof
                 // that the user-facing wait cleared; keep the row waiting
                 // until a tool event, response, or explicit later state
                 // transition says otherwise.
+                //
+                // REAL rows only. A SYNTHETIC detection row (screen inference /
+                // the herdr bridge) that reports `idle`/`done` is reading the
+                // pane's *current* screen — if the approval prompt is gone, the
+                // wait genuinely cleared, so a synthetic response-less stop must
+                // fall through to `Idle` rather than freezing on `WaitingInput`.
             } else if agent.state != AgentState::Error {
                 agent.state = AgentState::Idle;
             }
@@ -3562,6 +3569,83 @@ mod tests {
             .await;
         let agent = store.by_session("s").await.unwrap();
         assert_eq!(agent.last_response.as_deref(), Some("first answer"));
+    }
+
+    #[tokio::test]
+    async fn responseless_stop_keeps_real_waiting_row_waiting() {
+        // A REAL (hook) row waiting on a permission prompt must stay waiting on
+        // a response-less TurnStopped — the Codex Stop-during-permission guard.
+        let store = Store::shared();
+        let now = datetime!(2026-07-20 12:00:00 UTC);
+        store
+            .apply(&AgentEvent::Started {
+                id: id("real"),
+                at: now,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::NotificationFired {
+                id: id("real"),
+                level: NotificationLevel::NeedsInput,
+                message: "approve?".into(),
+                at: now,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("real").await.unwrap().state,
+            AgentState::WaitingInput
+        );
+        store
+            .apply(&AgentEvent::TurnStopped {
+                id: id("real"),
+                response: None,
+                recap: None,
+                ai_title: None,
+                at: now,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("real").await.unwrap().state,
+            AgentState::WaitingInput,
+            "a real waiting row stays waiting on a response-less stop",
+        );
+    }
+
+    #[tokio::test]
+    async fn responseless_stop_clears_synthetic_waiting_row_to_idle() {
+        // A SYNTHETIC detection row (screen inference / herdr bridge) that was
+        // WaitingInput and now reports idle (a response-less TurnStopped) must
+        // fall through to Idle — the screen no longer shows the prompt, so the
+        // wait genuinely cleared. This is what lets a screen `blocked -> idle`
+        // transition land.
+        let store = Store::shared();
+        let now = datetime!(2026-07-20 12:00:00 UTC);
+        store
+            .apply(&AgentEvent::NotificationFired {
+                id: id("synthetic-%1"),
+                level: NotificationLevel::NeedsInput,
+                message: "approve?".into(),
+                at: now,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("synthetic-%1").await.unwrap().state,
+            AgentState::WaitingInput,
+        );
+        store
+            .apply(&AgentEvent::TurnStopped {
+                id: id("synthetic-%1"),
+                response: None,
+                recap: None,
+                ai_title: None,
+                at: now,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("synthetic-%1").await.unwrap().state,
+            AgentState::Idle,
+            "a synthetic waiting row clears to Idle on a response-less stop",
+        );
     }
 
     #[tokio::test]

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -719,6 +719,7 @@ fn mutate_for_event(
             response,
             recap,
             ai_title,
+            idle_confirmed,
             ..
         } => {
             if let Some(text) = response {
@@ -751,7 +752,7 @@ fn mutate_for_event(
             } else if matches!(
                 agent.state,
                 AgentState::WaitingInput | AgentState::WaitingChoice
-            ) && !is_synthetic(&agent.session_id)
+            ) && !*idle_confirmed
             {
                 // Codex can emit `Stop` while a permission request is still
                 // sitting in the terminal. A response-less stop is not proof
@@ -759,11 +760,14 @@ fn mutate_for_event(
                 // until a tool event, response, or explicit later state
                 // transition says otherwise.
                 //
-                // REAL rows only. A SYNTHETIC detection row (screen inference /
-                // the herdr bridge) that reports `idle`/`done` is reading the
-                // pane's *current* screen — if the approval prompt is gone, the
-                // wait genuinely cleared, so a synthetic response-less stop must
-                // fall through to `Idle` rather than freezing on `WaitingInput`.
+                // EXCEPTION — `idle_confirmed`. A SYNTHETIC detection producer
+                // (screen inference / the herdr bridge) sets this flag when it
+                // has OBSERVED the pane go idle (the approval prompt is gone
+                // from the current screen). That IS proof the wait cleared, so a
+                // marked stop falls through to `Idle`. This keys on positive
+                // idle evidence, NOT on `is_synthetic`: a markerless
+                // response-less stop — a real Codex permission-gap stop, or any
+                // other bare synthetic stop — still freezes the waiting row.
             } else if agent.state != AgentState::Error {
                 agent.state = AgentState::Idle;
             }
@@ -2708,6 +2712,7 @@ mod tests {
                 response: Some("done".into()),
                 recap: None,
                 ai_title: None,
+                idle_confirmed: false,
                 at: now,
             })
             .await;
@@ -2824,6 +2829,7 @@ mod tests {
                 response: None,
                 recap: None,
                 ai_title: None,
+                idle_confirmed: false,
                 at: now,
             })
             .await;
@@ -3048,6 +3054,7 @@ mod tests {
                 response: None,
                 recap: None,
                 ai_title: None,
+                idle_confirmed: false,
                 at: now,
             })
             .await;
@@ -3070,6 +3077,7 @@ mod tests {
                 response: None,
                 recap: None,
                 ai_title: None,
+                idle_confirmed: false,
                 at: now,
             })
             .await;
@@ -3452,6 +3460,7 @@ mod tests {
                 response: Some("recovered".into()),
                 recap: None,
                 ai_title: None,
+                idle_confirmed: false,
                 at: t1,
             })
             .await;
@@ -3494,6 +3503,7 @@ mod tests {
                 response: None,
                 recap: None,
                 ai_title: None,
+                idle_confirmed: false,
                 at: t0,
             })
             .await;
@@ -3523,6 +3533,7 @@ mod tests {
                 response: Some("the assistant said hi".into()),
                 recap: None,
                 ai_title: None,
+                idle_confirmed: false,
                 at: now,
             })
             .await;
@@ -3552,6 +3563,7 @@ mod tests {
                 response: Some("first answer".into()),
                 recap: None,
                 ai_title: None,
+                idle_confirmed: false,
                 at: now,
             })
             .await;
@@ -3564,6 +3576,7 @@ mod tests {
                 response: None,
                 recap: None,
                 ai_title: None,
+                idle_confirmed: false,
                 at: now,
             })
             .await;
@@ -3601,23 +3614,26 @@ mod tests {
                 response: None,
                 recap: None,
                 ai_title: None,
+                // A bare (markerless) response-less stop — exactly the Codex
+                // permission-gap quirk.
+                idle_confirmed: false,
                 at: now,
             })
             .await;
         assert_eq!(
             store.by_session("real").await.unwrap().state,
             AgentState::WaitingInput,
-            "a real waiting row stays waiting on a response-less stop",
+            "a real waiting row stays waiting on a markerless response-less stop",
         );
     }
 
     #[tokio::test]
-    async fn responseless_stop_clears_synthetic_waiting_row_to_idle() {
-        // A SYNTHETIC detection row (screen inference / herdr bridge) that was
-        // WaitingInput and now reports idle (a response-less TurnStopped) must
-        // fall through to Idle — the screen no longer shows the prompt, so the
-        // wait genuinely cleared. This is what lets a screen `blocked -> idle`
-        // transition land.
+    async fn idle_confirmed_stop_clears_waiting_row_to_idle() {
+        // A SYNTHETIC detection producer (screen inference / herdr bridge) that
+        // was WaitingInput and now OBSERVES the pane go idle emits a response-
+        // less TurnStopped with `idle_confirmed = true`. That marker is positive
+        // proof the wait cleared, so the row must fall through to Idle — this is
+        // what lets a screen `blocked -> idle` transition land.
         let store = Store::shared();
         let now = datetime!(2026-07-20 12:00:00 UTC);
         store
@@ -3638,13 +3654,52 @@ mod tests {
                 response: None,
                 recap: None,
                 ai_title: None,
+                idle_confirmed: true,
                 at: now,
             })
             .await;
         assert_eq!(
             store.by_session("synthetic-%1").await.unwrap().state,
             AgentState::Idle,
-            "a synthetic waiting row clears to Idle on a response-less stop",
+            "an idle-confirmed stop clears a waiting row to Idle",
+        );
+    }
+
+    #[tokio::test]
+    async fn markerless_stop_keeps_synthetic_waiting_row_waiting() {
+        // The invariant guarding against transient/jitter idle: a SYNTHETIC row
+        // that is genuinely blocked must NOT be cleared by a bare, markerless
+        // response-less stop. Only an `idle_confirmed` stop (the producer
+        // actually observed the prompt disappear) may clear it. The distinction
+        // keys on the marker, NOT on the session being synthetic.
+        let store = Store::shared();
+        let now = datetime!(2026-07-20 12:00:00 UTC);
+        store
+            .apply(&AgentEvent::NotificationFired {
+                id: id("synthetic-%1"),
+                level: NotificationLevel::NeedsInput,
+                message: "approve?".into(),
+                at: now,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("synthetic-%1").await.unwrap().state,
+            AgentState::WaitingInput,
+        );
+        store
+            .apply(&AgentEvent::TurnStopped {
+                id: id("synthetic-%1"),
+                response: None,
+                recap: None,
+                ai_title: None,
+                idle_confirmed: false,
+                at: now,
+            })
+            .await;
+        assert_eq!(
+            store.by_session("synthetic-%1").await.unwrap().state,
+            AgentState::WaitingInput,
+            "a synthetic waiting row stays waiting on a markerless stop",
         );
     }
 

--- a/crates/muxad/src/herdr_bridge.rs
+++ b/crates/muxad/src/herdr_bridge.rs
@@ -44,9 +44,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use muxa::backend::herdr::{default_socket_path, PANE_ID_PREFIX};
-use muxa::event::{AgentEvent, AgentId, AgentKind, NotificationLevel};
+use muxa::event::{AgentEvent, AgentId, AgentKind};
 use muxa::state::{Agent, SYNTHETIC_SESSION_PREFIX};
 use muxa::{AgentState, HostKind, SharedBackend, SharedStore};
+
+use crate::synthetic::{self, SyntheticState};
 use serde_json::{json, Value};
 use time::OffsetDateTime;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -132,14 +134,6 @@ fn classify_agent(agent: &str) -> AgentKind {
     }
 }
 
-/// A short, human-facing label for the `working` [`AgentEvent::ToolStarted`].
-/// The tool string isn't persisted on the row (no `current_tool` field), so it
-/// only ever surfaces in the activity ledger — the herdr agent name is the
-/// most informative thing to record there.
-fn tool_label(name: &str) -> String {
-    name.to_owned()
-}
-
 /// The `last_notification` text for a `blocked` row. Prefers the herdr pane
 /// title (often "waiting for approval" style copy), else a generic line naming
 /// the agent.
@@ -213,78 +207,32 @@ pub fn translate(envelope: &Value, at: OffsetDateTime) -> Result<BridgeUpdate, D
         cwd: None,
     };
 
-    let status_event = match status {
-        "working" => AgentEvent::ToolStarted {
-            id: id.clone(),
-            tool: tool_label(name),
-            subagent: None,
-            at,
-        },
-        "blocked" => AgentEvent::NotificationFired {
-            id: id.clone(),
-            level: NotificationLevel::NeedsInput,
-            message: blocked_message(data, name),
-            at,
-        },
-        "idle" | "done" => AgentEvent::TurnStopped {
-            id: id.clone(),
-            response: None,
-            recap: None,
-            ai_title: None,
-            at,
-        },
+    // Map herdr's status onto the shared synthetic-state vocabulary, then let
+    // the shared builder produce the status event + name-bearing heartbeat (the
+    // exact same shape screen detection emits). `blocked` carries the herdr pane
+    // title as its message; `working`/`idle` need none.
+    let (state, message) = match status {
+        "working" => (SyntheticState::Working, None),
+        "blocked" => (SyntheticState::Blocked, Some(blocked_message(data, name))),
+        "idle" | "done" => (SyntheticState::Idle, None),
         "unknown" => return Err(DropReason::StatusUnknown),
         _ => return Err(DropReason::Malformed),
     };
 
-    // Carry the herdr agent name into `model` so an Unknown-kind row (cursor,
-    // amp, …) still tells the operator *which* agent it is. Harmless for a row
-    // that later gets real hooks — the bridge row is evicted first.
-    let heartbeat = AgentEvent::Heartbeat {
-        id,
-        model: Some(name.to_owned()),
-        context_used_pct: None,
-        cost_usd: None,
-        rate_limit_5h_pct: None,
-        rate_limit_5h_resets_at: None,
-        rate_limit_7d_pct: None,
-        rate_limit_7d_resets_at: None,
-        at,
-    };
+    // Carry the herdr agent name into `model` (via the heartbeat the builder
+    // appends) so an Unknown-kind row (cursor, amp, …) still tells the operator
+    // *which* agent it is. Harmless for a row that later gets real hooks — the
+    // bridge row is evicted first.
+    let events = synthetic::state_events(id, state, name, message, at);
 
-    Ok(BridgeUpdate {
-        pane_id,
-        events: vec![status_event, heartbeat],
-    })
+    Ok(BridgeUpdate { pane_id, events })
 }
 
-/// True when a bridge row already owning `pane` (a real, hook-driven,
-/// non-synthetic occupant) must be treated as owning it authoritatively.
-///
-/// A `Stopped` occupant does NOT own the pane: GC keeps a `Stopped` row around
-/// for up to an hour, and a fresh (hook-less) agent launched in that same pane
-/// during that window would otherwise be invisible to the bridge the whole
-/// time. So only NON-`Stopped` non-synthetic occupants block a bridge update.
-fn occupant_is_authoritative(agent: &Agent) -> bool {
-    !agent.session_id.starts_with(SYNTHETIC_SESSION_PREFIX) && agent.state != AgentState::Stopped
-}
-
-/// Apply a translated update, enforcing the hook-authoritative rule: if a
-/// *live* non-synthetic (real hook) row already owns the pane, drop the bridge
-/// update wholesale. A `Stopped` real row is a stale tombstone, not an owner —
-/// see [`occupant_is_authoritative`].
+/// Apply a translated update, enforcing the hook-authoritative rule via the
+/// shared [`synthetic::apply_if_unowned`]: if a *live* non-synthetic (real
+/// hook) row already owns the pane, drop the bridge update wholesale.
 async fn apply_update(store: &SharedStore, update: BridgeUpdate) {
-    let occupants = store.by_pane(&update.pane_id).await;
-    if occupants.iter().any(occupant_is_authoritative) {
-        tracing::debug!(
-            pane = %update.pane_id,
-            "herdr bridge: pane owned by a live hooked agent, dropping bridge update",
-        );
-        return;
-    }
-    for ev in &update.events {
-        store.apply(ev).await;
-    }
+    synthetic::apply_if_unowned(store, &update.pane_id, &update.events).await;
 }
 
 /// The muxa-namespaced pane id of an agent-less `pane.agent_status_changed`
@@ -299,50 +247,17 @@ fn agentless_pane_id(envelope: &Value) -> Option<String> {
     Some(format!("{PANE_ID_PREFIX}{raw}"))
 }
 
-/// Herdr says this pane has no agent. If a *synthetic* bridge row is still
-/// mirroring an agent there, stop it — otherwise its last state (`Working` /
-/// `WaitingInput`) would freeze forever: the pane's shell is alive (so the
-/// reconciler won't reap it) and the row isn't `Stopped` (so GC won't evict
-/// it). Emitting `SessionEnded` drives the synthetic row to `Stopped`, after
-/// which GC can reclaim it. A pane with no synthetic row is left untouched (no
-/// row is invented), and a real hook row is never disturbed by this path.
-async fn stop_agentless_synthetic(store: &SharedStore, pane_id: &str) {
-    let occupants = store.by_pane(pane_id).await;
-    for occ in occupants {
-        if !occ.session_id.starts_with(SYNTHETIC_SESSION_PREFIX) || occ.state == AgentState::Stopped
-        {
-            // Real hook rows are not ours to stop; already-`Stopped` synthetic
-            // rows need no further event.
-            continue;
-        }
-        let id = AgentId {
-            kind: occ.kind,
-            session_id: occ.session_id.clone(),
-            surface: occ.surface.clone(),
-            pane: occ.pane.clone(),
-            tmux_socket: None,
-            cwd: occ.cwd.clone(),
-        };
-        store
-            .apply(&AgentEvent::SessionEnded {
-                id,
-                at: OffsetDateTime::now_utc(),
-            })
-            .await;
-        tracing::debug!(pane = %pane_id, "herdr bridge: agent gone, stopped synthetic row");
-    }
-}
-
 /// Translate a wire/seed envelope and, when it yields an update, apply it.
 async fn ingest_envelope(store: &SharedStore, envelope: &Value) {
     match translate(envelope, OffsetDateTime::now_utc()) {
         Ok(update) => apply_update(store, update).await,
         // Agent gone: herdr no longer attributes an agent to this pane. If a
         // synthetic bridge row is still mirroring one there, stop it so it
-        // doesn't freeze; otherwise it's a plain shell and a no-op.
+        // doesn't freeze; otherwise it's a plain shell and a no-op. Shared with
+        // screen detection via [`synthetic::stop_synthetic_row`].
         Err(DropReason::NoAgent) => {
             if let Some(pane) = agentless_pane_id(envelope) {
-                stop_agentless_synthetic(store, &pane).await;
+                synthetic::stop_synthetic_row(store, &pane).await;
             }
         }
         // Unknown status is routine — keep it off the debug stream so the log
@@ -1016,7 +931,7 @@ pub fn spawn_herdr_report_task(
 
 #[cfg(test)]
 mod tests {
-    use muxa::event::AgentEvent;
+    use muxa::event::{AgentEvent, NotificationLevel};
     use muxa::state::Store;
     use muxa::AgentState;
     use serde_json::json;

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -28,6 +28,8 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::broadcast;
 
 mod herdr_bridge;
+mod screen_detect;
+mod synthetic;
 
 /// Inactivity window before a stopped agent is evicted from the in-memory store.
 const STOPPED_AGENT_TTL_MINUTES: i64 = 60;
@@ -210,6 +212,13 @@ async fn main() -> Result<()> {
     // transition stream the notifier/activity tasks use. Spawned when herdr ∈ set.
     let herdr_report_handle =
         herdr_bridge::spawn_herdr_report_task(&backends, store.clone(), &shutdown_tx);
+    // Screen-manifest fallback detection: for agent CLIs muxa has no hooks for
+    // (cursor-agent, amp, copilot, …), capture matching panes and classify their
+    // screen into synthetic rows. Skips herdr hosts (the herdr bridge covers
+    // them) and any pane a live hook owns. Spawned before the IPC server takes
+    // ownership of `store` so it shares the same registry.
+    let screen_detect_handle =
+        screen_detect::spawn_screen_detect_task(&cfg, &backends, store.clone(), &shutdown_tx);
     let session_activity_handle =
         spawn_session_activity_task(&cfg, &shutdown_tx, activity_log.clone(), &backends);
     let history_compaction_handle = spawn_history_compaction_task(&cfg, &store, &shutdown_tx);
@@ -364,6 +373,7 @@ async fn main() -> Result<()> {
     await_shutdown_task("reconciler", reconciler_handle).await;
     await_shutdown_task("herdr bridge", herdr_bridge_handle).await;
     await_shutdown_task("herdr report", herdr_report_handle).await;
+    await_shutdown_task("screen detection", screen_detect_handle).await;
     await_shutdown_task("session activity", session_activity_handle).await;
     await_shutdown_task("history compaction", history_compaction_handle).await;
     await_shutdown_task("activity compaction", activity_compaction_handle).await;

--- a/crates/muxad/src/screen_detect.rs
+++ b/crates/muxad/src/screen_detect.rs
@@ -1,0 +1,538 @@
+//! Screen-manifest fallback detection task.
+//!
+//! For agent CLIs muxa has **no hooks** for (cursor-agent, amp, copilot, aider,
+//! goose, …), this background task infers state from the pane's screen: every
+//! `[screen_detect] interval_secs` it finds panes whose foreground command
+//! matches a manifest, captures each, matches the manifest's regex rules against
+//! the visible tail, and — on a state CHANGE — ingests SYNTHETIC muxa events
+//! exactly the way [`crate::herdr_bridge`] does for herdr's detection. The pure
+//! manifest/classifier core lives in [`muxa::screen`]; the synthetic-row
+//! machinery (hook-authoritative precedence, row liveness, event building) is
+//! shared with the herdr bridge via [`crate::synthetic`].
+//!
+//! ## Precedence — hooks > herdr bridge > screen detection
+//!
+//! Screen rows are synthetic, so:
+//!
+//! * A real hook `Started`/tool/prompt event on the pane evicts the screen row
+//!   the instant it fires (`Store::apply`'s synthetic-eviction pass).
+//! * Before capturing OR applying, the task checks
+//!   [`synthetic::occupant_is_authoritative`]: if a live non-synthetic row owns
+//!   the pane, the pane is skipped entirely — no capture, no update.
+//! * **herdr hosts are skipped wholesale**: herdr's own detection + the herdr
+//!   bridge already cover those panes, so a herdr backend is never a screen
+//!   candidate (see [`detectable_backends`]).
+//!
+//! ## Cost / robustness
+//!
+//! Candidate discovery is one `list_panes` per backend per tick (`spawn_blocking`);
+//! when no pane matches a manifest, zero captures run. Each capture is a
+//! `spawn_blocking` `capture-pane` bounded by tmux's own 1s command timeout. A
+//! tick is skipped if the previous one is still running (interval with
+//! `MissedTickBehavior::Skip`, and each tick is fully awaited before the next).
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use muxa::screen::{ManifestSet, ScreenState};
+use muxa::tmux::PaneInfo;
+use muxa::{AgentId, AgentKind, Config, HostKind, PaneBackend, SharedBackend, SharedStore};
+use time::OffsetDateTime;
+use tokio::sync::broadcast;
+use tokio::task::spawn_blocking;
+
+use crate::synthetic::{self, SyntheticState};
+
+/// How many lines from the bottom of a capture the classifier sees. The active
+/// spinner/prompt/approval UI lives near the bottom; bounding the slice also
+/// bounds regex work.
+const CAPTURE_TAIL_LINES: usize = 40;
+
+/// The backends screen detection may run on: **non-herdr** (herdr panes are
+/// covered by the herdr bridge) and able to **capture panes**
+/// (`caps().capture_pane`). Zellij without its plugin reports
+/// `capture_pane = false` and drops out here.
+fn detectable_backends(backends: &[SharedBackend]) -> Vec<SharedBackend> {
+    backends
+        .iter()
+        .filter(|b| b.kind() != HostKind::Herdr && b.caps().capture_pane)
+        .cloned()
+        .collect()
+}
+
+/// Map the screen classifier's state onto the shared synthetic vocabulary.
+fn to_synthetic(state: ScreenState) -> SyntheticState {
+    match state {
+        ScreenState::Working => SyntheticState::Working,
+        ScreenState::Blocked => SyntheticState::Blocked,
+        ScreenState::Idle => SyntheticState::Idle,
+    }
+}
+
+/// Build the synthetic [`AgentId`] for a screen-detected pane. Uses the SAME
+/// [`muxa::synthetic_session_id`] convention discovery mints, so a discovery
+/// placeholder and this screen row collapse onto one registry key and share the
+/// hook-eviction precedence. `kind` is always `Unknown` — the manifest name
+/// rides in the row's `model` field (set by the heartbeat the shared builder
+/// appends), not the kind.
+fn synthetic_id(pane: &PaneInfo) -> AgentId {
+    AgentId {
+        kind: AgentKind::Unknown,
+        session_id: muxa::synthetic_session_id(pane),
+        surface: None,
+        pane: Some(pane.pane_id.clone()),
+        tmux_socket: pane.socket.clone(),
+        cwd: None,
+    }
+}
+
+/// The periodic screen detector. Owns the loaded manifests and the per-pane
+/// last-classified-state map that makes ingestion state-change-only.
+struct ScreenDetector {
+    backends: Vec<SharedBackend>,
+    store: SharedStore,
+    manifests: ManifestSet,
+    interval: Duration,
+    /// pane id → last classified state. A capture that classifies to the same
+    /// state is a no-op; a classification of `None` (unknown screen) leaves the
+    /// entry untouched — the "unknown transitions are dropped" rule.
+    last_state: HashMap<String, ScreenState>,
+    /// Panes we currently own a synthetic row for. When a tracked pane stops
+    /// being a candidate (its foreground command changed away from the agent),
+    /// its synthetic row is stopped so it doesn't freeze.
+    tracked: HashSet<String>,
+}
+
+impl ScreenDetector {
+    /// The reconnect-free main loop: tick on the interval, drain on shutdown.
+    async fn run(mut self, mut shutdown_rx: broadcast::Receiver<()>) {
+        let mut tick = tokio::time::interval(self.interval);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        tick.tick().await; // consume the immediate first tick
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.recv() => {
+                    tracing::debug!("screen detection shutting down");
+                    return;
+                }
+                _ = tick.tick() => {
+                    let _ = self.run_tick().await;
+                }
+            }
+        }
+    }
+
+    /// One detection pass. Returns the number of state CHANGES ingested (for
+    /// tests). Steps: gather candidate panes, stop rows for panes that dropped
+    /// out of candidacy, then capture/classify/ingest each candidate a live
+    /// hook doesn't own.
+    async fn run_tick(&mut self) -> usize {
+        let candidates = self.gather_candidates().await;
+        let current: HashSet<String> = candidates.iter().map(|(_, p)| p.pane_id.clone()).collect();
+
+        // Panes we tracked that are no longer candidates: the agent's foreground
+        // command changed (it exited, or a different program took over). Stop the
+        // synthetic row so it doesn't freeze at its last state.
+        let dropped: Vec<String> = self
+            .tracked
+            .iter()
+            .filter(|p| !current.contains(*p))
+            .cloned()
+            .collect();
+        for pane_id in dropped {
+            synthetic::stop_synthetic_row(&self.store, &pane_id).await;
+            self.tracked.remove(&pane_id);
+            self.last_state.remove(&pane_id);
+        }
+
+        let mut changes = 0;
+        for (backend_idx, pane) in candidates {
+            if self.process_candidate(backend_idx, &pane).await {
+                changes += 1;
+            }
+        }
+        changes
+    }
+
+    /// List panes across every detectable backend and keep the ones whose
+    /// foreground command matches a manifest. Returns `(backend_index, pane)`
+    /// so the capture step can target the right backend. The `list_panes` calls
+    /// (blocking tmux shell-outs) run inside one `spawn_blocking`.
+    async fn gather_candidates(&self) -> Vec<(usize, PaneInfo)> {
+        let backends = self.backends.clone();
+        let panes: Vec<(usize, PaneInfo)> = spawn_blocking(move || {
+            let mut out = Vec::new();
+            for (i, backend) in backends.iter().enumerate() {
+                for pane in backend.list_panes() {
+                    out.push((i, pane));
+                }
+            }
+            out
+        })
+        .await
+        .unwrap_or_default();
+
+        panes
+            .into_iter()
+            .filter(|(_, p)| {
+                self.manifests
+                    .manifest_for_command(&p.current_command)
+                    .is_some()
+            })
+            .collect()
+    }
+
+    /// Capture, classify, and (on a state change) ingest one candidate pane.
+    /// Returns `true` iff a state change was ingested. Skips panes a live hook
+    /// owns (no capture) and classifications that don't move the state.
+    async fn process_candidate(&mut self, backend_idx: usize, pane: &PaneInfo) -> bool {
+        let pane_id = pane.pane_id.clone();
+
+        // Hook-authoritative: a live real row owns the pane — don't even capture.
+        // Forget any tracking so a later stop-sweep doesn't touch the real row.
+        let occupants = self.store.by_pane(&pane_id).await;
+        if occupants.iter().any(synthetic::occupant_is_authoritative) {
+            self.tracked.remove(&pane_id);
+            self.last_state.remove(&pane_id);
+            return false;
+        }
+
+        let Some(raw) = self.capture(backend_idx, &pane_id).await else {
+            return false;
+        };
+        let prepared = muxa::screen::prepare_capture(&raw, CAPTURE_TAIL_LINES);
+
+        // Classify (borrow of `manifests` scoped so the mutations below are free
+        // of it). `None` = unknown screen → keep previous state, no change.
+        let Some((state, name)) = ({
+            let manifest = self.manifests.manifest_for_command(&pane.current_command);
+            manifest.and_then(|m| m.classify(&prepared).map(|s| (s, m.name.clone())))
+        }) else {
+            return false;
+        };
+
+        if self.last_state.get(&pane_id) == Some(&state) {
+            return false; // no change since last capture
+        }
+
+        let id = synthetic_id(pane);
+        let events = synthetic::state_events(
+            id,
+            to_synthetic(state),
+            &name,
+            None,
+            OffsetDateTime::now_utc(),
+        );
+        synthetic::apply_if_unowned(&self.store, &pane_id, &events).await;
+        self.last_state.insert(pane_id.clone(), state);
+        self.tracked.insert(pane_id);
+        true
+    }
+
+    /// Capture one pane on the given backend, off the async runtime.
+    async fn capture(&self, backend_idx: usize, pane_id: &str) -> Option<String> {
+        let backend = self.backends[backend_idx].clone();
+        let pane_id = pane_id.to_owned();
+        spawn_blocking(move || backend.capture_pane(&pane_id))
+            .await
+            .ok()
+            .flatten()
+    }
+}
+
+/// Spawn the screen-detection task, but only when it can do useful work: the
+/// feature is enabled, at least one detectable (non-herdr, capture-capable)
+/// backend exists, and at least one manifest loaded. Returns the join handle so
+/// the daemon can drain it on shutdown; `None` otherwise.
+pub fn spawn_screen_detect_task(
+    cfg: &Config,
+    backends: &[SharedBackend],
+    store: SharedStore,
+    shutdown_tx: &broadcast::Sender<()>,
+) -> Option<tokio::task::JoinHandle<()>> {
+    if !cfg.screen_detect.enabled {
+        tracing::info!("screen detection disabled by config");
+        return None;
+    }
+    let detectable = detectable_backends(backends);
+    if detectable.is_empty() {
+        tracing::debug!("screen detection: no non-herdr capture-capable backend; not spawning");
+        return None;
+    }
+    let manifests = muxa::screen::load_manifests();
+    if manifests.is_empty() {
+        tracing::debug!("screen detection: no manifests loaded; not spawning");
+        return None;
+    }
+    let interval = Duration::from_secs(cfg.screen_detect.interval_secs.max(1));
+    tracing::info!(
+        interval_secs = interval.as_secs(),
+        manifests = manifests.len(),
+        agents = ?manifests.names().collect::<Vec<_>>(),
+        hosts = ?detectable.iter().map(muxa::PaneBackend::kind).collect::<Vec<_>>(),
+        "screen detection enabled",
+    );
+    let detector = ScreenDetector {
+        backends: detectable,
+        store,
+        manifests,
+        interval,
+        last_state: HashMap::new(),
+        tracked: HashSet::new(),
+    };
+    Some(tokio::spawn(detector.run(shutdown_tx.subscribe())))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use muxa::backend::{BackendCaps, PaneObservation};
+    use muxa::event::{AgentEvent, AgentId};
+    use muxa::state::Store;
+    use muxa::AgentState;
+    use time::macros::datetime;
+
+    use super::*;
+
+    const AT: OffsetDateTime = datetime!(2026-07-20 12:00:00 UTC);
+
+    /// A fake backend: a fixed pane inventory plus a pane-id → capture-text map
+    /// that tests mutate between ticks to simulate the screen changing.
+    struct FakeBackend {
+        kind: HostKind,
+        caps: BackendCaps,
+        panes: Vec<PaneInfo>,
+        captures: Arc<Mutex<HashMap<String, String>>>,
+    }
+
+    impl FakeBackend {
+        fn tmux(panes: Vec<PaneInfo>, captures: Arc<Mutex<HashMap<String, String>>>) -> Self {
+            Self {
+                kind: HostKind::Tmux,
+                caps: BackendCaps::default(),
+                panes,
+                captures,
+            }
+        }
+    }
+
+    impl PaneBackend for FakeBackend {
+        fn kind(&self) -> HostKind {
+            self.kind
+        }
+        fn list_panes(&self) -> Vec<PaneInfo> {
+            self.panes.clone()
+        }
+        fn observe_panes(&self) -> PaneObservation {
+            PaneObservation::complete(self.panes.clone())
+        }
+        fn resolve_pane(&self, id: &str) -> Option<PaneInfo> {
+            self.panes.iter().find(|p| p.pane_id == id).cloned()
+        }
+        fn capture_pane(&self, pane_id: &str) -> Option<String> {
+            self.captures.lock().unwrap().get(pane_id).cloned()
+        }
+        fn pane_pid_map(&self) -> HashMap<u32, String> {
+            HashMap::new()
+        }
+        fn current_pane(&self) -> Option<String> {
+            None
+        }
+        fn focus_pane(&self, _: &str) -> bool {
+            true
+        }
+        fn caps(&self) -> BackendCaps {
+            self.caps
+        }
+    }
+
+    fn pane(pane_id: &str, command: &str) -> PaneInfo {
+        PaneInfo {
+            socket: Some("default".into()),
+            pane_id: pane_id.into(),
+            session: "s".into(),
+            window_index: "0".into(),
+            pane_index: "0".into(),
+            tty: String::new(),
+            current_command: command.into(),
+            title: String::new(),
+            pane_pid: 0,
+            current_path: String::new(),
+        }
+    }
+
+    fn detector(backends: Vec<SharedBackend>, store: SharedStore) -> ScreenDetector {
+        ScreenDetector {
+            backends,
+            store,
+            manifests: muxa::screen::load_manifests(),
+            interval: Duration::from_secs(3),
+            last_state: HashMap::new(),
+            tracked: HashSet::new(),
+        }
+    }
+
+    #[test]
+    fn detectable_backends_excludes_herdr_and_non_capturing() {
+        let caps_no_capture = BackendCaps {
+            capture_pane: false,
+            ..BackendCaps::default()
+        };
+        let captures = Arc::new(Mutex::new(HashMap::new()));
+        let tmux: SharedBackend = Arc::new(FakeBackend::tmux(vec![], captures.clone()));
+        let herdr: SharedBackend = Arc::new(FakeBackend {
+            kind: HostKind::Herdr,
+            caps: BackendCaps::default(),
+            panes: vec![],
+            captures: captures.clone(),
+        });
+        let zellij_no_cap: SharedBackend = Arc::new(FakeBackend {
+            kind: HostKind::Zellij,
+            caps: caps_no_capture,
+            panes: vec![],
+            captures,
+        });
+        let out = detectable_backends(&[tmux, herdr, zellij_no_cap]);
+        assert_eq!(
+            out.len(),
+            1,
+            "only the capture-capable tmux backend remains"
+        );
+        assert_eq!(out[0].kind(), HostKind::Tmux);
+    }
+
+    #[tokio::test]
+    async fn ingests_only_on_state_change() {
+        let captures = Arc::new(Mutex::new(HashMap::new()));
+        captures
+            .lock()
+            .unwrap()
+            .insert("%1".into(), "⠋ Thinking\nesc to interrupt".into());
+        let backend: SharedBackend = Arc::new(FakeBackend::tmux(
+            vec![pane("%1", "cursor-agent")],
+            captures.clone(),
+        ));
+        let store = Store::shared();
+        let mut det = detector(vec![backend], store.clone());
+
+        // First tick: a fresh Working row is created.
+        assert_eq!(
+            det.run_tick().await,
+            1,
+            "first working classification ingests"
+        );
+        let rows = store.by_pane("%1").await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].state, AgentState::Working);
+        assert_eq!(rows[0].kind, AgentKind::Unknown);
+        assert_eq!(rows[0].model.as_deref(), Some("cursor"));
+        assert!(rows[0].session_id.starts_with("synthetic-"));
+
+        // Second tick, same screen: no change ingested.
+        assert_eq!(det.run_tick().await, 0, "unchanged screen is a no-op");
+
+        // Screen flips to an approval prompt: one change.
+        captures.lock().unwrap().insert(
+            "%1".into(),
+            "Do you want to allow this command? [y/n]".into(),
+        );
+        assert_eq!(det.run_tick().await, 1, "blocked classification ingests");
+        assert_eq!(store.by_pane("%1").await[0].state, AgentState::WaitingInput);
+
+        // Unknown screen: state is KEPT (previous WaitingInput), no change.
+        captures
+            .lock()
+            .unwrap()
+            .insert("%1".into(), "ordinary log output with no markers".into());
+        assert_eq!(
+            det.run_tick().await,
+            0,
+            "unknown screen keeps previous state"
+        );
+        assert_eq!(
+            store.by_pane("%1").await[0].state,
+            AgentState::WaitingInput,
+            "state unchanged by an unrecognized screen",
+        );
+    }
+
+    #[tokio::test]
+    async fn skips_pane_owned_by_a_live_hook_row() {
+        let captures = Arc::new(Mutex::new(HashMap::new()));
+        captures
+            .lock()
+            .unwrap()
+            .insert("%1".into(), "⠋ Thinking".into());
+        let backend: SharedBackend = Arc::new(FakeBackend::tmux(
+            vec![pane("%1", "cursor-agent")],
+            captures,
+        ));
+        let store = Store::shared();
+        // A real hook row claims the pane first.
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    kind: AgentKind::ClaudeCode,
+                    session_id: "real".into(),
+                    surface: None,
+                    pane: Some("%1".into()),
+                    tmux_socket: Some("default".into()),
+                    cwd: None,
+                },
+                at: AT,
+            })
+            .await;
+        let mut det = detector(vec![backend], store.clone());
+        assert_eq!(det.run_tick().await, 0, "hook-owned pane is skipped");
+        let rows = store.by_pane("%1").await;
+        assert_eq!(rows.len(), 1, "no synthetic row added");
+        assert_eq!(rows[0].session_id, "real");
+    }
+
+    #[tokio::test]
+    async fn non_agent_panes_are_not_candidates() {
+        let captures = Arc::new(Mutex::new(HashMap::new()));
+        // A plain shell pane — no manifest matches "bash".
+        let backend: SharedBackend =
+            Arc::new(FakeBackend::tmux(vec![pane("%1", "bash")], captures));
+        let store = Store::shared();
+        let mut det = detector(vec![backend], store.clone());
+        assert_eq!(det.run_tick().await, 0);
+        assert!(
+            store.by_pane("%1").await.is_empty(),
+            "no row for a shell pane"
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_leaving_stops_the_synthetic_row() {
+        let captures = Arc::new(Mutex::new(HashMap::new()));
+        captures
+            .lock()
+            .unwrap()
+            .insert("%1".into(), "⠋ Thinking".into());
+        // Tick 1 with the agent present.
+        let store = Store::shared();
+        let backend_present: SharedBackend = Arc::new(FakeBackend::tmux(
+            vec![pane("%1", "cursor-agent")],
+            captures.clone(),
+        ));
+        let mut det = detector(vec![backend_present], store.clone());
+        assert_eq!(det.run_tick().await, 1);
+        assert_eq!(store.by_pane("%1").await[0].state, AgentState::Working);
+
+        // Tick 2: the pane's foreground command is now a shell (agent exited),
+        // so it's no longer a candidate. The synthetic row must be stopped.
+        let backend_gone: SharedBackend =
+            Arc::new(FakeBackend::tmux(vec![pane("%1", "bash")], captures));
+        det.backends = vec![backend_gone];
+        assert_eq!(det.run_tick().await, 0);
+        assert_eq!(
+            store.by_pane("%1").await[0].state,
+            AgentState::Stopped,
+            "row driven to Stopped when the agent leaves the pane",
+        );
+    }
+}

--- a/crates/muxad/src/screen_detect.rs
+++ b/crates/muxad/src/screen_detect.rs
@@ -34,7 +34,7 @@
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
-use muxa::screen::{ManifestSet, ScreenState};
+use muxa::screen::{AgentManifest, ManifestSet, ScreenState};
 use muxa::tmux::PaneInfo;
 use muxa::{AgentId, AgentKind, Config, HostKind, PaneBackend, SharedBackend, SharedStore};
 use time::OffsetDateTime;
@@ -128,7 +128,10 @@ impl ScreenDetector {
     /// hook doesn't own.
     async fn run_tick(&mut self) -> usize {
         let candidates = self.gather_candidates().await;
-        let current: HashSet<String> = candidates.iter().map(|(_, p)| p.pane_id.clone()).collect();
+        let current: HashSet<String> = candidates
+            .iter()
+            .map(|(_, p, _)| p.pane_id.clone())
+            .collect();
 
         // Panes we tracked that are no longer candidates: the agent's foreground
         // command changed (it exited, or a different program took over). Stop the
@@ -146,8 +149,8 @@ impl ScreenDetector {
         }
 
         let mut changes = 0;
-        for (backend_idx, pane) in candidates {
-            if self.process_candidate(backend_idx, &pane).await {
+        for (backend_idx, pane, manifest) in candidates {
+            if self.process_candidate(backend_idx, &pane, &manifest).await {
                 changes += 1;
             }
         }
@@ -155,10 +158,13 @@ impl ScreenDetector {
     }
 
     /// List panes across every detectable backend and keep the ones whose
-    /// foreground command matches a manifest. Returns `(backend_index, pane)`
-    /// so the capture step can target the right backend. The `list_panes` calls
-    /// (blocking tmux shell-outs) run inside one `spawn_blocking`.
-    async fn gather_candidates(&self) -> Vec<(usize, PaneInfo)> {
+    /// foreground command matches a manifest. Returns
+    /// `(backend_index, pane, manifest)` — the manifest that selected the pane
+    /// is carried forward (cloned; its `RegexSet`s are `Arc`-backed, so the
+    /// clone is cheap) so [`process_candidate`](Self::process_candidate) need
+    /// not re-resolve it. The `list_panes` calls (blocking tmux shell-outs) run
+    /// inside one `spawn_blocking`.
+    async fn gather_candidates(&self) -> Vec<(usize, PaneInfo, AgentManifest)> {
         let backends = self.backends.clone();
         let panes: Vec<(usize, PaneInfo)> = spawn_blocking(move || {
             let mut out = Vec::new();
@@ -174,10 +180,10 @@ impl ScreenDetector {
 
         panes
             .into_iter()
-            .filter(|(_, p)| {
+            .filter_map(|(i, p)| {
                 self.manifests
                     .manifest_for_command(&p.current_command)
-                    .is_some()
+                    .map(|m| (i, p, m.clone()))
             })
             .collect()
     }
@@ -185,7 +191,14 @@ impl ScreenDetector {
     /// Capture, classify, and (on a state change) ingest one candidate pane.
     /// Returns `true` iff a state change was ingested. Skips panes a live hook
     /// owns (no capture) and classifications that don't move the state.
-    async fn process_candidate(&mut self, backend_idx: usize, pane: &PaneInfo) -> bool {
+    /// `manifest` is the one `gather_candidates` already resolved for this
+    /// pane's command, carried forward so there is no second lookup.
+    async fn process_candidate(
+        &mut self,
+        backend_idx: usize,
+        pane: &PaneInfo,
+        manifest: &AgentManifest,
+    ) -> bool {
         let pane_id = pane.pane_id.clone();
 
         // Hook-authoritative: a live real row owns the pane — don't even capture.
@@ -202,12 +215,8 @@ impl ScreenDetector {
         };
         let prepared = muxa::screen::prepare_capture(&raw, CAPTURE_TAIL_LINES);
 
-        // Classify (borrow of `manifests` scoped so the mutations below are free
-        // of it). `None` = unknown screen → keep previous state, no change.
-        let Some((state, name)) = ({
-            let manifest = self.manifests.manifest_for_command(&pane.current_command);
-            manifest.and_then(|m| m.classify(&prepared).map(|s| (s, m.name.clone())))
-        }) else {
+        // `None` = unknown screen → keep previous state, no change.
+        let Some(state) = manifest.classify(&prepared) else {
             return false;
         };
 
@@ -219,7 +228,7 @@ impl ScreenDetector {
         let events = synthetic::state_events(
             id,
             to_synthetic(state),
-            &name,
+            &manifest.name,
             None,
             OffsetDateTime::now_utc(),
         );

--- a/crates/muxad/src/synthetic.rs
+++ b/crates/muxad/src/synthetic.rs
@@ -136,6 +136,12 @@ pub fn state_events(
             response: None,
             recap: None,
             ai_title: None,
+            // Positive idle evidence: the producer OBSERVED the pane go idle
+            // (the approval prompt / spinner is gone). This marker lets a
+            // synthetic `WaitingInput` row clear to `Idle` on this response-less
+            // stop, without reopening the Codex response-less-stop quirk (which
+            // is markerless). See `state::mutate_for_event`'s `TurnStopped` arm.
+            idle_confirmed: true,
             at,
         },
     };
@@ -214,9 +220,25 @@ mod tests {
     }
 
     #[test]
-    fn idle_builds_turn_stopped() {
+    fn idle_builds_idle_confirmed_turn_stopped() {
+        // The synthetic idle event MUST carry `idle_confirmed = true` — that
+        // marker is what lets it clear a WaitingInput row without reopening the
+        // Codex markerless-stop quirk (see state::mutate_for_event).
         let events = state_events(id("%1"), SyntheticState::Idle, "cursor", None, AT);
-        assert!(matches!(events[0], AgentEvent::TurnStopped { .. }));
+        match &events[0] {
+            AgentEvent::TurnStopped {
+                idle_confirmed,
+                response,
+                ..
+            } => {
+                assert!(
+                    *idle_confirmed,
+                    "synthetic idle is an explicit idle observation"
+                );
+                assert_eq!(*response, None);
+            }
+            other => panic!("expected TurnStopped, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/muxad/src/synthetic.rs
+++ b/crates/muxad/src/synthetic.rs
@@ -1,0 +1,330 @@
+//! Shared synthetic-row machinery for muxa's screen-inference producers.
+//!
+//! Two daemon tasks mint SYNTHETIC registry rows from non-hook sources: the
+//! [`herdr_bridge`](crate::herdr_bridge) (herdr's own agent-state detection) and
+//! [`screen_detect`](crate::screen_detect) (TOML manifest rules matched against
+//! a pane capture). Both obey the SAME precedence and row-identity rules, so the
+//! mechanics live here once:
+//!
+//! * **Hook-authoritative precedence** ([`occupant_is_authoritative`],
+//!   [`apply_if_unowned`]): a live, non-synthetic (real hook) row owns its pane;
+//!   a synthetic producer must drop its update wholesale rather than clobber it.
+//!   And because these rows are synthetic, `Store::apply`'s synthetic-eviction
+//!   pass drops them the instant a real hook `Started` claims the pane — so the
+//!   hook-authoritative rule falls out of the existing machinery for free.
+//! * **Row liveness** ([`stop_synthetic_row`]): when a producer stops seeing an
+//!   agent on a pane whose shell is still open, it drives the synthetic row to
+//!   `Stopped` so it doesn't freeze at its last state forever.
+//! * **State → events** ([`state_events`]): the working/blocked/idle → muxa
+//!   event mapping both producers share, plus the trailing `Heartbeat` that
+//!   stamps the agent name into the row's `model` field (so an `Unknown`-kind
+//!   row still names its agent).
+
+use muxa::event::{AgentEvent, AgentId, NotificationLevel};
+use muxa::state::{Agent, SYNTHETIC_SESSION_PREFIX};
+use muxa::{AgentState, SharedStore};
+use time::OffsetDateTime;
+
+/// The three states screen inference can distinguish. Both synthetic producers
+/// map their host-specific signal onto this before building events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyntheticState {
+    /// Actively generating → `AgentEvent::ToolStarted` → muxa `Working`.
+    Working,
+    /// Waiting on operator input → `NotificationFired(NeedsInput)` →
+    /// `WaitingInput`.
+    Blocked,
+    /// Idle prompt → `TurnStopped` → `Idle`.
+    Idle,
+}
+
+/// True when `agent` owns its pane *authoritatively* — i.e. it's a real
+/// (non-synthetic) hook-driven row that is not `Stopped`.
+///
+/// A `Stopped` occupant does NOT own the pane: GC keeps a `Stopped` row around
+/// for up to an hour, and a fresh (hook-less) agent launched in that same pane
+/// during that window would otherwise be invisible to a synthetic producer the
+/// whole time. So only NON-`Stopped` non-synthetic occupants block an update.
+#[must_use]
+pub fn occupant_is_authoritative(agent: &Agent) -> bool {
+    !agent.session_id.starts_with(SYNTHETIC_SESSION_PREFIX) && agent.state != AgentState::Stopped
+}
+
+/// Apply `events` to the pane, enforcing hook-authoritative precedence: if a
+/// *live* non-synthetic (real hook) row already owns `pane_id`, drop the whole
+/// update. A `Stopped` real row is a stale tombstone, not an owner — see
+/// [`occupant_is_authoritative`].
+pub async fn apply_if_unowned(store: &SharedStore, pane_id: &str, events: &[AgentEvent]) {
+    let occupants = store.by_pane(pane_id).await;
+    if occupants.iter().any(occupant_is_authoritative) {
+        tracing::debug!(
+            pane = %pane_id,
+            "synthetic: pane owned by a live hooked agent, dropping update",
+        );
+        return;
+    }
+    for ev in events {
+        store.apply(ev).await;
+    }
+}
+
+/// The producer no longer sees an agent on `pane_id`. If a *synthetic* row is
+/// still mirroring one there, stop it — otherwise its last state
+/// (`Working` / `WaitingInput`) freezes forever: the pane's shell is alive (so
+/// the reconciler won't reap it) and the row isn't `Stopped` (so GC won't evict
+/// it). Emitting `SessionEnded` drives the synthetic row to `Stopped`, after
+/// which GC can reclaim it. A pane with no synthetic row is left untouched (no
+/// row is invented), and a real hook row is never disturbed by this path.
+pub async fn stop_synthetic_row(store: &SharedStore, pane_id: &str) {
+    let occupants = store.by_pane(pane_id).await;
+    for occ in occupants {
+        if !occ.session_id.starts_with(SYNTHETIC_SESSION_PREFIX) || occ.state == AgentState::Stopped
+        {
+            // Real hook rows are not ours to stop; already-`Stopped` synthetic
+            // rows need no further event.
+            continue;
+        }
+        let id = AgentId {
+            kind: occ.kind,
+            session_id: occ.session_id.clone(),
+            surface: occ.surface.clone(),
+            pane: occ.pane.clone(),
+            tmux_socket: occ.tmux_socket.clone(),
+            cwd: occ.cwd.clone(),
+        };
+        store
+            .apply(&AgentEvent::SessionEnded {
+                id,
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+        tracing::debug!(pane = %pane_id, "synthetic: agent gone, stopped synthetic row");
+    }
+}
+
+/// Build the ordered events for one synthetic state change: the status-bearing
+/// event first (so a fresh row transitions straight into its real state),
+/// followed by a `Heartbeat` that stamps the agent `name` into the row's
+/// `model` metadata.
+///
+/// `message` is the human text for a `Blocked` row (the approval prompt / what
+/// it's waiting on); `None` falls back to `"<name> is waiting"`. It's ignored
+/// for `Working`/`Idle`.
+#[must_use]
+pub fn state_events(
+    id: AgentId,
+    state: SyntheticState,
+    name: &str,
+    message: Option<String>,
+    at: OffsetDateTime,
+) -> Vec<AgentEvent> {
+    let status_event = match state {
+        SyntheticState::Working => AgentEvent::ToolStarted {
+            id: id.clone(),
+            tool: name.to_owned(),
+            subagent: None,
+            at,
+        },
+        SyntheticState::Blocked => AgentEvent::NotificationFired {
+            id: id.clone(),
+            level: NotificationLevel::NeedsInput,
+            message: message.unwrap_or_else(|| format!("{name} is waiting")),
+            at,
+        },
+        SyntheticState::Idle => AgentEvent::TurnStopped {
+            id: id.clone(),
+            response: None,
+            recap: None,
+            ai_title: None,
+            at,
+        },
+    };
+    let heartbeat = AgentEvent::Heartbeat {
+        id,
+        model: Some(name.to_owned()),
+        context_used_pct: None,
+        cost_usd: None,
+        rate_limit_5h_pct: None,
+        rate_limit_5h_resets_at: None,
+        rate_limit_7d_pct: None,
+        rate_limit_7d_resets_at: None,
+        at,
+    };
+    vec![status_event, heartbeat]
+}
+
+#[cfg(test)]
+mod tests {
+    use muxa::event::AgentKind;
+    use muxa::state::Store;
+    use time::macros::datetime;
+
+    use super::*;
+
+    const AT: OffsetDateTime = datetime!(2026-07-20 12:00:00 UTC);
+
+    fn id(pane: &str) -> AgentId {
+        AgentId {
+            kind: AgentKind::Unknown,
+            session_id: format!("{SYNTHETIC_SESSION_PREFIX}{pane}"),
+            surface: None,
+            pane: Some(pane.to_owned()),
+            tmux_socket: None,
+            cwd: None,
+        }
+    }
+
+    #[test]
+    fn working_builds_tool_started_plus_named_heartbeat() {
+        let events = state_events(id("%1"), SyntheticState::Working, "cursor", None, AT);
+        assert_eq!(events.len(), 2);
+        match &events[0] {
+            AgentEvent::ToolStarted { tool, .. } => assert_eq!(tool, "cursor"),
+            other => panic!("expected ToolStarted, got {other:?}"),
+        }
+        match &events[1] {
+            AgentEvent::Heartbeat { model, .. } => assert_eq!(model.as_deref(), Some("cursor")),
+            other => panic!("expected Heartbeat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn blocked_uses_message_then_falls_back() {
+        let with_msg = state_events(
+            id("%1"),
+            SyntheticState::Blocked,
+            "cursor",
+            Some("Approve rm?".into()),
+            AT,
+        );
+        match &with_msg[0] {
+            AgentEvent::NotificationFired { level, message, .. } => {
+                assert_eq!(*level, NotificationLevel::NeedsInput);
+                assert_eq!(message, "Approve rm?");
+            }
+            other => panic!("expected NotificationFired, got {other:?}"),
+        }
+        let no_msg = state_events(id("%1"), SyntheticState::Blocked, "cursor", None, AT);
+        match &no_msg[0] {
+            AgentEvent::NotificationFired { message, .. } => {
+                assert_eq!(message, "cursor is waiting");
+            }
+            other => panic!("expected NotificationFired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn idle_builds_turn_stopped() {
+        let events = state_events(id("%1"), SyntheticState::Idle, "cursor", None, AT);
+        assert!(matches!(events[0], AgentEvent::TurnStopped { .. }));
+    }
+
+    #[tokio::test]
+    async fn apply_if_unowned_drops_when_a_live_hook_row_owns_the_pane() {
+        let store = Store::shared();
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    kind: AgentKind::ClaudeCode,
+                    session_id: "real".into(),
+                    surface: None,
+                    pane: Some("%1".into()),
+                    tmux_socket: None,
+                    cwd: None,
+                },
+                at: AT,
+            })
+            .await;
+        let events = state_events(id("%1"), SyntheticState::Working, "cursor", None, AT);
+        apply_if_unowned(&store, "%1", &events).await;
+
+        let rows = store.by_pane("%1").await;
+        assert_eq!(rows.len(), 1, "only the real row remains");
+        assert_eq!(rows[0].session_id, "real");
+    }
+
+    #[tokio::test]
+    async fn apply_if_unowned_applies_when_pane_is_free() {
+        let store = Store::shared();
+        let events = state_events(id("%1"), SyntheticState::Working, "cursor", None, AT);
+        apply_if_unowned(&store, "%1", &events).await;
+        let rows = store.by_pane("%1").await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].state, AgentState::Working);
+        assert_eq!(rows[0].model.as_deref(), Some("cursor"));
+    }
+
+    #[tokio::test]
+    async fn stop_synthetic_row_stops_a_synthetic_but_not_a_real_row() {
+        let store = Store::shared();
+        // Synthetic working row.
+        let events = state_events(id("%1"), SyntheticState::Working, "cursor", None, AT);
+        apply_if_unowned(&store, "%1", &events).await;
+        stop_synthetic_row(&store, "%1").await;
+        assert_eq!(store.by_pane("%1").await[0].state, AgentState::Stopped);
+
+        // A real row on another pane must be left alone.
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    kind: AgentKind::ClaudeCode,
+                    session_id: "real".into(),
+                    surface: None,
+                    pane: Some("%2".into()),
+                    tmux_socket: None,
+                    cwd: None,
+                },
+                at: AT,
+            })
+            .await;
+        stop_synthetic_row(&store, "%2").await;
+        assert_eq!(store.by_pane("%2").await[0].state, AgentState::Idle);
+    }
+
+    #[test]
+    fn stopped_real_row_is_not_authoritative() {
+        let mut agent = Agent {
+            kind: AgentKind::ClaudeCode,
+            session_id: "real".into(),
+            surface: None,
+            pane: Some("%1".into()),
+            tmux_socket: None,
+            tmux_session: None,
+            cwd: None,
+            pid: None,
+            workload: muxa::WorkloadSummary::default(),
+            subagents: Vec::new(),
+            state: AgentState::Working,
+            last_prompt: None,
+            last_response: None,
+            recap: None,
+            ai_title: None,
+            last_notification: None,
+            model: None,
+            context_used_pct: None,
+            cost_usd: None,
+            rate_limit_5h_pct: None,
+            rate_limit_5h_resets_at: None,
+            rate_limit_7d_pct: None,
+            rate_limit_7d_resets_at: None,
+            rate_limited_until: None,
+            rate_limit_scope: None,
+            rate_limit_source: None,
+            started_at: AT,
+            last_activity_at: AT,
+            state_entered_at: AT,
+        };
+        assert!(occupant_is_authoritative(&agent), "live real row owns pane");
+        agent.state = AgentState::Stopped;
+        assert!(
+            !occupant_is_authoritative(&agent),
+            "stopped real row is a tombstone, not an owner",
+        );
+        agent.session_id = format!("{SYNTHETIC_SESSION_PREFIX}%1");
+        agent.state = AgentState::Working;
+        assert!(
+            !occupant_is_authoritative(&agent),
+            "synthetic rows never own authoritatively",
+        );
+    }
+}

--- a/docs/SCREEN_DETECTION.md
+++ b/docs/SCREEN_DETECTION.md
@@ -1,0 +1,220 @@
+# Screen-manifest fallback detection
+
+Status: **implemented.** Core in `muxa::screen`, daemon task in
+`muxad::screen_detect`, shared synthetic-row machinery in `muxad::synthetic`.
+
+muxa gets authoritative agent state from **hooks** (Claude Code, Codex, Gemini)
+and, on herdr hosts, from **herdr's own detection** bridged into synthetic rows
+(`docs/HERDR.md`). For every *other* agent CLI — cursor-agent, amp, copilot,
+aider, goose, and anything a user declares — there is no event stream at all.
+Screen-manifest detection is the last-resort fallback herdr validated: capture
+the pane and match TOML-declared regex rules against the visible tail to infer
+`Working` / `WaitingInput` / `Idle`.
+
+This is deliberately the **weakest** signal in muxa's precedence chain, and the
+mechanics are built so it can never override a stronger one.
+
+## Precedence invariant
+
+```
+hooks  >  herdr bridge  >  screen detection
+```
+
+Screen rows are **synthetic** (session id `synthetic-…`), which buys the whole
+invariant from existing machinery:
+
+- **A real hook evicts a screen row instantly.** `Store::apply`'s
+  synthetic-eviction pass drops any synthetic row for a pane the moment a real
+  hook `Started`/tool/prompt event claims it (same rule the herdr bridge relies
+  on). The hook row then owns the pane.
+- **The screen task never clobbers a live authoritative row.** Before capturing
+  *or* applying, it checks `synthetic::occupant_is_authoritative`: a live
+  (non-`Stopped`), non-synthetic occupant means "skip this pane entirely — no
+  capture, no update." A `Stopped` real row is a stale tombstone, not an owner,
+  so a fresh hook-less agent in that same pane is still detectable.
+- **herdr hosts are skipped wholesale.** A herdr backend is never a screen
+  candidate — herdr's own detection plus the herdr bridge already cover those
+  panes. (`detectable_backends` filters `HostKind::Herdr` out.)
+
+Because screen rows reuse the exact `synthetic_session_id` convention discovery
+mints (`synthetic-<len>:<socket>:<pane_id>` on tmux, carrying the pane's tmux
+socket in the row's `tmux_socket`), a discovery placeholder and a screen row
+**collapse onto one registry key** and share that eviction precedence.
+
+## Manifest format
+
+A manifest is a TOML file:
+
+```toml
+[agent]
+name    = "cursor"            # row display name — goes into `model`; kind stays Unknown
+command = ["cursor-agent"]    # process basenames matched against PaneInfo.current_command
+
+[rules]                       # evaluated top-to-bottom against the captured tail
+blocked = ['(?i)\[y/n\]', '(?i)do you want to (allow|proceed|run)']  # regex list, ANY match
+working = ['[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]', '(?i)\b(thinking|generating)\b', '(?i)esc to interrupt']
+idle    = ['(?m)^\s*>\s*$']
+```
+
+- `[agent].name` — the display name carried into the synthetic row's **`model`**
+  field (the row's `AgentKind` stays `Unknown`, since these agents have no muxa
+  kind). It is also the **override key** (see below).
+- `[agent].command` — one or more command names. Matching is on the **basename**,
+  **case-insensitive** (`/usr/local/bin/Cursor-Agent` → `cursor-agent`),
+  mirroring `discovery::classify_command`. tmux only exposes the foreground
+  command basename, and muxa matches that basename only — there is **no
+  process-tree walk**, so an agent that runs under a `node`/`python` wrapper
+  won't be picked up unless its foreground command is the agent binary itself.
+- `[rules]` — three optional regex lists. Each compiles to a `regex::RegexSet`;
+  a category is a match when **any** pattern in it matches. Patterns are Rust
+  `regex` syntax; `(?i)` (case-insensitive), `(?m)` (multiline anchors), and
+  Unicode literals (spinner glyphs) all work. An omitted category matches
+  nothing.
+- **Unknown top-level keys are tolerated** (not rejected) so a manifest written
+  for a newer muxa still loads its known rules. A malformed regex, empty
+  `name`, or empty `command`, or invalid TOML, makes the file fail to load —
+  logged at `warn`, file skipped, never a crash.
+
+## Classifier semantics
+
+`AgentManifest::classify(prepared_text) -> Option<ScreenState>` tests categories
+in a **fixed order**, and every choice below is deliberate:
+
+1. **`blocked` first, and STRICT.** A false `blocked` is the worst possible
+   outcome — a busy agent shown as "needs input" pulls the operator's eye to a
+   pane that doesn't need them. So blocked is tested first *and* the bundled
+   patterns require an unambiguous approval affordance (a `[y/n]`/`(y/n)`
+   prompt, explicit "permission to run", "approve this command", aider's
+   `(Y)es/(N)o`). This is herdr's lesson: only clear approval/permission UI
+   counts; an unknown screen is **not** blocked.
+2. **`working` next** — spinner glyphs or an interrupt hint (`esc to interrupt`).
+3. **`idle` last** — a bare prompt marker (`^> $`).
+4. **No match → `None` → keep previous state.** An unrecognized screen never
+   *transitions* a row; only a positive match to a *different* category does.
+   This "unknown transitions are dropped" rule is what stops screen noise (a
+   half-drawn frame, log output between turns) from flapping a row. The daemon
+   also ingests **only on a state change** — a capture that classifies to the
+   same state as last tick is a no-op (no needless activity-timestamp churn).
+
+### Capture preparation
+
+`prepare_capture(raw, 40)` runs before classification:
+
+- **ANSI-strip.** `tmux capture-pane -ep` keeps color/attribute escapes; those
+  would defeat text regexes, so CSI/OSC sequences are removed. Spinner glyphs
+  and box-drawing characters are Unicode, not ANSI, so they survive.
+- **Bottom 40 lines.** `capture-pane` returns the visible screen; the active
+  spinner/prompt/approval UI lives near the bottom, and the slice bounds regex
+  work.
+
+### State mapping (shared with the herdr bridge)
+
+| `ScreenState` | synthetic event                       | resulting muxa state |
+|---------------|---------------------------------------|----------------------|
+| `Working`     | `ToolStarted { tool = <name> }`       | `Working`            |
+| `Blocked`     | `NotificationFired(NeedsInput)`       | `WaitingInput`       |
+| `Idle`        | `TurnStopped`                         | `Idle`               |
+
+Each state change also emits a trailing `Heartbeat { model: Some(<name>) }` so an
+`Unknown`-kind row still names its agent. This is the identical mapping and
+event shape the herdr bridge uses — both go through `synthetic::state_events`.
+Screen detection passes no `message`, so a `Blocked` row's notification reads
+`"<name> is waiting"` (screen inference can't reliably extract the specific
+prompt text).
+
+### Row liveness
+
+When a pane muxa was tracking stops being a candidate — its foreground command
+changed away from the agent (the agent exited but the shell stayed open) — the
+task drives that synthetic row to `Stopped` via `synthetic::stop_synthetic_row`
+(a `SessionEnded`), so it doesn't freeze at `Working`/`WaitingInput` forever
+(the shell is alive, so the reconciler won't reap it; the row isn't `Stopped`,
+so GC won't evict it). Pane *close* is still handled by the reconciler as usual.
+
+## Manifest sources
+
+1. **Bundled** — `cursor`, `amp`, `copilot`, `aider`, `goose` ship in the binary
+   via `include_str!` (`crates/muxa/src/screen/agents/*.toml`).
+2. **User overrides** — `$XDG_CONFIG_HOME/muxa/agents/*.toml`. `XDG_CONFIG_HOME`
+   is honored **first and explicitly** so the path works cross-platform: on
+   macOS `dirs::config_dir()` returns `~/Library/Application Support` and ignores
+   `XDG_CONFIG_HOME`, which would otherwise silently miss overrides. Falls back
+   to the platform config dir's `muxa/agents` when `XDG_CONFIG_HOME` is unset.
+
+A user file whose `[agent].name` **matches** a bundled manifest **replaces** it
+wholesale; a new name is **appended**. Files are loaded in sorted order; parse
+failures `warn` + skip.
+
+### Bundled-manifest confidence
+
+The bundled manifests are **best-effort and conservative**, written **without
+running** the CLIs (muxa's CI can't drive them), and every file says so in a
+header comment. The design bias when unsure is **no match over a wrong match** —
+an unmatched screen just keeps the row's previous state.
+
+| Pattern class | Confidence | Notes |
+|---------------|-----------|-------|
+| Braille spinner glyphs (`⠋⠙…`, `⣾⣽…`) as `working` | **Medium-high** | Near-universal across modern TUI CLIs; low false-positive risk in normal prose. |
+| `esc to interrupt` / interrupt hints as `working` | **Medium** | Common idiom (Claude/others show it); not verified per-CLI. |
+| `[y/n]` / `(y/n)` as `blocked` | **Medium-high** | Strong, specific approval affordance. |
+| aider `(Y)es/(N)o` as `blocked` | **Medium-high** | Aider's documented confirm format is distinctive. |
+| Generic "do you want to allow/proceed/run", "approve this command", "permission to run" as `blocked` | **Low-medium** | Plausible phrasings; specific enough to avoid most prose, but not verified against each CLI's exact copy. |
+| goose "would like to call" as `blocked` | **Low** | Speculative wording. |
+| bare `^> $` as `idle` | **Medium** | Common prompt shape; may miss CLIs with a richer prompt (model name, token count). |
+
+Operators who run these CLIs should refine the patterns against the real UI via
+a user override — that is the intended path to high-confidence detection.
+
+## Daemon task
+
+Configured by `[screen_detect]` (`crates/muxa/src/config.rs`, `enabled` default
+`true`, `interval_secs` default `3`). Spawned in `muxad` alongside the herdr
+tasks, **only** when: the feature is enabled, at least one **detectable**
+backend exists (non-herdr with `caps().capture_pane`), and at least one manifest
+loaded. Otherwise it returns `None` and never runs.
+
+Each tick (`interval` with `MissedTickBehavior::Skip`; a tick is fully awaited
+before the next, so **a slow tick skips rather than overlaps**):
+
+1. **Gather candidates** — one `list_panes` per detectable backend inside a
+   single `spawn_blocking`, keeping panes whose `current_command` matches a
+   manifest. When **nothing matches, zero captures run** — idle cost is ≈ one
+   pane list.
+2. **Stop dropped rows** — any previously-tracked pane no longer a candidate is
+   driven to `Stopped` (see Row liveness).
+3. **Per candidate** — skip if a live hook owns it (no capture); else
+   `capture_pane` inside `spawn_blocking` (bounded by tmux's 1s command
+   timeout), `prepare_capture`, `classify`, and **on a state change** ingest the
+   synthetic events through `synthetic::apply_if_unowned` (which re-checks
+   authoritative ownership as a final guard against races).
+
+The task applies directly to the in-process `Store` (like the reconciler and the
+herdr bridge), not over IPC, and is drained on daemon shutdown like the other
+background producers.
+
+## Shared helpers (refactor)
+
+The synthetic-row mechanics the herdr bridge already had were **extracted** into
+`muxad::synthetic` and are now shared verbatim, rather than copy-pasted:
+
+- `occupant_is_authoritative` — the "live non-synthetic row owns the pane" rule.
+- `apply_if_unowned` — the by-pane authoritative check + apply (herdr's
+  `apply_update` now delegates here).
+- `stop_synthetic_row` — the liveness stop (herdr's `stop_agentless_synthetic`
+  now delegates here).
+- `state_events` + `SyntheticState` — the working/blocked/idle → event builder
+  with the name-bearing heartbeat (herdr's `translate` now maps herdr's status
+  onto `SyntheticState` and calls this; the event shapes are byte-identical, so
+  every herdr-bridge test still passes).
+
+`muxa::discovery::synthetic_session_id` was made `pub` so screen detection mints
+the same registry key.
+
+## Limitations
+
+- Foreground-command match only (no wrapper/process-tree walk) — see the
+  `[agent].command` note.
+- Best-effort bundled patterns (see the confidence table).
+- Blocked notifications carry a generic `"<name> is waiting"` message; screen
+  inference does not extract the specific prompt text.
+- zellij without its plugin reports `capture_pane = false` and is skipped.

--- a/docs/SCREEN_DETECTION.md
+++ b/docs/SCREEN_DETECTION.md
@@ -155,12 +155,15 @@ an unmatched screen just keeps the row's previous state.
 | Pattern class | Confidence | Notes |
 |---------------|-----------|-------|
 | Braille spinner glyphs (`⠋⠙…`, `⣾⣽…`) as `working` | **Medium-high** | Near-universal across modern TUI CLIs; low false-positive risk in normal prose. |
+| `thinking` / `generating` (and cursor's `reasoning`) as `working` | **Medium** | Canonical spinner labels; uncommon in ordinary code/git output. |
 | `esc to interrupt` / interrupt hints as `working` | **Medium** | Common idiom (Claude/others show it); not verified per-CLI. |
 | `[y/n]` / `(y/n)` as `blocked` | **Medium-high** | Strong, specific approval affordance. |
 | aider `(Y)es/(N)o` as `blocked` | **Medium-high** | Aider's documented confirm format is distinctive. |
+| copilot `❯ Yes` selection widget as `blocked` | **Low-medium** | The highlighted-row arrow is specific to an actual menu, not prose. |
 | Generic "do you want to allow/proceed/run", "approve this command", "permission to run" as `blocked` | **Low-medium** | Plausible phrasings; specific enough to avoid most prose, but not verified against each CLI's exact copy. |
-| goose "would like to call" as `blocked` | **Low** | Speculative wording. |
+| goose "would like to call" / literal `Allow?` as `blocked` | **Low** | Speculative wording; `Allow?` requires the `?` affordance, not the bare word. |
 | bare `^> $` as `idle` | **Medium** | Common prompt shape; may miss CLIs with a richer prompt (model name, token count). |
+| **Excluded:** bare single English words (`working`, a lone `allow`) and loose `yes … no … ?` prose as a state marker | **Rejected** | Too common in ordinary output ("working tree clean", "these settings allow …", any sentence with yes/no/?); they falsely froze rows as busy or blocked. Removed in favor of spinner glyphs + unambiguous affordances above. `no match > wrong match`. |
 
 Operators who run these CLIs should refine the patterns against the real UI via
 a user override — that is the intended path to high-confidence detection.


### PR DESCRIPTION
## Summary
- Agent CLIs muxa has no hooks for (cursor, amp, copilot, aider, goose) now surface their state on tmux hosts via TOML manifests matched against a pane capture — the fallback-detection architecture herdr validated, with hooks staying authoritative.
- Classifier: `blocked → working → idle`, else keep previous; **blocked is strict** (only unambiguous approval UI) because a false blocked is the worst outcome; unknown screens never transition a row. State→event mapping is shared with the herdr bridge.
- 5 bundled manifests (`include_str!`) + user overrides at `$XDG_CONFIG_HOME/muxa/agents/*.toml` (same name replaces bundled; parse errors warn+skip). Bundled patterns are conservative best-effort — confidence table in `docs/SCREEN_DETECTION.md`.
- A muxad `[screen_detect]` task (3s, on by default) captures candidate panes across the multi-host backend set whose `current_command` matches a manifest and that no authoritative row owns, ingesting synthetic rows on state change. **herdr hosts are skipped** (bridge + herdr's own detection cover them).
- Precedence **hooks > herdr bridge > screen detection** falls out of a shared synthetic-row module (`muxad::synthetic`, extracted from and reused by the herdr bridge). Also fixes a latent store bug where a response-less `TurnStopped` kept a synthetic row `WaitingInput`.

## Test plan
- [x] `cargo test --workspace` green (manifest parse/override, classifier semantics incl. blocked-strict + unknown-keeps-previous, per-agent fixtures, candidate selection, state-change-only ingest, 2 new store tests, all 33 herdr-bridge tests unchanged); known-flaky scanner test passes isolated
- [x] clippy `-D warnings` / fmt clean
- [x] Live smoke: a scripted fake `cursor-agent` drove a synthetic row through working → waiting_input → idle following its phases, then a real claude hook evicted the synthetic row (precedence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)