### PR TITLE
chore(release): prepare v0.8.22; refresh docs for screen detection + MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.22] - 2026-07-21
+
 ### Added
 
 - **Control plane + MCP server (`muxa mcp`).** muxa can now *drive* agents,
@@ -53,6 +55,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bracketed paste for multi-line / trailing-`;` text) and herdr
   (`pane.send_text`) support keystroke injection; zellij does not
   (`write-chars` only reaches the focused pane).
+- **Screen-manifest fallback detection.** Agent CLIs muxa has no hooks for
+  (`cursor-agent`, `amp`, `copilot`, `aider`, `goose`) now surface their state
+  on tmux hosts by matching TOML manifests against a pane capture — the
+  fallback-detection model herdr validated, with hooks staying authoritative.
+  Classification is `blocked → working → idle`, else keep-previous; blocked is
+  strict (only unambiguous approval UI) so a false "needs input" is avoided.
+  Five conservative manifests ship bundled; override or add your own at
+  `$XDG_CONFIG_HOME/muxa/agents/*.toml`. Rows are synthetic, so a real hook
+  evicts them the moment it claims the pane (precedence: hooks > herdr bridge >
+  screen detection). A `muxad` `[screen_detect]` task (on by default, 3 s)
+  captures candidate panes across the multi-host backend set. See
+  [docs/SCREEN_DETECTION.md](docs/SCREEN_DETECTION.md).
 
 ## [0.8.21] - 2026-07-21
 
@@ -1516,7 +1530,8 @@ and opt-in desktop notifications. 92 tests green.
 - Hook ingest is best-effort — adapter or daemon hiccups never block
   the agent CLI's actual command from running.
 
-[Unreleased]: https://github.com/Open330/muxa/compare/v0.8.21...HEAD
+[Unreleased]: https://github.com/Open330/muxa/compare/v0.8.22...HEAD
+[0.8.22]: https://github.com/Open330/muxa/releases/tag/v0.8.22
 [0.8.21]: https://github.com/Open330/muxa/releases/tag/v0.8.21
 [0.8.15]: https://github.com/Open330/muxa/compare/v0.8.14...v0.8.15
 [0.8.14]: https://github.com/Open330/muxa/compare/v0.8.13...v0.8.14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,7 +2284,7 @@ checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
 name = "muxa"
-version = "0.8.21"
+version = "0.8.22"
 dependencies = [
  "axum",
  "dirs",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "muxa-cli"
-version = "0.8.21"
+version = "0.8.22"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "muxa-zellij-plugin"
-version = "0.8.21"
+version = "0.8.22"
 dependencies = [
  "serde",
  "serde_json",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "muxad"
-version = "0.8.21"
+version = "0.8.22"
 dependencies = [
  "anyhow",
  "clap 4.6.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/muxa", "crates/muxa-cli", "crates/muxad", "crates/muxa-zellij-plugin"]
 
 [workspace.package]
-version = "0.8.21"
+version = "0.8.22"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/README.ko.md
+++ b/README.ko.md
@@ -50,7 +50,16 @@ zellij는 CLI baseline과 richer plugin 경로를 준비 중입니다.
 
 ## 빠른 시작
 
-필요 조건: Rust 1.88+, tmux 3.x, Unix-like OS.
+필요 조건: tmux 3.x(또는 herdr), Unix-like OS.
+
+Homebrew(프리빌트 바이너리, Rust 툴체인 불필요):
+
+```bash
+brew install open330/tap/muxa
+muxa init
+```
+
+또는 원샷 설치 스크립트(소스 빌드, Rust 1.88+ 필요):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/install.sh | sh
@@ -124,12 +133,33 @@ case-sensitive이고 `*`, `?` wildcard를 지원합니다. 예:
 
 ## 지원 에이전트
 
+**훅 기반(authoritative).** 기존 훅/이벤트 시스템에 연결해 정확한 상태
+전이를 받습니다:
+
 | Agent | 상태 | Config |
 | --- | --- | --- |
 | Claude Code | 지원 | `~/.claude/settings.json` |
 | OpenAI Codex | 지원 | `~/.codex/config.toml` |
 | Google Gemini CLI | 지원 | `~/.gemini/settings.json` |
 | opencode | 예정 | [tracking issue](https://github.com/Open330/muxa/issues/14) |
+
+**화면 감지(fallback).** 훅이 없는 에이전트는 pane 내용을 TOML 매니페스트로
+분류합니다 — `cursor-agent`, `amp`, `copilot`, `aider`, `goose`용 매니페스트가
+기본 번들로 제공되며 사용자가 확장 가능. 훅이 있으면 항상 훅이 우선합니다.
+[docs/SCREEN_DETECTION.md](docs/SCREEN_DETECTION.md) 참고.
+
+## 호스트
+
+muxa는 여러 터미널 멀티플렉서 백엔드에서 에이전트를 관측하며, 여러 호스트를
+동시에 볼 수 있습니다(tmux→herdr 마이그레이션 등):
+
+| 호스트 | 상태 | 비고 |
+| --- | --- | --- |
+| tmux | 전체 | 기본 백엔드. |
+| [herdr](https://herdr.dev) | 전체 | herdr 소켓 API 경유; [docs/HERDR.md](docs/HERDR.md). |
+| zellij | CLI 기본 | 플러그인 경로 예정; [docs/ZELLIJ.md](docs/ZELLIJ.md). |
+
+여러 호스트 동시 관측은 [docs/MULTI_HOST.md](docs/MULTI_HOST.md) 참고.
 
 ## 상세 문서
 

--- a/README.md
+++ b/README.md
@@ -18,15 +18,17 @@ status line, a live TUI, desktop notifications, and local reports.
 
 ---
 
-`muxa` is a small daemon and CLI for observing AI coding agents running
-inside terminal multiplexer panes. It supports Claude Code, OpenAI Codex,
-and Google Gemini CLI through their existing hook/event systems, then
-correlates those events with tmux panes and sessions.
+`muxa` is a small daemon and CLI for observing — and now driving — AI
+coding agents running inside terminal multiplexer panes. It reads agent
+state from existing hook/event systems (Claude Code, OpenAI Codex, Google
+Gemini CLI), falls back to screen-manifest detection for hook-less agents,
+and correlates it all with multiplexer panes and sessions. Through `muxa
+mcp` a coding agent can also orchestrate the others — inspect state, send
+prompts, wait for changes.
 
-It does not fork tmux or modify agent binaries. tmux is the default full
-backend; [herdr](https://herdr.dev) is supported through its socket API
-(see [docs/HERDR.md](docs/HERDR.md)); zellij has a CLI baseline and a
-planned richer plugin path.
+It does not fork the multiplexer or modify agent binaries. tmux and
+[herdr](https://herdr.dev) are full backends and can be observed at the
+same time; zellij has a CLI baseline. See the Hosts table below.
 
 <div align="center">
   <img src="docs/demo.gif" alt="muxa demo" width="900" />
@@ -140,6 +142,9 @@ Patterns are case-sensitive and support `*` and `?`, e.g.
 
 ## Supported Agents
 
+**Hook-based (authoritative).** These wire into their existing hook/event
+systems, so muxa gets exact state transitions:
+
 | Agent | Status | Config |
 | --- | --- | --- |
 | Claude Code | Supported | `~/.claude/settings.json` |
@@ -147,12 +152,38 @@ Patterns are case-sensitive and support `*` and `?`, e.g.
 | Google Gemini CLI | Supported | `~/.gemini/settings.json` |
 | opencode | Planned | [tracking issue](https://github.com/Open330/muxa/issues/14) |
 
+**Screen-detected (fallback).** Agents with no hooks are classified from
+their pane contents via TOML manifests — bundled best-effort for
+`cursor-agent`, `amp`, `copilot`, `aider`, and `goose`, extensible per
+user. Hooks always win when present. See
+[docs/SCREEN_DETECTION.md](docs/SCREEN_DETECTION.md).
+
+On [herdr](https://herdr.dev) hosts, muxa additionally surfaces every
+agent herdr's own detection sees, with no manifest needed.
+
+## Hosts
+
+muxa observes agents across terminal-multiplexer backends and can watch
+several at once (e.g. during a tmux→herdr migration):
+
+| Host | Status | Notes |
+| --- | --- | --- |
+| tmux | Full | The default backend. |
+| [herdr](https://herdr.dev) | Full | Via herdr's socket API; see [docs/HERDR.md](docs/HERDR.md). |
+| zellij | CLI baseline | Richer plugin path planned; see [docs/ZELLIJ.md](docs/ZELLIJ.md). |
+
+See [docs/MULTI_HOST.md](docs/MULTI_HOST.md) for observing multiple hosts
+simultaneously.
+
 ## More Docs
 
 | Topic | Doc |
 | --- | --- |
 | Install and wiring | [docs/INSTALL.md](docs/INSTALL.md) |
 | MCP control plane (`muxa mcp`) | [docs/MCP.md](docs/MCP.md) |
+| herdr host support | [docs/HERDR.md](docs/HERDR.md) |
+| Multi-host observation | [docs/MULTI_HOST.md](docs/MULTI_HOST.md) |
+| Screen-manifest detection | [docs/SCREEN_DETECTION.md](docs/SCREEN_DETECTION.md) |
 | Live TUI and prompt composer | [docs/WATCH.md](docs/WATCH.md) |
 | CLI dashboard | [docs/DASHBOARD_CLI.md](docs/DASHBOARD_CLI.md) |
 | Stats, reports, activity ledger | [docs/ACTIVITY.md](docs/ACTIVITY.md) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,12 +6,14 @@ database.
 ## Flow
 
 ```text
-agent hook/status event
+agent hook/status event ─┐
+herdr agent_status event ─┤
+screen-manifest match ───┘
         |
         v
       muxa hook  ---- unix socket ---->  muxad in-memory registry
-                                             |
-                                             +--> state.json
+      (or a daemon                           |
+       detection task)                       +--> state.json
                                              +--> prompts.ndjson
                                              +--> activity.ndjson
                                              +--> notifications / sinks
@@ -19,17 +21,24 @@ agent hook/status event
 ```
 
 The CLI reads live daemon state over the socket and local retained files
-for history/reporting views.
+for history/reporting views, and can drive agents back through the socket
+(`send_prompt`/`capture`, exposed to other agents via `muxa mcp`).
 
 ## Components
 
 | Component | Role |
 | --- | --- |
 | `muxad` | Long-running daemon. Owns the registry, IPC server, background tasks, and optional dashboard. |
-| `muxa` | CLI for status, watch, attend, recap, stats, reports, activity queries, init, and hook entrypoints. |
+| `muxa` | CLI for status, watch, attend, recap, stats, reports, activity queries, init, hook entrypoints, and the `mcp` control server. |
 | Agent adapters | Translate Claude/Codex/Gemini hook events into muxa state transitions. |
-| tmux backend | Resolves panes, sessions, pane captures, and foreground session activity. |
-| Activity ledger | Append-only duration source for state/tmux/human intervals. |
+| Pane backends | Resolve panes, sessions, captures, and foreground activity per host (tmux, herdr, zellij). The daemon can observe several at once; each pane id is namespaced by host. |
+| herdr bridge | Translates herdr's own `agent_status` stream into synthetic rows for agents muxa has no hooks for. |
+| Screen detection | Classifies hook-less agents (cursor, amp, …) from pane captures against TOML manifests; synthetic, hook-authoritative. |
+| Activity ledger | Append-only duration source for state/foreground/human intervals. |
+
+Precedence when several producers describe one pane: **hooks > herdr
+bridge > screen detection** — synthetic rows are evicted the moment a real
+hook claims the pane.
 
 ## Data Files
 


### PR DESCRIPTION
## Summary
- Bump to 0.8.22 and cut the CHANGELOG section: the MCP control plane (#71) and screen-manifest detection (#72) merged after v0.8.21 and need a release.
- **Adds the missing screen-detection CHANGELOG entry** (#72 shipped without one).
- Docs refresh for staleness: README intro (observe **and drive**), Supported Agents split into hook-based vs screen-detected, a new Hosts table (tmux/herdr/zellij), and doc links for herdr/multi-host/screen. README.ko mirrored. ARCHITECTURE flow + components updated with the herdr bridge, screen detection, multi-host backends, and the control path, plus the precedence note.

## Test plan
- [x] `cargo check`, `cargo fmt --all --check` clean; all README doc-links resolve to existing files
- [ ] After merge: tag v0.8.22 → release workflow builds assets → publish → formula bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)