### PR TITLE
feat(fleet): manage remote Muxa hosts over SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Central SSH fleet management adds a physical host → session → window →
+  pane(agent) control plane.** `muxad` now maintains one isolated persistent
+  OpenSSH stdio relay and last-known cache per configured node, with stable
+  UUID identity, duplicate-node protection, bounded reconnect/concurrency,
+  keepalive health, revision-gap reconciliation, and explicit
+  observe/control authorization. `muxa host` manages inventory plus
+  Kubernetes-style labels/annotations and selectors; `muxa fleet` and
+  `muxa watch --fleet` provide status, focused hierarchy navigation, high
+  density inspectors, lazy pane/window capture with real tmux geometry,
+  exact prompt delivery, and separate-TTY remote attach. The same cache is
+  exposed through authenticated dashboard APIs and three explicit MCP tools.
+  The relay opens no TCP listener, forces SSH forwarding off, keeps prompt
+  bodies out of audit logs, bounds/sanitizes terminal data, and never retries
+  mutations. See [docs/FLEET.md](docs/FLEET.md).
+
 - **Agents can call a colleague naturally through Muxa MCP.** Connected Claude
   and Codex conversations now map `@peer`, provider/alias/role targets, and
   registered `/skills` to `muxa_call_peer`. The high-level tool expands the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bodies out of audit logs, bounds/sanitizes terminal data, and never retries
   mutations. See [docs/FLEET.md](docs/FLEET.md).
 
+  The controller is itself an always-present first-class `local` node, even
+  when remote Fleet connections are disabled. It exposes the same topology,
+  selectors, capture/send/attach, dashboard, and MCP surfaces through an
+  in-process adapter. Kubernetes-style system labels identify the local
+  hostname/OS/architecture, while user labels and annotations remain editable
+  through `muxa host label local` and `muxa host annotate local`.
+
 - **Agents can call a colleague naturally through Muxa MCP.** Connected Claude
   and Codex conversations now map `@peer`, provider/alias/role targets, and
   registered `/skills` to `muxa_call_peer`. The high-level tool expands the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hostname/OS/architecture, while user labels and annotations remain editable
   through `muxa host label local` and `muxa host annotate local`.
 
+  Human host tables are terminal-width aware and concise by default; labels
+  move behind `--show-labels` or explicit `-L` columns, while `-o wide/json`
+  preserve richer output. A Fleet selection containing only `local` now opens
+  the full native `muxa watch` experience without a redundant host row. The
+  multi-node view shares watch themes, view/expansion/sort choices, swarm mode,
+  dense inspectors, `/` message skills, exact capture/send/attach, and uses a
+  Fleet invalidation stream with a slow reconciliation poll instead of fixed
+  high-frequency full redraws.
+
 - **Agents can call a colleague naturally through Muxa MCP.** Connected Claude
   and Codex conversations now map `@peer`, provider/alias/role targets, and
   registered `/skills` to `muxa_call_peer`. The high-level tool expands the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Agents can call a colleague naturally through Muxa MCP.** Connected Claude
+  and Codex conversations now map `@peer`, provider/alias/role targets, and
+  registered `/skills` to `muxa_call_peer`. The high-level tool expands the
+  template, selects a healthy peer deterministically, sends a durable request,
+  and can wait for its structured reply. Calls default to `REVIEW · READ-ONLY`;
+  execution requires an explicit task authorization, and creating a new pane
+  requires separate user confirmation. `muxa_peer_report` retrieves prior
+  structured replies for phrases such as “`@peer`'s report”; reserved routing
+  refuses to substitute GitHub or invent a PR when no explicit PR number or
+  GitHub PR URL grounds that workflow. Repository/cwd context alone is not
+  sufficient.
+
 ## [0.8.34] - 2026-08-14
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,6 +2310,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
  "wiremock",
 ]
 
@@ -2335,6 +2336,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "toml",
  "toml_edit 0.22.27",
  "tracing",
  "tracing-subscriber",
@@ -2363,6 +2365,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -101,7 +101,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1107,7 +1107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1381,9 +1381,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1863,7 +1863,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2471,7 +2471,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3371,7 +3371,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3684,7 +3684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3858,7 +3858,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4361,7 +4361,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4788,7 +4788,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ rust-embed = "8"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 url = "2"
 portable-pty = "0.9"
+uuid = { version = "1", features = ["v4", "serde"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -39,6 +39,11 @@ prompt requests, results, errors, and explicit resync markers. See
 [`docs/FLEET.md`](docs/FLEET.md); `FLEET_PROTOCOL_VERSION` is negotiated
 separately from this local IPC protocol.
 
+The controller itself is always represented as host `local`. Its snapshot and
+commands use the same `FleetSnapshot`/`FleetOperation` schema and exact pane
+keys, but muxad executes them against its in-process Store/backends without an
+SSH or relay hop. `[fleet] enabled` therefore controls only remote transports.
+
 ## Request
 
 ```json
@@ -77,8 +82,9 @@ Response:
 
 #### `fleet_snapshot`
 
-Read muxad's per-physical-host cache. `selector` is an optional Kubernetes-
-style label selector. This operation never opens request-scoped SSH.
+Read muxad's per-physical-host cache, including the always-present `local`
+node. `selector` is an optional Kubernetes-style label selector. This
+operation never opens request-scoped SSH.
 
 ```json
 { "protocol": 4, "kind": "fleet_snapshot", "selector": "region=icn" }
@@ -86,8 +92,9 @@ style label selector. This operation never opens request-scoped SSH.
 
 #### `fleet_command`
 
-Dispatch one operation to an exact configured host. The manager rechecks the
-host's observe/control mode; the relay rechecks complete pane identity. Prompt
+Dispatch one operation to an exact host. The local adapter rechecks complete
+pane identity in process. For remote hosts the manager also rechecks
+observe/control mode and the relay verifies complete pane identity. Prompt
 mutations are not retried.
 
 ```json

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -90,6 +90,23 @@ operation never opens request-scoped SSH.
 { "protocol": 4, "kind": "fleet_snapshot", "selector": "region=icn" }
 ```
 
+#### `fleet_subscribe`
+
+Long-lived compact invalidation stream for the central Fleet cache. The server
+first acknowledges with `ok`, then writes newline-delimited `FleetUpdate`
+objects containing `host`, `state`, and an optional `revision`. Empty lines are
+keepalives. Updates are hints rather than partial snapshots: clients coalesce a
+burst and issue one selector-filtered `fleet_snapshot`, with a slow fallback
+poll for reconciliation.
+
+```json
+{ "protocol": 4, "kind": "fleet_subscribe" }
+```
+
+```json
+{ "host": "dev", "state": "online", "revision": 42 }
+```
+
 #### `fleet_command`
 
 Dispatch one operation to an exact host. The local adapter rechecks complete

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -31,6 +31,14 @@ Post-1.0: the protocol is stable within a major version; breaking changes bump
 Each connection is full-duplex: a client may issue multiple
 request/response pairs over the same stream.
 
+Physical-host Fleet uses a second, versioned JSON-lines protocol over an
+OpenSSH stdio channel. It is intentionally not a network service. The remote
+`muxa relay --stdio` announces a stable node UUID and capabilities, then
+exchanges full snapshots, revisioned transitions/keepalives, exact capture or
+prompt requests, results, errors, and explicit resync markers. See
+[`docs/FLEET.md`](docs/FLEET.md); `FLEET_PROTOCOL_VERSION` is negotiated
+separately from this local IPC protocol.
+
 ## Request
 
 ```json
@@ -65,6 +73,30 @@ Response:
 
 ```json
 { "ok": true, "protocol": 1, "agents": [ <Agent>, ... ] }
+```
+
+#### `fleet_snapshot`
+
+Read muxad's per-physical-host cache. `selector` is an optional Kubernetes-
+style label selector. This operation never opens request-scoped SSH.
+
+```json
+{ "protocol": 4, "kind": "fleet_snapshot", "selector": "region=icn" }
+```
+
+#### `fleet_command`
+
+Dispatch one operation to an exact configured host. The manager rechecks the
+host's observe/control mode; the relay rechecks complete pane identity. Prompt
+mutations are not retried.
+
+```json
+{
+  "protocol": 4,
+  "kind": "fleet_command",
+  "host": "dev",
+  "operation": { "kind": "refresh" }
+}
 ```
 
 #### `by_pane`

--- a/README.ko.md
+++ b/README.ko.md
@@ -148,6 +148,24 @@ subagent로 활용하라는 협업 지침이 자동으로 노출됩니다. 요�
 AIR 1.0 artifact 참조를 첨부할 수 있고, watch mailbox가 profile별 색상 배지로
 표시합니다.
 
+연결된 Claude 또는 Codex 대화 안에서 바로 동료를 호출할 수도 있습니다. agent가
+다음 표현을 Muxa의 durable peer-call 도구로 변환합니다.
+
+```text
+@peer 현재 변경사항을 리뷰해줘
+@codex /review-plan-feedback commit abc123을 context로 사용해줘
+@peer의 보고를 요약하고 타당한 조언만 반영해줘
+```
+
+`@peer`와 `@muxa-peer`는 Muxa 협업 전용 표현입니다. 새 요청은 peer-call 도구로,
+기존 peer 보고는 durable mailbox 보고 도구로 연결되며 명시적인 PR 참조 없이는
+GitHub PR을 의미하지 않습니다. `@peer`는 같은 window의 정상 agent를 결정적으로
+선택하고, `@claude`, `@codex`,
+`@gemini`, `@alias`, `role:name`으로 대상을 좁힐 수 있습니다. 기본 계약은
+`REVIEW · READ-ONLY`입니다. 변경 실행은 명시적인 task 승인, 새 agent pane 생성은
+별도 확인이 있어야 합니다. Muxa를 업그레이드하거나 등록된 스킬을 바꾼 뒤에는
+실행 중이던 agent를 재시작해야 MCP process가 새 도구와 템플릿을 읽습니다.
+
 `muxa doctor`에서 synthetic으로 표시되는 agent는 안정적인 session identity가
 생길 때까지 협업 대상에서 제외됩니다. 새 prompt로 hook을 발생시키거나 agent를
 재시작한 뒤 다시 확인하세요.
@@ -200,6 +218,7 @@ footer에서 굵은 노란색으로 강조합니다. `j`, `l`, `Alt-T`, `o`, `?`
 | `muxa peek [--plain]` | 현재 tmux window의 pane별 오버레이. `--plain`은 텍스트로 출력. |
 | `muxa recap [--pane %N]` | 보관된 disk history에서 최근 prompt 조회. |
 | `muxa peers` / `muxa identity` / `muxa msg` | 같은 tmux window의 agent를 찾고 이름/역할을 지정해 durable request/reply 메시지를 주고받음. |
+| `muxa skill add/list/show/remove` | watch/dashboard 메시지, watch ask, MCP peer call에서 사용할 `/` prompt 템플릿 관리. |
 | `muxa stats --since today` | WACT/ACT/WORK/WAIT 중심 summary. day/project/agent/session 단위로 묶을 수 있고, `--graph`는 WACT 시간 그래프만, `--verbose`는 진단 컬럼을 표시. |
 | `muxa report --since week` | day/project/agent/session 모든 breakdown을 ACT/WACT 중심 테이블로 표시 (`--json` / `--markdown`로 export). |
 | `muxa timeline --since today` | session별로 묶은 interactive timeline. `--session main`, `--agent codex`로 필터링하고 `--sort waiting` 정렬이나 `--view heatmap`을 사용할 수 있음. |

--- a/README.ko.md
+++ b/README.ko.md
@@ -219,6 +219,8 @@ footer에서 굵은 노란색으로 강조합니다. `j`, `l`, `Alt-T`, `o`, `?`
 | `muxa recap [--pane %N]` | 보관된 disk history에서 최근 prompt 조회. |
 | `muxa peers` / `muxa identity` / `muxa msg` | 같은 tmux window의 agent를 찾고 이름/역할을 지정해 durable request/reply 메시지를 주고받음. |
 | `muxa skill add/list/show/remove` | watch/dashboard 메시지, watch ask, MCP peer call에서 사용할 `/` prompt 템플릿 관리. |
+| `muxa host add/list/label/annotate/doctor` | physical SSH node와 Kubernetes-style label/annotation 관리. |
+| `muxa fleet status/watch/capture/send/attach` | 중앙 host → session → window → pane(agent) 관측/제어. |
 | `muxa stats --since today` | WACT/ACT/WORK/WAIT 중심 summary. day/project/agent/session 단위로 묶을 수 있고, `--graph`는 WACT 시간 그래프만, `--verbose`는 진단 컬럼을 표시. |
 | `muxa report --since week` | day/project/agent/session 모든 breakdown을 ACT/WACT 중심 테이블로 표시 (`--json` / `--markdown`로 export). |
 | `muxa timeline --since today` | session별로 묶은 interactive timeline. `--session main`, `--agent codex`로 필터링하고 `--sort waiting` 정렬이나 `--view heatmap`을 사용할 수 있음. |
@@ -278,7 +280,24 @@ case-sensitive이고 `*`, `?` wildcard를 지원합니다. 예:
 기본 번들로 제공되며 사용자가 확장 가능. 훅이 있으면 항상 훅이 우선합니다.
 [docs/SCREEN_DETECTION.md](docs/SCREEN_DETECTION.md) 참고.
 
-## 호스트
+## Fleet host
+
+로컬 muxad를 여러 SSH host의 중앙 controller로 사용할 수 있습니다. 각 physical node는
+stable UUID와 label/annotation metadata를 가지며 controller는 node마다 persistent outbound
+SSH stdio relay와 독립적인 last-known cache를 유지합니다. 기본값은 `observe`이고
+`control`은 host별로 명시해야 합니다. 원격 TCP listener는 열지 않습니다.
+
+```bash
+muxa host add dev muxa-devbox --label environment=development --mode observe
+muxa host doctor dev
+muxa fleet watch
+# 같은 진입점: muxa watch --fleet
+```
+
+selector, TUI key, 보안/성능, MCP/dashboard API는
+[docs/FLEET.ko.md](docs/FLEET.ko.md)를 참고하세요.
+
+## Pane backend
 
 muxa는 여러 터미널 멀티플렉서 백엔드에서 에이전트를 관측하며, 여러 호스트를
 동시에 볼 수 있습니다(tmux→herdr 마이그레이션 등):
@@ -298,6 +317,7 @@ muxa는 여러 터미널 멀티플렉서 백엔드에서 에이전트를 관측�
 | 설치와 wiring | [docs/INSTALL.ko.md](docs/INSTALL.ko.md) |
 | 온보딩과 work/agent 운영 정책 | [docs/ONBOARDING.ko.md](docs/ONBOARDING.ko.md) |
 | MCP control plane (`muxa mcp`) | [docs/MCP.md](docs/MCP.md) |
+| Physical SSH fleet | [docs/FLEET.ko.md](docs/FLEET.ko.md) |
 | Live TUI와 prompt composer | [docs/WATCH.ko.md](docs/WATCH.ko.md) |
 | CLI dashboard | [docs/DASHBOARD_CLI.ko.md](docs/DASHBOARD_CLI.ko.md) |
 | Stats, report, activity ledger | [docs/ACTIVITY.ko.md](docs/ACTIVITY.ko.md) |

--- a/README.ko.md
+++ b/README.ko.md
@@ -290,11 +290,14 @@ SSH stdio relay와 독립적인 last-known cache를 유지합니다. 기본값�
 
 ```bash
 muxa fleet status                         # local은 이미 표시됨
+muxa fleet status -L environment,region   # 필요한 label column만 추가
+muxa fleet status -o wide                 # 공간에 따라 hostname/version/latency
 muxa host label local environment=development
 muxa host add dev muxa-devbox --label environment=development --mode observe
 muxa host doctor dev
 muxa fleet watch
 # 같은 진입점: muxa watch --fleet
+# local 하나뿐이면 불필요한 host row 없이 완전한 native watch 사용
 ```
 
 selector, TUI key, 보안/성능, MCP/dashboard API는

--- a/README.ko.md
+++ b/README.ko.md
@@ -282,12 +282,15 @@ case-sensitive이고 `*`, `?` wildcard를 지원합니다. 예:
 
 ## Fleet host
 
-로컬 muxad를 여러 SSH host의 중앙 controller로 사용할 수 있습니다. 각 physical node는
+로컬 muxad를 현재 장비와 여러 SSH host의 중앙 controller로 사용할 수 있습니다.
+controller 장비는 별도 Fleet 설정 없이 즉시 `local` node로 나타납니다. 각 physical node는
 stable UUID와 label/annotation metadata를 가지며 controller는 node마다 persistent outbound
 SSH stdio relay와 독립적인 last-known cache를 유지합니다. 기본값은 `observe`이고
 `control`은 host별로 명시해야 합니다. 원격 TCP listener는 열지 않습니다.
 
 ```bash
+muxa fleet status                         # local은 이미 표시됨
+muxa host label local environment=development
 muxa host add dev muxa-devbox --label environment=development --mode observe
 muxa host doctor dev
 muxa fleet watch

--- a/README.md
+++ b/README.md
@@ -324,13 +324,16 @@ agent herdr's own detection sees, with no manifest needed.
 
 ## Fleet Hosts
 
-Run muxad locally as a central controller for several SSH-reachable machines.
-Each physical node keeps its own stable UUID and label/annotation metadata;
+Run muxad locally as a central controller for this machine and several
+SSH-reachable machines. The controller appears immediately as the `local`
+node, without Fleet configuration. Each physical node keeps its own stable UUID and label/annotation metadata;
 the controller maintains one persistent outbound SSH stdio relay and an
 independent last-known cache per node. `observe` is the default, while
 `control` must be granted per host. No remote TCP listener is opened.
 
 ```bash
+muxa fleet status                         # local is already present
+muxa host label local environment=development
 muxa host add dev muxa-devbox --label environment=development --mode observe
 muxa host doctor dev
 muxa fleet watch

--- a/README.md
+++ b/README.md
@@ -177,6 +177,25 @@ narrowly scoped execution subagents. Requests and replies can also carry
 validated AIR 1.0 artifact references, which watch visualizes with
 profile-colored mailbox badges.
 
+You can call a colleague directly from a connected Claude or Codex
+conversation. The agent maps the mention to Muxa's durable peer-call tool:
+
+```text
+@peer review the current changes
+@codex /review-plan-feedback using commit abc123 as context
+@peer's report: summarize it and apply only valid advice
+```
+
+`@peer` and `@muxa-peer` are reserved for Muxa collaboration. New requests use
+the peer-call tool; references to an existing peer report use the durable
+mailbox report tool and never imply a GitHub PR without an explicit PR reference.
+`@peer` chooses a healthy same-window agent deterministically; `@claude`,
+`@codex`, `@gemini`, `@alias`, and `role:name` narrow the target. Calls default
+to `REVIEW · READ-ONLY`. Executing changes requires an explicit task
+authorization, and creating a new agent pane requires a separate confirmation.
+Restart an already-running agent after upgrading Muxa or changing registered
+skills so its MCP process loads the new tool and templates.
+
 Agents reported as synthetic by `muxa doctor` are omitted from collaboration
 until a hook event establishes a stable session identity. Submit a prompt or
 restart that agent, then check again.
@@ -234,7 +253,7 @@ Korean is selected automatically for a Korean locale, can be requested with
 | `muxa peek [--plain]` | Per-pane overlay for the current tmux window; `--plain` prints it as text. |
 | `muxa recap [--pane %N]` | Recent prompts from retained disk history. |
 | `muxa peers` / `muxa identity` / `muxa msg` | Discover and name same-window agents, then exchange durable request/reply messages. |
-| `muxa skill add/list/show/remove` | Manage reusable `/` prompt templates for watch/dashboard messages and watch ask. |
+| `muxa skill add/list/show/remove` | Manage reusable `/` prompt templates for watch/dashboard messages, watch ask, and MCP peer calls. |
 | `muxa stats --since today` | Focused WACT/ACT/WORK/WAIT summary; group by day/project/agent/session. Add `--graph` for graph-only WACT over time or `--verbose` for diagnostic columns. |
 | `muxa report --since week` | All breakdowns (day/project/agent/session) as focused ACT/WACT tables; add `--json` or `--markdown` to export. |
 | `muxa timeline --since today` | Interactive session-grouped timeline; filter with `--session main` / `--agent codex`, sort with `--sort waiting`, or use `--view heatmap`. |

--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ Korean is selected automatically for a Korean locale, can be requested with
 | `muxa recap [--pane %N]` | Recent prompts from retained disk history. |
 | `muxa peers` / `muxa identity` / `muxa msg` | Discover and name same-window agents, then exchange durable request/reply messages. |
 | `muxa skill add/list/show/remove` | Manage reusable `/` prompt templates for watch/dashboard messages, watch ask, and MCP peer calls. |
+| `muxa host add/list/label/annotate/doctor` | Manage physical SSH nodes and Kubernetes-style labels/annotations. |
+| `muxa fleet status/watch/capture/send/attach` | Central host → session → window → pane(agent) observation and control. |
 | `muxa stats --since today` | Focused WACT/ACT/WORK/WAIT summary; group by day/project/agent/session. Add `--graph` for graph-only WACT over time or `--verbose` for diagnostic columns. |
 | `muxa report --since week` | All breakdowns (day/project/agent/session) as focused ACT/WACT tables; add `--json` or `--markdown` to export. |
 | `muxa timeline --since today` | Interactive session-grouped timeline; filter with `--session main` / `--agent codex`, sort with `--sort waiting`, or use `--view heatmap`. |
@@ -320,7 +322,25 @@ user. Hooks always win when present. See
 On [herdr](https://herdr.dev) hosts, muxa additionally surfaces every
 agent herdr's own detection sees, with no manifest needed.
 
-## Hosts
+## Fleet Hosts
+
+Run muxad locally as a central controller for several SSH-reachable machines.
+Each physical node keeps its own stable UUID and label/annotation metadata;
+the controller maintains one persistent outbound SSH stdio relay and an
+independent last-known cache per node. `observe` is the default, while
+`control` must be granted per host. No remote TCP listener is opened.
+
+```bash
+muxa host add dev muxa-devbox --label environment=development --mode observe
+muxa host doctor dev
+muxa fleet watch
+# equivalent entry point: muxa watch --fleet
+```
+
+See [docs/FLEET.md](docs/FLEET.md) for selectors, TUI controls, security,
+performance, MCP tools, and dashboard APIs.
+
+## Pane Backends
 
 muxa observes agents across terminal-multiplexer backends and can watch
 several at once (e.g. during a tmux→herdr migration):
@@ -345,6 +365,7 @@ simultaneously.
 | herdr host support | [docs/HERDR.md](docs/HERDR.md) |
 | rmux host support | [docs/RMUX.md](docs/RMUX.md) |
 | Multi-host observation | [docs/MULTI_HOST.md](docs/MULTI_HOST.md) |
+| Physical SSH fleet | [docs/FLEET.md](docs/FLEET.md) |
 | Screen-manifest detection | [docs/SCREEN_DETECTION.md](docs/SCREEN_DETECTION.md) |
 | Live TUI and prompt composer | [docs/WATCH.md](docs/WATCH.md) |
 | CLI dashboard | [docs/DASHBOARD_CLI.md](docs/DASHBOARD_CLI.md) |

--- a/README.md
+++ b/README.md
@@ -333,11 +333,14 @@ independent last-known cache per node. `observe` is the default, while
 
 ```bash
 muxa fleet status                         # local is already present
+muxa fleet status -L environment,region   # opt-in label columns
+muxa fleet status -o wide                 # hostname/version/latency when space permits
 muxa host label local environment=development
 muxa host add dev muxa-devbox --label environment=development --mode observe
 muxa host doctor dev
 muxa fleet watch
 # equivalent entry point: muxa watch --fleet
+# with only local, this is the full native watch with no redundant host row
 ```
 
 See [docs/FLEET.md](docs/FLEET.md) for selectors, TUI controls, security,

--- a/config.example.toml
+++ b/config.example.toml
@@ -96,7 +96,7 @@
 # no TCP listener is opened on either side. SSH identity, ProxyJump, port, and
 # host-key policy belong in ~/.ssh/config. See docs/FLEET.md.
 [fleet]
-# enabled               = false
+# enabled               = false      # outbound SSH hosts; local is always visible
 # refresh_secs          = 15
 # keepalive_secs        = 10
 # offline_after_secs    = 30       # must be at least 2 × keepalive_secs
@@ -104,6 +104,15 @@
 # command_timeout_secs  = 10
 # max_parallel_connects = 6
 # capture_policy        = "selected" # selected | never; pane text is fetched on demand only
+
+# Optional metadata for the built-in controller node. `muxa host label local`
+# and `muxa host annotate local` edit these tables. muxad supplies immutable
+# muxa.io/local, muxa.io/transport, and kubernetes.io/* identity labels.
+# [fleet.local.labels]
+# environment = "development"
+
+# [fleet.local.annotations]
+# "muxa.dev/owner" = "platform-team"
 
 # [fleet.hosts.devbox]
 # ssh           = "muxa-devbox"    # OpenSSH Host alias; no embedded flags

--- a/config.example.toml
+++ b/config.example.toml
@@ -91,6 +91,39 @@
 # cursor. peer/@alias/role: selectors stay window-scoped either way.
 # scope = "window"
 
+# Central physical-host management over persistent, outbound OpenSSH stdio
+# relays. The remote side needs the same muxa version and an owner-local muxad;
+# no TCP listener is opened on either side. SSH identity, ProxyJump, port, and
+# host-key policy belong in ~/.ssh/config. See docs/FLEET.md.
+[fleet]
+# enabled               = false
+# refresh_secs          = 15
+# keepalive_secs        = 10
+# offline_after_secs    = 30       # must be at least 2 × keepalive_secs
+# connect_timeout_secs  = 10
+# command_timeout_secs  = 10
+# max_parallel_connects = 6
+# capture_policy        = "selected" # selected | never; pane text is fetched on demand only
+
+# [fleet.hosts.devbox]
+# ssh           = "muxa-devbox"    # OpenSSH Host alias; no embedded flags
+# muxa_path     = "muxa"
+# enabled       = true
+# connect       = "auto"           # auto | on_demand
+# mode          = "observe"        # observe | control
+# remote_socket = "/run/user/1000/muxa.sock" # optional
+
+# Kubernetes-style labels are selector/indexing metadata. Values are short
+# identifiers; use annotations for descriptive or URL-like data.
+# [fleet.hosts.devbox.labels]
+# environment = "development"
+# region = "icn"
+# accelerator = "gpu"
+
+# [fleet.hosts.devbox.annotations]
+# "muxa.dev/owner" = "platform-team"
+# "muxa.dev/runbook" = "https://example.invalid/runbooks/devbox"
+
 [history]
 # enabled               = true
 # path                  = "/home/$USER/.local/share/muxa/prompts.ndjson"

--- a/crates/muxa-cli/Cargo.toml
+++ b/crates/muxa-cli/Cargo.toml
@@ -55,6 +55,7 @@ which = "7"
 # by codex hook merger and dashboard token writer. Plain `toml` would
 # rewrite the whole file from scratch.
 toml_edit = "0.22"
+toml = { workspace = true }
 # Width-aware truncation for human CLI tables; important for CJK prompts.
 unicode-width = "0.2"
 # Cryptographically-strong dashboard tokens via the OS RNG.

--- a/crates/muxa-cli/src/fleet_cli.rs
+++ b/crates/muxa-cli/src/fleet_cli.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use clap::{Args, Subcommand, ValueEnum};
 use comfy_table::presets::UTF8_BORDERS_ONLY;
-use comfy_table::{Cell, Table};
+use comfy_table::{Cell, ColumnConstraint, ContentArrangement, Table, Width};
 use muxa::config::{FleetConnectPolicy, FleetHostConfig};
 use muxa::fleet::{
     drain_bounded, read_bounded_line, sanitize_terminal_text, validate_label_key,
@@ -21,6 +21,49 @@ use muxa::ipc::Client;
 use muxa::{Config, PaneKey};
 use tokio::io::BufReader;
 use tokio::process::Command;
+use unicode_width::UnicodeWidthStr;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+enum HostOutputArg {
+    #[default]
+    Table,
+    Wide,
+    Json,
+}
+
+#[derive(Debug, Args)]
+struct HostTableArgs {
+    #[arg(short = 'l', long = "selector")]
+    selector: Option<String>,
+    /// Output format: table (default), wide, or json.
+    #[arg(short = 'o', long = "output", value_enum, value_name = "FORMAT")]
+    output: Option<HostOutputArg>,
+    /// Backwards-compatible alias for `-o json`.
+    #[arg(long, conflicts_with = "output")]
+    json: bool,
+    /// Append all Kubernetes-style labels to the human table.
+    #[arg(long, conflicts_with = "json")]
+    show_labels: bool,
+    /// Append selected label values as columns, for example `-L environment,region`.
+    #[arg(
+        short = 'L',
+        long = "label-columns",
+        value_delimiter = ',',
+        value_name = "KEYS",
+        conflicts_with = "json"
+    )]
+    label_columns: Vec<String>,
+}
+
+impl HostTableArgs {
+    fn output(&self) -> HostOutputArg {
+        if self.json {
+            HostOutputArg::Json
+        } else {
+            self.output.unwrap_or_default()
+        }
+    }
+}
 
 #[derive(Debug, Args)]
 pub(crate) struct HostArgs {
@@ -52,10 +95,8 @@ enum HostCommand {
     },
     /// List inventory and live connection state.
     List {
-        #[arg(short = 'l', long = "selector")]
-        selector: Option<String>,
-        #[arg(long)]
-        json: bool,
+        #[command(flatten)]
+        table: HostTableArgs,
     },
     /// Show one host's full configuration and live metadata.
     Show { alias: String },
@@ -98,15 +139,28 @@ pub(crate) struct FleetArgs {
 enum FleetCommand {
     /// Print the aggregated host/session/window/pane state.
     Status {
-        #[arg(short = 'l', long = "selector")]
-        selector: Option<String>,
-        #[arg(long)]
-        json: bool,
+        #[command(flatten)]
+        table: HostTableArgs,
     },
     /// Open the central host/session/window/pane TUI.
     Watch {
         #[arg(short = 'l', long = "selector")]
         selector: Option<String>,
+        /// Show agents without an attached multiplexer pane.
+        #[arg(long)]
+        include_paneless: bool,
+        /// Default hierarchy depth, shared with `muxa watch`.
+        #[arg(long, value_enum)]
+        view: Option<crate::WatchViewArg>,
+        /// Tree or swarm presentation, shared with `muxa watch`.
+        #[arg(long, value_enum)]
+        layout: Option<crate::WatchLayoutArg>,
+        /// One-shot sibling ordering, shared with `muxa watch`.
+        #[arg(long, value_enum)]
+        sort: Option<crate::WatchSortArg>,
+        /// One-shot visual theme override.
+        #[arg(long, value_enum)]
+        theme: Option<crate::theme::ThemeArg>,
     },
     /// Connect an on-demand host.
     Connect { host: String },
@@ -212,14 +266,13 @@ pub(crate) async fn run_host(
             request_reload(client).await;
             Ok(())
         }
-        HostCommand::List { selector, json } => {
-            let selector = parse_selector(selector.as_deref())?;
+        HostCommand::List { table } => {
+            let selector = parse_selector(table.selector.as_deref())?;
             let live = client.fleet_snapshot(selector.as_deref()).await.ok();
             let hosts = inventory_with_live(cfg, live.as_ref(), selector.as_deref())?;
-            if json {
-                println!("{}", serde_json::to_string_pretty(&hosts)?);
-            } else {
-                print_hosts(&hosts);
+            match table.output() {
+                HostOutputArg::Json => println!("{}", serde_json::to_string_pretty(&hosts)?),
+                output => print_hosts(&hosts, output, &table.label_columns, table.show_labels),
             }
             Ok(())
         }
@@ -328,29 +381,55 @@ pub(crate) async fn run_host(
     }
 }
 
+#[allow(clippy::too_many_lines)] // explicit subcommand dispatch remains easiest to audit
 pub(crate) async fn run_fleet(
     args: FleetArgs,
     client: &Client,
     cfg: &Config,
-    _config_path: Option<&Path>,
+    config_path: Option<&Path>,
 ) -> Result<()> {
     match args.command {
-        FleetCommand::Status { selector, json } => {
-            let selector = parse_selector(selector.as_deref())?;
+        FleetCommand::Status { table } => {
+            let selector = parse_selector(table.selector.as_deref())?;
             let snapshot = client
                 .fleet_snapshot(selector.as_deref())
                 .await
                 .context("reading fleet state from muxad")?;
-            if json {
-                println!("{}", serde_json::to_string_pretty(&snapshot)?);
-            } else {
-                print_hosts(&snapshot.hosts);
+            match table.output() {
+                HostOutputArg::Json => println!("{}", serde_json::to_string_pretty(&snapshot)?),
+                output => print_hosts(
+                    &snapshot.hosts,
+                    output,
+                    &table.label_columns,
+                    table.show_labels,
+                ),
             }
             Ok(())
         }
-        FleetCommand::Watch { selector } => {
+        FleetCommand::Watch {
+            selector,
+            include_paneless,
+            view,
+            layout,
+            sort,
+            theme,
+        } => {
             let selector = parse_selector(selector.as_deref())?;
-            crate::fleet_watch::run(client.clone(), cfg, selector).await
+            crate::cmd_fleet_watch(
+                client,
+                cfg.clone(),
+                config_path.map(Path::to_path_buf),
+                selector,
+                crate::WatchInvocation {
+                    include_paneless,
+                    view,
+                    layout,
+                    sort,
+                    theme,
+                    caller_pane: None,
+                },
+            )
+            .await
         }
         FleetCommand::Connect { host } => {
             execute_simple(client, &host, FleetOperation::Connect).await
@@ -818,36 +897,239 @@ fn reject_local_inventory_mutation(alias: &str, action: &str) -> Result<()> {
     Ok(())
 }
 
-fn print_hosts(hosts: &[FleetHostSnapshot]) {
-    let mut table = Table::new();
-    table.load_preset(UTF8_BORDERS_ONLY);
-    table.set_header([
-        "HOST",
-        "STATE",
-        "MODE",
-        "LABELS",
-        "AGENTS",
-        "ATTN",
-        "LAST/ERROR",
-    ]);
-    for host in hosts {
-        let last = host.error.clone().unwrap_or_else(|| {
-            host.received_at.map_or_else(
-                || "-".into(),
-                |time| format!("{}", time.replace_nanosecond(0).unwrap_or(time)),
-            )
-        });
-        table.add_row([
-            Cell::new(&host.alias),
-            Cell::new(format!("{:?}", host.state).to_lowercase()),
-            Cell::new(format!("{:?}", host.mode).to_lowercase()),
-            Cell::new(format_map(&host.labels)),
-            Cell::new(host.agent_count()),
-            Cell::new(host.needs_attention()),
-            Cell::new(sanitize_terminal_text(&last)),
-        ]);
+#[derive(Debug, Clone)]
+enum HostColumnKind {
+    Host,
+    State,
+    Mode,
+    Inventory,
+    Agents,
+    Panes,
+    Attention,
+    Age,
+    Hostname,
+    Version,
+    Latency,
+    Label(String),
+    Labels,
+}
+
+#[derive(Debug, Clone)]
+struct HostColumn {
+    header: String,
+    kind: HostColumnKind,
+    width: usize,
+    min_width: usize,
+}
+
+impl HostColumn {
+    fn new(header: impl Into<String>, kind: HostColumnKind, min_width: usize) -> Self {
+        let header = header.into();
+        let width = UnicodeWidthStr::width(header.as_str());
+        Self {
+            header,
+            kind,
+            width,
+            min_width,
+        }
     }
-    println!("{table}");
+
+    fn cap(&self) -> usize {
+        match self.kind {
+            HostColumnKind::Host | HostColumnKind::Label(_) => 24,
+            HostColumnKind::State => 12,
+            HostColumnKind::Mode | HostColumnKind::Age | HostColumnKind::Latency => 8,
+            HostColumnKind::Inventory => 11,
+            HostColumnKind::Agents | HostColumnKind::Panes | HostColumnKind::Attention => 7,
+            HostColumnKind::Hostname => 28,
+            HostColumnKind::Version => 14,
+            HostColumnKind::Labels => 48,
+        }
+    }
+}
+
+fn print_hosts(
+    hosts: &[FleetHostSnapshot],
+    output: HostOutputArg,
+    label_columns: &[String],
+    show_labels: bool,
+) {
+    println!(
+        "{}",
+        render_hosts(
+            hosts,
+            output,
+            label_columns,
+            show_labels,
+            crate::terminal_width()
+        )
+    );
+}
+
+fn render_hosts(
+    hosts: &[FleetHostSnapshot],
+    output: HostOutputArg,
+    label_columns: &[String],
+    show_labels: bool,
+    terminal_width: usize,
+) -> String {
+    let mut columns = host_columns(output, label_columns, show_labels, terminal_width);
+    let now = time::OffsetDateTime::now_utc();
+    for column in &mut columns {
+        let content_width = hosts
+            .iter()
+            .map(|host| UnicodeWidthStr::width(host_column_value(host, &column.kind, now).as_str()))
+            .max()
+            .unwrap_or(0);
+        column.width = column.width.max(content_width).min(column.cap());
+    }
+    fit_host_columns(&mut columns, terminal_width);
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_BORDERS_ONLY)
+        .set_content_arrangement(ContentArrangement::Disabled)
+        .set_constraints(columns.iter().map(|column| {
+            ColumnConstraint::Absolute(Width::Fixed(
+                u16::try_from(column.width).unwrap_or(u16::MAX),
+            ))
+        }))
+        .set_header(
+            columns
+                .iter()
+                .map(|column| Cell::new(crate::truncate_cell(&column.header, column.width))),
+        );
+    for host in hosts {
+        table.add_row(columns.iter().map(|column| {
+            Cell::new(crate::truncate_cell(
+                &host_column_value(host, &column.kind, now),
+                column.width,
+            ))
+        }));
+    }
+    format!("{table}")
+}
+
+fn host_columns(
+    output: HostOutputArg,
+    label_columns: &[String],
+    show_labels: bool,
+    terminal_width: usize,
+) -> Vec<HostColumn> {
+    let mut columns = if terminal_width < 64 {
+        vec![
+            HostColumn::new("HOST", HostColumnKind::Host, 8),
+            HostColumn::new("STATE", HostColumnKind::State, 6),
+            HostColumn::new("A/P", HostColumnKind::Inventory, 5),
+            HostColumn::new("ATTN", HostColumnKind::Attention, 4),
+            HostColumn::new("AGE", HostColumnKind::Age, 4),
+        ]
+    } else {
+        vec![
+            HostColumn::new("HOST", HostColumnKind::Host, 8),
+            HostColumn::new("STATE", HostColumnKind::State, 6),
+            HostColumn::new("MODE", HostColumnKind::Mode, 4),
+            HostColumn::new("AGENTS", HostColumnKind::Agents, 3),
+            HostColumn::new("PANES", HostColumnKind::Panes, 3),
+            HostColumn::new("ATTN", HostColumnKind::Attention, 4),
+            HostColumn::new("AGE", HostColumnKind::Age, 4),
+        ]
+    };
+    if output == HostOutputArg::Wide {
+        if terminal_width >= 78 {
+            columns.push(HostColumn::new("HOSTNAME", HostColumnKind::Hostname, 8));
+        }
+        if terminal_width >= 96 {
+            columns.push(HostColumn::new("VERSION", HostColumnKind::Version, 6));
+        }
+        if terminal_width >= 112 {
+            columns.push(HostColumn::new("LATENCY", HostColumnKind::Latency, 4));
+        }
+    }
+    columns.extend(label_columns.iter().map(|key| {
+        HostColumn::new(
+            key.to_ascii_uppercase(),
+            HostColumnKind::Label(key.clone()),
+            4,
+        )
+    }));
+    if show_labels {
+        columns.push(HostColumn::new("LABELS", HostColumnKind::Labels, 8));
+    }
+    columns
+}
+
+fn host_column_value(
+    host: &FleetHostSnapshot,
+    kind: &HostColumnKind,
+    now: time::OffsetDateTime,
+) -> String {
+    match kind {
+        HostColumnKind::Host => sanitize_terminal_text(&host.alias),
+        HostColumnKind::State => format!("{:?}", host.state).to_lowercase(),
+        HostColumnKind::Mode => format!("{:?}", host.mode).to_lowercase(),
+        HostColumnKind::Inventory => format!("{}/{}", host.agent_count(), host.pane_count()),
+        HostColumnKind::Agents => host.agent_count().to_string(),
+        HostColumnKind::Panes => host.pane_count().to_string(),
+        HostColumnKind::Attention => host.needs_attention().to_string(),
+        HostColumnKind::Age => host.received_at.map_or_else(
+            || "-".into(),
+            |seen| {
+                let age = crate::relative_time(now, seen);
+                let age = age.strip_suffix(" ago").unwrap_or(&age);
+                if age == "0s" {
+                    "now".into()
+                } else {
+                    age.into()
+                }
+            },
+        ),
+        HostColumnKind::Hostname => sanitize_terminal_text(host.hostname.as_deref().unwrap_or("-")),
+        HostColumnKind::Version => {
+            sanitize_terminal_text(host.muxa_version.as_deref().unwrap_or("-"))
+        }
+        HostColumnKind::Latency => host
+            .latency_ms
+            .map_or_else(|| "-".into(), |latency| format!("{latency}ms")),
+        HostColumnKind::Label(key) => host
+            .labels
+            .get(key)
+            .map_or_else(|| "<none>".into(), |value| sanitize_terminal_text(value)),
+        HostColumnKind::Labels => format_map(&host.labels),
+    }
+}
+
+fn fit_host_columns(columns: &mut Vec<HostColumn>, terminal_width: usize) {
+    // comfy-table's borders, separators, and one-cell padding consume three
+    // characters per column plus the closing border. Drop optional right-most
+    // columns only in pathologically narrow terminals where even one visible
+    // character per cell would not fit.
+    while columns.len() > 1 && columns.len().saturating_mul(4).saturating_add(1) > terminal_width {
+        columns.pop();
+    }
+    let content_budget = terminal_width
+        .saturating_sub(columns.len().saturating_mul(3).saturating_add(1))
+        .max(columns.len());
+    while columns.iter().map(|column| column.width).sum::<usize>() > content_budget {
+        let candidate = columns
+            .iter()
+            .enumerate()
+            .filter(|(_, column)| column.width > column.min_width)
+            .max_by_key(|(_, column)| column.width - column.min_width)
+            .map(|(index, _)| index)
+            .or_else(|| {
+                columns
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, column)| column.width > 1)
+                    .max_by_key(|(_, column)| column.width)
+                    .map(|(index, _)| index)
+            });
+        let Some(index) = candidate else {
+            break;
+        };
+        columns[index].width -= 1;
+    }
 }
 
 fn format_map(values: &BTreeMap<String, String>) -> String {
@@ -1153,6 +1435,91 @@ async fn request_reload(client: &Client) {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    fn local_host_for_table() -> FleetHostSnapshot {
+        FleetHostSnapshot {
+            alias: "local".into(),
+            local: true,
+            ssh_target: "local://".into(),
+            labels: BTreeMap::from([
+                ("kubernetes.io/hostname".into(), "june.rtzr.ai".into()),
+                ("muxa.io/local".into(), "true".into()),
+                ("muxa.io/transport".into(), "local".into()),
+            ]),
+            annotations: BTreeMap::new(),
+            mode: HostAccessMode::Control,
+            state: FleetHostState::Online,
+            node_id: None,
+            hostname: Some("june.rtzr.ai".into()),
+            os: Some("linux".into()),
+            arch: Some("x86_64".into()),
+            muxa_version: Some("0.8.34".into()),
+            protocol: Some(FLEET_PROTOCOL_VERSION),
+            capabilities: Vec::new(),
+            daemon_generation: Some(17),
+            boot_id: None,
+            latency_ms: Some(0),
+            last_seen_at: Some(time::OffsetDateTime::now_utc()),
+            received_at: Some(time::OffsetDateTime::now_utc()),
+            error: None,
+            remote: None,
+        }
+    }
+
+    #[test]
+    fn default_host_table_is_compact_and_hides_labels() {
+        let rendered = render_hosts(
+            &[local_host_for_table()],
+            HostOutputArg::Table,
+            &[],
+            false,
+            80,
+        );
+        assert!(rendered.contains("HOST"));
+        assert!(rendered.contains("AGENTS"));
+        assert!(rendered.contains("PANES"));
+        assert!(!rendered.contains("muxa.io/local"));
+        assert!(
+            rendered
+                .lines()
+                .all(|line| UnicodeWidthStr::width(line) <= 80),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn host_table_exposes_wide_and_opt_in_label_views_without_overflow() {
+        let host = local_host_for_table();
+        let wide = render_hosts(
+            std::slice::from_ref(&host),
+            HostOutputArg::Wide,
+            &[],
+            false,
+            140,
+        );
+        assert!(wide.contains("HOSTNAME"));
+        assert!(wide.contains("VERSION"));
+        assert!(wide.contains("LATENCY"));
+
+        let selected = render_hosts(
+            std::slice::from_ref(&host),
+            HostOutputArg::Table,
+            &["muxa.io/local".into()],
+            false,
+            92,
+        );
+        assert!(selected.contains("MUXA.IO/LOCAL"));
+        assert!(selected.contains("true"));
+        assert!(selected
+            .lines()
+            .all(|line| UnicodeWidthStr::width(line) <= 92));
+
+        let labels = render_hosts(&[host], HostOutputArg::Table, &[], true, 92);
+        assert!(labels.contains("LABELS"));
+        assert!(labels
+            .lines()
+            .all(|line| UnicodeWidthStr::width(line) <= 92));
+    }
 
     #[test]
     fn inventory_editor_preserves_unrelated_config_and_validates_labels() {

--- a/crates/muxa-cli/src/fleet_cli.rs
+++ b/crates/muxa-cli/src/fleet_cli.rs
@@ -15,7 +15,7 @@ use muxa::fleet::{
     drain_bounded, read_bounded_line, sanitize_terminal_text, validate_label_key,
     validate_label_value, FleetHostSnapshot, FleetHostState, FleetOperation, GlobalPaneRef,
     HostAccessMode, LabelSelector, RelayFrame, FLEET_MAX_DIAGNOSTIC_BYTES, FLEET_MAX_FRAME_BYTES,
-    FLEET_PROTOCOL_VERSION,
+    FLEET_PROTOCOL_VERSION, LOCAL_HOST_ALIAS, LOCAL_MANAGED_LABELS,
 };
 use muxa::ipc::Client;
 use muxa::{Config, PaneKey};
@@ -114,15 +114,15 @@ enum FleetCommand {
     Disconnect { host: String },
     /// Force a fresh full snapshot.
     Refresh { host: String },
-    /// List remote panes and their complete collision-free keys.
+    /// List panes on a local or remote Fleet host with collision-free keys.
     Panes {
         host: String,
         #[arg(long)]
         json: bool,
     },
-    /// Capture one exact remote pane selected by native pane id.
+    /// Capture one exact pane on a local or remote Fleet host.
     Capture { host: String, pane: String },
-    /// Send text to one exact remote agent pane.
+    /// Send text to one exact agent pane on a named Fleet host.
     Send {
         host: String,
         pane: String,
@@ -130,7 +130,7 @@ enum FleetCommand {
         #[arg(long, default_value_t = true)]
         submit: bool,
     },
-    /// Attach this terminal to one exact remote pane over a separate SSH TTY.
+    /// Attach to one exact pane directly when local, or through a separate SSH TTY.
     Attach { host: String, pane: String },
 }
 
@@ -185,6 +185,11 @@ pub(crate) async fn run_host(
         } => {
             let path = config_path.context("no config directory is available on this system")?;
             validate_label_value(&alias).map_err(anyhow::Error::msg)?;
+            if alias == LOCAL_HOST_ALIAS {
+                bail!(
+                    "host alias '{LOCAL_HOST_ALIAS}' is reserved for this node; use `muxa host label local` or `muxa host annotate local`"
+                );
+            }
             if cfg.fleet.hosts.contains_key(&alias) && !overwrite {
                 bail!("host '{alias}' already exists; pass --overwrite to replace it");
             }
@@ -219,6 +224,28 @@ pub(crate) async fn run_host(
             Ok(())
         }
         HostCommand::Show { alias } => {
+            if alias == LOCAL_HOST_ALIAS {
+                let live = client.fleet_snapshot(None).await.ok().and_then(|snapshot| {
+                    snapshot
+                        .hosts
+                        .into_iter()
+                        .find(|item| item.alias == LOCAL_HOST_ALIAS)
+                });
+                println!("alias:       {LOCAL_HOST_ALIAS}");
+                println!("transport:   local (in-process)");
+                println!("mode:        Control");
+                println!("connect:     Always");
+                println!("enabled:     true");
+                println!("labels:      {}", format_map(&cfg.fleet.local.labels));
+                println!("annotations: {}", format_map(&cfg.fleet.local.annotations));
+                if let Some(live) = live {
+                    println!("effective:   {}", format_map(&live.labels));
+                    print_live_host(&live);
+                } else {
+                    println!("state:       Offline (muxad Fleet IPC unavailable)");
+                }
+                return Ok(());
+            }
             let host = cfg
                 .fleet
                 .hosts
@@ -237,27 +264,12 @@ pub(crate) async fn run_host(
             println!("labels:      {}", format_map(&host.labels));
             println!("annotations: {}", format_map(&host.annotations));
             if let Some(live) = live {
-                println!("state:       {:?}", live.state);
-                println!(
-                    "node id:     {}",
-                    live.node_id.as_ref().map_or("-", muxa::NodeId::as_str)
-                );
-                println!(
-                    "hostname:    {}",
-                    sanitize_terminal_text(live.hostname.as_deref().unwrap_or("-"))
-                );
-                println!(
-                    "version:     {}",
-                    sanitize_terminal_text(live.muxa_version.as_deref().unwrap_or("-"))
-                );
-                println!("agents:      {}", live.agent_count());
-                if let Some(error) = live.error {
-                    println!("error:       {}", sanitize_terminal_text(&error));
-                }
+                print_live_host(&live);
             }
             Ok(())
         }
         HostCommand::Remove { alias } => {
+            reject_local_inventory_mutation(&alias, "removed")?;
             let path = config_path.context("no config directory is available on this system")?;
             if !cfg.fleet.hosts.contains_key(&alias) {
                 bail!("host '{alias}' is not configured");
@@ -302,15 +314,17 @@ pub(crate) async fn run_host(
             .await
         }
         HostCommand::Enable { alias } => {
+            reject_local_inventory_mutation(&alias, "enabled or disabled")?;
             set_host_enabled(config_path, cfg, client, &alias, true).await
         }
         HostCommand::Disable { alias } => {
+            reject_local_inventory_mutation(&alias, "enabled or disabled")?;
             set_host_enabled(config_path, cfg, client, &alias, false).await
         }
         HostCommand::Doctor {
             alias,
             timeout_secs,
-        } => doctor(cfg, &alias, Duration::from_secs(timeout_secs)).await,
+        } => doctor(client, cfg, &alias, Duration::from_secs(timeout_secs)).await,
     }
 }
 
@@ -506,6 +520,9 @@ async fn attach(client: &Client, cfg: &Config, host: &str, pane: &str) -> Result
 
 pub(crate) fn attach_exact(cfg: &Config, host: &str, target: &GlobalPaneRef) -> Result<()> {
     let token = crate::relay::encode_attach_token(target)?;
+    if host == LOCAL_HOST_ALIAS {
+        return crate::relay::remote_attach(&token);
+    }
     let configured = cfg
         .fleet
         .hosts
@@ -532,7 +549,47 @@ pub(crate) fn attach_exact(cfg: &Config, host: &str, target: &GlobalPaneRef) -> 
     Ok(())
 }
 
-async fn doctor(cfg: &Config, alias: &str, timeout: Duration) -> Result<()> {
+async fn doctor(client: &Client, cfg: &Config, alias: &str, timeout: Duration) -> Result<()> {
+    if alias == LOCAL_HOST_ALIAS {
+        return doctor_local(client, timeout).await;
+    }
+    doctor_remote(cfg, alias, timeout).await
+}
+
+async fn doctor_local(client: &Client, timeout: Duration) -> Result<()> {
+    println!("1/4 inventory       ok (built-in local node)");
+    let hello = tokio::time::timeout(timeout, client.hello(timeout))
+        .await
+        .map_err(|_| anyhow::anyhow!("local muxad hello timed out after {timeout:?}"))??;
+    println!(
+        "2/4 local muxad     ok (generation {})",
+        hello
+            .generation
+            .map_or_else(|| "-".into(), |value| value.to_string())
+    );
+    let snapshot = tokio::time::timeout(timeout, client.fleet_snapshot(None))
+        .await
+        .map_err(|_| anyhow::anyhow!("local Fleet snapshot timed out after {timeout:?}"))??;
+    let local = snapshot
+        .hosts
+        .into_iter()
+        .find(|host| host.local)
+        .context("muxad did not publish its local Fleet node")?;
+    let node_id = local.node_id.context("local Fleet node has no NodeId")?;
+    println!("3/4 local NodeId    ok ({node_id})");
+    let remote = local
+        .remote
+        .context("local Fleet node has no topology snapshot")?;
+    println!(
+        "4/4 local topology  ok ({} agents · {} panes · revision {})",
+        remote.agents.len(),
+        remote.panes.len(),
+        remote.revision
+    );
+    Ok(())
+}
+
+async fn doctor_remote(cfg: &Config, alias: &str, timeout: Duration) -> Result<()> {
     let host = cfg
         .fleet
         .hosts
@@ -638,46 +695,127 @@ fn inventory_with_live(
         .map(str::parse::<LabelSelector>)
         .transpose()
         .map_err(anyhow::Error::msg)?;
-    Ok(cfg
-        .fleet
-        .hosts
-        .iter()
-        .filter(|(_, host)| {
-            selector
+    let mut hosts = live.map_or_else(Vec::new, |snapshot| snapshot.hosts.clone());
+    if !hosts.iter().any(|host| host.local) {
+        let labels = local_inventory_labels(cfg);
+        if selector
+            .as_ref()
+            .is_none_or(|selector| selector.matches(&labels))
+        {
+            hosts.push(FleetHostSnapshot {
+                alias: LOCAL_HOST_ALIAS.into(),
+                local: true,
+                ssh_target: "local://".into(),
+                labels,
+                annotations: cfg.fleet.local.annotations.clone(),
+                mode: HostAccessMode::Control,
+                state: FleetHostState::Offline,
+                node_id: None,
+                hostname: None,
+                os: Some(std::env::consts::OS.into()),
+                arch: Some(std::env::consts::ARCH.into()),
+                muxa_version: Some(env!("CARGO_PKG_VERSION").into()),
+                protocol: Some(FLEET_PROTOCOL_VERSION),
+                capabilities: Vec::new(),
+                daemon_generation: None,
+                boot_id: None,
+                latency_ms: Some(0),
+                last_seen_at: None,
+                received_at: None,
+                error: Some("muxad Fleet IPC is unavailable".into()),
+                remote: None,
+            });
+        }
+    }
+    for (alias, host) in &cfg.fleet.hosts {
+        if hosts.iter().any(|item| item.alias == *alias)
+            || selector
                 .as_ref()
-                .is_none_or(|selector| selector.matches(&host.labels))
-        })
-        .map(|(alias, host)| {
-            live.and_then(|snapshot| snapshot.hosts.iter().find(|item| item.alias == *alias))
-                .cloned()
-                .unwrap_or_else(|| FleetHostSnapshot {
-                    alias: alias.clone(),
-                    ssh_target: host.ssh.clone(),
-                    labels: host.labels.clone(),
-                    annotations: host.annotations.clone(),
-                    mode: host.mode,
-                    state: if host.enabled {
-                        FleetHostState::Offline
-                    } else {
-                        FleetHostState::Disabled
-                    },
-                    node_id: None,
-                    hostname: None,
-                    os: None,
-                    arch: None,
-                    muxa_version: None,
-                    protocol: None,
-                    capabilities: Vec::new(),
-                    daemon_generation: None,
-                    boot_id: None,
-                    latency_ms: None,
-                    last_seen_at: None,
-                    received_at: None,
-                    error: Some("muxad has not loaded this inventory entry".into()),
-                    remote: None,
-                })
-        })
-        .collect())
+                .is_some_and(|selector| !selector.matches(&host.labels))
+        {
+            continue;
+        }
+        hosts.push(FleetHostSnapshot {
+            alias: alias.clone(),
+            local: false,
+            ssh_target: host.ssh.clone(),
+            labels: host.labels.clone(),
+            annotations: host.annotations.clone(),
+            mode: host.mode,
+            state: if cfg.fleet.enabled && host.enabled {
+                FleetHostState::Offline
+            } else {
+                FleetHostState::Disabled
+            },
+            node_id: None,
+            hostname: None,
+            os: None,
+            arch: None,
+            muxa_version: None,
+            protocol: None,
+            capabilities: Vec::new(),
+            daemon_generation: None,
+            boot_id: None,
+            latency_ms: None,
+            last_seen_at: None,
+            received_at: None,
+            error: Some("muxad has not loaded this inventory entry".into()),
+            remote: None,
+        });
+    }
+    hosts.sort_by(|left, right| {
+        right
+            .local
+            .cmp(&left.local)
+            .then(left.alias.cmp(&right.alias))
+    });
+    Ok(hosts)
+}
+
+fn local_inventory_labels(cfg: &Config) -> BTreeMap<String, String> {
+    let mut labels = cfg.fleet.local.labels.clone();
+    labels.insert("muxa.io/local".into(), "true".into());
+    labels.insert("muxa.io/transport".into(), "local".into());
+    labels.insert("kubernetes.io/os".into(), std::env::consts::OS.into());
+    labels.insert("kubernetes.io/arch".into(), std::env::consts::ARCH.into());
+    let hostname = std::fs::read_to_string("/etc/hostname")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var("HOSTNAME").ok());
+    if let Some(hostname) = hostname.filter(|value| validate_label_value(value).is_ok()) {
+        labels.insert("kubernetes.io/hostname".into(), hostname);
+    }
+    labels
+}
+
+fn print_live_host(live: &FleetHostSnapshot) {
+    println!("state:       {:?}", live.state);
+    println!(
+        "node id:     {}",
+        live.node_id.as_ref().map_or("-", muxa::NodeId::as_str)
+    );
+    println!(
+        "hostname:    {}",
+        sanitize_terminal_text(live.hostname.as_deref().unwrap_or("-"))
+    );
+    println!(
+        "version:     {}",
+        sanitize_terminal_text(live.muxa_version.as_deref().unwrap_or("-"))
+    );
+    println!("agents:      {}", live.agent_count());
+    if let Some(error) = &live.error {
+        println!("error:       {}", sanitize_terminal_text(error));
+    }
+}
+
+fn reject_local_inventory_mutation(alias: &str, action: &str) -> Result<()> {
+    if alias == LOCAL_HOST_ALIAS {
+        bail!(
+            "the always-present local host cannot be {action}; only its labels and annotations are user-managed"
+        );
+    }
+    Ok(())
 }
 
 fn print_hosts(hosts: &[FleetHostSnapshot]) {
@@ -758,18 +896,26 @@ async fn edit_metadata(
     annotation: bool,
 ) -> Result<()> {
     let path = config_path.context("no config directory is available on this system")?;
-    let current = cfg
-        .fleet
-        .hosts
-        .get(alias)
-        .with_context(|| format!("host '{alias}' is not configured"))?;
-    if changes.is_empty() {
-        let values = if annotation {
-            &current.annotations
+    let current = if alias == LOCAL_HOST_ALIAS {
+        if annotation {
+            &cfg.fleet.local.annotations
         } else {
-            &current.labels
-        };
-        println!("{}", format_map(values));
+            &cfg.fleet.local.labels
+        }
+    } else {
+        let host = cfg
+            .fleet
+            .hosts
+            .get(alias)
+            .with_context(|| format!("host '{alias}' is not configured"))?;
+        if annotation {
+            &host.annotations
+        } else {
+            &host.labels
+        }
+    };
+    if changes.is_empty() {
+        println!("{}", format_map(current));
         return Ok(());
     }
     edit_config(path, |document| {
@@ -777,6 +923,9 @@ async fn edit_metadata(
         for change in changes {
             if let Some(key) = change.strip_suffix('-').filter(|key| !key.contains('=')) {
                 validate_label_key(key).map_err(anyhow::Error::msg)?;
+                if !annotation && alias == LOCAL_HOST_ALIAS && LOCAL_MANAGED_LABELS.contains(&key) {
+                    bail!("label key '{key}' is managed by muxad and cannot be changed");
+                }
                 table.remove(key);
                 continue;
             }
@@ -785,6 +934,9 @@ async fn edit_metadata(
                 .with_context(|| format!("metadata '{change}' must be KEY=VALUE or KEY-"))?;
             validate_label_key(key).map_err(anyhow::Error::msg)?;
             if !annotation {
+                if alias == LOCAL_HOST_ALIAS && LOCAL_MANAGED_LABELS.contains(&key) {
+                    bail!("label key '{key}' is managed by muxad and cannot be changed");
+                }
                 validate_label_value(value).map_err(anyhow::Error::msg)?;
             }
             if table.contains_key(key) && !overwrite {
@@ -882,12 +1034,7 @@ fn write_document(path: &Path, text: &str) -> Result<()> {
 }
 
 fn fleet_hosts_table_mut(document: &mut toml_edit::DocumentMut) -> Result<&mut toml_edit::Table> {
-    if document.get("fleet").is_none() {
-        document["fleet"] = toml_edit::Item::Table(toml_edit::Table::new());
-    }
-    let fleet = document["fleet"]
-        .as_table_mut()
-        .context("[fleet] is not a table")?;
+    let fleet = fleet_table_mut(document)?;
     fleet.insert("enabled", toml_edit::value(true));
     if fleet.get("hosts").is_none() {
         fleet["hosts"] = toml_edit::Item::Table(toml_edit::Table::new());
@@ -895,6 +1042,15 @@ fn fleet_hosts_table_mut(document: &mut toml_edit::DocumentMut) -> Result<&mut t
     fleet["hosts"]
         .as_table_mut()
         .context("[fleet.hosts] is not a table")
+}
+
+fn fleet_table_mut(document: &mut toml_edit::DocumentMut) -> Result<&mut toml_edit::Table> {
+    if document.get("fleet").is_none() {
+        document["fleet"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    document["fleet"]
+        .as_table_mut()
+        .context("[fleet] is not a table")
 }
 
 fn host_table_mut<'a>(
@@ -912,6 +1068,21 @@ fn metadata_table_mut<'a>(
     alias: &str,
     field: &str,
 ) -> Result<&'a mut toml_edit::Table> {
+    if alias == LOCAL_HOST_ALIAS {
+        let fleet = fleet_table_mut(document)?;
+        if fleet.get("local").is_none() {
+            fleet["local"] = toml_edit::Item::Table(toml_edit::Table::new());
+        }
+        let local = fleet["local"]
+            .as_table_mut()
+            .context("[fleet.local] is not a table")?;
+        if local.get(field).is_none() {
+            local[field] = toml_edit::Item::Table(toml_edit::Table::new());
+        }
+        return local[field]
+            .as_table_mut()
+            .with_context(|| format!("[fleet.local.{field}] is not a table"));
+    }
     let host = host_table_mut(document, alias)?;
     if host.get(field).is_none() {
         host[field] = toml_edit::Item::Table(toml_edit::Table::new());
@@ -1005,5 +1176,35 @@ mod tests {
     fn pair_parser_accepts_annotation_urls_but_not_label_urls() {
         assert!(parse_pairs(&["docs=https://example.com/a".into()], true).is_ok());
         assert!(parse_pairs(&["docs=https://example.com/a".into()], false).is_err());
+    }
+
+    #[test]
+    fn local_inventory_is_visible_without_enabling_remote_fleet() {
+        let cfg = Config::default();
+        let hosts = inventory_with_live(&cfg, None, None).unwrap();
+        assert_eq!(hosts.len(), 1);
+        assert!(hosts[0].local);
+        assert_eq!(hosts[0].alias, LOCAL_HOST_ALIAS);
+        assert_eq!(hosts[0].labels["muxa.io/local"], "true");
+
+        let selected = inventory_with_live(&cfg, None, Some("muxa.io/local=true")).unwrap();
+        assert_eq!(selected.len(), 1);
+        let excluded = inventory_with_live(&cfg, None, Some("muxa.io/local=false")).unwrap();
+        assert!(excluded.is_empty());
+    }
+
+    #[test]
+    fn editing_local_metadata_does_not_enable_remote_connections() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        edit_config(&path, |document| {
+            metadata_table_mut(document, LOCAL_HOST_ALIAS, "labels")?
+                .insert("environment", toml_edit::value("development"));
+            Ok(())
+        })
+        .unwrap();
+        let updated = Config::load(&path).unwrap();
+        assert!(!updated.fleet.enabled);
+        assert_eq!(updated.fleet.local.labels["environment"], "development");
     }
 }

--- a/crates/muxa-cli/src/fleet_cli.rs
+++ b/crates/muxa-cli/src/fleet_cli.rs
@@ -1,0 +1,1009 @@
+//! Host inventory and non-interactive Muxa Fleet commands.
+
+use std::collections::BTreeMap;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use clap::{Args, Subcommand, ValueEnum};
+use comfy_table::presets::UTF8_BORDERS_ONLY;
+use comfy_table::{Cell, Table};
+use muxa::config::{FleetConnectPolicy, FleetHostConfig};
+use muxa::fleet::{
+    drain_bounded, read_bounded_line, sanitize_terminal_text, validate_label_key,
+    validate_label_value, FleetHostSnapshot, FleetHostState, FleetOperation, GlobalPaneRef,
+    HostAccessMode, LabelSelector, RelayFrame, FLEET_MAX_DIAGNOSTIC_BYTES, FLEET_MAX_FRAME_BYTES,
+    FLEET_PROTOCOL_VERSION,
+};
+use muxa::ipc::Client;
+use muxa::{Config, PaneKey};
+use tokio::io::BufReader;
+use tokio::process::Command;
+
+#[derive(Debug, Args)]
+pub(crate) struct HostArgs {
+    #[command(subcommand)]
+    command: HostCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum HostCommand {
+    /// Register or update one OpenSSH Host alias.
+    Add {
+        alias: String,
+        ssh: String,
+        #[arg(long = "label", value_name = "KEY=VALUE")]
+        labels: Vec<String>,
+        #[arg(long = "annotation", value_name = "KEY=VALUE")]
+        annotations: Vec<String>,
+        #[arg(long, value_enum, default_value_t = AccessArg::Observe)]
+        mode: AccessArg,
+        #[arg(long, value_enum, default_value_t = ConnectArg::Auto)]
+        connect: ConnectArg,
+        #[arg(long, default_value = "muxa")]
+        muxa_path: String,
+        #[arg(long)]
+        remote_socket: Option<PathBuf>,
+        /// Replace an existing host entry.
+        #[arg(long)]
+        overwrite: bool,
+    },
+    /// List inventory and live connection state.
+    List {
+        #[arg(short = 'l', long = "selector")]
+        selector: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show one host's full configuration and live metadata.
+    Show { alias: String },
+    /// Remove a host from the central inventory.
+    Remove { alias: String },
+    /// Add, replace, or remove labels (`key=value`; trailing `key-` removes).
+    #[command(visible_alias = "tag")]
+    Label {
+        alias: String,
+        changes: Vec<String>,
+        #[arg(long)]
+        overwrite: bool,
+    },
+    /// Add, replace, or remove annotations (`key=value`; trailing `key-` removes).
+    Annotate {
+        alias: String,
+        changes: Vec<String>,
+        #[arg(long)]
+        overwrite: bool,
+    },
+    /// Enable a configured host.
+    Enable { alias: String },
+    /// Disable a configured host without removing its metadata.
+    Disable { alias: String },
+    /// Verify OpenSSH trust/auth, remote muxa, daemon IPC, and protocol.
+    Doctor {
+        alias: String,
+        #[arg(long, default_value_t = 10)]
+        timeout_secs: u64,
+    },
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct FleetArgs {
+    #[command(subcommand)]
+    command: FleetCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum FleetCommand {
+    /// Print the aggregated host/session/window/pane state.
+    Status {
+        #[arg(short = 'l', long = "selector")]
+        selector: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Open the central host/session/window/pane TUI.
+    Watch {
+        #[arg(short = 'l', long = "selector")]
+        selector: Option<String>,
+    },
+    /// Connect an on-demand host.
+    Connect { host: String },
+    /// Close the persistent relay for one host.
+    Disconnect { host: String },
+    /// Force a fresh full snapshot.
+    Refresh { host: String },
+    /// List remote panes and their complete collision-free keys.
+    Panes {
+        host: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Capture one exact remote pane selected by native pane id.
+    Capture { host: String, pane: String },
+    /// Send text to one exact remote agent pane.
+    Send {
+        host: String,
+        pane: String,
+        text: String,
+        #[arg(long, default_value_t = true)]
+        submit: bool,
+    },
+    /// Attach this terminal to one exact remote pane over a separate SSH TTY.
+    Attach { host: String, pane: String },
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum AccessArg {
+    Observe,
+    Control,
+}
+
+impl From<AccessArg> for HostAccessMode {
+    fn from(value: AccessArg) -> Self {
+        match value {
+            AccessArg::Observe => Self::Observe,
+            AccessArg::Control => Self::Control,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ConnectArg {
+    Auto,
+    OnDemand,
+}
+
+impl From<ConnectArg> for FleetConnectPolicy {
+    fn from(value: ConnectArg) -> Self {
+        match value {
+            ConnectArg::Auto => Self::Auto,
+            ConnectArg::OnDemand => Self::OnDemand,
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)] // explicit CLI subcommand dispatch table
+pub(crate) async fn run_host(
+    args: HostArgs,
+    client: &Client,
+    cfg: &Config,
+    config_path: Option<&Path>,
+) -> Result<()> {
+    match args.command {
+        HostCommand::Add {
+            alias,
+            ssh,
+            labels,
+            annotations,
+            mode,
+            connect,
+            muxa_path,
+            remote_socket,
+            overwrite,
+        } => {
+            let path = config_path.context("no config directory is available on this system")?;
+            validate_label_value(&alias).map_err(anyhow::Error::msg)?;
+            if cfg.fleet.hosts.contains_key(&alias) && !overwrite {
+                bail!("host '{alias}' already exists; pass --overwrite to replace it");
+            }
+            let host = FleetHostConfig {
+                ssh,
+                muxa_path,
+                remote_socket,
+                enabled: true,
+                connect: connect.into(),
+                mode: mode.into(),
+                labels: parse_pairs(&labels, false)?,
+                annotations: parse_pairs(&annotations, true)?,
+            };
+            edit_config(path, |document| upsert_host(document, &alias, &host))?;
+            println!(
+                "{} host {alias} in {}",
+                if overwrite { "updated" } else { "added" },
+                path.display()
+            );
+            request_reload(client).await;
+            Ok(())
+        }
+        HostCommand::List { selector, json } => {
+            let selector = parse_selector(selector.as_deref())?;
+            let live = client.fleet_snapshot(selector.as_deref()).await.ok();
+            let hosts = inventory_with_live(cfg, live.as_ref(), selector.as_deref())?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&hosts)?);
+            } else {
+                print_hosts(&hosts);
+            }
+            Ok(())
+        }
+        HostCommand::Show { alias } => {
+            let host = cfg
+                .fleet
+                .hosts
+                .get(&alias)
+                .with_context(|| format!("host '{alias}' is not configured"))?;
+            let live =
+                client.fleet_snapshot(None).await.ok().and_then(|snapshot| {
+                    snapshot.hosts.into_iter().find(|item| item.alias == alias)
+                });
+            println!("alias:       {alias}");
+            println!("ssh:         {}", host.ssh);
+            println!("mode:        {:?}", host.mode);
+            println!("connect:     {:?}", host.connect);
+            println!("enabled:     {}", host.enabled);
+            println!("muxa path:   {}", host.muxa_path);
+            println!("labels:      {}", format_map(&host.labels));
+            println!("annotations: {}", format_map(&host.annotations));
+            if let Some(live) = live {
+                println!("state:       {:?}", live.state);
+                println!(
+                    "node id:     {}",
+                    live.node_id.as_ref().map_or("-", muxa::NodeId::as_str)
+                );
+                println!(
+                    "hostname:    {}",
+                    sanitize_terminal_text(live.hostname.as_deref().unwrap_or("-"))
+                );
+                println!(
+                    "version:     {}",
+                    sanitize_terminal_text(live.muxa_version.as_deref().unwrap_or("-"))
+                );
+                println!("agents:      {}", live.agent_count());
+                if let Some(error) = live.error {
+                    println!("error:       {}", sanitize_terminal_text(&error));
+                }
+            }
+            Ok(())
+        }
+        HostCommand::Remove { alias } => {
+            let path = config_path.context("no config directory is available on this system")?;
+            if !cfg.fleet.hosts.contains_key(&alias) {
+                bail!("host '{alias}' is not configured");
+            }
+            edit_config(path, |document| remove_host(document, &alias))?;
+            println!("removed host {alias} from {}", path.display());
+            request_reload(client).await;
+            Ok(())
+        }
+        HostCommand::Label {
+            alias,
+            changes,
+            overwrite,
+        } => {
+            edit_metadata(
+                config_path,
+                cfg,
+                client,
+                &alias,
+                "labels",
+                &changes,
+                overwrite,
+                false,
+            )
+            .await
+        }
+        HostCommand::Annotate {
+            alias,
+            changes,
+            overwrite,
+        } => {
+            edit_metadata(
+                config_path,
+                cfg,
+                client,
+                &alias,
+                "annotations",
+                &changes,
+                overwrite,
+                true,
+            )
+            .await
+        }
+        HostCommand::Enable { alias } => {
+            set_host_enabled(config_path, cfg, client, &alias, true).await
+        }
+        HostCommand::Disable { alias } => {
+            set_host_enabled(config_path, cfg, client, &alias, false).await
+        }
+        HostCommand::Doctor {
+            alias,
+            timeout_secs,
+        } => doctor(cfg, &alias, Duration::from_secs(timeout_secs)).await,
+    }
+}
+
+pub(crate) async fn run_fleet(
+    args: FleetArgs,
+    client: &Client,
+    cfg: &Config,
+    _config_path: Option<&Path>,
+) -> Result<()> {
+    match args.command {
+        FleetCommand::Status { selector, json } => {
+            let selector = parse_selector(selector.as_deref())?;
+            let snapshot = client
+                .fleet_snapshot(selector.as_deref())
+                .await
+                .context("reading fleet state from muxad")?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&snapshot)?);
+            } else {
+                print_hosts(&snapshot.hosts);
+            }
+            Ok(())
+        }
+        FleetCommand::Watch { selector } => {
+            let selector = parse_selector(selector.as_deref())?;
+            crate::fleet_watch::run(client.clone(), cfg, selector).await
+        }
+        FleetCommand::Connect { host } => {
+            execute_simple(client, &host, FleetOperation::Connect).await
+        }
+        FleetCommand::Disconnect { host } => {
+            execute_simple(client, &host, FleetOperation::Disconnect).await
+        }
+        FleetCommand::Refresh { host } => {
+            execute_simple(client, &host, FleetOperation::Refresh).await
+        }
+        FleetCommand::Panes { host, json } => {
+            let records = pane_records(client, &host).await?;
+            if json {
+                let records = records
+                    .into_iter()
+                    .map(|(pane, key, display)| {
+                        serde_json::json!({
+                            "display": display,
+                            "key": key,
+                            "command": pane.current_command,
+                            "cwd": pane.current_path,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                println!("{}", serde_json::to_string_pretty(&records)?);
+            } else {
+                let mut table = Table::new();
+                table.load_preset(UTF8_BORDERS_ONLY);
+                table.set_header(["PANE", "PATH", "BACKEND", "ENDPOINT", "COMMAND"]);
+                for (pane, key, display) in records {
+                    table.add_row([
+                        Cell::new(sanitize_terminal_text(&pane.pane_id)),
+                        Cell::new(sanitize_terminal_text(&display)),
+                        Cell::new(key.window.session.endpoint.host),
+                        Cell::new(sanitize_terminal_text(&key.window.session.endpoint.socket)),
+                        Cell::new(sanitize_terminal_text(&pane.current_command)),
+                    ]);
+                }
+                println!("{table}");
+                println!(
+                    "Use --json and pass an exact `key` object as PANE when a display path is ambiguous."
+                );
+            }
+            Ok(())
+        }
+        FleetCommand::Capture { host, pane } => {
+            let target = resolve_pane(client, &host, &pane).await?;
+            let result = client
+                .fleet_execute(&host, &FleetOperation::Capture { pane: target })
+                .await?;
+            if let Some(capture) = result.capture {
+                print!("{capture}");
+                io::stdout().flush()?;
+            }
+            Ok(())
+        }
+        FleetCommand::Send {
+            host,
+            pane,
+            text,
+            submit,
+        } => {
+            let target = resolve_pane(client, &host, &pane).await?;
+            let result = client
+                .fleet_execute(
+                    &host,
+                    &FleetOperation::SendPrompt {
+                        pane: target,
+                        text,
+                        submit,
+                    },
+                )
+                .await?;
+            if let Some(send) = result.send {
+                println!("sent={} submitted={}", send.sent, send.submitted);
+            }
+            Ok(())
+        }
+        FleetCommand::Attach { host, pane } => attach(client, cfg, &host, &pane).await,
+    }
+}
+
+async fn execute_simple(client: &Client, host: &str, operation: FleetOperation) -> Result<()> {
+    let result = client.fleet_execute(host, &operation).await?;
+    println!("{}", result.message.unwrap_or_else(|| "accepted".into()));
+    Ok(())
+}
+
+pub(crate) async fn resolve_pane(client: &Client, host: &str, query: &str) -> Result<PaneKey> {
+    let records = pane_records(client, host).await?;
+    if query.trim_start().starts_with('{') {
+        let exact: PaneKey = serde_json::from_str(query).context("decoding exact PaneKey JSON")?;
+        return records
+            .iter()
+            .any(|(_, key, _)| key == &exact)
+            .then_some(exact)
+            .with_context(|| format!("exact pane key is stale or absent on host '{host}'"));
+    }
+    let mut matches = records
+        .into_iter()
+        .filter_map(|(pane, key, display)| {
+            (pane.pane_id == query || display == query).then_some(key)
+        })
+        .collect::<Vec<_>>();
+    match matches.len() {
+        0 => bail!("pane '{query}' was not found on host '{host}'"),
+        1 => Ok(matches.remove(0)),
+        count => bail!(
+            "pane '{query}' is ambiguous across {count} backend endpoints on host '{host}'; run `muxa fleet panes {host} --json` and pass an exact key object",
+        ),
+    }
+}
+
+async fn pane_records(
+    client: &Client,
+    host: &str,
+) -> Result<Vec<(muxa::tmux::PaneInfo, PaneKey, String)>> {
+    let snapshot = client.fleet_snapshot(None).await?;
+    let host_snapshot = snapshot
+        .hosts
+        .into_iter()
+        .find(|candidate| candidate.alias == host)
+        .with_context(|| format!("fleet host '{host}' is not known"))?;
+    let remote = host_snapshot
+        .remote
+        .with_context(|| format!("fleet host '{}' has no snapshot", host_snapshot.alias))?;
+    let fallback_kind = remote.backends.first().map(|backend| backend.kind);
+    Ok(remote
+        .panes
+        .into_iter()
+        .filter_map(|pane| {
+            let kind = muxa::backend::pane_id_host_kind(&pane.pane_id).or(fallback_kind)?;
+            let key = PaneKey::from_pane(kind, &pane);
+            let display = format!(
+                "{}/{}/{}",
+                pane.session,
+                if pane.window_name.is_empty() {
+                    &pane.window_index
+                } else {
+                    &pane.window_name
+                },
+                pane.pane_id
+            );
+            Some((pane, key, display))
+        })
+        .collect())
+}
+
+async fn attach(client: &Client, cfg: &Config, host: &str, pane: &str) -> Result<()> {
+    let key = resolve_pane(client, host, pane).await?;
+    let snapshot = client.fleet_snapshot(None).await?;
+    let live = snapshot
+        .hosts
+        .into_iter()
+        .find(|candidate| candidate.alias == host)
+        .context("host disappeared from fleet snapshot")?;
+    let node_id = live
+        .node_id
+        .context("host has not completed its relay handshake")?;
+    let target = GlobalPaneRef {
+        node_id,
+        pane: key,
+        agent_session_id: None,
+    };
+    attach_exact(cfg, host, &target)
+}
+
+pub(crate) fn attach_exact(cfg: &Config, host: &str, target: &GlobalPaneRef) -> Result<()> {
+    let token = crate::relay::encode_attach_token(target)?;
+    let configured = cfg
+        .fleet
+        .hosts
+        .get(host)
+        .with_context(|| format!("host '{host}' is not configured locally"))?;
+    let mut command = std::process::Command::new("ssh");
+    command.args([
+        "-t",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ClearAllForwardings=yes",
+        "--",
+        &configured.ssh,
+        &configured.muxa_path,
+    ]);
+    if let Some(socket) = &configured.remote_socket {
+        command.arg("--socket").arg(socket);
+    }
+    let status = command.args(["fleet-remote-attach", &token]).status()?;
+    if !status.success() {
+        bail!("remote attach exited with {status}");
+    }
+    Ok(())
+}
+
+async fn doctor(cfg: &Config, alias: &str, timeout: Duration) -> Result<()> {
+    let host = cfg
+        .fleet
+        .hosts
+        .get(alias)
+        .with_context(|| format!("host '{alias}' is not configured"))?;
+    println!("1/4 inventory       ok ({})", host.ssh);
+    let mut command = Command::new("ssh");
+    command
+        .kill_on_drop(true)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .args([
+            "-T",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ClearAllForwardings=yes",
+            "--",
+            &host.ssh,
+            &host.muxa_path,
+        ]);
+    if let Some(socket) = &host.remote_socket {
+        command.arg("--socket").arg(socket);
+    }
+    command.args(["relay", "--stdio"]);
+    let mut child = command.spawn().context("starting OpenSSH")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("OpenSSH stdout is unavailable")?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .context("OpenSSH stderr is unavailable")?;
+    let stderr_task = tokio::spawn(async move {
+        let bytes = drain_bounded(&mut stderr, FLEET_MAX_DIAGNOSTIC_BYTES)
+            .await
+            .unwrap_or_default();
+        sanitize_terminal_text(String::from_utf8_lossy(&bytes).trim())
+    });
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    let read = tokio::time::timeout(
+        timeout,
+        read_bounded_line(&mut reader, &mut line, FLEET_MAX_FRAME_BYTES),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("SSH/relay handshake timed out after {timeout:?}"))??;
+    if read == 0 {
+        let _ = child.wait().await;
+        let error = stderr_task.await.unwrap_or_default();
+        bail!("SSH relay exited before hello: {error}");
+    }
+    let frame: RelayFrame = serde_json::from_str(line.trim()).context("decoding relay hello")?;
+    let RelayFrame::Hello { hello } = frame else {
+        bail!("remote did not send a relay hello frame");
+    };
+    println!("2/4 ssh + host key  ok");
+    println!(
+        "3/4 remote muxad    ok (muxa {})",
+        sanitize_terminal_text(&hello.muxa_version)
+    );
+    if hello.min_fleet_protocol > FLEET_PROTOCOL_VERSION
+        || hello.fleet_protocol < FLEET_PROTOCOL_VERSION
+    {
+        bail!(
+            "fleet protocol mismatch: local={FLEET_PROTOCOL_VERSION}, remote=[{},{}]",
+            hello.min_fleet_protocol,
+            hello.fleet_protocol
+        );
+    }
+    println!(
+        "4/4 fleet protocol ok (node {} · {} · {}/{})",
+        hello.node_id,
+        sanitize_terminal_text(&hello.hostname),
+        sanitize_terminal_text(&hello.os),
+        sanitize_terminal_text(&hello.arch)
+    );
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+    let _ = stderr_task.await;
+    Ok(())
+}
+
+fn parse_selector(selector: Option<&str>) -> Result<Option<String>> {
+    selector
+        .map(|selector| {
+            selector
+                .parse::<LabelSelector>()
+                .map_err(anyhow::Error::msg)?;
+            Ok(selector.to_string())
+        })
+        .transpose()
+}
+
+fn inventory_with_live(
+    cfg: &Config,
+    live: Option<&muxa::FleetSnapshot>,
+    selector: Option<&str>,
+) -> Result<Vec<FleetHostSnapshot>> {
+    let selector = selector
+        .map(str::parse::<LabelSelector>)
+        .transpose()
+        .map_err(anyhow::Error::msg)?;
+    Ok(cfg
+        .fleet
+        .hosts
+        .iter()
+        .filter(|(_, host)| {
+            selector
+                .as_ref()
+                .is_none_or(|selector| selector.matches(&host.labels))
+        })
+        .map(|(alias, host)| {
+            live.and_then(|snapshot| snapshot.hosts.iter().find(|item| item.alias == *alias))
+                .cloned()
+                .unwrap_or_else(|| FleetHostSnapshot {
+                    alias: alias.clone(),
+                    ssh_target: host.ssh.clone(),
+                    labels: host.labels.clone(),
+                    annotations: host.annotations.clone(),
+                    mode: host.mode,
+                    state: if host.enabled {
+                        FleetHostState::Offline
+                    } else {
+                        FleetHostState::Disabled
+                    },
+                    node_id: None,
+                    hostname: None,
+                    os: None,
+                    arch: None,
+                    muxa_version: None,
+                    protocol: None,
+                    capabilities: Vec::new(),
+                    daemon_generation: None,
+                    boot_id: None,
+                    latency_ms: None,
+                    last_seen_at: None,
+                    received_at: None,
+                    error: Some("muxad has not loaded this inventory entry".into()),
+                    remote: None,
+                })
+        })
+        .collect())
+}
+
+fn print_hosts(hosts: &[FleetHostSnapshot]) {
+    let mut table = Table::new();
+    table.load_preset(UTF8_BORDERS_ONLY);
+    table.set_header([
+        "HOST",
+        "STATE",
+        "MODE",
+        "LABELS",
+        "AGENTS",
+        "ATTN",
+        "LAST/ERROR",
+    ]);
+    for host in hosts {
+        let last = host.error.clone().unwrap_or_else(|| {
+            host.received_at.map_or_else(
+                || "-".into(),
+                |time| format!("{}", time.replace_nanosecond(0).unwrap_or(time)),
+            )
+        });
+        table.add_row([
+            Cell::new(&host.alias),
+            Cell::new(format!("{:?}", host.state).to_lowercase()),
+            Cell::new(format!("{:?}", host.mode).to_lowercase()),
+            Cell::new(format_map(&host.labels)),
+            Cell::new(host.agent_count()),
+            Cell::new(host.needs_attention()),
+            Cell::new(sanitize_terminal_text(&last)),
+        ]);
+    }
+    println!("{table}");
+}
+
+fn format_map(values: &BTreeMap<String, String>) -> String {
+    if values.is_empty() {
+        "-".into()
+    } else {
+        values
+            .iter()
+            .map(|(key, value)| {
+                format!(
+                    "{}={}",
+                    sanitize_terminal_text(key),
+                    sanitize_terminal_text(value)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+fn parse_pairs(values: &[String], annotation: bool) -> Result<BTreeMap<String, String>> {
+    values
+        .iter()
+        .map(|value| {
+            let (key, value) = value
+                .split_once('=')
+                .with_context(|| format!("metadata '{value}' must be KEY=VALUE"))?;
+            validate_label_key(key).map_err(anyhow::Error::msg)?;
+            if !annotation {
+                validate_label_value(value).map_err(anyhow::Error::msg)?;
+            }
+            Ok((key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)] // keeps the shared atomic edit path explicit at both call sites
+async fn edit_metadata(
+    config_path: Option<&Path>,
+    cfg: &Config,
+    client: &Client,
+    alias: &str,
+    field: &str,
+    changes: &[String],
+    overwrite: bool,
+    annotation: bool,
+) -> Result<()> {
+    let path = config_path.context("no config directory is available on this system")?;
+    let current = cfg
+        .fleet
+        .hosts
+        .get(alias)
+        .with_context(|| format!("host '{alias}' is not configured"))?;
+    if changes.is_empty() {
+        let values = if annotation {
+            &current.annotations
+        } else {
+            &current.labels
+        };
+        println!("{}", format_map(values));
+        return Ok(());
+    }
+    edit_config(path, |document| {
+        let table = metadata_table_mut(document, alias, field)?;
+        for change in changes {
+            if let Some(key) = change.strip_suffix('-').filter(|key| !key.contains('=')) {
+                validate_label_key(key).map_err(anyhow::Error::msg)?;
+                table.remove(key);
+                continue;
+            }
+            let (key, value) = change
+                .split_once('=')
+                .with_context(|| format!("metadata '{change}' must be KEY=VALUE or KEY-"))?;
+            validate_label_key(key).map_err(anyhow::Error::msg)?;
+            if !annotation {
+                validate_label_value(value).map_err(anyhow::Error::msg)?;
+            }
+            if table.contains_key(key) && !overwrite {
+                bail!("{field} key '{key}' already exists; pass --overwrite to replace it");
+            }
+            table.insert(key, toml_edit::value(value));
+        }
+        Ok(())
+    })?;
+    println!("updated {field} for host {alias}");
+    request_reload(client).await;
+    Ok(())
+}
+
+async fn set_host_enabled(
+    config_path: Option<&Path>,
+    cfg: &Config,
+    client: &Client,
+    alias: &str,
+    enabled: bool,
+) -> Result<()> {
+    let path = config_path.context("no config directory is available on this system")?;
+    if !cfg.fleet.hosts.contains_key(alias) {
+        bail!("host '{alias}' is not configured");
+    }
+    edit_config(path, |document| {
+        host_table_mut(document, alias)?.insert("enabled", toml_edit::value(enabled));
+        Ok(())
+    })?;
+    println!(
+        "{} host {alias}",
+        if enabled { "enabled" } else { "disabled" }
+    );
+    request_reload(client).await;
+    Ok(())
+}
+
+fn load_document(path: &Path) -> Result<toml_edit::DocumentMut> {
+    match std::fs::read_to_string(path) {
+        Ok(text) if !text.trim().is_empty() => text
+            .parse::<toml_edit::DocumentMut>()
+            .with_context(|| format!("parsing {}", path.display())),
+        Ok(_) => Ok(toml_edit::DocumentMut::new()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(toml_edit::DocumentMut::new()),
+        Err(error) => Err(error).with_context(|| format!("reading {}", path.display())),
+    }
+}
+
+fn edit_config(
+    path: &Path,
+    edit: impl FnOnce(&mut toml_edit::DocumentMut) -> Result<()>,
+) -> Result<()> {
+    let mut document = load_document(path)?;
+    edit(&mut document)?;
+    let text = document.to_string();
+    let parsed: Config = toml::from_str(&text).context("validating updated muxa config")?;
+    parsed
+        .validate()
+        .context("validating updated muxa config")?;
+    write_document(path, &text)
+}
+
+fn write_document(path: &Path, text: &str) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty());
+    if let Some(parent) = parent {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("config.toml");
+    let temporary = path.with_file_name(format!(".{file_name}.muxa-{}.tmp", std::process::id()));
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&temporary)
+        .with_context(|| format!("creating {}", temporary.display()))?;
+    if let Err(error) = (|| -> Result<()> {
+        file.write_all(text.as_bytes())?;
+        file.sync_all()?;
+        std::fs::rename(&temporary, path)?;
+        Ok(())
+    })() {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(error).with_context(|| format!("writing {}", path.display()));
+    }
+    Ok(())
+}
+
+fn fleet_hosts_table_mut(document: &mut toml_edit::DocumentMut) -> Result<&mut toml_edit::Table> {
+    if document.get("fleet").is_none() {
+        document["fleet"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    let fleet = document["fleet"]
+        .as_table_mut()
+        .context("[fleet] is not a table")?;
+    fleet.insert("enabled", toml_edit::value(true));
+    if fleet.get("hosts").is_none() {
+        fleet["hosts"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    fleet["hosts"]
+        .as_table_mut()
+        .context("[fleet.hosts] is not a table")
+}
+
+fn host_table_mut<'a>(
+    document: &'a mut toml_edit::DocumentMut,
+    alias: &str,
+) -> Result<&'a mut toml_edit::Table> {
+    fleet_hosts_table_mut(document)?
+        .get_mut(alias)
+        .and_then(toml_edit::Item::as_table_mut)
+        .with_context(|| format!("[fleet.hosts.{alias}] is missing or is not a table"))
+}
+
+fn metadata_table_mut<'a>(
+    document: &'a mut toml_edit::DocumentMut,
+    alias: &str,
+    field: &str,
+) -> Result<&'a mut toml_edit::Table> {
+    let host = host_table_mut(document, alias)?;
+    if host.get(field).is_none() {
+        host[field] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    host[field]
+        .as_table_mut()
+        .with_context(|| format!("[fleet.hosts.{alias}.{field}] is not a table"))
+}
+
+fn upsert_host(
+    document: &mut toml_edit::DocumentMut,
+    alias: &str,
+    host: &FleetHostConfig,
+) -> Result<()> {
+    let mut table = toml_edit::Table::new();
+    table.insert("ssh", toml_edit::value(&host.ssh));
+    table.insert("muxa_path", toml_edit::value(&host.muxa_path));
+    table.insert("enabled", toml_edit::value(host.enabled));
+    table.insert(
+        "connect",
+        toml_edit::value(match host.connect {
+            FleetConnectPolicy::Auto => "auto",
+            FleetConnectPolicy::OnDemand => "on_demand",
+        }),
+    );
+    table.insert(
+        "mode",
+        toml_edit::value(match host.mode {
+            HostAccessMode::Observe => "observe",
+            HostAccessMode::Control => "control",
+        }),
+    );
+    if let Some(socket) = &host.remote_socket {
+        table.insert(
+            "remote_socket",
+            toml_edit::value(socket.to_string_lossy().as_ref()),
+        );
+    }
+    let mut labels = toml_edit::Table::new();
+    for (key, value) in &host.labels {
+        labels.insert(key, toml_edit::value(value));
+    }
+    table.insert("labels", toml_edit::Item::Table(labels));
+    let mut annotations = toml_edit::Table::new();
+    for (key, value) in &host.annotations {
+        annotations.insert(key, toml_edit::value(value));
+    }
+    table.insert("annotations", toml_edit::Item::Table(annotations));
+    fleet_hosts_table_mut(document)?.insert(alias, toml_edit::Item::Table(table));
+    Ok(())
+}
+
+fn remove_host(document: &mut toml_edit::DocumentMut, alias: &str) -> Result<()> {
+    fleet_hosts_table_mut(document)?.remove(alias);
+    Ok(())
+}
+
+async fn request_reload(client: &Client) {
+    match client.restart(Duration::from_secs(2)).await {
+        Ok(()) => println!("requested muxad reload"),
+        Err(error) => eprintln!(
+            "warning: config was saved but muxad could not reload itself ({error}); restart muxad manually"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn inventory_editor_preserves_unrelated_config_and_validates_labels() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "[watch]\nspinner = false\n").unwrap();
+        let host = FleetHostConfig {
+            ssh: "devbox".into(),
+            mode: HostAccessMode::Control,
+            labels: BTreeMap::from([("environment".into(), "dev".into())]),
+            ..FleetHostConfig::default()
+        };
+        edit_config(&path, |document| upsert_host(document, "dev", &host)).unwrap();
+        let updated = Config::load(&path).unwrap();
+        assert!(!updated.watch.spinner);
+        assert!(updated.fleet.enabled);
+        assert_eq!(updated.fleet.hosts["dev"].labels["environment"], "dev");
+    }
+
+    #[test]
+    fn pair_parser_accepts_annotation_urls_but_not_label_urls() {
+        assert!(parse_pairs(&["docs=https://example.com/a".into()], true).is_ok());
+        assert!(parse_pairs(&["docs=https://example.com/a".into()], false).is_err());
+    }
+}

--- a/crates/muxa-cli/src/fleet_watch.rs
+++ b/crates/muxa-cli/src/fleet_watch.rs
@@ -1,0 +1,1781 @@
+//! Central host → session → window → pane(agent) Fleet TUI.
+
+use std::collections::{HashMap, HashSet};
+use std::io::{self, Stdout};
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use crossterm::event::{
+    self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+    Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
+};
+use crossterm::execute;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use muxa::fleet::{
+    FleetCommandResult, FleetHostSnapshot, FleetHostState, FleetOperation, FleetSnapshot,
+    FleetWindowCapture, GlobalPaneRef,
+};
+use muxa::ipc::Client;
+use muxa::{
+    AgentState, Config, HostKind, PaneKey, PaneNode, SessionKey, SessionNode, StateDistribution,
+    TopologyInput, TopologySnapshot, WindowKey, WindowNode,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{
+    Block, BorderType, Borders, Cell, Clear, Paragraph, Row, Table, TableState, Wrap,
+};
+use ratatui::{Frame, Terminal};
+use time::OffsetDateTime;
+use tokio::sync::mpsc;
+
+const REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+const WINDOW_CAPTURE_INTERVAL: Duration = Duration::from_secs(2);
+const INPUT_POLL: Duration = Duration::from_millis(50);
+
+type FleetTerminal = Terminal<CrosstermBackend<Stdout>>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum NodeKey {
+    Host(String),
+    Session { host: String, key: SessionKey },
+    Window { host: String, key: WindowKey },
+    Pane { host: String, key: PaneKey },
+}
+
+impl NodeKey {
+    fn host(&self) -> &str {
+        match self {
+            Self::Host(host)
+            | Self::Session { host, .. }
+            | Self::Window { host, .. }
+            | Self::Pane { host, .. } => host,
+        }
+    }
+
+    fn parent(&self) -> Option<Self> {
+        match self {
+            Self::Host(_) => None,
+            Self::Session { host, .. } => Some(Self::Host(host.clone())),
+            Self::Window { host, key } => Some(Self::Session {
+                host: host.clone(),
+                key: key.session.clone(),
+            }),
+            Self::Pane { host, key } => Some(Self::Window {
+                host: host.clone(),
+                key: key.window.clone(),
+            }),
+        }
+    }
+
+    fn ancestors(&self) -> Vec<Self> {
+        let mut ancestors = Vec::new();
+        let mut current = self.parent();
+        while let Some(parent) = current {
+            current = parent.parent();
+            ancestors.push(parent);
+        }
+        ancestors
+    }
+
+    fn is_parent(&self) -> bool {
+        !matches!(self, Self::Pane { .. })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TreeRow {
+    key: NodeKey,
+    depth: usize,
+    label: String,
+    detail: String,
+    state: Option<AgentState>,
+    attention: usize,
+    children: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InputMode {
+    Normal,
+    Search,
+    Message,
+}
+
+struct App {
+    snapshot: FleetSnapshot,
+    topologies: HashMap<String, TopologySnapshot>,
+    topology_versions: HashMap<String, (Option<muxa::NodeId>, u64, OffsetDateTime)>,
+    rows: Vec<TreeRow>,
+    selected: usize,
+    expanded: HashSet<NodeKey>,
+    query: String,
+    attention_only: bool,
+    mode: InputMode,
+    composer: String,
+    popup: Option<String>,
+    help: bool,
+    status: Option<(String, Instant)>,
+    selector: Option<String>,
+    window_capture: Option<(String, FleetWindowCapture)>,
+    window_capture_pending: bool,
+    last_window_capture: Option<Instant>,
+}
+
+impl App {
+    fn new(selector: Option<String>) -> Self {
+        Self {
+            snapshot: FleetSnapshot {
+                generated_at: OffsetDateTime::now_utc(),
+                hosts: Vec::new(),
+            },
+            topologies: HashMap::new(),
+            topology_versions: HashMap::new(),
+            rows: Vec::new(),
+            selected: 0,
+            expanded: HashSet::new(),
+            query: String::new(),
+            attention_only: false,
+            mode: InputMode::Normal,
+            composer: String::new(),
+            popup: None,
+            help: false,
+            status: None,
+            selector,
+            window_capture: None,
+            window_capture_pending: false,
+            last_window_capture: None,
+        }
+    }
+
+    fn apply_snapshot(&mut self, mut snapshot: FleetSnapshot) {
+        let selected = self.selected_key().cloned();
+        snapshot.hosts.sort_by(|left, right| {
+            right
+                .needs_attention()
+                .cmp(&left.needs_attention())
+                .then_with(|| left.alias.cmp(&right.alias))
+        });
+        let mut topologies = HashMap::new();
+        let mut versions = HashMap::new();
+        for host in &snapshot.hosts {
+            let Some(remote) = &host.remote else {
+                continue;
+            };
+            let version = (host.node_id.clone(), remote.revision, remote.observed_at);
+            let topology = if self.topology_versions.get(&host.alias) == Some(&version) {
+                self.topologies.remove(&host.alias)
+            } else {
+                host_topology(host)
+            };
+            if let Some(topology) = topology {
+                topologies.insert(host.alias.clone(), topology);
+                versions.insert(host.alias.clone(), version);
+            }
+        }
+        self.topologies = topologies;
+        self.topology_versions = versions;
+        self.snapshot = snapshot;
+        if self.expanded.is_empty() {
+            if let Some(host) = self.snapshot.hosts.first() {
+                self.expanded.insert(NodeKey::Host(host.alias.clone()));
+            }
+        }
+        self.rebuild_rows(selected.as_ref());
+    }
+
+    fn selected_key(&self) -> Option<&NodeKey> {
+        self.rows.get(self.selected).map(|row| &row.key)
+    }
+
+    fn selected_host(&self) -> Option<&FleetHostSnapshot> {
+        let alias = self.selected_key()?.host();
+        self.snapshot.hosts.iter().find(|host| host.alias == alias)
+    }
+
+    fn selected_pane(&self) -> Option<(String, PaneKey)> {
+        match self.selected_key()? {
+            NodeKey::Pane { host, key } => Some((host.clone(), key.clone())),
+            _ => None,
+        }
+    }
+
+    fn selected_window(&self) -> Option<(String, WindowKey)> {
+        match self.selected_key()? {
+            NodeKey::Window { host, key } => Some((host.clone(), key.clone())),
+            _ => None,
+        }
+    }
+
+    fn rebuild_rows(&mut self, preserve: Option<&NodeKey>) {
+        self.rows = build_rows(
+            &self.snapshot,
+            &self.topologies,
+            &self.expanded,
+            &self.query,
+            self.attention_only,
+        );
+        if let Some(key) = preserve {
+            if let Some(index) = self.rows.iter().position(|row| &row.key == key) {
+                self.selected = index;
+                return;
+            }
+        }
+        self.selected = self.selected.min(self.rows.len().saturating_sub(1));
+    }
+
+    fn focus_key(&mut self, key: NodeKey) {
+        self.expanded.clear();
+        for ancestor in key.ancestors() {
+            self.expanded.insert(ancestor);
+        }
+        if key.is_parent() {
+            self.expanded.insert(key.clone());
+        }
+        self.rebuild_rows(Some(&key));
+    }
+
+    fn move_row(&mut self, delta: isize) {
+        if self.rows.is_empty() {
+            return;
+        }
+        self.selected = self
+            .selected
+            .saturating_add_signed(delta)
+            .min(self.rows.len() - 1);
+        if let Some(key) = self.selected_key().cloned() {
+            self.focus_key(key);
+        }
+    }
+
+    /// Vim `j/k` jumps between actionable agent panes. Arrow keys retain
+    /// access to every host/session/window inspector, so a single-child tree
+    /// does not force the common path through four structural rows.
+    fn move_pane(&mut self, delta: isize) {
+        let panes = all_pane_keys(
+            &self.snapshot,
+            &self.topologies,
+            &self.query,
+            self.attention_only,
+        );
+        if panes.is_empty() {
+            self.move_row(delta);
+            return;
+        }
+        let current = self.selected_key();
+        let index = current
+            .and_then(|key| panes.iter().position(|pane| pane == key))
+            .or_else(|| {
+                current.and_then(|key| {
+                    let host = key.host();
+                    panes.iter().position(|pane| pane.host() == host)
+                })
+            });
+        let next = match (index, delta.is_negative()) {
+            (Some(index), false) => (index + 1).min(panes.len() - 1),
+            (Some(index), true) => index.saturating_sub(1),
+            (None, false) => 0,
+            (None, true) => panes.len() - 1,
+        };
+        self.focus_key(panes[next].clone());
+    }
+
+    fn toggle_selected(&mut self) {
+        let Some(key) = self.selected_key().cloned() else {
+            return;
+        };
+        if !key.is_parent() {
+            return;
+        }
+        if !self.expanded.remove(&key) {
+            self.expanded.insert(key.clone());
+        }
+        self.rebuild_rows(Some(&key));
+    }
+
+    fn collapse_or_parent(&mut self) {
+        let Some(key) = self.selected_key().cloned() else {
+            return;
+        };
+        if self.expanded.remove(&key) {
+            self.rebuild_rows(Some(&key));
+        } else if let Some(parent) = key.parent() {
+            self.focus_key(parent);
+        }
+    }
+
+    fn expand_or_child(&mut self) {
+        let Some(key) = self.selected_key().cloned() else {
+            return;
+        };
+        self.expanded.insert(key.clone());
+        self.rebuild_rows(Some(&key));
+        if let Some(index) = self
+            .rows
+            .iter()
+            .enumerate()
+            .skip(self.selected + 1)
+            .find_map(|(index, row)| (row.key.parent().as_ref() == Some(&key)).then_some(index))
+        {
+            self.selected = index;
+        }
+    }
+
+    fn status(&mut self, message: impl Into<String>) {
+        self.status = Some((message.into(), Instant::now()));
+    }
+
+    fn active_status(&self) -> Option<&str> {
+        self.status
+            .as_ref()
+            .filter(|(_, at)| at.elapsed() < Duration::from_secs(4))
+            .map(|(message, _)| message.as_str())
+    }
+}
+
+enum BackgroundResult {
+    Window {
+        host: String,
+        window: WindowKey,
+        result: std::result::Result<FleetCommandResult, String>,
+    },
+    PaneCapture(std::result::Result<FleetCommandResult, String>),
+    Command(std::result::Result<FleetCommandResult, String>),
+}
+
+pub(crate) async fn run(client: Client, cfg: &Config, selector: Option<String>) -> Result<()> {
+    let mut terminal = TerminalSession::enter()?;
+    let mut app = App::new(selector);
+    let (background_tx, mut background_rx) = mpsc::unbounded_channel();
+    let now = Instant::now();
+    let mut last_refresh = now.checked_sub(REFRESH_INTERVAL).unwrap_or(now);
+    let mut quit = false;
+
+    while !quit {
+        if last_refresh.elapsed() >= REFRESH_INTERVAL {
+            match client.fleet_snapshot(app.selector.as_deref()).await {
+                Ok(snapshot) => app.apply_snapshot(snapshot),
+                Err(error) => app.status(format!("fleet refresh failed: {error}")),
+            }
+            last_refresh = Instant::now();
+        }
+
+        while let Ok(result) = background_rx.try_recv() {
+            match result {
+                BackgroundResult::Window {
+                    host,
+                    window,
+                    result,
+                } => {
+                    app.window_capture_pending = false;
+                    app.last_window_capture = Some(Instant::now());
+                    match result {
+                        Ok(result) => {
+                            if let Some(capture) = result.window_capture {
+                                if capture.window == window {
+                                    app.window_capture = Some((host, capture));
+                                }
+                            }
+                        }
+                        Err(error) => app.status(format!("window capture: {error}")),
+                    }
+                }
+                BackgroundResult::PaneCapture(result) => match result {
+                    Ok(result) => {
+                        app.popup = Some(result.capture.map_or_else(
+                            || "(no capture available)".into(),
+                            |capture| safe_text(&capture),
+                        ));
+                    }
+                    Err(error) => app.status(format!("pane capture: {error}")),
+                },
+                BackgroundResult::Command(result) => match result {
+                    Ok(result) => app.status(
+                        result
+                            .message
+                            .unwrap_or_else(|| "remote command completed".into()),
+                    ),
+                    Err(error) => app.status(error),
+                },
+            }
+        }
+
+        maybe_capture_window(&client, &mut app, &background_tx);
+        terminal.terminal.draw(|frame| render(frame, &app))?;
+
+        if event::poll(INPUT_POLL)? {
+            match event::read()? {
+                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    quit = handle_key(key, &client, cfg, &mut terminal, &mut app, &background_tx)?;
+                }
+                Event::Paste(text) => match app.mode {
+                    InputMode::Search => {
+                        app.query.push_str(&safe_text(&text).replace('\n', " "));
+                        app.rebuild_rows(None);
+                    }
+                    InputMode::Message => app.composer.push_str(&text),
+                    InputMode::Normal => {}
+                },
+                Event::Resize(_, _)
+                | Event::Mouse(_)
+                | Event::FocusGained
+                | Event::FocusLost
+                | Event::Key(_) => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_lines)] // one keymap is easier to audit than scattered state handlers
+fn handle_key(
+    key: KeyEvent,
+    client: &Client,
+    cfg: &Config,
+    terminal: &mut TerminalSession,
+    app: &mut App,
+    background: &mpsc::UnboundedSender<BackgroundResult>,
+) -> Result<bool> {
+    match app.mode {
+        InputMode::Search => {
+            match key.code {
+                KeyCode::Esc => {
+                    app.query.clear();
+                    app.mode = InputMode::Normal;
+                    app.rebuild_rows(None);
+                }
+                KeyCode::Enter => app.mode = InputMode::Normal,
+                KeyCode::Backspace => {
+                    app.query.pop();
+                    app.rebuild_rows(None);
+                }
+                KeyCode::Char(character) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    app.query.push(character);
+                    app.rebuild_rows(None);
+                }
+                _ => {}
+            }
+            return Ok(false);
+        }
+        InputMode::Message => {
+            match key.code {
+                KeyCode::Esc => {
+                    app.mode = InputMode::Normal;
+                    app.composer.clear();
+                }
+                KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                    app.composer.push('\n');
+                }
+                KeyCode::Enter => {
+                    let Some((host, pane)) = app.selected_pane() else {
+                        app.mode = InputMode::Normal;
+                        return Ok(false);
+                    };
+                    if app.composer.trim().is_empty() {
+                        app.status("message is empty");
+                        return Ok(false);
+                    }
+                    let text = std::mem::take(&mut app.composer);
+                    app.mode = InputMode::Normal;
+                    let client = client.clone();
+                    let sender = background.clone();
+                    tokio::spawn(async move {
+                        let result = client
+                            .fleet_execute(
+                                &host,
+                                &FleetOperation::SendPrompt {
+                                    pane,
+                                    text,
+                                    submit: true,
+                                },
+                            )
+                            .await
+                            .map_err(|error| error.to_string());
+                        let _ = sender.send(BackgroundResult::Command(result));
+                    });
+                    app.status("sending prompt…");
+                }
+                KeyCode::Backspace => {
+                    app.composer.pop();
+                }
+                KeyCode::Char(character) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    app.composer.push(character);
+                }
+                _ => {}
+            }
+            return Ok(false);
+        }
+        InputMode::Normal => {}
+    }
+
+    if app.popup.is_some() {
+        if matches!(key.code, KeyCode::Esc | KeyCode::Char('q') | KeyCode::Enter) {
+            app.popup = None;
+        }
+        return Ok(false);
+    }
+    if app.help {
+        if matches!(key.code, KeyCode::Esc | KeyCode::Char('?' | 'q')) {
+            app.help = false;
+        }
+        return Ok(false);
+    }
+
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => return Ok(true),
+        KeyCode::Down => app.move_row(1),
+        KeyCode::Up => app.move_row(-1),
+        KeyCode::Char('j') => app.move_pane(1),
+        KeyCode::Char('k') => app.move_pane(-1),
+        KeyCode::Home | KeyCode::Char('g') => {
+            if let Some(first) = app.rows.first().map(|row| row.key.clone()) {
+                app.focus_key(first);
+            }
+        }
+        KeyCode::End | KeyCode::Char('G') => {
+            if let Some(last) = app.rows.last().map(|row| row.key.clone()) {
+                app.focus_key(last);
+            }
+        }
+        KeyCode::Left | KeyCode::Char('h') => app.collapse_or_parent(),
+        KeyCode::Right | KeyCode::Char('l') => app.expand_or_child(),
+        KeyCode::Char(' ') => app.toggle_selected(),
+        KeyCode::Char('/') => app.mode = InputMode::Search,
+        KeyCode::Char('a') => {
+            app.attention_only = !app.attention_only;
+            app.rebuild_rows(None);
+        }
+        KeyCode::Char('?') => app.help = true,
+        KeyCode::Char('r') => {
+            if let Some(host) = app.selected_key().map(|key| key.host().to_string()) {
+                spawn_command(client, background, host, FleetOperation::Refresh);
+                app.status("refresh requested…");
+            }
+        }
+        KeyCode::Char('c') => {
+            if let Some(host) = app.selected_host() {
+                let operation = if matches!(
+                    host.state,
+                    FleetHostState::Online | FleetHostState::Connecting | FleetHostState::Degraded
+                ) {
+                    FleetOperation::Disconnect
+                } else {
+                    FleetOperation::Connect
+                };
+                let alias = host.alias.clone();
+                spawn_command(client, background, alias, operation);
+                app.status("connection command requested…");
+            }
+        }
+        KeyCode::Char('p') => {
+            if let Some((host, pane)) = app.selected_pane() {
+                let client = client.clone();
+                let sender = background.clone();
+                tokio::spawn(async move {
+                    let result = client
+                        .fleet_execute(&host, &FleetOperation::Capture { pane })
+                        .await
+                        .map_err(|error| error.to_string());
+                    let _ = sender.send(BackgroundResult::PaneCapture(result));
+                });
+                app.status("capturing selected pane…");
+            }
+        }
+        KeyCode::Char('m') => {
+            if app.selected_pane().is_some() {
+                app.mode = InputMode::Message;
+                app.composer.clear();
+            } else {
+                app.status("select a pane before sending a prompt");
+            }
+        }
+        KeyCode::Enter => {
+            if let Some((host_alias, pane)) = app.selected_pane() {
+                let Some(host) = app
+                    .snapshot
+                    .hosts
+                    .iter()
+                    .find(|host| host.alias == host_alias)
+                else {
+                    return Ok(false);
+                };
+                let Some(node_id) = host.node_id.clone() else {
+                    app.status("host has not completed its relay handshake");
+                    return Ok(false);
+                };
+                let target = GlobalPaneRef {
+                    node_id,
+                    pane,
+                    agent_session_id: None,
+                };
+                terminal.suspend()?;
+                let result = crate::fleet_cli::attach_exact(cfg, &host_alias, &target);
+                terminal.resume()?;
+                if let Err(error) = result {
+                    app.status(format!("attach failed: {error}"));
+                }
+                app.window_capture = None;
+                app.last_window_capture = None;
+            } else {
+                app.toggle_selected();
+            }
+        }
+        _ => {}
+    }
+    Ok(false)
+}
+
+fn spawn_command(
+    client: &Client,
+    background: &mpsc::UnboundedSender<BackgroundResult>,
+    host: String,
+    operation: FleetOperation,
+) {
+    let client = client.clone();
+    let sender = background.clone();
+    tokio::spawn(async move {
+        let result = client
+            .fleet_execute(&host, &operation)
+            .await
+            .map_err(|error| error.to_string());
+        let _ = sender.send(BackgroundResult::Command(result));
+    });
+}
+
+fn maybe_capture_window(
+    client: &Client,
+    app: &mut App,
+    background: &mpsc::UnboundedSender<BackgroundResult>,
+) {
+    let Some((host, window)) = app.selected_window() else {
+        app.window_capture_pending = false;
+        return;
+    };
+    let same = app
+        .window_capture
+        .as_ref()
+        .is_some_and(|(capture_host, capture)| capture_host == &host && capture.window == window);
+    let due = !same
+        || app
+            .last_window_capture
+            .is_none_or(|last| last.elapsed() >= WINDOW_CAPTURE_INTERVAL);
+    if !due || app.window_capture_pending {
+        return;
+    }
+    app.window_capture_pending = true;
+    let client = client.clone();
+    let sender = background.clone();
+    let request_window = window.clone();
+    tokio::spawn(async move {
+        let result = client
+            .fleet_execute(
+                &host,
+                &FleetOperation::CaptureWindow {
+                    window: request_window.clone(),
+                },
+            )
+            .await
+            .map_err(|error| error.to_string());
+        let _ = sender.send(BackgroundResult::Window {
+            host,
+            window: request_window,
+            result,
+        });
+    });
+}
+
+fn host_topology(host: &FleetHostSnapshot) -> Option<TopologySnapshot> {
+    let remote = host.remote.as_ref()?;
+    let mut grouped = HashMap::<HostKind, Vec<muxa::tmux::PaneInfo>>::new();
+    for pane in &remote.panes {
+        let kind = muxa::backend::pane_id_host_kind(&pane.pane_id)
+            .or_else(|| {
+                remote
+                    .backends
+                    .iter()
+                    .find(|backend| {
+                        pane.socket.as_ref().is_none_or(|socket| {
+                            backend.kind != HostKind::Tmux || !socket.is_empty()
+                        })
+                    })
+                    .map(|backend| backend.kind)
+            })
+            .unwrap_or(HostKind::Tmux);
+        grouped.entry(kind).or_default().push(pane.clone());
+    }
+    let inputs = grouped
+        .into_iter()
+        .map(|(kind, panes)| TopologyInput::new(kind, panes))
+        .collect();
+    Some(TopologySnapshot::build(
+        remote.observed_at,
+        inputs,
+        remote.agents.clone(),
+    ))
+}
+
+#[allow(clippy::too_many_lines)] // hierarchy construction stays in one deterministic traversal
+fn build_rows(
+    snapshot: &FleetSnapshot,
+    topologies: &HashMap<String, TopologySnapshot>,
+    expanded: &HashSet<NodeKey>,
+    query: &str,
+    attention_only: bool,
+) -> Vec<TreeRow> {
+    let mut rows = Vec::new();
+    for host in &snapshot.hosts {
+        let topology = topologies.get(&host.alias);
+        if !host_relevant(host, topology, query, attention_only) {
+            continue;
+        }
+        let host_key = NodeKey::Host(host.alias.clone());
+        rows.push(TreeRow {
+            key: host_key.clone(),
+            depth: 0,
+            label: host.alias.clone(),
+            detail: format!(
+                "{} · {} sessions · {} panes · {} agents",
+                host_state_label(host.state),
+                topology.map_or(0, |topology| topology.sessions.len()),
+                host.pane_count(),
+                host.agent_count(),
+            ),
+            state: dominant_host_state(host),
+            attention: host.needs_attention(),
+            children: topology.map_or(0, |topology| topology.sessions.len()),
+        });
+        let show_host = expanded.contains(&host_key) || !query.is_empty() || attention_only;
+        if !show_host {
+            continue;
+        }
+        let Some(topology) = topology else {
+            continue;
+        };
+        for session in &topology.sessions {
+            if !session_relevant(session, query, attention_only) {
+                continue;
+            }
+            let session_key = NodeKey::Session {
+                host: host.alias.clone(),
+                key: session.key.clone(),
+            };
+            rows.push(TreeRow {
+                key: session_key.clone(),
+                depth: 1,
+                label: session.name.clone(),
+                detail: format!(
+                    "{} windows · {} panes",
+                    session.windows.len(),
+                    session.pane_count()
+                ),
+                state: dominant_distribution(&session.states),
+                attention: distribution_attention(&session.states),
+                children: session.windows.len(),
+            });
+            let show_session =
+                expanded.contains(&session_key) || !query.is_empty() || attention_only;
+            if !show_session {
+                continue;
+            }
+            for window in &session.windows {
+                if !window_relevant(window, query, attention_only) {
+                    continue;
+                }
+                let window_key = NodeKey::Window {
+                    host: host.alias.clone(),
+                    key: window.key.clone(),
+                };
+                rows.push(TreeRow {
+                    key: window_key.clone(),
+                    depth: 2,
+                    label: if window.name.is_empty() {
+                        format!("window {}", window.index)
+                    } else {
+                        window.name.clone()
+                    },
+                    detail: format!("{} panes", window.panes.len()),
+                    state: dominant_distribution(&window.states),
+                    attention: distribution_attention(&window.states),
+                    children: window.panes.len(),
+                });
+                let show_window =
+                    expanded.contains(&window_key) || !query.is_empty() || attention_only;
+                if !show_window {
+                    continue;
+                }
+                for pane in &window.panes {
+                    if !pane_relevant(pane, query, attention_only) {
+                        continue;
+                    }
+                    let (state, attention, detail) = pane.agent.as_ref().map_or_else(
+                        || (None, 0, pane.current_command.clone()),
+                        |agent| {
+                            (
+                                Some(agent.state),
+                                usize::from(needs_attention(agent.state)),
+                                format!(
+                                    "{} · {}",
+                                    agent.kind,
+                                    agent
+                                        .ai_title
+                                        .as_deref()
+                                        .or(agent.last_prompt.as_deref())
+                                        .unwrap_or(&agent.session_id)
+                                ),
+                            )
+                        },
+                    );
+                    rows.push(TreeRow {
+                        key: NodeKey::Pane {
+                            host: host.alias.clone(),
+                            key: pane.key.clone(),
+                        },
+                        depth: 3,
+                        label: format!("{} ({})", pane.key.pane_id, pane.index),
+                        detail,
+                        state,
+                        attention,
+                        children: 0,
+                    });
+                }
+            }
+        }
+    }
+    rows
+}
+
+fn all_pane_keys(
+    snapshot: &FleetSnapshot,
+    topologies: &HashMap<String, TopologySnapshot>,
+    query: &str,
+    attention_only: bool,
+) -> Vec<NodeKey> {
+    snapshot
+        .hosts
+        .iter()
+        .filter(|host| host_relevant(host, topologies.get(&host.alias), query, attention_only))
+        .flat_map(|host| {
+            topologies
+                .get(&host.alias)
+                .into_iter()
+                .flat_map(|topology| &topology.sessions)
+                .flat_map(|session| &session.windows)
+                .flat_map(|window| &window.panes)
+                .filter(|pane| pane_relevant(pane, query, attention_only))
+                .map(|pane| NodeKey::Pane {
+                    host: host.alias.clone(),
+                    key: pane.key.clone(),
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn host_relevant(
+    host: &FleetHostSnapshot,
+    topology: Option<&TopologySnapshot>,
+    query: &str,
+    attention_only: bool,
+) -> bool {
+    if attention_only && host.needs_attention() == 0 {
+        return false;
+    }
+    let query = query.to_lowercase();
+    query.is_empty()
+        || searchable(&host.alias, &query)
+        || host
+            .hostname
+            .as_deref()
+            .is_some_and(|value| searchable(value, &query))
+        || host
+            .labels
+            .iter()
+            .any(|(key, value)| searchable(key, &query) || searchable(value, &query))
+        || topology.is_some_and(|topology| {
+            topology
+                .sessions
+                .iter()
+                .any(|session| session_relevant(session, &query, false))
+        })
+}
+
+fn session_relevant(session: &SessionNode, query: &str, attention_only: bool) -> bool {
+    (!attention_only || distribution_attention(&session.states) > 0)
+        && (query.is_empty()
+            || searchable(&session.name, query)
+            || session
+                .windows
+                .iter()
+                .any(|window| window_relevant(window, query, false)))
+}
+
+fn window_relevant(window: &WindowNode, query: &str, attention_only: bool) -> bool {
+    (!attention_only || distribution_attention(&window.states) > 0)
+        && (query.is_empty()
+            || searchable(&window.name, query)
+            || window
+                .panes
+                .iter()
+                .any(|pane| pane_relevant(pane, query, false)))
+}
+
+fn pane_relevant(pane: &PaneNode, query: &str, attention_only: bool) -> bool {
+    let attention = pane
+        .agent
+        .as_ref()
+        .is_some_and(|agent| needs_attention(agent.state));
+    (!attention_only || attention)
+        && (query.is_empty()
+            || searchable(&pane.key.pane_id, query)
+            || searchable(&pane.title, query)
+            || searchable(&pane.cwd, query)
+            || pane.agent.as_ref().is_some_and(|agent| {
+                searchable(&agent.session_id, query)
+                    || agent
+                        .last_prompt
+                        .as_deref()
+                        .is_some_and(|value| searchable(value, query))
+                    || agent
+                        .ai_title
+                        .as_deref()
+                        .is_some_and(|value| searchable(value, query))
+            }))
+}
+
+fn searchable(value: &str, lowercase_query: &str) -> bool {
+    value.to_lowercase().contains(lowercase_query)
+}
+
+fn dominant_host_state(host: &FleetHostSnapshot) -> Option<AgentState> {
+    let mut distribution = StateDistribution::default();
+    if let Some(remote) = &host.remote {
+        for agent in &remote.agents {
+            match agent.state {
+                AgentState::Starting => distribution.starting += 1,
+                AgentState::Working => distribution.working += 1,
+                AgentState::Idle => distribution.idle += 1,
+                AgentState::WaitingInput => distribution.waiting_input += 1,
+                AgentState::WaitingChoice => distribution.waiting_choice += 1,
+                AgentState::Error => distribution.error += 1,
+                AgentState::Stopped => distribution.stopped += 1,
+            }
+        }
+    }
+    dominant_distribution(&distribution)
+}
+
+fn dominant_distribution(distribution: &StateDistribution) -> Option<AgentState> {
+    if distribution.error > 0 {
+        Some(AgentState::Error)
+    } else if distribution.waiting_choice > 0 {
+        Some(AgentState::WaitingChoice)
+    } else if distribution.waiting_input > 0 {
+        Some(AgentState::WaitingInput)
+    } else if distribution.working > 0 {
+        Some(AgentState::Working)
+    } else if distribution.starting > 0 {
+        Some(AgentState::Starting)
+    } else if distribution.idle > 0 {
+        Some(AgentState::Idle)
+    } else if distribution.stopped > 0 {
+        Some(AgentState::Stopped)
+    } else {
+        None
+    }
+}
+
+fn distribution_attention(distribution: &StateDistribution) -> usize {
+    distribution.waiting_input + distribution.waiting_choice + distribution.error
+}
+
+fn needs_attention(state: AgentState) -> bool {
+    matches!(
+        state,
+        AgentState::WaitingInput | AgentState::WaitingChoice | AgentState::Error
+    )
+}
+
+fn render(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+    let vertical = area.width < 100;
+    let chunks = Layout::default()
+        .direction(if vertical {
+            Direction::Vertical
+        } else {
+            Direction::Horizontal
+        })
+        .constraints([Constraint::Percentage(58), Constraint::Percentage(42)])
+        .split(area);
+    render_tree(frame, chunks[0], app);
+    render_inspector(frame, chunks[1], app);
+    if app.mode == InputMode::Message {
+        render_composer(frame, area, app);
+    }
+    if let Some(capture) = &app.popup {
+        render_popup(frame, area, " pane capture ", capture);
+    }
+    if app.help {
+        render_popup(
+            frame,
+            area,
+            " fleet keys ",
+            "↑/↓ every node    j/k previous/next agent pane\nh/l collapse/expand    Space toggle\nEnter attach pane      p capture pane\nm send prompt          r refresh host\nc connect/disconnect   a attention only\n/ search               ? help    q quit",
+        );
+    }
+}
+
+fn render_tree(frame: &mut Frame, area: Rect, app: &App) {
+    let total_agents: usize = app
+        .snapshot
+        .hosts
+        .iter()
+        .map(FleetHostSnapshot::agent_count)
+        .sum();
+    let attention: usize = app
+        .snapshot
+        .hosts
+        .iter()
+        .map(FleetHostSnapshot::needs_attention)
+        .sum();
+    let selector = app
+        .selector
+        .as_deref()
+        .map_or(String::new(), |selector| format!(" · -l {selector}"));
+    let title = format!(
+        " muxa fleet · {} hosts · {total_agents} agents · {attention} attention{selector} ",
+        app.snapshot.hosts.len()
+    );
+    let widths = [
+        Constraint::Percentage(48),
+        Constraint::Length(12),
+        Constraint::Percentage(52),
+    ];
+    let rows = app.rows.iter().map(|row| {
+        let branch = if row.children == 0 {
+            "•"
+        } else if app.expanded.contains(&row.key) || !app.query.is_empty() || app.attention_only {
+            "▾"
+        } else {
+            "▸"
+        };
+        let indent = "  ".repeat(row.depth);
+        let marker = row.state.map_or("○", state_marker);
+        let attention = if row.attention > 0 {
+            format!(" !{}", row.attention)
+        } else {
+            String::new()
+        };
+        Row::new(vec![
+            Cell::from(format!("{indent}{branch} {}", safe_text(&row.label))),
+            Cell::from(format!("{marker}{attention}")),
+            Cell::from(safe_text(&row.detail)),
+        ])
+    });
+    let footer = app.active_status().map_or_else(
+        || match app.mode {
+            InputMode::Search => format!(" search: {}_ ", app.query),
+            _ if !app.query.is_empty() => format!(" filter: {} · Esc/q clear/quit ", app.query),
+            _ if app.attention_only => " attention only · a clear ".into(),
+            _ => " ↑↓ nodes · j/k agents · Enter attach · m message · ? help ".into(),
+        },
+        |status| format!(" {} ", safe_text(status)),
+    );
+    let table = Table::new(rows, widths)
+        .header(
+            Row::new(["NODE", "STATE", "DETAIL"]).style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        )
+        .block(
+            Block::default()
+                .title(title)
+                .title_bottom(footer)
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(Color::DarkGray)),
+        )
+        .row_highlight_style(
+            Style::default()
+                .bg(Color::Rgb(45, 52, 66))
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("› ");
+    let mut state = TableState::default().with_selected(Some(app.selected));
+    frame.render_stateful_widget(table, area, &mut state);
+}
+
+fn render_inspector(frame: &mut Frame, area: Rect, app: &App) {
+    let block = Block::default()
+        .title(" inspector ")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(Color::DarkGray));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let Some(key) = app.selected_key() else {
+        frame.render_widget(Paragraph::new("No fleet hosts configured."), inner);
+        return;
+    };
+    let host = app
+        .snapshot
+        .hosts
+        .iter()
+        .find(|host| host.alias == key.host());
+    let topology = app.topologies.get(key.host());
+    let mut lines = Vec::new();
+    match key {
+        NodeKey::Host(_) => {
+            if let Some(host) = host {
+                lines.extend(host_inspector(host));
+            }
+        }
+        NodeKey::Session { key, .. } => {
+            if let Some(session) = topology
+                .and_then(|topology| topology.sessions.iter().find(|session| &session.key == key))
+            {
+                lines.extend(session_inspector(host, session));
+            }
+        }
+        NodeKey::Window { key, .. } => {
+            if let Some(window) = topology.and_then(|topology| find_window(topology, key)) {
+                lines.extend(window_inspector(host, window));
+            }
+        }
+        NodeKey::Pane { key, .. } => {
+            if let Some(pane) = topology.and_then(|topology| find_pane(topology, key)) {
+                lines.extend(pane_inspector(host, pane));
+            }
+        }
+    }
+    frame.render_widget(
+        Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false }),
+        inner,
+    );
+
+    if let NodeKey::Window { host, key } = key {
+        if let Some((capture_host, capture)) = app
+            .window_capture
+            .as_ref()
+            .filter(|(capture_host, capture)| capture_host == host && &capture.window == key)
+        {
+            let _ = capture_host;
+            render_window_mosaic(frame, inner, capture);
+        }
+    }
+}
+
+fn host_inspector(host: &FleetHostSnapshot) -> Vec<Line<'static>> {
+    let mut lines = vec![
+        heading(format!("{}  {}", host.alias, host_state_label(host.state))),
+        kv("ssh", &host.ssh_target),
+        kv(
+            "node",
+            host.node_id.as_ref().map_or("-", muxa::NodeId::as_str),
+        ),
+        kv("hostname", host.hostname.as_deref().unwrap_or("-")),
+        kv(
+            "platform",
+            &format!(
+                "{}/{}",
+                host.os.as_deref().unwrap_or("-"),
+                host.arch.as_deref().unwrap_or("-")
+            ),
+        ),
+        kv("version", host.muxa_version.as_deref().unwrap_or("-")),
+        kv("mode", &format!("{:?}", host.mode).to_lowercase()),
+        kv("labels", &format_map(&host.labels)),
+        kv("annotations", &format_map(&host.annotations)),
+        kv(
+            "latency",
+            &host
+                .latency_ms
+                .map_or_else(|| "-".into(), |value| format!("{value} ms")),
+        ),
+        kv(
+            "last seen",
+            &host.received_at.map_or_else(
+                || "never".into(),
+                |at| format_age(at, OffsetDateTime::now_utc()),
+            ),
+        ),
+        kv(
+            "inventory",
+            &format!(
+                "{} agents · {} panes · {} attention",
+                host.agent_count(),
+                host.pane_count(),
+                host.needs_attention()
+            ),
+        ),
+    ];
+    if let Some(error) = &host.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            safe_text(error),
+            Style::default().fg(Color::Red),
+        )));
+    }
+    lines
+}
+
+fn session_inspector(
+    host: Option<&FleetHostSnapshot>,
+    session: &SessionNode,
+) -> Vec<Line<'static>> {
+    let mut lines = vec![
+        heading(format!(
+            "{} › {}",
+            host.map_or("?", |host| host.alias.as_str()),
+            safe_text(&session.name)
+        )),
+        kv("session id", &session.key.session_id),
+        kv("backend", &session.key.endpoint.host.to_string()),
+        kv("endpoint", &session.key.endpoint.socket),
+        kv(
+            "topology",
+            &format!(
+                "{} windows · {} panes",
+                session.windows.len(),
+                session.pane_count()
+            ),
+        ),
+        kv("states", &distribution_label(&session.states)),
+        Line::from(""),
+        heading("windows"),
+    ];
+    for window in &session.windows {
+        lines.push(Line::from(format!(
+            "  {}  {} panes · {}",
+            safe_text(&window.name),
+            window.panes.len(),
+            distribution_label(&window.states)
+        )));
+        for pane in window.panes.iter().take(3) {
+            lines.push(Line::from(format!(
+                "    {}  {}",
+                pane.key.pane_id,
+                pane.agent.as_ref().map_or_else(
+                    || safe_text(&pane.current_command),
+                    |agent| format!("{} {}", agent.kind, state_label(agent.state))
+                )
+            )));
+        }
+    }
+    lines
+}
+
+fn window_inspector(host: Option<&FleetHostSnapshot>, window: &WindowNode) -> Vec<Line<'static>> {
+    vec![
+        heading(format!(
+            "{} › {}",
+            host.map_or("?", |host| host.alias.as_str()),
+            safe_text(&window.name)
+        )),
+        kv("window id", &window.key.window_id),
+        kv("index", &window.index),
+        kv("panes", &window.panes.len().to_string()),
+        kv("states", &distribution_label(&window.states)),
+        kv("preview", "live layout · selected window only"),
+    ]
+}
+
+fn pane_inspector(host: Option<&FleetHostSnapshot>, pane: &PaneNode) -> Vec<Line<'static>> {
+    let mut lines = vec![
+        heading(format!(
+            "{} › {}",
+            host.map_or("?", |host| host.alias.as_str()),
+            pane.key.pane_id
+        )),
+        kv(
+            "backend",
+            &pane.key.window.session.endpoint.host.to_string(),
+        ),
+        kv("endpoint", &pane.key.window.session.endpoint.socket),
+        kv("cwd", &pane.cwd),
+        kv("command", &pane.current_command),
+        kv("title", &pane.title),
+    ];
+    if let Some(agent) = &pane.agent {
+        lines.extend([
+            kv("agent", &agent.kind.to_string()),
+            kv("state", state_label(agent.state)),
+            kv("agent session", &agent.session_id),
+            kv("model", agent.model.as_deref().unwrap_or("-")),
+            Line::from(""),
+            heading("latest"),
+            Line::from(safe_text(
+                agent
+                    .last_response
+                    .as_deref()
+                    .or(agent.last_prompt.as_deref())
+                    .or(agent.last_notification.as_deref())
+                    .unwrap_or("(no prompt or response recorded)"),
+            )),
+        ]);
+    }
+    lines
+}
+
+fn render_window_mosaic(frame: &mut Frame, inner: Rect, capture: &FleetWindowCapture) {
+    if capture.panes.is_empty() || inner.height < 12 || inner.width < 32 {
+        return;
+    }
+    let top = inner.y.saturating_add(7).min(inner.bottom());
+    let area = Rect::new(
+        inner.x,
+        top,
+        inner.width,
+        inner.bottom().saturating_sub(top),
+    );
+    if area.width < 10 || area.height < 4 {
+        return;
+    }
+    frame.render_widget(Clear, area);
+    let source_width = capture
+        .panes
+        .iter()
+        .map(|pane| u32::from(pane.geometry.left) + u32::from(pane.geometry.width))
+        .max()
+        .unwrap_or(1);
+    let source_height = capture
+        .panes
+        .iter()
+        .map(|pane| u32::from(pane.geometry.top) + u32::from(pane.geometry.height))
+        .max()
+        .unwrap_or(1);
+    for pane in &capture.panes {
+        let Some(rect) = scale_geometry(
+            pane.geometry.left,
+            pane.geometry.top,
+            pane.geometry.width,
+            pane.geometry.height,
+            source_width,
+            source_height,
+            area,
+        ) else {
+            continue;
+        };
+        let border = if pane.geometry.active {
+            Color::Cyan
+        } else {
+            Color::DarkGray
+        };
+        let body = pane
+            .text
+            .as_deref()
+            .map_or_else(|| "(capture unavailable)".into(), safe_text);
+        frame.render_widget(
+            Paragraph::new(body)
+                .block(
+                    Block::default()
+                        .title(format!(" {} ", pane.geometry.pane_id))
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(border)),
+                )
+                .wrap(Wrap { trim: false }),
+            rect,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn scale_geometry(
+    left: u16,
+    top: u16,
+    width: u16,
+    height: u16,
+    source_width: u32,
+    source_height: u32,
+    area: Rect,
+) -> Option<Rect> {
+    let scale = |value: u32, source: u32, target: u16| {
+        u16::try_from(value.saturating_mul(u32::from(target)) / source.max(1)).unwrap_or(target)
+    };
+    let x = scale(u32::from(left), source_width, area.width);
+    let y = scale(u32::from(top), source_height, area.height);
+    let right = scale(u32::from(left) + u32::from(width), source_width, area.width)
+        .max(x.saturating_add(1))
+        .min(area.width);
+    let bottom = scale(
+        u32::from(top) + u32::from(height),
+        source_height,
+        area.height,
+    )
+    .max(y.saturating_add(1))
+    .min(area.height);
+    (x < area.width && y < area.height && right > x && bottom > y).then(|| {
+        Rect::new(
+            area.x.saturating_add(x),
+            area.y.saturating_add(y),
+            right - x,
+            bottom - y,
+        )
+    })
+}
+
+fn render_composer(frame: &mut Frame, area: Rect, app: &App) {
+    let popup = centered(area, 76, 12);
+    frame.render_widget(Clear, popup);
+    let title = app.selected_key().map_or_else(
+        || " message ".into(),
+        |key| format!(" message · {} ", key_path(key)),
+    );
+    frame.render_widget(
+        Paragraph::new(format!("{}_", app.composer))
+            .block(
+                Block::default()
+                    .title(title)
+                    .title_bottom(" Enter send · Shift-Enter newline · Esc cancel ")
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(Color::Cyan)),
+            )
+            .wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
+fn render_popup(frame: &mut Frame, area: Rect, title: &str, body: &str) {
+    let popup = centered(area, 82, 70);
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        Paragraph::new(body.to_string())
+            .block(
+                Block::default()
+                    .title(title.to_string())
+                    .title_bottom(" Esc/Enter close ")
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(Color::Cyan)),
+            )
+            .wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
+fn centered(area: Rect, width_percent: u16, height: u16) -> Rect {
+    let width = area
+        .width
+        .saturating_mul(width_percent)
+        .saturating_div(100)
+        .max(20);
+    let height = if height <= 100 {
+        area.height
+            .saturating_mul(height)
+            .saturating_div(100)
+            .max(6)
+    } else {
+        height.min(area.height)
+    };
+    Rect::new(
+        area.x + area.width.saturating_sub(width) / 2,
+        area.y + area.height.saturating_sub(height) / 2,
+        width.min(area.width),
+        height.min(area.height),
+    )
+}
+
+fn find_window<'a>(topology: &'a TopologySnapshot, key: &WindowKey) -> Option<&'a WindowNode> {
+    topology
+        .sessions
+        .iter()
+        .flat_map(|session| &session.windows)
+        .find(|window| &window.key == key)
+}
+
+fn find_pane<'a>(topology: &'a TopologySnapshot, key: &PaneKey) -> Option<&'a PaneNode> {
+    topology
+        .sessions
+        .iter()
+        .flat_map(|session| &session.windows)
+        .flat_map(|window| &window.panes)
+        .find(|pane| &pane.key == key)
+}
+
+fn key_path(key: &NodeKey) -> String {
+    match key {
+        NodeKey::Host(host) => host.clone(),
+        NodeKey::Session { host, key } => format!("{host} › {}", key.session_id),
+        NodeKey::Window { host, key } => {
+            format!("{host} › {} › {}", key.session.session_id, key.window_id)
+        }
+        NodeKey::Pane { host, key } => format!(
+            "{host} › {} › {} › {}",
+            key.window.session.session_id, key.window.window_id, key.pane_id
+        ),
+    }
+}
+
+fn heading(value: impl Into<String>) -> Line<'static> {
+    Line::from(Span::styled(
+        safe_text(&value.into()),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    ))
+}
+
+fn kv(key: &str, value: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("{key:<12}"), Style::default().fg(Color::DarkGray)),
+        Span::raw(safe_text(value)),
+    ])
+}
+
+fn state_marker(state: AgentState) -> &'static str {
+    match state {
+        AgentState::Starting => "◌",
+        AgentState::Working => "●",
+        AgentState::Idle => "○",
+        AgentState::WaitingInput => "▶",
+        AgentState::WaitingChoice => "◆",
+        AgentState::Error => "■",
+        AgentState::Stopped => "×",
+    }
+}
+
+fn state_label(state: AgentState) -> &'static str {
+    match state {
+        AgentState::Starting => "starting",
+        AgentState::Working => "working",
+        AgentState::Idle => "idle",
+        AgentState::WaitingInput => "waiting input",
+        AgentState::WaitingChoice => "waiting choice",
+        AgentState::Error => "error",
+        AgentState::Stopped => "stopped",
+    }
+}
+
+fn host_state_label(state: FleetHostState) -> &'static str {
+    match state {
+        FleetHostState::Disabled => "disabled",
+        FleetHostState::Connecting => "connecting",
+        FleetHostState::Online => "online",
+        FleetHostState::Degraded => "degraded",
+        FleetHostState::Offline => "offline",
+        FleetHostState::AuthFailed => "auth failed",
+        FleetHostState::VersionSkew => "version skew",
+    }
+}
+
+fn distribution_label(distribution: &StateDistribution) -> String {
+    let mut values = Vec::new();
+    for (count, label) in [
+        (distribution.error, "error"),
+        (distribution.waiting_choice, "choice"),
+        (distribution.waiting_input, "input"),
+        (distribution.working, "working"),
+        (distribution.idle, "idle"),
+        (distribution.starting, "starting"),
+        (distribution.stopped, "stopped"),
+    ] {
+        if count > 0 {
+            values.push(format!("{count} {label}"));
+        }
+    }
+    if values.is_empty() {
+        "no agents".into()
+    } else {
+        values.join(" · ")
+    }
+}
+
+fn format_map(values: &std::collections::BTreeMap<String, String>) -> String {
+    if values.is_empty() {
+        "-".into()
+    } else {
+        values
+            .iter()
+            .map(|(key, value)| format!("{}={}", safe_text(key), safe_text(value)))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+fn format_age(at: OffsetDateTime, now: OffsetDateTime) -> String {
+    let seconds = u64::try_from((now - at).whole_seconds().max(0)).unwrap_or(0);
+    if seconds < 60 {
+        format!("{seconds}s ago")
+    } else if seconds < 3_600 {
+        format!("{}m ago", seconds / 60)
+    } else if seconds < 86_400 {
+        format!("{}h ago", seconds / 3_600)
+    } else {
+        format!("{}d ago", seconds / 86_400)
+    }
+}
+
+/// Strip C0 controls and common ANSI CSI/OSC sequences from every remote
+/// string before it reaches the terminal renderer. A compromised host may
+/// control pane titles and screen contents; it must not emit terminal control
+/// sequences through the trusted central UI.
+fn safe_text(value: &str) -> String {
+    muxa::fleet::sanitize_terminal_text(value)
+}
+
+struct TerminalSession {
+    terminal: FleetTerminal,
+    active: bool,
+}
+
+impl TerminalSession {
+    fn enter() -> Result<Self> {
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        execute!(
+            stdout,
+            EnterAlternateScreen,
+            EnableMouseCapture,
+            EnableBracketedPaste
+        )?;
+        let mut terminal = Terminal::new(CrosstermBackend::new(stdout))?;
+        terminal.clear()?;
+        Ok(Self {
+            terminal,
+            active: true,
+        })
+    }
+
+    fn suspend(&mut self) -> Result<()> {
+        if !self.active {
+            return Ok(());
+        }
+        disable_raw_mode()?;
+        execute!(
+            self.terminal.backend_mut(),
+            DisableBracketedPaste,
+            DisableMouseCapture,
+            LeaveAlternateScreen
+        )?;
+        self.terminal.show_cursor()?;
+        self.active = false;
+        Ok(())
+    }
+
+    fn resume(&mut self) -> Result<()> {
+        if self.active {
+            return Ok(());
+        }
+        enable_raw_mode()?;
+        execute!(
+            self.terminal.backend_mut(),
+            EnterAlternateScreen,
+            EnableMouseCapture,
+            EnableBracketedPaste
+        )?;
+        self.terminal.clear()?;
+        self.active = true;
+        Ok(())
+    }
+}
+
+impl Drop for TerminalSession {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = disable_raw_mode();
+            let _ = execute!(
+                self.terminal.backend_mut(),
+                DisableBracketedPaste,
+                DisableMouseCapture,
+                LeaveAlternateScreen
+            );
+            let _ = self.terminal.show_cursor();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use muxa::fleet::{FleetBackendInfo, HostAccessMode, NodeId, RemoteSnapshot};
+    use muxa::tmux::PaneInfo;
+
+    fn host() -> FleetHostSnapshot {
+        FleetHostSnapshot {
+            alias: "dev".into(),
+            ssh_target: "devbox".into(),
+            labels: std::collections::BTreeMap::from([("tier".into(), "gpu".into())]),
+            annotations: std::collections::BTreeMap::new(),
+            mode: HostAccessMode::Control,
+            state: FleetHostState::Online,
+            node_id: Some(NodeId::generate()),
+            hostname: Some("devbox".into()),
+            os: Some("linux".into()),
+            arch: Some("x86_64".into()),
+            muxa_version: Some("0.8.34".into()),
+            protocol: Some(1),
+            capabilities: Vec::new(),
+            daemon_generation: Some(0),
+            boot_id: Some("boot".into()),
+            latency_ms: Some(2),
+            last_seen_at: Some(OffsetDateTime::now_utc()),
+            received_at: Some(OffsetDateTime::now_utc()),
+            error: None,
+            remote: Some(RemoteSnapshot {
+                revision: 1,
+                observed_at: OffsetDateTime::now_utc(),
+                agents: Vec::new(),
+                panes: vec![PaneInfo {
+                    pane_id: "%1".into(),
+                    session_id: "$1".into(),
+                    session: "work".into(),
+                    window_id: "@1".into(),
+                    window_name: "CAL-1".into(),
+                    window_index: "0".into(),
+                    pane_index: "0".into(),
+                    tty: String::new(),
+                    current_command: "codex".into(),
+                    title: String::new(),
+                    current_path: "/repo".into(),
+                    pane_pid: 1,
+                    socket: Some("default".into()),
+                }],
+                sessions: Vec::new(),
+                backends: vec![FleetBackendInfo {
+                    kind: HostKind::Tmux,
+                    current_command: true,
+                    pane_pid_map: true,
+                    capture_pane: true,
+                    focus_pane: true,
+                    send_text: true,
+                }],
+            }),
+        }
+    }
+
+    #[test]
+    fn focus_tree_keeps_structural_nodes_but_j_targets_panes() {
+        let host = host();
+        let topology = host_topology(&host).unwrap();
+        let mut app = App::new(None);
+        app.apply_snapshot(FleetSnapshot {
+            generated_at: OffsetDateTime::now_utc(),
+            hosts: vec![host],
+        });
+        app.topologies.insert("dev".into(), topology);
+        app.rebuild_rows(None);
+        assert!(matches!(app.selected_key(), Some(NodeKey::Host(_))));
+        app.move_pane(1);
+        assert!(matches!(app.selected_key(), Some(NodeKey::Pane { .. })));
+        assert!(app
+            .rows
+            .iter()
+            .any(|row| matches!(row.key, NodeKey::Session { .. })));
+        assert!(app
+            .rows
+            .iter()
+            .any(|row| matches!(row.key, NodeKey::Window { .. })));
+    }
+
+    #[test]
+    fn remote_terminal_sequences_are_removed() {
+        assert_eq!(safe_text("ok\u{1b}[31m red\u{1b}[0m"), "ok red");
+        assert_eq!(safe_text("title\u{1b}]0;owned\u{7}safe"), "titlesafe");
+    }
+}

--- a/crates/muxa-cli/src/fleet_watch.rs
+++ b/crates/muxa-cli/src/fleet_watch.rs
@@ -1,6 +1,6 @@
 //! Central host → session → window → pane(agent) Fleet TUI.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::{self, Stdout};
 use std::time::{Duration, Instant};
 
@@ -13,6 +13,7 @@ use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
+use muxa::config::{WatchLayout, WatchSortKey, WatchTheme, WatchTreeExpansion, WatchView};
 use muxa::fleet::{
     FleetCommandResult, FleetHostSnapshot, FleetHostState, FleetOperation, FleetSnapshot,
     FleetWindowCapture, GlobalPaneRef,
@@ -26,25 +27,43 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{
-    Block, BorderType, Borders, Cell, Clear, Paragraph, Row, Table, TableState, Wrap,
-};
+use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState, Wrap};
 use ratatui::{Frame, Terminal};
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
 
-const REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+const POLL_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+const STREAM_FALLBACK_INTERVAL: Duration = Duration::from_secs(15);
 const WINDOW_CAPTURE_INTERVAL: Duration = Duration::from_secs(2);
 const INPUT_POLL: Duration = Duration::from_millis(50);
+const IDLE_REDRAW_INTERVAL: Duration = Duration::from_secs(1);
 
 type FleetTerminal = Terminal<CrosstermBackend<Stdout>>;
+
+pub(crate) fn uses_native_local_watch(snapshot: &FleetSnapshot) -> bool {
+    snapshot.hosts.len() == 1 && snapshot.hosts[0].local
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum NodeKey {
     Host(String),
-    Session { host: String, key: SessionKey },
-    Window { host: String, key: WindowKey },
-    Pane { host: String, key: PaneKey },
+    Session {
+        host: String,
+        key: SessionKey,
+    },
+    Window {
+        host: String,
+        key: WindowKey,
+    },
+    Pane {
+        host: String,
+        key: PaneKey,
+    },
+    PanelessAgent {
+        host: String,
+        kind: String,
+        session_id: String,
+    },
 }
 
 impl NodeKey {
@@ -53,14 +72,17 @@ impl NodeKey {
             Self::Host(host)
             | Self::Session { host, .. }
             | Self::Window { host, .. }
-            | Self::Pane { host, .. } => host,
+            | Self::Pane { host, .. }
+            | Self::PanelessAgent { host, .. } => host,
         }
     }
 
     fn parent(&self) -> Option<Self> {
         match self {
             Self::Host(_) => None,
-            Self::Session { host, .. } => Some(Self::Host(host.clone())),
+            Self::Session { host, .. } | Self::PanelessAgent { host, .. } => {
+                Some(Self::Host(host.clone()))
+            }
             Self::Window { host, key } => Some(Self::Session {
                 host: host.clone(),
                 key: key.session.clone(),
@@ -83,7 +105,7 @@ impl NodeKey {
     }
 
     fn is_parent(&self) -> bool {
-        !matches!(self, Self::Pane { .. })
+        !matches!(self, Self::Pane { .. } | Self::PanelessAgent { .. })
     }
 }
 
@@ -105,6 +127,7 @@ enum InputMode {
     Message,
 }
 
+#[allow(clippy::struct_excessive_bools)] // independent TUI state flags
 struct App {
     snapshot: FleetSnapshot,
     topologies: HashMap<String, TopologySnapshot>,
@@ -123,10 +146,27 @@ struct App {
     window_capture: Option<(String, FleetWindowCapture)>,
     window_capture_pending: bool,
     last_window_capture: Option<Instant>,
+    theme: WatchTheme,
+    message_skills: BTreeMap<String, String>,
+    skill_palette: Option<crate::message_skill::Palette>,
+    layout: WatchLayout,
+    view: WatchView,
+    expansion: WatchTreeExpansion,
+    expansion_initialized: bool,
+    sort: WatchSortKey,
+    show_paneless: bool,
 }
 
 impl App {
-    fn new(selector: Option<String>) -> Self {
+    fn new(
+        selector: Option<String>,
+        theme: WatchTheme,
+        message_skills: BTreeMap<String, String>,
+        layout: WatchLayout,
+        view: WatchView,
+        expansion: WatchTreeExpansion,
+        sort: WatchSortKey,
+    ) -> Self {
         Self {
             snapshot: FleetSnapshot {
                 generated_at: OffsetDateTime::now_utc(),
@@ -148,6 +188,15 @@ impl App {
             window_capture: None,
             window_capture_pending: false,
             last_window_capture: None,
+            theme,
+            message_skills,
+            skill_palette: None,
+            layout,
+            view,
+            expansion,
+            expansion_initialized: false,
+            sort,
+            show_paneless: false,
         }
     }
 
@@ -155,8 +204,9 @@ impl App {
         let selected = self.selected_key().cloned();
         snapshot.hosts.sort_by(|left, right| {
             right
-                .needs_attention()
-                .cmp(&left.needs_attention())
+                .local
+                .cmp(&left.local)
+                .then_with(|| compare_hosts(left, right, self.sort))
                 .then_with(|| left.alias.cmp(&right.alias))
         });
         let mut topologies = HashMap::new();
@@ -179,12 +229,76 @@ impl App {
         self.topologies = topologies;
         self.topology_versions = versions;
         self.snapshot = snapshot;
-        if self.expanded.is_empty() {
-            if let Some(host) = self.snapshot.hosts.first() {
-                self.expanded.insert(NodeKey::Host(host.alias.clone()));
-            }
+        if !self.expansion_initialized && !self.snapshot.hosts.is_empty() {
+            self.initialize_expansion();
+            self.expansion_initialized = true;
         }
         self.rebuild_rows(selected.as_ref());
+        if self.layout == WatchLayout::Swarm
+            && !matches!(
+                self.selected_key(),
+                Some(NodeKey::Pane { .. } | NodeKey::PanelessAgent { .. })
+            )
+        {
+            if let Some(first) = all_swarm_keys(
+                &self.snapshot,
+                &self.topologies,
+                &self.query,
+                self.attention_only,
+                self.sort,
+                self.show_paneless,
+            )
+            .into_iter()
+            .next()
+            {
+                self.focus_key(first);
+            }
+        }
+    }
+
+    fn initialize_expansion(&mut self) {
+        let hosts = if self.expansion == WatchTreeExpansion::Always {
+            self.snapshot.hosts.iter().collect::<Vec<_>>()
+        } else if self.expansion == WatchTreeExpansion::Focus {
+            self.snapshot.hosts.first().into_iter().collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        for host in hosts {
+            let host_key = NodeKey::Host(host.alias.clone());
+            self.expanded.insert(host_key);
+            if self.view == WatchView::Session {
+                continue;
+            }
+            let Some(topology) = self.topologies.get(&host.alias) else {
+                continue;
+            };
+            let sessions = if self.expansion == WatchTreeExpansion::Always {
+                topology.sessions.iter().collect::<Vec<_>>()
+            } else {
+                topology.sessions.first().into_iter().collect::<Vec<_>>()
+            };
+            for session in sessions {
+                self.expanded.insert(NodeKey::Session {
+                    host: host.alias.clone(),
+                    key: session.key.clone(),
+                });
+                if self.view != WatchView::Pane {
+                    continue;
+                }
+                let windows = if self.expansion == WatchTreeExpansion::Always {
+                    session.windows.iter().collect::<Vec<_>>()
+                } else {
+                    session.windows.first().into_iter().collect::<Vec<_>>()
+                };
+                for window in windows {
+                    self.expanded.insert(NodeKey::Window {
+                        host: host.alias.clone(),
+                        key: window.key.clone(),
+                    });
+                }
+            }
+        }
     }
 
     fn selected_key(&self) -> Option<&NodeKey> {
@@ -217,6 +331,8 @@ impl App {
             &self.expanded,
             &self.query,
             self.attention_only,
+            self.sort,
+            self.show_paneless,
         );
         if let Some(key) = preserve {
             if let Some(index) = self.rows.iter().position(|row| &row.key == key) {
@@ -228,7 +344,9 @@ impl App {
     }
 
     fn focus_key(&mut self, key: NodeKey) {
-        self.expanded.clear();
+        if self.expansion != WatchTreeExpansion::Always {
+            self.expanded.clear();
+        }
         for ancestor in key.ancestors() {
             self.expanded.insert(ancestor);
         }
@@ -260,6 +378,7 @@ impl App {
             &self.topologies,
             &self.query,
             self.attention_only,
+            self.sort,
         );
         if panes.is_empty() {
             self.move_row(delta);
@@ -281,6 +400,29 @@ impl App {
             (None, true) => panes.len() - 1,
         };
         self.focus_key(panes[next].clone());
+    }
+
+    fn move_swarm(&mut self, delta: isize) {
+        let nodes = all_swarm_keys(
+            &self.snapshot,
+            &self.topologies,
+            &self.query,
+            self.attention_only,
+            self.sort,
+            self.show_paneless,
+        );
+        if nodes.is_empty() {
+            return;
+        }
+        let current = self.selected_key();
+        let index = current.and_then(|key| nodes.iter().position(|node| node == key));
+        let next = match (index, delta.is_negative()) {
+            (Some(index), false) => (index + 1).min(nodes.len() - 1),
+            (Some(index), true) => index.saturating_sub(1),
+            (None, false) => 0,
+            (None, true) => nodes.len() - 1,
+        };
+        self.focus_key(nodes[next].clone());
     }
 
     fn toggle_selected(&mut self) {
@@ -346,24 +488,95 @@ enum BackgroundResult {
     Command(std::result::Result<FleetCommandResult, String>),
 }
 
-pub(crate) async fn run(client: Client, cfg: &Config, selector: Option<String>) -> Result<()> {
+#[allow(clippy::too_many_lines)] // one event loop keeps refresh and terminal cleanup auditable
+pub(crate) async fn run(
+    client: Client,
+    cfg: &Config,
+    selector: Option<String>,
+    initial: FleetSnapshot,
+    invocation: crate::WatchInvocation,
+) -> Result<()> {
     let mut terminal = TerminalSession::enter()?;
-    let mut app = App::new(selector);
+    let theme = invocation
+        .theme
+        .map(WatchTheme::from)
+        .or(cfg.watch.theme)
+        .unwrap_or(cfg.ui.theme);
+    let layout = invocation
+        .layout
+        .map_or(cfg.watch.layout, WatchLayout::from);
+    let view = invocation.view.map_or(cfg.watch.view, WatchView::from);
+    let sort = invocation.sort.map_or_else(
+        || {
+            cfg.watch
+                .sort
+                .first()
+                .copied()
+                .unwrap_or(WatchSortKey::Name)
+        },
+        |sort| sort.keys()[0],
+    );
+    let mut app = App::new(
+        selector,
+        theme,
+        cfg.message.skills.clone(),
+        layout,
+        view,
+        cfg.watch.tree_expansion,
+        sort,
+    );
+    app.show_paneless = invocation.include_paneless || !cfg.watch.hide_paneless;
+    app.apply_snapshot(initial);
     let (background_tx, mut background_rx) = mpsc::unbounded_channel();
+    let (fleet_update_tx, mut fleet_update_rx) = mpsc::channel(1);
+    let fleet_stream = client.fleet_subscribe().await.ok();
+    let mut streaming = fleet_stream.is_some();
+    let fleet_update_task = fleet_stream.map(|mut stream| {
+        tokio::spawn(async move {
+            loop {
+                match stream.recv().await {
+                    Ok(Some(_)) => {
+                        // One pending invalidation represents the entire cache;
+                        // a fresh snapshot subsumes any burst behind it.
+                        let _ = fleet_update_tx.try_send(());
+                    }
+                    Ok(None) | Err(_) => return,
+                }
+            }
+        })
+    });
     let now = Instant::now();
-    let mut last_refresh = now.checked_sub(REFRESH_INTERVAL).unwrap_or(now);
+    let mut last_refresh = now;
+    let mut last_render = now.checked_sub(IDLE_REDRAW_INTERVAL).unwrap_or(now);
+    let mut needs_render = true;
     let mut quit = false;
 
     while !quit {
-        if last_refresh.elapsed() >= REFRESH_INTERVAL {
+        let mut invalidated = false;
+        while fleet_update_rx.try_recv().is_ok() {
+            invalidated = true;
+        }
+        if streaming && fleet_update_rx.is_closed() {
+            streaming = false;
+        }
+        let refresh_interval = if streaming {
+            STREAM_FALLBACK_INTERVAL
+        } else {
+            POLL_REFRESH_INTERVAL
+        };
+        if invalidated || last_refresh.elapsed() >= refresh_interval {
             match client.fleet_snapshot(app.selector.as_deref()).await {
-                Ok(snapshot) => app.apply_snapshot(snapshot),
+                Ok(snapshot) => {
+                    app.apply_snapshot(snapshot);
+                    needs_render = true;
+                }
                 Err(error) => app.status(format!("fleet refresh failed: {error}")),
             }
             last_refresh = Instant::now();
         }
 
         while let Ok(result) = background_rx.try_recv() {
+            needs_render = true;
             match result {
                 BackgroundResult::Window {
                     host,
@@ -404,9 +617,14 @@ pub(crate) async fn run(client: Client, cfg: &Config, selector: Option<String>) 
         }
 
         maybe_capture_window(&client, &mut app, &background_tx);
-        terminal.terminal.draw(|frame| render(frame, &app))?;
+        if needs_render || last_render.elapsed() >= IDLE_REDRAW_INTERVAL {
+            terminal.terminal.draw(|frame| render(frame, &app))?;
+            last_render = Instant::now();
+            needs_render = false;
+        }
 
         if event::poll(INPUT_POLL)? {
+            needs_render = true;
             match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     quit = handle_key(key, &client, cfg, &mut terminal, &mut app, &background_tx)?;
@@ -426,6 +644,9 @@ pub(crate) async fn run(client: Client, cfg: &Config, selector: Option<String>) 
                 | Event::Key(_) => {}
             }
         }
+    }
+    if let Some(task) = fleet_update_task {
+        task.abort();
     }
     Ok(())
 }
@@ -461,10 +682,43 @@ fn handle_key(
             return Ok(false);
         }
         InputMode::Message => {
+            if let Some(palette) = app.skill_palette.as_mut() {
+                match key.code {
+                    KeyCode::Esc => app.skill_palette = None,
+                    KeyCode::Enter => {
+                        if let Some(prompt) = palette.selected_prompt(&app.message_skills) {
+                            let mut cursor = app.composer.chars().count();
+                            crate::message_skill::insert_prompt(
+                                &mut app.composer,
+                                &mut cursor,
+                                &prompt,
+                            );
+                            app.skill_palette = None;
+                        }
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        palette.move_selection(1, &app.message_skills);
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        palette.move_selection(-1, &app.message_skills);
+                    }
+                    KeyCode::Backspace => {
+                        if !palette.backspace() {
+                            app.skill_palette = None;
+                        }
+                    }
+                    KeyCode::Char(character) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        palette.insert(character);
+                    }
+                    _ => {}
+                }
+                return Ok(false);
+            }
             match key.code {
                 KeyCode::Esc => {
                     app.mode = InputMode::Normal;
                     app.composer.clear();
+                    app.skill_palette = None;
                 }
                 KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
                     app.composer.push('\n');
@@ -501,6 +755,9 @@ fn handle_key(
                 KeyCode::Backspace => {
                     app.composer.pop();
                 }
+                KeyCode::Char('/') if !app.message_skills.is_empty() => {
+                    app.skill_palette = Some(crate::message_skill::Palette::default());
+                }
                 KeyCode::Char(character) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
                     app.composer.push(character);
                 }
@@ -526,6 +783,8 @@ fn handle_key(
 
     match key.code {
         KeyCode::Char('q') | KeyCode::Esc => return Ok(true),
+        KeyCode::Down if app.layout == WatchLayout::Swarm => app.move_swarm(1),
+        KeyCode::Up if app.layout == WatchLayout::Swarm => app.move_swarm(-1),
         KeyCode::Down => app.move_row(1),
         KeyCode::Up => app.move_row(-1),
         KeyCode::Char('j') => app.move_pane(1),
@@ -574,7 +833,7 @@ fn handle_key(
                 app.status("connection command requested…");
             }
         }
-        KeyCode::Char('p') => {
+        KeyCode::Char('o' | 'p') => {
             if let Some((host, pane)) = app.selected_pane() {
                 let client = client.clone();
                 let sender = background.clone();
@@ -592,6 +851,7 @@ fn handle_key(
             if app.selected_pane().is_some() {
                 app.mode = InputMode::Message;
                 app.composer.clear();
+                app.skill_palette = None;
             } else {
                 app.status("select a pane before sending a prompt");
             }
@@ -728,6 +988,8 @@ fn build_rows(
     expanded: &HashSet<NodeKey>,
     query: &str,
     attention_only: bool,
+    sort: WatchSortKey,
+    show_paneless: bool,
 ) -> Vec<TreeRow> {
     let mut rows = Vec::new();
     for host in &snapshot.hosts {
@@ -736,6 +998,9 @@ fn build_rows(
             continue;
         }
         let host_key = NodeKey::Host(host.alias.clone());
+        let paneless_count = topology.map_or(0, |topology| {
+            usize::from(show_paneless) * topology.unassigned_agents.len()
+        });
         rows.push(TreeRow {
             key: host_key.clone(),
             depth: 0,
@@ -749,7 +1014,7 @@ fn build_rows(
             ),
             state: dominant_host_state(host),
             attention: host.needs_attention(),
-            children: topology.map_or(0, |topology| topology.sessions.len()),
+            children: topology.map_or(0, |topology| topology.sessions.len()) + paneless_count,
         });
         let show_host = expanded.contains(&host_key) || !query.is_empty() || attention_only;
         if !show_host {
@@ -758,7 +1023,9 @@ fn build_rows(
         let Some(topology) = topology else {
             continue;
         };
-        for session in &topology.sessions {
+        let mut sessions = topology.sessions.iter().collect::<Vec<_>>();
+        sessions.sort_by(|left, right| compare_sessions(left, right, sort));
+        for session in sessions {
             if !session_relevant(session, query, attention_only) {
                 continue;
             }
@@ -784,7 +1051,9 @@ fn build_rows(
             if !show_session {
                 continue;
             }
-            for window in &session.windows {
+            let mut windows = session.windows.iter().collect::<Vec<_>>();
+            windows.sort_by(|left, right| compare_windows(left, right, sort));
+            for window in windows {
                 if !window_relevant(window, query, attention_only) {
                     continue;
                 }
@@ -810,7 +1079,9 @@ fn build_rows(
                 if !show_window {
                     continue;
                 }
-                for pane in &window.panes {
+                let mut panes = window.panes.iter().collect::<Vec<_>>();
+                panes.sort_by(|left, right| compare_panes(left, right, sort));
+                for pane in panes {
                     if !pane_relevant(pane, query, attention_only) {
                         continue;
                     }
@@ -847,8 +1118,181 @@ fn build_rows(
                 }
             }
         }
+        if show_paneless {
+            let mut agents = topology
+                .unassigned_agents
+                .iter()
+                .filter(|agent| agent_relevant(agent, query, attention_only))
+                .collect::<Vec<_>>();
+            agents.sort_by(|left, right| compare_agents(left, right, sort));
+            for agent in agents {
+                rows.push(TreeRow {
+                    key: paneless_agent_key(&host.alias, agent),
+                    depth: 1,
+                    label: format!("[paneless] {}", agent.kind),
+                    detail: format!(
+                        "{} · {} · {}",
+                        agent.session_id,
+                        state_label(agent.state),
+                        agent_summary(agent)
+                    ),
+                    state: Some(agent.state),
+                    attention: usize::from(needs_attention(agent.state)),
+                    children: 0,
+                });
+            }
+        }
     }
     rows
+}
+
+fn paneless_agent_key(host: &str, agent: &muxa::Agent) -> NodeKey {
+    NodeKey::PanelessAgent {
+        host: host.to_string(),
+        kind: agent.kind.to_string(),
+        session_id: agent.session_id.clone(),
+    }
+}
+
+fn compare_agents(
+    left: &muxa::Agent,
+    right: &muxa::Agent,
+    sort: WatchSortKey,
+) -> std::cmp::Ordering {
+    let order = match sort {
+        WatchSortKey::Activity => right.last_activity_at.cmp(&left.last_activity_at),
+        WatchSortKey::Duration => left.state_entered_at.cmp(&right.state_entered_at),
+        WatchSortKey::State => {
+            state_sort_rank(Some(right.state)).cmp(&state_sort_rank(Some(left.state)))
+        }
+        WatchSortKey::Name | WatchSortKey::Pane | WatchSortKey::PaneId => {
+            left.kind.to_string().cmp(&right.kind.to_string())
+        }
+    };
+    order.then_with(|| left.session_id.cmp(&right.session_id))
+}
+
+fn compare_sessions(
+    left: &SessionNode,
+    right: &SessionNode,
+    sort: WatchSortKey,
+) -> std::cmp::Ordering {
+    compare_node_agents(
+        left.windows.iter().flat_map(|window| &window.panes),
+        right.windows.iter().flat_map(|window| &window.panes),
+        sort,
+    )
+    .then_with(|| left.name.cmp(&right.name))
+}
+
+fn compare_hosts(
+    left: &FleetHostSnapshot,
+    right: &FleetHostSnapshot,
+    sort: WatchSortKey,
+) -> std::cmp::Ordering {
+    match sort {
+        WatchSortKey::Activity => host_latest_activity(right).cmp(&host_latest_activity(left)),
+        WatchSortKey::Duration => host_earliest_start(left).cmp(&host_earliest_start(right)),
+        WatchSortKey::State => right
+            .needs_attention()
+            .cmp(&left.needs_attention())
+            .then_with(|| right.agent_count().cmp(&left.agent_count())),
+        WatchSortKey::Name | WatchSortKey::Pane | WatchSortKey::PaneId => {
+            left.alias.cmp(&right.alias)
+        }
+    }
+}
+
+fn host_latest_activity(host: &FleetHostSnapshot) -> Option<OffsetDateTime> {
+    host.remote
+        .as_ref()?
+        .agents
+        .iter()
+        .map(|agent| agent.last_activity_at)
+        .max()
+}
+
+fn host_earliest_start(host: &FleetHostSnapshot) -> Option<OffsetDateTime> {
+    host.remote
+        .as_ref()?
+        .agents
+        .iter()
+        .map(|agent| agent.started_at)
+        .min()
+}
+
+fn compare_windows(
+    left: &WindowNode,
+    right: &WindowNode,
+    sort: WatchSortKey,
+) -> std::cmp::Ordering {
+    let order = match sort {
+        WatchSortKey::Pane => left
+            .index
+            .parse::<u32>()
+            .ok()
+            .cmp(&right.index.parse::<u32>().ok()),
+        _ => compare_node_agents(left.panes.iter(), right.panes.iter(), sort),
+    };
+    order.then_with(|| left.name.cmp(&right.name))
+}
+
+fn compare_node_agents<'a>(
+    left: impl Iterator<Item = &'a PaneNode>,
+    right: impl Iterator<Item = &'a PaneNode>,
+    sort: WatchSortKey,
+) -> std::cmp::Ordering {
+    let left = left
+        .filter_map(|pane| pane.agent.as_ref())
+        .collect::<Vec<_>>();
+    let right = right
+        .filter_map(|pane| pane.agent.as_ref())
+        .collect::<Vec<_>>();
+    match sort {
+        WatchSortKey::Activity => right
+            .iter()
+            .map(|agent| agent.last_activity_at)
+            .max()
+            .cmp(&left.iter().map(|agent| agent.last_activity_at).max()),
+        WatchSortKey::Duration => left
+            .iter()
+            .map(|agent| agent.started_at)
+            .min()
+            .cmp(&right.iter().map(|agent| agent.started_at).min()),
+        WatchSortKey::State => {
+            let rank = |agents: &[&muxa::Agent]| {
+                agents
+                    .iter()
+                    .map(|agent| state_sort_rank(Some(agent.state)))
+                    .max()
+                    .unwrap_or(0)
+            };
+            rank(&right).cmp(&rank(&left))
+        }
+        WatchSortKey::Name | WatchSortKey::Pane | WatchSortKey::PaneId => std::cmp::Ordering::Equal,
+    }
+}
+
+fn compare_panes(left: &PaneNode, right: &PaneNode, sort: WatchSortKey) -> std::cmp::Ordering {
+    let left_agent = left.agent.as_ref();
+    let right_agent = right.agent.as_ref();
+    match sort {
+        WatchSortKey::Activity => right_agent
+            .map(|agent| agent.last_activity_at)
+            .cmp(&left_agent.map(|agent| agent.last_activity_at)),
+        WatchSortKey::Duration => left_agent
+            .map(|agent| agent.state_entered_at)
+            .cmp(&right_agent.map(|agent| agent.state_entered_at)),
+        WatchSortKey::State => state_sort_rank(right_agent.map(|agent| agent.state))
+            .cmp(&state_sort_rank(left_agent.map(|agent| agent.state))),
+        WatchSortKey::Pane => left
+            .index
+            .parse::<u32>()
+            .ok()
+            .cmp(&right.index.parse::<u32>().ok()),
+        WatchSortKey::PaneId => left.key.pane_id.cmp(&right.key.pane_id),
+        WatchSortKey::Name => left.index.cmp(&right.index),
+    }
 }
 
 fn all_pane_keys(
@@ -856,8 +1300,15 @@ fn all_pane_keys(
     topologies: &HashMap<String, TopologySnapshot>,
     query: &str,
     attention_only: bool,
+    sort: WatchSortKey,
 ) -> Vec<NodeKey> {
-    snapshot
+    let host_order = snapshot
+        .hosts
+        .iter()
+        .enumerate()
+        .map(|(index, host)| (host.alias.as_str(), index))
+        .collect::<HashMap<_, _>>();
+    let mut panes = snapshot
         .hosts
         .iter()
         .filter(|host| host_relevant(host, topologies.get(&host.alias), query, attention_only))
@@ -875,7 +1326,122 @@ fn all_pane_keys(
                 })
                 .collect::<Vec<_>>()
         })
-        .collect()
+        .collect::<Vec<_>>();
+    panes.sort_by(|left, right| {
+        host_order
+            .get(left.host())
+            .cmp(&host_order.get(right.host()))
+            .then_with(|| compare_pane_keys(left, right, topologies, sort))
+    });
+    panes
+}
+
+fn all_swarm_keys(
+    snapshot: &FleetSnapshot,
+    topologies: &HashMap<String, TopologySnapshot>,
+    query: &str,
+    attention_only: bool,
+    sort: WatchSortKey,
+    show_paneless: bool,
+) -> Vec<NodeKey> {
+    let mut nodes = Vec::new();
+    for host in &snapshot.hosts {
+        let Some(topology) = topologies.get(&host.alias) else {
+            continue;
+        };
+        let mut panes = topology
+            .sessions
+            .iter()
+            .flat_map(|session| &session.windows)
+            .flat_map(|window| &window.panes)
+            .filter(|pane| pane_relevant(pane, query, attention_only))
+            .map(|pane| NodeKey::Pane {
+                host: host.alias.clone(),
+                key: pane.key.clone(),
+            })
+            .collect::<Vec<_>>();
+        panes.sort_by(|left, right| compare_pane_keys(left, right, topologies, sort));
+        nodes.extend(panes);
+        if show_paneless {
+            let mut agents = topology
+                .unassigned_agents
+                .iter()
+                .filter(|agent| agent_relevant(agent, query, attention_only))
+                .collect::<Vec<_>>();
+            agents.sort_by(|left, right| compare_agents(left, right, sort));
+            nodes.extend(
+                agents
+                    .into_iter()
+                    .map(|agent| paneless_agent_key(&host.alias, agent)),
+            );
+        }
+    }
+    nodes
+}
+
+fn compare_pane_keys(
+    left: &NodeKey,
+    right: &NodeKey,
+    topologies: &HashMap<String, TopologySnapshot>,
+    sort: WatchSortKey,
+) -> std::cmp::Ordering {
+    let pane = |key: &NodeKey| match key {
+        NodeKey::Pane { host, key } => topologies
+            .get(host)
+            .and_then(|topology| find_pane(topology, key)),
+        _ => None,
+    };
+    let Some(left_pane) = pane(left) else {
+        return std::cmp::Ordering::Equal;
+    };
+    let Some(right_pane) = pane(right) else {
+        return std::cmp::Ordering::Equal;
+    };
+    let left_agent = left_pane.agent.as_ref();
+    let right_agent = right_pane.agent.as_ref();
+    match sort {
+        WatchSortKey::Activity => right_agent
+            .map(|agent| agent.last_activity_at)
+            .cmp(&left_agent.map(|agent| agent.last_activity_at)),
+        WatchSortKey::Duration => left_agent
+            .map(|agent| agent.state_entered_at)
+            .cmp(&right_agent.map(|agent| agent.state_entered_at)),
+        WatchSortKey::State => state_sort_rank(right_agent.map(|agent| agent.state))
+            .cmp(&state_sort_rank(left_agent.map(|agent| agent.state))),
+        WatchSortKey::Pane => left_pane
+            .index
+            .parse::<u32>()
+            .ok()
+            .cmp(&right_pane.index.parse::<u32>().ok()),
+        WatchSortKey::PaneId => left_pane.key.pane_id.cmp(&right_pane.key.pane_id),
+        WatchSortKey::Name => left_pane
+            .key
+            .window
+            .session
+            .session_id
+            .cmp(&right_pane.key.window.session.session_id)
+            .then(
+                left_pane
+                    .key
+                    .window
+                    .window_id
+                    .cmp(&right_pane.key.window.window_id),
+            )
+            .then(left_pane.index.cmp(&right_pane.index)),
+    }
+}
+
+fn state_sort_rank(state: Option<AgentState>) -> u8 {
+    match state {
+        Some(AgentState::Error) => 7,
+        Some(AgentState::WaitingInput) => 6,
+        Some(AgentState::WaitingChoice) => 5,
+        Some(AgentState::Working) => 4,
+        Some(AgentState::Starting) => 3,
+        Some(AgentState::Idle) => 2,
+        Some(AgentState::Stopped) => 1,
+        None => 0,
+    }
 }
 
 fn host_relevant(
@@ -949,6 +1515,25 @@ fn pane_relevant(pane: &PaneNode, query: &str, attention_only: bool) -> bool {
             }))
 }
 
+fn agent_relevant(agent: &muxa::Agent, query: &str, attention_only: bool) -> bool {
+    (!attention_only || needs_attention(agent.state))
+        && (query.is_empty()
+            || searchable(&agent.kind.to_string(), query)
+            || searchable(&agent.session_id, query)
+            || agent
+                .cwd
+                .as_deref()
+                .is_some_and(|value| searchable(value, query))
+            || agent
+                .last_prompt
+                .as_deref()
+                .is_some_and(|value| searchable(value, query))
+            || agent
+                .ai_title
+                .as_deref()
+                .is_some_and(|value| searchable(value, query)))
+}
+
 fn searchable(value: &str, lowercase_query: &str) -> bool {
     value.to_lowercase().contains(lowercase_query)
 }
@@ -1013,13 +1598,20 @@ fn render(frame: &mut Frame, app: &App) {
         })
         .constraints([Constraint::Percentage(58), Constraint::Percentage(42)])
         .split(area);
-    render_tree(frame, chunks[0], app);
+    if app.layout == WatchLayout::Swarm {
+        render_swarm(frame, chunks[0], app);
+    } else {
+        render_tree(frame, chunks[0], app);
+    }
     render_inspector(frame, chunks[1], app);
     if app.mode == InputMode::Message {
         render_composer(frame, area, app);
+        if app.skill_palette.is_some() {
+            render_skill_palette(frame, area, app);
+        }
     }
     if let Some(capture) = &app.popup {
-        render_popup(frame, area, " pane capture ", capture);
+        render_popup(frame, area, " pane capture ", capture, app.theme);
     }
     if app.help {
         render_popup(
@@ -1027,11 +1619,13 @@ fn render(frame: &mut Frame, app: &App) {
             area,
             " fleet keys ",
             "↑/↓ every node    j/k previous/next agent pane\nh/l collapse/expand    Space toggle\nEnter attach pane      p capture pane\nm send prompt          r refresh host\nc connect/disconnect   a attention only\n/ search               ? help    q quit",
+            app.theme,
         );
     }
 }
 
 fn render_tree(frame: &mut Frame, area: Rect, app: &App) {
+    let theme = crate::watch::watch_theme(app.theme);
     let total_agents: usize = app
         .snapshot
         .hosts
@@ -1088,38 +1682,160 @@ fn render_tree(frame: &mut Frame, area: Rect, app: &App) {
         |status| format!(" {} ", safe_text(status)),
     );
     let table = Table::new(rows, widths)
-        .header(
-            Row::new(["NODE", "STATE", "DETAIL"]).style(
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            ),
-        )
+        .header(Row::new(["NODE", "STATE", "DETAIL"]).style(theme.table_header_style()))
         .block(
             Block::default()
                 .title(title)
                 .title_bottom(footer)
                 .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(Style::default().fg(Color::DarkGray)),
+                .border_type(theme.border_type)
+                .border_style(theme.border_style()),
         )
-        .row_highlight_style(
-            Style::default()
-                .bg(Color::Rgb(45, 52, 66))
-                .fg(Color::White)
-                .add_modifier(Modifier::BOLD),
-        )
+        .row_highlight_style(theme.selected_style())
         .highlight_symbol("› ");
     let mut state = TableState::default().with_selected(Some(app.selected));
     frame.render_stateful_widget(table, area, &mut state);
 }
 
+fn render_swarm(frame: &mut Frame, area: Rect, app: &App) {
+    let theme = crate::watch::watch_theme(app.theme);
+    let nodes = all_swarm_keys(
+        &app.snapshot,
+        &app.topologies,
+        &app.query,
+        app.attention_only,
+        app.sort,
+        app.show_paneless,
+    );
+    if nodes.is_empty() {
+        frame.render_widget(
+            Paragraph::new("No agents or panes match the current Fleet filter.").block(
+                Block::default()
+                    .title(" muxa fleet · swarm ")
+                    .borders(Borders::ALL)
+                    .border_type(theme.border_type)
+                    .border_style(theme.border_style()),
+            ),
+            area,
+        );
+        return;
+    }
+    let now = OffsetDateTime::now_utc();
+    let rows = nodes
+        .iter()
+        .filter_map(|key| swarm_row(key, app, theme, now));
+    let title = format!(
+        " muxa fleet · swarm · {} hosts · {} rows ",
+        app.snapshot.hosts.len(),
+        nodes.len()
+    );
+    let footer = if app.query.is_empty() {
+        " j/k move · Enter attach · o/p capture · m message · / search · ? help ".to_string()
+    } else {
+        format!(" filter: {} · Esc clear ", app.query)
+    };
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(14),
+            Constraint::Percentage(30),
+            Constraint::Length(15),
+            Constraint::Length(7),
+            Constraint::Percentage(70),
+        ],
+    )
+    .header(
+        Row::new(["HOST", "AGENT / PANE", "STATE", "AGE", "SUMMARY"])
+            .style(theme.table_header_style()),
+    )
+    .block(
+        Block::default()
+            .title(title)
+            .title_bottom(footer)
+            .borders(Borders::ALL)
+            .border_type(theme.border_type)
+            .border_style(theme.border_style()),
+    )
+    .row_highlight_style(theme.selected_style())
+    .highlight_symbol("> ");
+    let selected = app
+        .selected_key()
+        .and_then(|selected| nodes.iter().position(|key| key == selected))
+        .unwrap_or(0);
+    let mut state = TableState::default().with_selected(Some(selected));
+    frame.render_stateful_widget(table, area, &mut state);
+}
+
+fn swarm_row(
+    key: &NodeKey,
+    app: &App,
+    theme: crate::watch::WatchThemeSpec,
+    now: OffsetDateTime,
+) -> Option<Row<'static>> {
+    let host = key.host();
+    let (agent, state, age, summary) = match key {
+        NodeKey::Pane { key, .. } => {
+            let pane = app
+                .topologies
+                .get(host)
+                .and_then(|topology| find_pane(topology, key))?;
+            pane.agent.as_ref().map_or_else(
+                || {
+                    (
+                        safe_text(&pane.current_command),
+                        Line::from(Span::styled("process", theme.dim_style())),
+                        "-".into(),
+                        safe_text(&pane.title),
+                    )
+                },
+                |agent| {
+                    (
+                        format!("{} · {}", agent.kind, pane.key.pane_id),
+                        Line::from(Span::styled(
+                            format!("{} {}", state_marker(agent.state), state_label(agent.state)),
+                            theme.state_style(agent.state),
+                        )),
+                        format_age(agent.state_entered_at, now),
+                        agent_summary(agent),
+                    )
+                },
+            )
+        }
+        NodeKey::PanelessAgent {
+            kind, session_id, ..
+        } => {
+            let agent = app
+                .topologies
+                .get(host)
+                .and_then(|topology| find_paneless_agent(topology, kind, session_id))?;
+            (
+                format!("{} · paneless", agent.kind),
+                Line::from(Span::styled(
+                    format!("{} {}", state_marker(agent.state), state_label(agent.state)),
+                    theme.state_style(agent.state),
+                )),
+                format_age(agent.state_entered_at, now),
+                agent_summary(agent),
+            )
+        }
+        _ => return None,
+    };
+    Some(Row::new(vec![
+        Cell::from(safe_text(host)),
+        Cell::from(agent),
+        Cell::from(state),
+        Cell::from(age),
+        Cell::from(summary),
+    ]))
+}
+
 fn render_inspector(frame: &mut Frame, area: Rect, app: &App) {
+    let theme = crate::watch::watch_theme(app.theme);
     let block = Block::default()
         .title(" inspector ")
         .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(Color::DarkGray));
+        .border_type(theme.border_type)
+        .border_style(theme.border_style());
     let inner = block.inner(area);
     frame.render_widget(block, area);
     let Some(key) = app.selected_key() else {
@@ -1156,6 +1872,15 @@ fn render_inspector(frame: &mut Frame, area: Rect, app: &App) {
                 lines.extend(pane_inspector(host, pane));
             }
         }
+        NodeKey::PanelessAgent {
+            kind, session_id, ..
+        } => {
+            if let Some(agent) =
+                topology.and_then(|topology| find_paneless_agent(topology, kind, session_id))
+            {
+                lines.extend(paneless_agent_inspector(host, agent));
+            }
+        }
     }
     frame.render_widget(
         Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false }),
@@ -1169,7 +1894,7 @@ fn render_inspector(frame: &mut Frame, area: Rect, app: &App) {
             .filter(|(capture_host, capture)| capture_host == host && &capture.window == key)
         {
             let _ = capture_host;
-            render_window_mosaic(frame, inner, capture);
+            render_window_mosaic(frame, inner, capture, app.theme);
         }
     }
 }
@@ -1232,6 +1957,35 @@ fn session_inspector(
     host: Option<&FleetHostSnapshot>,
     session: &SessionNode,
 ) -> Vec<Line<'static>> {
+    let now = OffsetDateTime::now_utc();
+    let agents = session
+        .windows
+        .iter()
+        .flat_map(|window| &window.panes)
+        .filter_map(|pane| pane.agent.as_ref())
+        .collect::<Vec<_>>();
+    let latest = agents
+        .iter()
+        .max_by_key(|agent| agent.last_activity_at)
+        .map_or_else(
+            || "-".into(),
+            |agent| {
+                format!(
+                    "{} · {} · {}",
+                    format_age(agent.last_activity_at, now),
+                    agent.kind,
+                    agent_summary(agent)
+                )
+            },
+        );
+    let processes: usize = agents
+        .iter()
+        .map(|agent| usize::from(agent.workload.process_count))
+        .sum();
+    let subagents: usize = agents
+        .iter()
+        .map(|agent| usize::from(agent.workload.subagent_count).max(agent.subagents.len()))
+        .sum();
     let mut lines = vec![
         heading(format!(
             "{} › {}",
@@ -1250,6 +2004,17 @@ fn session_inspector(
             ),
         ),
         kv("states", &distribution_label(&session.states)),
+        kv(
+            "presence",
+            &session
+                .attached_clients
+                .map_or_else(|| "unknown".into(), |count| format!("{count} clients")),
+        ),
+        kv(
+            "load",
+            &format!("{processes} processes · {subagents} subagents"),
+        ),
+        kv("latest", &latest),
         Line::from(""),
         heading("windows"),
     ];
@@ -1260,14 +2025,17 @@ fn session_inspector(
             window.panes.len(),
             distribution_label(&window.states)
         )));
-        for pane in window.panes.iter().take(3) {
+        for pane in &window.panes {
             lines.push(Line::from(format!(
-                "    {}  {}",
+                "    {}  {} · {}",
                 pane.key.pane_id,
                 pane.agent.as_ref().map_or_else(
                     || safe_text(&pane.current_command),
                     |agent| format!("{} {}", agent.kind, state_label(agent.state))
-                )
+                ),
+                pane.agent
+                    .as_ref()
+                    .map_or_else(|| "-".into(), agent_summary),
             )));
         }
     }
@@ -1275,7 +2043,39 @@ fn session_inspector(
 }
 
 fn window_inspector(host: Option<&FleetHostSnapshot>, window: &WindowNode) -> Vec<Line<'static>> {
-    vec![
+    let now = OffsetDateTime::now_utc();
+    let agents = window
+        .panes
+        .iter()
+        .filter_map(|pane| pane.agent.as_ref())
+        .collect::<Vec<_>>();
+    let latest = agents
+        .iter()
+        .max_by_key(|agent| agent.last_activity_at)
+        .map_or_else(
+            || "-".into(),
+            |agent| {
+                format!(
+                    "{} · {} · {}",
+                    format_age(agent.last_activity_at, now),
+                    agent.kind,
+                    agent_summary(agent)
+                )
+            },
+        );
+    let process_count: usize = agents
+        .iter()
+        .map(|agent| usize::from(agent.workload.process_count))
+        .sum();
+    let shell_count: usize = agents
+        .iter()
+        .map(|agent| usize::from(agent.workload.shell_count))
+        .sum();
+    let subagent_count: usize = agents
+        .iter()
+        .map(|agent| usize::from(agent.workload.subagent_count).max(agent.subagents.len()))
+        .sum();
+    let mut lines = vec![
         heading(format!(
             "{} › {}",
             host.map_or("?", |host| host.alias.as_str()),
@@ -1285,8 +2085,31 @@ fn window_inspector(host: Option<&FleetHostSnapshot>, window: &WindowNode) -> Ve
         kv("index", &window.index),
         kv("panes", &window.panes.len().to_string()),
         kv("states", &distribution_label(&window.states)),
+        kv("cwd", window.cwd.as_deref().unwrap_or("mixed/unknown")),
+        kv(
+            "load",
+            &format!(
+                "{process_count} processes · {shell_count} shells · {subagent_count} subagents"
+            ),
+        ),
+        kv("latest", &latest),
         kv("preview", "live layout · selected window only"),
-    ]
+    ];
+    lines.push(Line::from(""));
+    lines.push(heading("panes"));
+    for pane in &window.panes {
+        lines.push(Line::from(format!(
+            "  {}  {}  {}",
+            pane.key.pane_id,
+            pane.agent
+                .as_ref()
+                .map_or("process", |agent| state_label(agent.state)),
+            pane.agent
+                .as_ref()
+                .map_or_else(|| safe_text(&pane.current_command), agent_summary)
+        )));
+    }
+    lines
 }
 
 fn pane_inspector(host: Option<&FleetHostSnapshot>, pane: &PaneNode) -> Vec<Line<'static>> {
@@ -1306,31 +2129,140 @@ fn pane_inspector(host: Option<&FleetHostSnapshot>, pane: &PaneNode) -> Vec<Line
         kv("title", &pane.title),
     ];
     if let Some(agent) = &pane.agent {
+        let now = OffsetDateTime::now_utc();
         lines.extend([
             kv("agent", &agent.kind.to_string()),
-            kv("state", state_label(agent.state)),
+            kv(
+                "state",
+                &format!(
+                    "{} · {}",
+                    state_label(agent.state),
+                    format_age(agent.state_entered_at, now)
+                ),
+            ),
+            kv("activity", &format_age(agent.last_activity_at, now)),
             kv("agent session", &agent.session_id),
             kv("model", agent.model.as_deref().unwrap_or("-")),
+            kv(
+                "usage",
+                &format!(
+                    "ctx {} · cost {}",
+                    agent
+                        .context_used_pct
+                        .map_or_else(|| "-".into(), |value| format!("{value:.0}%")),
+                    agent
+                        .cost_usd
+                        .map_or_else(|| "-".into(), |value| format!("${value:.2}"))
+                ),
+            ),
+            kv(
+                "workload",
+                &format!(
+                    "{} processes · {} shells · {} subagents",
+                    agent.workload.process_count,
+                    agent.workload.shell_count,
+                    usize::from(agent.workload.subagent_count).max(agent.subagents.len())
+                ),
+            ),
             Line::from(""),
-            heading("latest"),
-            Line::from(safe_text(
-                agent
-                    .last_response
-                    .as_deref()
-                    .or(agent.last_prompt.as_deref())
-                    .or(agent.last_notification.as_deref())
-                    .unwrap_or("(no prompt or response recorded)"),
-            )),
+            heading("last prompt"),
+            Line::from(safe_text(agent.last_prompt.as_deref().unwrap_or("-"))),
+            Line::from(""),
+            heading("last response"),
+            Line::from(safe_text(agent.last_response.as_deref().unwrap_or("-"))),
         ]);
+        if !agent.workload.preview.is_empty() {
+            lines.push(Line::from(""));
+            lines.push(heading("process tree"));
+            lines.extend(agent.workload.preview.iter().map(|process| {
+                Line::from(format!(
+                    "  {}pid {}  {}",
+                    "  ".repeat(usize::from(process.depth.saturating_sub(1))),
+                    process.pid,
+                    safe_text(&process.command)
+                ))
+            }));
+        }
     }
     lines
 }
 
-fn render_window_mosaic(frame: &mut Frame, inner: Rect, capture: &FleetWindowCapture) {
+fn paneless_agent_inspector(
+    host: Option<&FleetHostSnapshot>,
+    agent: &muxa::Agent,
+) -> Vec<Line<'static>> {
+    let now = OffsetDateTime::now_utc();
+    let mut lines = vec![
+        heading(format!(
+            "{} › {} (paneless)",
+            host.map_or("?", |host| host.alias.as_str()),
+            agent.kind
+        )),
+        kv("agent session", &agent.session_id),
+        kv("cwd", agent.cwd.as_deref().unwrap_or("-")),
+        kv(
+            "state",
+            &format!(
+                "{} · {}",
+                state_label(agent.state),
+                format_age(agent.state_entered_at, now)
+            ),
+        ),
+        kv("activity", &format_age(agent.last_activity_at, now)),
+        kv("model", agent.model.as_deref().unwrap_or("-")),
+        kv(
+            "usage",
+            &format!(
+                "ctx {} · cost {}",
+                agent
+                    .context_used_pct
+                    .map_or_else(|| "-".into(), |value| format!("{value:.0}%")),
+                agent
+                    .cost_usd
+                    .map_or_else(|| "-".into(), |value| format!("${value:.2}"))
+            ),
+        ),
+        Line::from(""),
+        heading("last prompt"),
+        Line::from(safe_text(agent.last_prompt.as_deref().unwrap_or("-"))),
+        Line::from(""),
+        heading("last response"),
+        Line::from(safe_text(agent.last_response.as_deref().unwrap_or("-"))),
+    ];
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "No pane is attached; attach, capture, and message actions are unavailable.",
+        Style::default().fg(Color::DarkGray),
+    )));
+    lines
+}
+
+fn agent_summary(agent: &muxa::Agent) -> String {
+    safe_text(
+        agent
+            .recap
+            .as_deref()
+            .or(agent.ai_title.as_deref())
+            .or(agent.last_prompt.as_deref())
+            .or(agent.last_notification.as_deref())
+            .unwrap_or("-"),
+    )
+    .replace('\n', " ")
+}
+
+fn render_window_mosaic(
+    frame: &mut Frame,
+    inner: Rect,
+    capture: &FleetWindowCapture,
+    watch_theme: WatchTheme,
+) {
     if capture.panes.is_empty() || inner.height < 12 || inner.width < 32 {
         return;
     }
-    let top = inner.y.saturating_add(7).min(inner.bottom());
+    // Keep the dense window summary (scope/cwd/load/latest) readable above
+    // the live mosaic. The previous seven-line offset painted pane captures
+    // over the final inspector fields as soon as they became richer.
+    let top = inner.y.saturating_add(10).min(inner.bottom());
     let area = Rect::new(
         inner.x,
         top,
@@ -1365,10 +2297,11 @@ fn render_window_mosaic(frame: &mut Frame, inner: Rect, capture: &FleetWindowCap
         ) else {
             continue;
         };
+        let theme = crate::watch::watch_theme(watch_theme);
         let border = if pane.geometry.active {
-            Color::Cyan
+            theme.accent_badge()
         } else {
-            Color::DarkGray
+            theme.border_style()
         };
         let body = pane
             .text
@@ -1380,7 +2313,8 @@ fn render_window_mosaic(frame: &mut Frame, inner: Rect, capture: &FleetWindowCap
                     Block::default()
                         .title(format!(" {} ", pane.geometry.pane_id))
                         .borders(Borders::ALL)
-                        .border_style(Style::default().fg(border)),
+                        .border_type(theme.border_type)
+                        .border_style(border),
                 )
                 .wrap(Wrap { trim: false }),
             rect,
@@ -1424,6 +2358,7 @@ fn scale_geometry(
 }
 
 fn render_composer(frame: &mut Frame, area: Rect, app: &App) {
+    let theme = crate::watch::watch_theme(app.theme);
     let popup = centered(area, 76, 12);
     frame.render_widget(Clear, popup);
     let title = app.selected_key().map_or_else(
@@ -1435,17 +2370,64 @@ fn render_composer(frame: &mut Frame, area: Rect, app: &App) {
             .block(
                 Block::default()
                     .title(title)
-                    .title_bottom(" Enter send · Shift-Enter newline · Esc cancel ")
+                    .title_bottom(" Enter send · Shift-Enter newline · / skills · Esc cancel ")
                     .borders(Borders::ALL)
-                    .border_type(BorderType::Rounded)
-                    .border_style(Style::default().fg(Color::Cyan)),
+                    .border_type(theme.border_type)
+                    .border_style(theme.border_style()),
             )
             .wrap(Wrap { trim: false }),
         popup,
     );
 }
 
-fn render_popup(frame: &mut Frame, area: Rect, title: &str, body: &str) {
+fn render_skill_palette(frame: &mut Frame, area: Rect, app: &App) {
+    let Some(palette) = app.skill_palette.as_ref() else {
+        return;
+    };
+    let theme = crate::watch::watch_theme(app.theme);
+    let matches = crate::message_skill::matching_skills(&app.message_skills, &palette.query);
+    let popup = centered(area, 68, 48);
+    frame.render_widget(Clear, popup);
+    let visible = usize::from(popup.height.saturating_sub(3)).max(1);
+    let start = palette.selected.saturating_add(1).saturating_sub(visible);
+    let lines = matches
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(visible)
+        .map(|(index, (name, prompt))| {
+            let marker = if index == palette.selected { ">" } else { " " };
+            let summary = prompt.lines().next().unwrap_or_default();
+            let line = format!("{marker} /{name:<24}  {}", safe_text(summary));
+            if index == palette.selected {
+                Line::from(Span::styled(line, theme.selected_style()))
+            } else {
+                Line::from(line)
+            }
+        })
+        .collect::<Vec<_>>();
+    let query = if palette.query.is_empty() {
+        "all skills".into()
+    } else {
+        format!("/{}", palette.query)
+    };
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .title(format!(" skills · {query} "))
+                    .title_bottom(" type filter · ↑/↓ select · Enter insert · Esc back ")
+                    .borders(Borders::ALL)
+                    .border_type(theme.border_type)
+                    .border_style(theme.border_style()),
+            )
+            .wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
+fn render_popup(frame: &mut Frame, area: Rect, title: &str, body: &str, watch_theme: WatchTheme) {
+    let theme = crate::watch::watch_theme(watch_theme);
     let popup = centered(area, 82, 70);
     frame.render_widget(Clear, popup);
     frame.render_widget(
@@ -1455,8 +2437,8 @@ fn render_popup(frame: &mut Frame, area: Rect, title: &str, body: &str) {
                     .title(title.to_string())
                     .title_bottom(" Esc/Enter close ")
                     .borders(Borders::ALL)
-                    .border_type(BorderType::Rounded)
-                    .border_style(Style::default().fg(Color::Cyan)),
+                    .border_type(theme.border_type)
+                    .border_style(theme.border_style()),
             )
             .wrap(Wrap { trim: false }),
         popup,
@@ -1502,6 +2484,17 @@ fn find_pane<'a>(topology: &'a TopologySnapshot, key: &PaneKey) -> Option<&'a Pa
         .find(|pane| &pane.key == key)
 }
 
+fn find_paneless_agent<'a>(
+    topology: &'a TopologySnapshot,
+    kind: &str,
+    session_id: &str,
+) -> Option<&'a muxa::Agent> {
+    topology
+        .unassigned_agents
+        .iter()
+        .find(|agent| agent.kind.to_string() == kind && agent.session_id == session_id)
+}
+
 fn key_path(key: &NodeKey) -> String {
     match key {
         NodeKey::Host(host) => host.clone(),
@@ -1513,6 +2506,11 @@ fn key_path(key: &NodeKey) -> String {
             "{host} › {} › {} › {}",
             key.window.session.session_id, key.window.window_id, key.pane_id
         ),
+        NodeKey::PanelessAgent {
+            host,
+            kind,
+            session_id,
+        } => format!("{host} › [paneless] {kind} › {session_id}"),
     }
 }
 
@@ -1699,6 +2697,7 @@ mod tests {
     use super::*;
     use muxa::fleet::{FleetBackendInfo, HostAccessMode, NodeId, RemoteSnapshot};
     use muxa::tmux::PaneInfo;
+    use ratatui::backend::TestBackend;
 
     fn host() -> FleetHostSnapshot {
         FleetHostSnapshot {
@@ -1754,11 +2753,39 @@ mod tests {
         }
     }
 
+    fn paneless_agent() -> muxa::Agent {
+        serde_json::from_value(serde_json::json!({
+            "kind": "codex",
+            "agent_session_id": "detached-review",
+            "pane": null,
+            "cwd": "/repo",
+            "state": "idle",
+            "last_prompt": "review the changes",
+            "last_response": null,
+            "last_notification": null,
+            "model": "gpt-5",
+            "context_used_pct": null,
+            "cost_usd": null,
+            "started_at": "2026-08-20T00:00:00Z",
+            "last_activity_at": "2026-08-20T00:01:00Z",
+            "state_entered_at": "2026-08-20T00:01:00Z"
+        }))
+        .unwrap()
+    }
+
     #[test]
     fn focus_tree_keeps_structural_nodes_but_j_targets_panes() {
         let host = host();
         let topology = host_topology(&host).unwrap();
-        let mut app = App::new(None);
+        let mut app = App::new(
+            None,
+            WatchTheme::Classic,
+            BTreeMap::new(),
+            WatchLayout::Tree,
+            WatchView::Window,
+            WatchTreeExpansion::Focus,
+            WatchSortKey::Name,
+        );
         app.apply_snapshot(FleetSnapshot {
             generated_at: OffsetDateTime::now_utc(),
             hosts: vec![host],
@@ -1782,5 +2809,130 @@ mod tests {
     fn remote_terminal_sequences_are_removed() {
         assert_eq!(safe_text("ok\u{1b}[31m red\u{1b}[0m"), "ok red");
         assert_eq!(safe_text("title\u{1b}]0;owned\u{7}safe"), "titlesafe");
+    }
+
+    #[test]
+    fn lone_local_host_uses_the_full_native_watch() {
+        let mut local = host();
+        local.alias = "local".into();
+        local.local = true;
+        let local_only = FleetSnapshot {
+            generated_at: OffsetDateTime::now_utc(),
+            hosts: vec![local.clone()],
+        };
+        assert!(uses_native_local_watch(&local_only));
+
+        let mut remote = host();
+        remote.alias = "dev".into();
+        assert!(!uses_native_local_watch(&FleetSnapshot {
+            generated_at: OffsetDateTime::now_utc(),
+            hosts: vec![local, remote],
+        }));
+    }
+
+    #[test]
+    fn multi_host_tree_pins_local_first_and_swarm_uses_shared_renderer() {
+        let mut local = host();
+        local.alias = "local".into();
+        local.local = true;
+        let mut remote = host();
+        remote.alias = "aaa-remote".into();
+
+        let snapshot = FleetSnapshot {
+            generated_at: OffsetDateTime::now_utc(),
+            hosts: vec![remote, local],
+        };
+        let mut app = App::new(
+            None,
+            WatchTheme::OhMyMuxa,
+            BTreeMap::new(),
+            WatchLayout::Tree,
+            WatchView::Window,
+            WatchTreeExpansion::Focus,
+            WatchSortKey::Name,
+        );
+        app.apply_snapshot(snapshot.clone());
+        assert_eq!(app.snapshot.hosts[0].alias, "local");
+        assert!(matches!(app.rows[0].key, NodeKey::Host(ref host) if host == "local"));
+
+        let backend = TestBackend::new(140, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(frame, &app)).unwrap();
+        let tree = terminal.backend().to_string();
+        assert!(tree.contains("muxa fleet"));
+        assert!(tree.contains("local"));
+        assert!(tree.contains("aaa-remote"));
+
+        let mut swarm = App::new(
+            None,
+            WatchTheme::OhMyMuxa,
+            BTreeMap::new(),
+            WatchLayout::Swarm,
+            WatchView::Pane,
+            WatchTreeExpansion::Focus,
+            WatchSortKey::Name,
+        );
+        swarm.apply_snapshot(snapshot);
+        terminal.draw(|frame| render(frame, &swarm)).unwrap();
+        let swarm_screen = terminal.backend().to_string();
+        assert!(swarm_screen.contains("swarm"));
+        assert!(swarm_screen.contains("HOST"));
+        assert!(swarm_screen.contains("AGENT / PANE"));
+    }
+
+    #[test]
+    fn paneless_agents_are_explicit_and_only_shown_when_requested() {
+        let mut remote = host();
+        remote
+            .remote
+            .as_mut()
+            .unwrap()
+            .agents
+            .push(paneless_agent());
+        let snapshot = FleetSnapshot {
+            generated_at: OffsetDateTime::now_utc(),
+            hosts: vec![remote],
+        };
+
+        let mut hidden = App::new(
+            None,
+            WatchTheme::Classic,
+            BTreeMap::new(),
+            WatchLayout::Tree,
+            WatchView::Window,
+            WatchTreeExpansion::Focus,
+            WatchSortKey::Name,
+        );
+        hidden.apply_snapshot(snapshot.clone());
+        assert!(!hidden
+            .rows
+            .iter()
+            .any(|row| matches!(row.key, NodeKey::PanelessAgent { .. })));
+
+        let mut shown = App::new(
+            None,
+            WatchTheme::Classic,
+            BTreeMap::new(),
+            WatchLayout::Swarm,
+            WatchView::Pane,
+            WatchTreeExpansion::Focus,
+            WatchSortKey::Name,
+        );
+        shown.show_paneless = true;
+        shown.apply_snapshot(snapshot);
+        assert!(matches!(
+            shown.selected_key(),
+            Some(NodeKey::Pane { .. } | NodeKey::PanelessAgent { .. })
+        ));
+        assert!(all_swarm_keys(
+            &shown.snapshot,
+            &shown.topologies,
+            "detached-review",
+            false,
+            WatchSortKey::Name,
+            true
+        )
+        .iter()
+        .any(|key| matches!(key, NodeKey::PanelessAgent { .. })));
     }
 }

--- a/crates/muxa-cli/src/fleet_watch.rs
+++ b/crates/muxa-cli/src/fleet_watch.rs
@@ -34,6 +34,8 @@ use tokio::sync::mpsc;
 
 const POLL_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 const STREAM_FALLBACK_INTERVAL: Duration = Duration::from_secs(15);
+const STREAM_COALESCE_INTERVAL: Duration = Duration::from_millis(75);
+const STREAM_MIN_REFRESH_INTERVAL: Duration = Duration::from_millis(250);
 const WINDOW_CAPTURE_INTERVAL: Duration = Duration::from_secs(2);
 const INPUT_POLL: Duration = Duration::from_millis(50);
 const IDLE_REDRAW_INTERVAL: Duration = Duration::from_secs(1);
@@ -144,7 +146,7 @@ struct App {
     status: Option<(String, Instant)>,
     selector: Option<String>,
     window_capture: Option<(String, FleetWindowCapture)>,
-    window_capture_pending: bool,
+    window_capture_pending: Option<(String, WindowKey)>,
     last_window_capture: Option<Instant>,
     theme: WatchTheme,
     message_skills: BTreeMap<String, String>,
@@ -186,7 +188,7 @@ impl App {
             status: None,
             selector,
             window_capture: None,
-            window_capture_pending: false,
+            window_capture_pending: None,
             last_window_capture: None,
             theme,
             message_skills,
@@ -234,26 +236,6 @@ impl App {
             self.expansion_initialized = true;
         }
         self.rebuild_rows(selected.as_ref());
-        if self.layout == WatchLayout::Swarm
-            && !matches!(
-                self.selected_key(),
-                Some(NodeKey::Pane { .. } | NodeKey::PanelessAgent { .. })
-            )
-        {
-            if let Some(first) = all_swarm_keys(
-                &self.snapshot,
-                &self.topologies,
-                &self.query,
-                self.attention_only,
-                self.sort,
-                self.show_paneless,
-            )
-            .into_iter()
-            .next()
-            {
-                self.focus_key(first);
-            }
-        }
     }
 
     fn initialize_expansion(&mut self) {
@@ -317,6 +299,36 @@ impl App {
         }
     }
 
+    /// Resolve a message target without forcing the operator to descend a
+    /// single-child tree. Parent nodes choose the lowest stable window/pane
+    /// index that currently owns a live agent.
+    fn selected_message_pane(&self) -> Option<(String, PaneKey)> {
+        let selected = self.selected_key()?;
+        let host_alias = selected.host();
+        let topology = self.topologies.get(host_alias)?;
+        let pane = match selected {
+            NodeKey::Pane { key, .. } => topology
+                .sessions
+                .iter()
+                .flat_map(|session| &session.windows)
+                .flat_map(|window| &window.panes)
+                .find(|pane| pane.key == *key && pane_has_live_agent(pane)),
+            NodeKey::Window { key, .. } => topology
+                .sessions
+                .iter()
+                .flat_map(|session| &session.windows)
+                .find(|window| window.key == *key)
+                .and_then(lowest_live_pane),
+            NodeKey::Session { key, .. } => topology
+                .sessions
+                .iter()
+                .find(|session| session.key == *key)
+                .and_then(lowest_live_session_pane),
+            NodeKey::Host(_) | NodeKey::PanelessAgent { .. } => None,
+        }?;
+        Some((host_alias.to_string(), pane.key.clone()))
+    }
+
     fn selected_window(&self) -> Option<(String, WindowKey)> {
         match self.selected_key()? {
             NodeKey::Window { host, key } => Some((host.clone(), key.clone())),
@@ -325,6 +337,27 @@ impl App {
     }
 
     fn rebuild_rows(&mut self, preserve: Option<&NodeKey>) {
+        let preserve = preserve.cloned().or_else(|| self.selected_key().cloned());
+        let swarm_selected = (self.layout == WatchLayout::Swarm).then(|| {
+            let nodes = all_swarm_keys(
+                &self.snapshot,
+                &self.topologies,
+                &self.query,
+                self.attention_only,
+                self.sort,
+                self.show_paneless,
+            );
+            preserve
+                .clone()
+                .filter(|key| nodes.contains(key))
+                .or_else(|| nodes.into_iter().next())
+        });
+        // `selected` indexes the backing tree even in Swarm mode. Its leaf
+        // therefore needs visible ancestors regardless of tree-expansion
+        // policy; those structural rows are not rendered in the Swarm table.
+        if let Some(Some(key)) = &swarm_selected {
+            self.expanded.extend(key.ancestors());
+        }
         self.rows = build_rows(
             &self.snapshot,
             &self.topologies,
@@ -334,8 +367,15 @@ impl App {
             self.sort,
             self.show_paneless,
         );
-        if let Some(key) = preserve {
-            if let Some(index) = self.rows.iter().position(|row| &row.key == key) {
+        if self.layout == WatchLayout::Swarm {
+            if let Some(Some(key)) = swarm_selected {
+                if let Some(index) = self.rows.iter().position(|row| row.key == key) {
+                    self.selected = index;
+                    return;
+                }
+            }
+        } else if let Some(key) = preserve {
+            if let Some(index) = self.rows.iter().position(|row| row.key == key) {
                 self.selected = index;
                 return;
             }
@@ -344,13 +384,30 @@ impl App {
     }
 
     fn focus_key(&mut self, key: NodeKey) {
-        if self.expansion != WatchTreeExpansion::Always {
+        self.select_key(key, false);
+    }
+
+    fn reveal_key(&mut self, key: NodeKey) {
+        self.select_key(key, true);
+    }
+
+    fn select_key(&mut self, key: NodeKey, reveal: bool) {
+        if self.expansion == WatchTreeExpansion::Focus {
             self.expanded.clear();
         }
-        for ancestor in key.ancestors() {
-            self.expanded.insert(ancestor);
+        if reveal || self.expansion == WatchTreeExpansion::Focus {
+            for ancestor in key.ancestors() {
+                self.expanded.insert(ancestor);
+            }
         }
-        if key.is_parent() {
+        if self.expansion == WatchTreeExpansion::Focus
+            && match &key {
+                NodeKey::Host(_) => true,
+                NodeKey::Session { .. } => self.view != WatchView::Session,
+                NodeKey::Window { .. } => self.view == WatchView::Pane,
+                NodeKey::Pane { .. } | NodeKey::PanelessAgent { .. } => false,
+            }
+        {
             self.expanded.insert(key.clone());
         }
         self.rebuild_rows(Some(&key));
@@ -399,7 +456,7 @@ impl App {
             (None, false) => 0,
             (None, true) => panes.len() - 1,
         };
-        self.focus_key(panes[next].clone());
+        self.reveal_key(panes[next].clone());
     }
 
     fn move_swarm(&mut self, delta: isize) {
@@ -422,7 +479,7 @@ impl App {
             (None, false) => 0,
             (None, true) => nodes.len() - 1,
         };
-        self.focus_key(nodes[next].clone());
+        self.reveal_key(nodes[next].clone());
     }
 
     fn toggle_selected(&mut self) {
@@ -478,6 +535,55 @@ impl App {
     }
 }
 
+fn pane_has_live_agent(pane: &PaneNode) -> bool {
+    pane.agent
+        .as_ref()
+        .is_some_and(|agent| agent.state != AgentState::Stopped)
+}
+
+fn compare_numeric_index(left: &str, right: &str) -> std::cmp::Ordering {
+    match (left.parse::<u64>().ok(), right.parse::<u64>().ok()) {
+        (Some(left), Some(right)) => left.cmp(&right),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => left.cmp(right),
+    }
+}
+
+fn compare_optional_ascending<T: Ord>(left: Option<T>, right: Option<T>) -> std::cmp::Ordering {
+    match (left, right) {
+        (Some(left), Some(right)) => left.cmp(&right),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    }
+}
+
+fn lowest_live_pane(window: &WindowNode) -> Option<&PaneNode> {
+    window
+        .panes
+        .iter()
+        .filter(|pane| pane_has_live_agent(pane))
+        .min_by(|left, right| {
+            compare_numeric_index(&left.index, &right.index)
+                .then_with(|| left.key.pane_id.cmp(&right.key.pane_id))
+        })
+}
+
+fn lowest_live_session_pane(session: &SessionNode) -> Option<&PaneNode> {
+    session
+        .windows
+        .iter()
+        .filter_map(|window| lowest_live_pane(window).map(|pane| (window, pane)))
+        .min_by(|(left_window, left_pane), (right_window, right_pane)| {
+            compare_numeric_index(&left_window.index, &right_window.index)
+                .then_with(|| left_window.key.window_id.cmp(&right_window.key.window_id))
+                .then_with(|| compare_numeric_index(&left_pane.index, &right_pane.index))
+                .then_with(|| left_pane.key.pane_id.cmp(&right_pane.key.pane_id))
+        })
+        .map(|(_, pane)| pane)
+}
+
 enum BackgroundResult {
     Window {
         host: String,
@@ -529,8 +635,17 @@ pub(crate) async fn run(
     app.apply_snapshot(initial);
     let (background_tx, mut background_rx) = mpsc::unbounded_channel();
     let (fleet_update_tx, mut fleet_update_rx) = mpsc::channel(1);
-    let fleet_stream = client.fleet_subscribe().await.ok();
+    let fleet_stream = client.fleet_subscribe(app.selector.as_deref()).await.ok();
     let mut streaming = fleet_stream.is_some();
+    if streaming {
+        // The server installs its receiver before ACK. Fetching again here
+        // closes the initial-snapshot/subscription gap without requiring a
+        // heavyweight snapshot on every stream frame.
+        match client.fleet_snapshot(app.selector.as_deref()).await {
+            Ok(snapshot) => app.apply_snapshot(snapshot),
+            Err(error) => app.status(format!("initial fleet refresh failed: {error}")),
+        }
+    }
     let fleet_update_task = fleet_stream.map(|mut stream| {
         tokio::spawn(async move {
             loop {
@@ -547,6 +662,7 @@ pub(crate) async fn run(
     });
     let now = Instant::now();
     let mut last_refresh = now;
+    let mut refresh_deadline = None;
     let mut last_render = now.checked_sub(IDLE_REDRAW_INTERVAL).unwrap_or(now);
     let mut needs_render = true;
     let mut quit = false;
@@ -564,7 +680,15 @@ pub(crate) async fn run(
         } else {
             POLL_REFRESH_INTERVAL
         };
-        if invalidated || last_refresh.elapsed() >= refresh_interval {
+        if invalidated && refresh_deadline.is_none() {
+            let now = Instant::now();
+            refresh_deadline = Some(
+                (now + STREAM_COALESCE_INTERVAL).max(last_refresh + STREAM_MIN_REFRESH_INTERVAL),
+            );
+        }
+        let streamed_refresh_due =
+            refresh_deadline.is_some_and(|deadline| Instant::now() >= deadline);
+        if streamed_refresh_due || last_refresh.elapsed() >= refresh_interval {
             match client.fleet_snapshot(app.selector.as_deref()).await {
                 Ok(snapshot) => {
                     app.apply_snapshot(snapshot);
@@ -573,6 +697,7 @@ pub(crate) async fn run(
                 Err(error) => app.status(format!("fleet refresh failed: {error}")),
             }
             last_refresh = Instant::now();
+            refresh_deadline = None;
         }
 
         while let Ok(result) = background_rx.try_recv() {
@@ -583,7 +708,7 @@ pub(crate) async fn run(
                     window,
                     result,
                 } => {
-                    app.window_capture_pending = false;
+                    app.window_capture_pending = None;
                     app.last_window_capture = Some(Instant::now());
                     match result {
                         Ok(result) => {
@@ -724,8 +849,8 @@ fn handle_key(
                     app.composer.push('\n');
                 }
                 KeyCode::Enter => {
-                    let Some((host, pane)) = app.selected_pane() else {
-                        app.mode = InputMode::Normal;
+                    let Some((host, pane)) = app.selected_message_pane() else {
+                        app.status("selected node has no live agent pane");
                         return Ok(false);
                     };
                     if app.composer.trim().is_empty() {
@@ -790,12 +915,40 @@ fn handle_key(
         KeyCode::Char('j') => app.move_pane(1),
         KeyCode::Char('k') => app.move_pane(-1),
         KeyCode::Home | KeyCode::Char('g') => {
-            if let Some(first) = app.rows.first().map(|row| row.key.clone()) {
+            if app.layout == WatchLayout::Swarm {
+                if let Some(first) = all_swarm_keys(
+                    &app.snapshot,
+                    &app.topologies,
+                    &app.query,
+                    app.attention_only,
+                    app.sort,
+                    app.show_paneless,
+                )
+                .into_iter()
+                .next()
+                {
+                    app.reveal_key(first);
+                }
+            } else if let Some(first) = app.rows.first().map(|row| row.key.clone()) {
                 app.focus_key(first);
             }
         }
         KeyCode::End | KeyCode::Char('G') => {
-            if let Some(last) = app.rows.last().map(|row| row.key.clone()) {
+            if app.layout == WatchLayout::Swarm {
+                if let Some(last) = all_swarm_keys(
+                    &app.snapshot,
+                    &app.topologies,
+                    &app.query,
+                    app.attention_only,
+                    app.sort,
+                    app.show_paneless,
+                )
+                .into_iter()
+                .last()
+                {
+                    app.reveal_key(last);
+                }
+            } else if let Some(last) = app.rows.last().map(|row| row.key.clone()) {
                 app.focus_key(last);
             }
         }
@@ -848,12 +1001,12 @@ fn handle_key(
             }
         }
         KeyCode::Char('m') => {
-            if app.selected_pane().is_some() {
+            if app.selected_message_pane().is_some() {
                 app.mode = InputMode::Message;
                 app.composer.clear();
                 app.skill_palette = None;
             } else {
-                app.status("select a pane before sending a prompt");
+                app.status("select a session, window, or pane with a live agent");
             }
         }
         KeyCode::Enter => {
@@ -915,7 +1068,6 @@ fn maybe_capture_window(
     background: &mpsc::UnboundedSender<BackgroundResult>,
 ) {
     let Some((host, window)) = app.selected_window() else {
-        app.window_capture_pending = false;
         return;
     };
     let same = app
@@ -926,10 +1078,10 @@ fn maybe_capture_window(
         || app
             .last_window_capture
             .is_none_or(|last| last.elapsed() >= WINDOW_CAPTURE_INTERVAL);
-    if !due || app.window_capture_pending {
+    if !due || app.window_capture_pending.is_some() {
         return;
     }
-    app.window_capture_pending = true;
+    app.window_capture_pending = Some((host.clone(), window.clone()));
     let client = client.clone();
     let sender = background.clone();
     let request_window = window.clone();
@@ -994,7 +1146,7 @@ fn build_rows(
     let mut rows = Vec::new();
     for host in &snapshot.hosts {
         let topology = topologies.get(&host.alias);
-        if !host_relevant(host, topology, query, attention_only) {
+        if !host_relevant(host, topology, query, attention_only, show_paneless) {
             continue;
         }
         let host_key = NodeKey::Host(host.alias.clone());
@@ -1013,7 +1165,7 @@ fn build_rows(
                 host.agent_count(),
             ),
             state: dominant_host_state(host),
-            attention: host.needs_attention(),
+            attention: visible_host_attention(host, topology, show_paneless),
             children: topology.map_or(0, |topology| topology.sessions.len()) + paneless_count,
         });
         let show_host = expanded.contains(&host_key) || !query.is_empty() || attention_only;
@@ -1192,7 +1344,9 @@ fn compare_hosts(
 ) -> std::cmp::Ordering {
     match sort {
         WatchSortKey::Activity => host_latest_activity(right).cmp(&host_latest_activity(left)),
-        WatchSortKey::Duration => host_earliest_start(left).cmp(&host_earliest_start(right)),
+        WatchSortKey::Duration => {
+            compare_optional_ascending(host_earliest_start(left), host_earliest_start(right))
+        }
         WatchSortKey::State => right
             .needs_attention()
             .cmp(&left.needs_attention())
@@ -1227,11 +1381,7 @@ fn compare_windows(
     sort: WatchSortKey,
 ) -> std::cmp::Ordering {
     let order = match sort {
-        WatchSortKey::Pane => left
-            .index
-            .parse::<u32>()
-            .ok()
-            .cmp(&right.index.parse::<u32>().ok()),
+        WatchSortKey::Pane => compare_numeric_index(&left.index, &right.index),
         _ => compare_node_agents(left.panes.iter(), right.panes.iter(), sort),
     };
     order.then_with(|| left.name.cmp(&right.name))
@@ -1254,11 +1404,10 @@ fn compare_node_agents<'a>(
             .map(|agent| agent.last_activity_at)
             .max()
             .cmp(&left.iter().map(|agent| agent.last_activity_at).max()),
-        WatchSortKey::Duration => left
-            .iter()
-            .map(|agent| agent.started_at)
-            .min()
-            .cmp(&right.iter().map(|agent| agent.started_at).min()),
+        WatchSortKey::Duration => compare_optional_ascending(
+            left.iter().map(|agent| agent.started_at).min(),
+            right.iter().map(|agent| agent.started_at).min(),
+        ),
         WatchSortKey::State => {
             let rank = |agents: &[&muxa::Agent]| {
                 agents
@@ -1280,16 +1429,13 @@ fn compare_panes(left: &PaneNode, right: &PaneNode, sort: WatchSortKey) -> std::
         WatchSortKey::Activity => right_agent
             .map(|agent| agent.last_activity_at)
             .cmp(&left_agent.map(|agent| agent.last_activity_at)),
-        WatchSortKey::Duration => left_agent
-            .map(|agent| agent.state_entered_at)
-            .cmp(&right_agent.map(|agent| agent.state_entered_at)),
+        WatchSortKey::Duration => compare_optional_ascending(
+            left_agent.map(|agent| agent.state_entered_at),
+            right_agent.map(|agent| agent.state_entered_at),
+        ),
         WatchSortKey::State => state_sort_rank(right_agent.map(|agent| agent.state))
             .cmp(&state_sort_rank(left_agent.map(|agent| agent.state))),
-        WatchSortKey::Pane => left
-            .index
-            .parse::<u32>()
-            .ok()
-            .cmp(&right.index.parse::<u32>().ok()),
+        WatchSortKey::Pane => compare_numeric_index(&left.index, &right.index),
         WatchSortKey::PaneId => left.key.pane_id.cmp(&right.key.pane_id),
         WatchSortKey::Name => left.index.cmp(&right.index),
     }
@@ -1311,7 +1457,15 @@ fn all_pane_keys(
     let mut panes = snapshot
         .hosts
         .iter()
-        .filter(|host| host_relevant(host, topologies.get(&host.alias), query, attention_only))
+        .filter(|host| {
+            host_relevant(
+                host,
+                topologies.get(&host.alias),
+                query,
+                attention_only,
+                false,
+            )
+        })
         .flat_map(|host| {
             topologies
                 .get(&host.alias)
@@ -1403,16 +1557,13 @@ fn compare_pane_keys(
         WatchSortKey::Activity => right_agent
             .map(|agent| agent.last_activity_at)
             .cmp(&left_agent.map(|agent| agent.last_activity_at)),
-        WatchSortKey::Duration => left_agent
-            .map(|agent| agent.state_entered_at)
-            .cmp(&right_agent.map(|agent| agent.state_entered_at)),
+        WatchSortKey::Duration => compare_optional_ascending(
+            left_agent.map(|agent| agent.state_entered_at),
+            right_agent.map(|agent| agent.state_entered_at),
+        ),
         WatchSortKey::State => state_sort_rank(right_agent.map(|agent| agent.state))
             .cmp(&state_sort_rank(left_agent.map(|agent| agent.state))),
-        WatchSortKey::Pane => left_pane
-            .index
-            .parse::<u32>()
-            .ok()
-            .cmp(&right_pane.index.parse::<u32>().ok()),
+        WatchSortKey::Pane => compare_numeric_index(&left_pane.index, &right_pane.index),
         WatchSortKey::PaneId => left_pane.key.pane_id.cmp(&right_pane.key.pane_id),
         WatchSortKey::Name => left_pane
             .key
@@ -1449,8 +1600,9 @@ fn host_relevant(
     topology: Option<&TopologySnapshot>,
     query: &str,
     attention_only: bool,
+    show_paneless: bool,
 ) -> bool {
-    if attention_only && host.needs_attention() == 0 {
+    if attention_only && visible_host_attention(host, topology, show_paneless) == 0 {
         return false;
     }
     let query = query.to_lowercase();
@@ -1469,7 +1621,36 @@ fn host_relevant(
                 .sessions
                 .iter()
                 .any(|session| session_relevant(session, &query, false))
+                || (show_paneless
+                    && topology
+                        .unassigned_agents
+                        .iter()
+                        .any(|agent| agent_relevant(agent, &query, false)))
         })
+}
+
+fn visible_host_attention(
+    host: &FleetHostSnapshot,
+    topology: Option<&TopologySnapshot>,
+    show_paneless: bool,
+) -> usize {
+    topology.map_or_else(
+        || host.needs_attention(),
+        |topology| {
+            let attached = topology
+                .sessions
+                .iter()
+                .map(|session| distribution_attention(&session.states))
+                .sum::<usize>();
+            attached
+                + usize::from(show_paneless)
+                    * topology
+                        .unassigned_agents
+                        .iter()
+                        .filter(|agent| needs_attention(agent.state))
+                        .count()
+        },
+    )
 }
 
 fn session_relevant(session: &SessionNode, query: &str, attention_only: bool) -> bool {
@@ -1790,7 +1971,7 @@ fn swarm_row(
                 },
                 |agent| {
                     (
-                        format!("{} · {}", agent.kind, pane.key.pane_id),
+                        safe_text(&format!("{} · {}", agent.kind, pane.key.pane_id)),
                         Line::from(Span::styled(
                             format!("{} {}", state_marker(agent.state), state_label(agent.state)),
                             theme.state_style(agent.state),
@@ -2026,7 +2207,7 @@ fn session_inspector(
             distribution_label(&window.states)
         )));
         for pane in &window.panes {
-            lines.push(Line::from(format!(
+            lines.push(Line::from(safe_text(&format!(
                 "    {}  {} · {}",
                 pane.key.pane_id,
                 pane.agent.as_ref().map_or_else(
@@ -2036,7 +2217,7 @@ fn session_inspector(
                 pane.agent
                     .as_ref()
                     .map_or_else(|| "-".into(), agent_summary),
-            )));
+            ))));
         }
     }
     lines
@@ -2098,7 +2279,7 @@ fn window_inspector(host: Option<&FleetHostSnapshot>, window: &WindowNode) -> Ve
     lines.push(Line::from(""));
     lines.push(heading("panes"));
     for pane in &window.panes {
-        lines.push(Line::from(format!(
+        lines.push(Line::from(safe_text(&format!(
             "  {}  {}  {}",
             pane.key.pane_id,
             pane.agent
@@ -2107,7 +2288,7 @@ fn window_inspector(host: Option<&FleetHostSnapshot>, window: &WindowNode) -> Ve
             pane.agent
                 .as_ref()
                 .map_or_else(|| safe_text(&pane.current_command), agent_summary)
-        )));
+        ))));
     }
     lines
 }
@@ -2311,7 +2492,7 @@ fn render_window_mosaic(
             Paragraph::new(body)
                 .block(
                     Block::default()
-                        .title(format!(" {} ", pane.geometry.pane_id))
+                        .title(format!(" {} ", safe_text(&pane.geometry.pane_id)))
                         .borders(Borders::ALL)
                         .border_type(theme.border_type)
                         .border_style(border),
@@ -2366,7 +2547,7 @@ fn render_composer(frame: &mut Frame, area: Rect, app: &App) {
         |key| format!(" message · {} ", key_path(key)),
     );
     frame.render_widget(
-        Paragraph::new(format!("{}_", app.composer))
+        Paragraph::new(format!("{}_", safe_text(&app.composer)))
             .block(
                 Block::default()
                     .title(title)
@@ -2496,7 +2677,7 @@ fn find_paneless_agent<'a>(
 }
 
 fn key_path(key: &NodeKey) -> String {
-    match key {
+    safe_text(&match key {
         NodeKey::Host(host) => host.clone(),
         NodeKey::Session { host, key } => format!("{host} › {}", key.session_id),
         NodeKey::Window { host, key } => {
@@ -2511,7 +2692,7 @@ fn key_path(key: &NodeKey) -> String {
             kind,
             session_id,
         } => format!("{host} › [paneless] {kind} › {session_id}"),
-    }
+    })
 }
 
 fn heading(value: impl Into<String>) -> Line<'static> {
@@ -2773,6 +2954,15 @@ mod tests {
         .unwrap()
     }
 
+    fn attached_agent(session_id: &str, pane_id: &str) -> muxa::Agent {
+        let mut agent = paneless_agent();
+        agent.session_id = session_id.into();
+        agent.pane = Some(pane_id.into());
+        agent.tmux_socket = Some("default".into());
+        agent.state = AgentState::Idle;
+        agent
+    }
+
     #[test]
     fn focus_tree_keeps_structural_nodes_but_j_targets_panes() {
         let host = host();
@@ -2806,9 +2996,166 @@ mod tests {
     }
 
     #[test]
+    fn expansion_policy_respects_view_and_manual_navigation() {
+        let snapshot = FleetSnapshot {
+            generated_at: OffsetDateTime::now_utc(),
+            hosts: vec![host()],
+        };
+
+        let mut session_view = App::new(
+            None,
+            WatchTheme::Classic,
+            BTreeMap::new(),
+            WatchLayout::Tree,
+            WatchView::Session,
+            WatchTreeExpansion::Focus,
+            WatchSortKey::Name,
+        );
+        session_view.apply_snapshot(snapshot.clone());
+        let session = session_view
+            .rows
+            .iter()
+            .find_map(|row| matches!(&row.key, NodeKey::Session { .. }).then(|| row.key.clone()))
+            .unwrap();
+        session_view.focus_key(session);
+        assert!(!session_view
+            .rows
+            .iter()
+            .any(|row| matches!(row.key, NodeKey::Window { .. })));
+
+        let mut window_view = App::new(
+            None,
+            WatchTheme::Classic,
+            BTreeMap::new(),
+            WatchLayout::Tree,
+            WatchView::Window,
+            WatchTreeExpansion::Focus,
+            WatchSortKey::Name,
+        );
+        window_view.apply_snapshot(snapshot.clone());
+        let session = window_view
+            .rows
+            .iter()
+            .find_map(|row| matches!(&row.key, NodeKey::Session { .. }).then(|| row.key.clone()))
+            .unwrap();
+        window_view.focus_key(session);
+        let window = window_view
+            .rows
+            .iter()
+            .find_map(|row| matches!(&row.key, NodeKey::Window { .. }).then(|| row.key.clone()))
+            .unwrap();
+        window_view.focus_key(window);
+        assert!(!window_view
+            .rows
+            .iter()
+            .any(|row| matches!(row.key, NodeKey::Pane { .. })));
+
+        let mut manual = App::new(
+            None,
+            WatchTheme::Classic,
+            BTreeMap::new(),
+            WatchLayout::Tree,
+            WatchView::Pane,
+            WatchTreeExpansion::Manual,
+            WatchSortKey::Name,
+        );
+        manual.apply_snapshot(snapshot);
+        assert_eq!(manual.rows.len(), 1);
+        manual.focus_key(NodeKey::Host("dev".into()));
+        assert_eq!(
+            manual.rows.len(),
+            1,
+            "ordinary movement must not expand manual trees"
+        );
+        manual.move_pane(1);
+        assert!(matches!(manual.selected_key(), Some(NodeKey::Pane { .. })));
+        assert!(manual
+            .rows
+            .iter()
+            .any(|row| matches!(row.key, NodeKey::Session { .. })));
+    }
+
+    #[test]
+    fn parent_message_target_is_the_lowest_live_window_and_pane() {
+        let mut remote_host = host();
+        let remote = remote_host.remote.as_mut().unwrap();
+        remote.panes[0].window_index = "1".into();
+        let mut pane_nine = remote.panes[0].clone();
+        pane_nine.pane_id = "%9".into();
+        pane_nine.window_id = "@0".into();
+        pane_nine.window_index = "0".into();
+        pane_nine.pane_index = "9".into();
+        let mut pane_two = pane_nine.clone();
+        pane_two.pane_id = "%2".into();
+        pane_two.pane_index = "2".into();
+        remote.panes.extend([pane_nine, pane_two]);
+        remote.agents.extend([
+            attached_agent("agent-one", "%1"),
+            attached_agent("agent-nine", "%9"),
+            attached_agent("agent-two", "%2"),
+        ]);
+
+        let mut app = App::new(
+            None,
+            WatchTheme::Classic,
+            BTreeMap::new(),
+            WatchLayout::Tree,
+            WatchView::Pane,
+            WatchTreeExpansion::Focus,
+            WatchSortKey::Name,
+        );
+        app.apply_snapshot(FleetSnapshot {
+            generated_at: OffsetDateTime::now_utc(),
+            hosts: vec![remote_host],
+        });
+        let session = app
+            .rows
+            .iter()
+            .find_map(|row| matches!(&row.key, NodeKey::Session { .. }).then(|| row.key.clone()))
+            .unwrap();
+        app.reveal_key(session);
+        assert_eq!(
+            app.selected_message_pane().map(|(_, pane)| pane.pane_id),
+            Some("%2".into())
+        );
+        let window = app
+            .rows
+            .iter()
+            .find_map(|row| match &row.key {
+                NodeKey::Window { key, .. } if key.window_id == "@0" => Some(row.key.clone()),
+                _ => None,
+            })
+            .unwrap();
+        app.reveal_key(window);
+        assert_eq!(
+            app.selected_message_pane().map(|(_, pane)| pane.pane_id),
+            Some("%2".into())
+        );
+    }
+
+    #[test]
     fn remote_terminal_sequences_are_removed() {
         assert_eq!(safe_text("ok\u{1b}[31m red\u{1b}[0m"), "ok red");
         assert_eq!(safe_text("title\u{1b}]0;owned\u{7}safe"), "titlesafe");
+        assert_eq!(
+            key_path(&NodeKey::Pane {
+                host: "dev\u{1b}[31m".into(),
+                key: PaneKey {
+                    window: WindowKey {
+                        session: SessionKey {
+                            endpoint: muxa::BackendEndpoint {
+                                host: HostKind::Tmux,
+                                socket: "default".into(),
+                            },
+                            session_id: "$1".into(),
+                        },
+                        window_id: "@1".into(),
+                    },
+                    pane_id: "%1\u{1b}]0;owned\u{7}".into(),
+                },
+            }),
+            "dev › $1 › @1 › %1"
+        );
     }
 
     #[test]
@@ -2869,7 +3216,7 @@ mod tests {
             BTreeMap::new(),
             WatchLayout::Swarm,
             WatchView::Pane,
-            WatchTreeExpansion::Focus,
+            WatchTreeExpansion::Manual,
             WatchSortKey::Name,
         );
         swarm.apply_snapshot(snapshot);
@@ -2915,7 +3262,7 @@ mod tests {
             BTreeMap::new(),
             WatchLayout::Swarm,
             WatchView::Pane,
-            WatchTreeExpansion::Focus,
+            WatchTreeExpansion::Manual,
             WatchSortKey::Name,
         );
         shown.show_paneless = true;
@@ -2934,5 +3281,52 @@ mod tests {
         )
         .iter()
         .any(|key| matches!(key, NodeKey::PanelessAgent { .. })));
+
+        shown.layout = WatchLayout::Tree;
+        shown.query = "detached-review".into();
+        shown.rebuild_rows(None);
+        assert!(shown
+            .rows
+            .iter()
+            .any(|row| matches!(row.key, NodeKey::Host(_))));
+        assert!(shown
+            .rows
+            .iter()
+            .any(|row| matches!(row.key, NodeKey::PanelessAgent { .. })));
+    }
+
+    #[test]
+    fn swarm_rebuild_never_leaves_a_structural_action_target_selected() {
+        let mut remote = host();
+        remote
+            .remote
+            .as_mut()
+            .unwrap()
+            .agents
+            .push(paneless_agent());
+        let mut app = App::new(
+            None,
+            WatchTheme::Classic,
+            BTreeMap::new(),
+            WatchLayout::Swarm,
+            WatchView::Pane,
+            WatchTreeExpansion::Manual,
+            WatchSortKey::Name,
+        );
+        app.show_paneless = true;
+        app.apply_snapshot(FleetSnapshot {
+            generated_at: OffsetDateTime::now_utc(),
+            hosts: vec![remote],
+        });
+        assert!(matches!(
+            app.selected_key(),
+            Some(NodeKey::Pane { .. } | NodeKey::PanelessAgent { .. })
+        ));
+        app.query = "detached-review".into();
+        app.rebuild_rows(None);
+        assert!(matches!(
+            app.selected_key(),
+            Some(NodeKey::PanelessAgent { .. })
+        ));
     }
 }

--- a/crates/muxa-cli/src/fleet_watch.rs
+++ b/crates/muxa-cli/src/fleet_watch.rs
@@ -557,6 +557,10 @@ fn handle_key(
         }
         KeyCode::Char('c') => {
             if let Some(host) = app.selected_host() {
+                if host.local {
+                    app.status("local host is always connected");
+                    return Ok(false);
+                }
                 let operation = if matches!(
                     host.state,
                     FleetHostState::Online | FleetHostState::Connecting | FleetHostState::Degraded
@@ -1699,6 +1703,7 @@ mod tests {
     fn host() -> FleetHostSnapshot {
         FleetHostSnapshot {
             alias: "dev".into(),
+            local: false,
             ssh_target: "devbox".into(),
             labels: std::collections::BTreeMap::from([("tier".into(), "gpu".into())]),
             annotations: std::collections::BTreeMap::new(),

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -465,7 +465,7 @@ enum HookCmd {
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
-enum WatchViewArg {
+pub(crate) enum WatchViewArg {
     Session,
     Window,
     Pane,
@@ -482,7 +482,7 @@ impl From<WatchViewArg> for muxa::config::WatchView {
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
-enum WatchLayoutArg {
+pub(crate) enum WatchLayoutArg {
     Tree,
     Swarm,
 }
@@ -497,7 +497,7 @@ impl From<WatchLayoutArg> for muxa::config::WatchLayout {
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
-enum WatchSortArg {
+pub(crate) enum WatchSortArg {
     Name,
     #[value(alias = "activity", alias = "act")]
     Latest,
@@ -626,25 +626,27 @@ async fn main() -> Result<()> {
             caller_client,
             caller_pane,
         } => {
-            if fleet {
-                selector
-                    .as_deref()
-                    .map(str::parse::<muxa::LabelSelector>)
-                    .transpose()
-                    .map_err(anyhow::Error::msg)
-                    .context("invalid fleet label selector")?;
-                return fleet_watch::run(client, &cfg, selector).await;
-            }
-            // Pin focus-moving commands to the requesting client; jump_to_pane_tmux reads it.
-            //
-            // A value still containing `#{` is a binding that never expanded
-            // its formats (plain `display-popup` does not expand; only the
-            // `run-shell` wrapper does). Passing it on would aim every
-            // switch-client at a client named `#{client_name}` — a silent
-            // no-op that presents as "Enter does nothing". Drop it and fall
-            // back instead.
+            // Pin focus-moving commands to the requesting client. A value
+            // still containing `#{` is a binding that never expanded.
             if let Some(client_name) = caller_client.filter(|c| !c.contains("#{")) {
                 let _ = CALLER_CLIENT.set(client_name);
+            }
+            if fleet {
+                return cmd_fleet_watch(
+                    &client,
+                    cfg,
+                    config_path.clone(),
+                    selector,
+                    WatchInvocation {
+                        include_paneless,
+                        view,
+                        layout,
+                        sort,
+                        theme,
+                        caller_pane: caller_pane.filter(|p| p.starts_with('%')),
+                    },
+                )
+                .await;
             }
             cmd_watch(
                 &client,
@@ -1329,16 +1331,44 @@ async fn cmd_sync(client: &Client) -> Result<()> {
 /// One-shot per-invocation overrides for `muxa watch`, bundled so the
 /// argument list stays a description of *this run* rather than a flat
 /// parade of options.
-struct WatchInvocation {
-    include_paneless: bool,
-    view: Option<WatchViewArg>,
-    layout: Option<WatchLayoutArg>,
-    sort: Option<WatchSortArg>,
-    theme: Option<ThemeArg>,
-    caller_pane: Option<String>,
+#[derive(Debug, Clone)]
+pub(crate) struct WatchInvocation {
+    pub(crate) include_paneless: bool,
+    pub(crate) view: Option<WatchViewArg>,
+    pub(crate) layout: Option<WatchLayoutArg>,
+    pub(crate) sort: Option<WatchSortArg>,
+    pub(crate) theme: Option<ThemeArg>,
+    pub(crate) caller_pane: Option<String>,
 }
 
-async fn cmd_watch(
+pub(crate) async fn cmd_fleet_watch(
+    client: &Client,
+    cfg: Config,
+    config_path: Option<PathBuf>,
+    selector: Option<String>,
+    invocation: WatchInvocation,
+) -> Result<()> {
+    selector
+        .as_deref()
+        .map(str::parse::<muxa::LabelSelector>)
+        .transpose()
+        .map_err(anyhow::Error::msg)
+        .context("invalid fleet label selector")?;
+    let initial = client
+        .fleet_snapshot(selector.as_deref())
+        .await
+        .context("reading initial fleet state from muxad")?;
+    // A lone local controller is the overwhelmingly common case and should
+    // feel exactly like `muxa watch`: adding the Fleet feature must not insert
+    // a redundant host row or discard the mature inspector and collaboration
+    // surface. Host hierarchy becomes visible only when it carries information.
+    if fleet_watch::uses_native_local_watch(&initial) {
+        return cmd_watch(client, cfg, config_path, invocation.clone()).await;
+    }
+    fleet_watch::run(client.clone(), &cfg, selector, initial, invocation).await
+}
+
+pub(crate) async fn cmd_watch(
     client: &Client,
     cfg: Config,
     config_path: Option<PathBuf>,

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -647,7 +647,7 @@ async fn main() -> Result<()> {
         Cmd::Init(init_args) => init::run(init_args, socket).await,
         Cmd::Doctor => doctor::run(socket).await,
         Cmd::Onboard(onboard_args) => onboarding::run(onboard_args),
-        Cmd::Mcp => mcp::run(client).await,
+        Cmd::Mcp => mcp::run(client, cfg.message.skills.clone()).await,
         Cmd::Logs(logs_args) => logs::run(logs_args).await,
         Cmd::Upgrade(upgrade_args) => upgrade::run(upgrade_args, socket).await,
         Cmd::Prune {

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -5,12 +5,15 @@ mod agent_launch;
 mod attend;
 mod dashboard_tui;
 mod doctor;
+mod fleet_cli;
+mod fleet_watch;
 mod init;
 mod logs;
 mod mcp;
 mod message_skill;
 mod onboarding;
 mod peek;
+mod relay;
 mod stats;
 mod theme;
 mod time_range;
@@ -120,6 +123,10 @@ enum Cmd {
     },
     /// Register reusable `/` templates for the interactive message composer.
     Skill(message_skill::Args),
+    /// Manage the SSH host inventory and Kubernetes-style metadata.
+    Host(fleet_cli::HostArgs),
+    /// Observe and control SSH-connected Muxa hosts.
+    Fleet(fleet_cli::FleetArgs),
     /// Deterministic tmux agent lifecycle operations.
     Agent {
         #[command(subcommand)]
@@ -171,6 +178,13 @@ enum Cmd {
     Peek(peek::Args),
     /// Fullscreen nested session/window/pane topology of tracked agents.
     Watch {
+        /// Show the SSH fleet host/session/window/pane hierarchy instead of
+        /// the local topology.
+        #[arg(long)]
+        fleet: bool,
+        /// Kubernetes-style host label selector used with `--fleet`.
+        #[arg(short = 'l', long = "selector", requires = "fleet")]
+        selector: Option<String>,
         /// Show agents that have no tmux pane attached. Default behavior
         /// (governed by `[watch] hide_paneless = true`) hides them
         /// because Enter on the picker can't attach to them anyway —
@@ -247,6 +261,15 @@ enum Cmd {
         #[arg(long)]
         json: String,
     },
+    /// Bridge the owner-only local muxad socket over an authenticated SSH
+    /// stdio channel for Muxa Fleet. Usually launched by another muxad.
+    Relay {
+        #[arg(long, default_value_t = true)]
+        stdio: bool,
+    },
+    /// Exact remote pane attach endpoint used by `muxa fleet attach`.
+    #[command(hide = true)]
+    FleetRemoteAttach { token: String },
     /// Jump to the agent that needs you — focus the pane of whichever
     /// agent has been blocked on input/choice/error longest. `--cycle`
     /// rotates through them (bind it to a tmux key); `--list` prints the
@@ -539,6 +562,7 @@ fn collaboration_client_kind(command: &Cmd) -> CollaborationClientKind {
     }
 }
 
+#[allow(clippy::too_many_lines)] // top-level CLI subcommand wiring
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -576,6 +600,8 @@ async fn main() -> Result<()> {
         Cmd::Peers { json } => cmd_peers(&client, json).await,
         Cmd::Msg { action } => cmd_msg(&client, action).await,
         Cmd::Skill(a) => message_skill::run(a, &cfg.message, skill_path.as_deref()),
+        Cmd::Host(a) => fleet_cli::run_host(a, &client, &cfg, config_path.as_deref()).await,
+        Cmd::Fleet(a) => fleet_cli::run_fleet(a, &client, &cfg, config_path.as_deref()).await,
         Cmd::Agent { action } => run_agent_cmd(action),
         Cmd::Window { action } => run_window_cmd(action),
         Cmd::Work { action } => run_work_cmd(action),
@@ -590,6 +616,8 @@ async fn main() -> Result<()> {
         Cmd::Panes => cmd_panes(),
         Cmd::Peek(peek_args) => peek::run(&client, peek_args).await,
         Cmd::Watch {
+            fleet,
+            selector,
             include_paneless,
             view,
             layout,
@@ -598,6 +626,15 @@ async fn main() -> Result<()> {
             caller_client,
             caller_pane,
         } => {
+            if fleet {
+                selector
+                    .as_deref()
+                    .map(str::parse::<muxa::LabelSelector>)
+                    .transpose()
+                    .map_err(anyhow::Error::msg)
+                    .context("invalid fleet label selector")?;
+                return fleet_watch::run(client, &cfg, selector).await;
+            }
             // Pin focus-moving commands to the requesting client; jump_to_pane_tmux reads it.
             //
             // A value still containing `#{` is a binding that never expanded
@@ -642,6 +679,13 @@ async fn main() -> Result<()> {
             pane,
         } => cmd_register(&client, name, pid, cwd, pane).await,
         Cmd::ZellijPluginSnapshot { json } => cmd_zellij_plugin_snapshot(&client, &json).await,
+        Cmd::Relay { stdio } => {
+            if !stdio {
+                anyhow::bail!("only --stdio relay transport is supported");
+            }
+            relay::run(client).await
+        }
+        Cmd::FleetRemoteAttach { token } => relay::remote_attach(&token),
         Cmd::Attend(attend_args) => cmd_attend(&client, attend_args).await,
         Cmd::Sync => cmd_sync(&client).await,
         Cmd::Init(init_args) => init::run(init_args, socket).await,

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -123,9 +123,9 @@ enum Cmd {
     },
     /// Register reusable `/` templates for the interactive message composer.
     Skill(message_skill::Args),
-    /// Manage the SSH host inventory and Kubernetes-style metadata.
+    /// Manage local/SSH host inventory and Kubernetes-style metadata.
     Host(fleet_cli::HostArgs),
-    /// Observe and control SSH-connected Muxa hosts.
+    /// Observe and control this node plus SSH-connected Muxa hosts.
     Fleet(fleet_cli::FleetArgs),
     /// Deterministic tmux agent lifecycle operations.
     Agent {

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -26,14 +26,14 @@
 
 use anyhow::{bail, Result};
 use muxa::collaboration::{
-    AirArtifactReference, CollaborationOrigin, NewRequest, RequestKind, RequestMailbox,
-    RequestStatus, RoomContext, WorkMode,
+    AirArtifactReference, CollaborationOrigin, CollaborationRequest, NewRequest, Participant,
+    RequestKind, RequestMailbox, RequestStatus, RoomContext, WorkMode,
 };
-use muxa::event::AgentState;
+use muxa::event::{AgentKind, AgentState};
 use muxa::ipc::Client;
 use muxa::state::{Agent, Transition};
 use serde_json::{json, Value};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
@@ -61,6 +61,23 @@ const MCP_SERVER_INSTRUCTIONS: &str = "muxa is your same-tmux-window peer team c
     as one work/ticket, and one pane as one agent. Use muxa_start_agent with a work id instead \
     of delegating tmux setup to another model; use muxa_manage_tmux for lifecycle \
     control and never invent raw tmux commands. \
+    Reserved routing: @peer and @muxa-peer always mean Muxa collaboration, never \
+    a GitHub user, pull-request reviewer, issue, or review thread. A request for \
+    @peer's report, reply, previous findings, or conversation must call \
+    muxa_peer_report first. A request that asks @peer, @codex, @claude, @gemini, \
+    an explicit @alias, or a colleague to do new work must call muxa_call_peer. \
+    If these Muxa tools are unavailable, tell the user to restart the agent so \
+    its MCP process reloads; never substitute a GitHub workflow. Use GitHub PR or \
+    review tools only when the user or already-grounded context provides an \
+    explicit PR number or GitHub PR URL; a repository or cwd alone is not enough. \
+    Never invent a PR, issue, or review thread. Resolving peer \
+    feedback means adjudicating the Muxa report and recording accepted/rejected \
+    findings unless an explicit PR establishes GitHub review threads. A /name in \
+    a new peer request selects a registered Muxa message skill; pass the remaining \
+    request-specific details as body or context. Never \
+    set execute=true unless the user explicitly authorizes edits, and never set \
+    spawn_if_missing=true until the user explicitly confirms creating a new \
+    bypass-permission agent pane. By default peer calls are review + read_only. \
     At the start of substantial work, call muxa_collaboration_guide (or \
     muxa_room_context) to discover available peer agents. Improve important work \
     with a peer when useful: use review + read_only after implementation and tests \
@@ -88,7 +105,7 @@ const RECONCILE_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Run the MCP stdio server until stdin closes. Refuses to start if the
 /// daemon socket is unreachable.
-pub async fn run(client: Client) -> Result<()> {
+pub async fn run(client: Client, message_skills: BTreeMap<String, String>) -> Result<()> {
     // Refuse to start against an absent/dead daemon: a control plane the
     // tools can't reach is worse than a clear failure.
     if let Err(e) = client.snapshot_with_timeout(PROBE_TIMEOUT).await {
@@ -98,10 +115,11 @@ pub async fn run(client: Client) -> Result<()> {
         );
     }
 
-    serve(
+    serve_with_skills(
         client,
         BufReader::new(tokio::io::stdin()),
         tokio::io::stdout(),
+        Arc::new(message_skills),
     )
     .await
 }
@@ -125,7 +143,21 @@ pub async fn run(client: Client) -> Result<()> {
 ///
 /// Generic over the transport so tests can drive it through an in-memory
 /// duplex pipe instead of the real stdio handles.
+#[cfg(test)]
 async fn serve<R, W>(client: Client, reader: R, writer: W) -> Result<()>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    serve_with_skills(client, reader, writer, Arc::new(BTreeMap::new())).await
+}
+
+async fn serve_with_skills<R, W>(
+    client: Client,
+    reader: R,
+    writer: W,
+    message_skills: Arc<BTreeMap<String, String>>,
+) -> Result<()>
 where
     R: AsyncBufRead + Unpin,
     W: AsyncWrite + Unpin + Send + 'static,
@@ -142,9 +174,10 @@ where
         }
         let client = client.clone();
         let writer = Arc::clone(&writer);
+        let message_skills = Arc::clone(&message_skills);
         tasks.spawn(async move {
             let response = match serde_json::from_str::<Value>(&line) {
-                Ok(req) => dispatch(&client, &req).await,
+                Ok(req) => dispatch_with_skills(&client, &req, &message_skills).await,
                 // A line that isn't valid JSON at all: -32700, id unknown.
                 Err(e) => Some(error_response(
                     &Value::Null,
@@ -199,9 +232,18 @@ where
 /// - an **object** is routed by [`dispatch_object`], which still returns a
 ///   proper error for a missing/invalid `jsonrpc` or `method` whenever an
 ///   `id` is present to address the reply to.
+#[cfg(test)]
 async fn dispatch(client: &Client, req: &Value) -> Option<Value> {
+    dispatch_with_skills(client, req, &BTreeMap::new()).await
+}
+
+async fn dispatch_with_skills(
+    client: &Client,
+    req: &Value,
+    message_skills: &BTreeMap<String, String>,
+) -> Option<Value> {
     match req {
-        Value::Object(_) => dispatch_object(client, req).await,
+        Value::Object(_) => dispatch_object(client, req, message_skills).await,
         Value::Array(_) => Some(error_response(
             &Value::Null,
             -32600,
@@ -219,7 +261,11 @@ async fn dispatch(client: &Client, req: &Value) -> Option<Value> {
 
 /// Route a JSON-RPC **object**: split notifications (no `id`) from requests,
 /// validate the envelope, then dispatch by `method`.
-async fn dispatch_object(client: &Client, req: &Value) -> Option<Value> {
+async fn dispatch_object(
+    client: &Client,
+    req: &Value,
+    message_skills: &BTreeMap<String, String>,
+) -> Option<Value> {
     let id = req.get("id").cloned();
 
     // No `id` key at all → notification: never answered (even if malformed,
@@ -245,10 +291,10 @@ async fn dispatch_object(client: &Client, req: &Value) -> Option<Value> {
     };
 
     let response = match method {
-        "initialize" => success(&id, initialize_result()),
+        "initialize" => success(&id, initialize_result(message_skills)),
         "ping" => success(&id, json!({})),
         "tools/list" => success(&id, json!({ "tools": tool_definitions() })),
-        "tools/call" => match call_tool(client, req.get("params")).await {
+        "tools/call" => match call_tool(client, req.get("params"), message_skills).await {
             Ok(result) => success(&id, result),
             // A malformed `tools/call` (missing name / bad args) is a
             // protocol error; a tool that *ran* but failed reports
@@ -260,7 +306,17 @@ async fn dispatch_object(client: &Client, req: &Value) -> Option<Value> {
     Some(response)
 }
 
-fn initialize_result() -> Value {
+fn initialize_result(message_skills: &BTreeMap<String, String>) -> Value {
+    let instructions = if message_skills.is_empty() {
+        MCP_SERVER_INSTRUCTIONS.to_string()
+    } else {
+        let names = message_skills
+            .keys()
+            .map(|name| format!("/{name}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("{MCP_SERVER_INSTRUCTIONS} Registered Muxa message skills available to muxa_call_peer: {names}.")
+    };
     json!({
         "protocolVersion": MCP_PROTOCOL_VERSION,
         "capabilities": { "tools": {} },
@@ -268,7 +324,7 @@ fn initialize_result() -> Value {
             "name": "muxa",
             "version": env!("CARGO_PKG_VERSION"),
         },
-        "instructions": MCP_SERVER_INSTRUCTIONS,
+        "instructions": instructions,
     })
 }
 
@@ -455,6 +511,46 @@ fn tool_definitions() -> Vec<Value> {
             "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false },
         }),
         json!({
+            "name": "muxa_call_peer",
+            "description": "Create a new natural colleague request for Muxa-reserved @peer/@muxa-peer routing. Deterministically selects a healthy same-window peer (or an explicit provider, @alias, role, or pane), optionally expands a registered Muxa /skill, sends one durable request, and optionally waits for its structured reply. Use muxa_peer_report instead when the user asks about an existing peer report, reply, findings, or conversation. Defaults to review + read_only. Set execute=true only after explicit user authorization. If no peer exists, the default result asks for confirmation; set spawn_if_missing=true only after the user explicitly approves creating a bypass-permission agent pane.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": { "type": "string", "description": "Default auto. Accepts auto/peer, codex/claude/gemini/opencode (with or without @), pane:%N/%N, @alias, or role:<name>." },
+                    "intent": { "type": "string", "enum": ["review", "question", "task"], "description": "Default review." },
+                    "body": { "type": "string", "description": "Request-specific instruction. Optional when skill is supplied." },
+                    "skill": { "type": "string", "description": "Registered Muxa message skill name, with or without leading /. Its prompt is expanded before sending." },
+                    "context": { "type": "string", "description": "Optional bounded context appended after the skill/body. Muxa never attaches transcripts or diffs implicitly." },
+                    "execute": { "type": "boolean", "description": "Default false. Requires intent=task and explicit user authorization." },
+                    "paths": { "type": "array", "items": { "type": "string" }, "description": "Advisory path scope, especially for execute work." },
+                    "wait": { "type": "boolean", "description": "Wait for the structured reply in this call. Default true." },
+                    "timeout_secs": { "type": "integer", "minimum": 1, "maximum": 600, "description": "Reply wait timeout. Default 300." },
+                    "spawn_if_missing": { "type": "boolean", "description": "Default false. Create a same-window bypass-permission peer only after explicit user confirmation." },
+                    "spawn_agent": { "type": "string", "enum": ["claude", "codex", "gemini", "opencode"], "description": "Provider to create when spawn_if_missing=true. Defaults to the current agent's opposite provider." },
+                    "spawn_timeout_secs": { "type": "integer", "minimum": 1, "maximum": 60, "description": "How long to wait for the new pane to register as a collaboration peer. Default 30." },
+                    "air_artifacts": {
+                        "type": "array",
+                        "maxItems": 8,
+                        "items": air_artifact_reference_schema(),
+                        "description": "Optional validated AIR artifact references carried with the request."
+                    }
+                },
+                "additionalProperties": false
+            },
+        }),
+        json!({
+            "name": "muxa_peer_report",
+            "description": "Read the newest completed Muxa peer report/reply sent to this agent, or retrieve an exact request_id. Use this first for possessive requests such as '@peer's report', 'peer findings', 'the peer conversation', or 'resolve the peer feedback'. This is Muxa mailbox data, not a GitHub PR review; never infer a PR number or review thread from it.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": { "type": "string", "description": "Optional report author filter: peer/auto/@muxa-peer, provider, pane id, @alias, or role:<name>. Default newest report from any peer." },
+                    "request_id": { "type": "string", "description": "Retrieve one exact prior Muxa request/reply instead of selecting the newest report." }
+                },
+                "additionalProperties": false
+            },
+        }),
+        json!({
             "name": "muxa_set_identity",
             "description": "Replace this exact agent session's room-local alias and roles. Aliases enable @alias routing; roles enable role:<name> routing. An empty call clears identity.",
             "inputSchema": {
@@ -496,7 +592,7 @@ fn tool_definitions() -> Vec<Value> {
         }),
         json!({
             "name": "muxa_list_messages",
-            "description": "List incoming, sent, or all collaboration requests for this exact agent session without claiming them.",
+            "description": "List incoming, sent, or all Muxa collaboration requests for this exact agent session without claiming them. Results are newest first. For the latest completed report addressed to this agent's request, prefer muxa_peer_report.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -557,7 +653,11 @@ fn tool_definitions() -> Vec<Value> {
 /// its job returns an `isError` result so the calling model sees the
 /// message rather than a transport fault.
 #[allow(clippy::too_many_lines)] // one explicit MCP tool dispatch table
-async fn call_tool(client: &Client, params: Option<&Value>) -> Result<Value> {
+async fn call_tool(
+    client: &Client,
+    params: Option<&Value>,
+    message_skills: &BTreeMap<String, String>,
+) -> Result<Value> {
     let params = params.ok_or_else(|| anyhow::anyhow!("missing params"))?;
     let name = params
         .get("name")
@@ -792,6 +892,8 @@ async fn call_tool(client: &Client, params: Option<&Value>) -> Result<Value> {
                 Err(error) => error_result(&format!("room context failed: {error}")),
             })
         }
+        "muxa_call_peer" => Ok(call_peer(client, &args, message_skills).await),
+        "muxa_peer_report" => Ok(peer_report(client, &args).await),
         "muxa_set_identity" => {
             let alias = args.get("alias").and_then(Value::as_str);
             let roles = string_array(&args, "roles");
@@ -1003,6 +1105,609 @@ fn collaboration_guide(room: RoomContext) -> Value {
             "Do not delegate merely for ceremony or recursively bounce work without a concrete benefit."
         ]
     })
+}
+
+#[derive(Debug, Clone)]
+struct PeerSelection {
+    peer: Participant,
+    reason: String,
+}
+
+/// Read a prior peer's structured response without asking it to do new work.
+/// Listing is non-claiming; the final exact get records that the sender read
+/// the reply, matching `muxa_wait_reply` semantics.
+async fn peer_report(client: &Client, args: &Value) -> Value {
+    let origin = match current_collaboration_origin() {
+        Ok(origin) => origin,
+        Err(error) => return error_result(&error),
+    };
+    if let Some(request_id) = args.get("request_id").and_then(Value::as_str) {
+        return match client.collaboration_get(&origin, request_id).await {
+            Ok(request) if request.reply.is_some() => json_result(&json!({
+                "selection_reason": "explicit request_id",
+                "request": request,
+            })),
+            Ok(_) => error_result(&format!(
+                "Muxa request {request_id:?} does not have a completed peer report yet"
+            )),
+            Err(error) => error_result(&format!("peer_report failed: {error}")),
+        };
+    }
+
+    let target = args.get("target").and_then(Value::as_str).unwrap_or("peer");
+    let requests = match client
+        .collaboration_list(&origin, RequestMailbox::Sent)
+        .await
+    {
+        Ok(requests) => requests,
+        Err(error) => return error_result(&format!("peer_report list failed: {error}")),
+    };
+    let selected = requests
+        .into_iter()
+        .filter(|request| {
+            request.reply.is_some() && peer_report_target_matches(&request.to, target)
+        })
+        .max_by_key(|request| request.created_at);
+    let Some(selected) = selected else {
+        return error_result(&format!(
+            "no completed Muxa peer report matches {target:?}; use muxa_call_peer only if the user wants a new request"
+        ));
+    };
+    match client.collaboration_get(&origin, &selected.id).await {
+        Ok(request) => json_result(&json!({
+            "selection_reason": format!("newest completed report matching {target:?}"),
+            "request": request,
+        })),
+        Err(error) => error_result(&format!("peer_report failed: {error}")),
+    }
+}
+
+fn peer_report_target_matches(peer: &Participant, target: &str) -> bool {
+    let target = target.trim();
+    if target.is_empty()
+        || target.eq_ignore_ascii_case("auto")
+        || target.eq_ignore_ascii_case("peer")
+        || target.eq_ignore_ascii_case("@peer")
+        || target.eq_ignore_ascii_case("@muxa-peer")
+    {
+        return true;
+    }
+    let pane_target = target.strip_prefix("pane:").unwrap_or(target);
+    if peer.pane == pane_target {
+        return true;
+    }
+    if let Some(kind) = provider_kind(target) {
+        return peer.agent_kind == kind;
+    }
+    if let Some(role) = target.strip_prefix("role:") {
+        return peer
+            .roles
+            .iter()
+            .any(|value| value.eq_ignore_ascii_case(role));
+    }
+    let alias = target
+        .strip_prefix('@')
+        .or_else(|| target.strip_prefix("alias:"))
+        .unwrap_or(target);
+    peer.alias
+        .as_deref()
+        .is_some_and(|value| value.eq_ignore_ascii_case(alias))
+}
+
+/// One high-level colleague call behind the conversational `@peer` protocol.
+/// The model still owns understanding the user's sentence; muxa owns every
+/// deterministic and security-sensitive step after that: prompt expansion,
+/// target selection, contract construction, optional explicit spawn, durable
+/// delivery, and reply correlation.
+#[allow(clippy::too_many_lines)] // keep the security-sensitive call sequence linear and auditable
+async fn call_peer(
+    client: &Client,
+    args: &Value,
+    message_skills: &BTreeMap<String, String>,
+) -> Value {
+    let (body, expanded_skill) = match peer_call_body(args, message_skills) {
+        Ok(body) => body,
+        Err(error) => return error_result(&error),
+    };
+    let (kind, work_mode) = match peer_call_contract(args) {
+        Ok(contract) => contract,
+        Err(error) => return error_result(error),
+    };
+    let air_artifacts = match parse_air_artifact_references(args) {
+        Ok(references) => references,
+        Err(error) => return error_result(&error),
+    };
+    let origin = match current_collaboration_origin() {
+        Ok(origin) => origin,
+        Err(error) => return error_result(&error),
+    };
+    let room = match client.collaboration_context(&origin).await {
+        Ok(room) => room,
+        Err(error) => return error_result(&format!("call_peer context failed: {error}")),
+    };
+    let target = args.get("target").and_then(Value::as_str).unwrap_or("auto");
+    let mut selection = match select_peer(&room, target) {
+        Ok(selection) => selection,
+        Err(error) => return error_result(&error),
+    };
+    let mut spawned = None;
+
+    if selection.is_none() {
+        let suggested = match peer_spawn_program(args, &room.current, target) {
+            Ok(program) => program,
+            Err(error) => return error_result(&error),
+        };
+        if !args
+            .get("spawn_if_missing")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            return json_result(&json!({
+                "sent": false,
+                "action_required": "confirm_spawn",
+                "message": format!(
+                    "No eligible {target:?} peer is available. Ask the user before creating a new bypass-permission agent pane."
+                ),
+                "suggested_call": {
+                    "target": target,
+                    "spawn_if_missing": true,
+                    "spawn_agent": agent_program_label(suggested),
+                },
+                "available_peers": room.peers,
+            }));
+        }
+        match spawn_peer(client, &origin, &room, args, target, suggested).await {
+            Ok((new_selection, start_result)) => {
+                selection = Some(new_selection);
+                spawned = Some(start_result);
+            }
+            Err(error) => return error_result(&error),
+        }
+    }
+
+    let selection = selection.expect("missing selection handled above");
+    let paths = string_array(args, "paths");
+    let request = NewRequest {
+        kind,
+        body,
+        expects_reply: true,
+        work_mode,
+        paths,
+        air_artifacts,
+    };
+    let selector = format!("pane:{}", selection.peer.pane);
+    let sent = match client
+        .collaboration_send(&origin, &selector, &request)
+        .await
+    {
+        Ok(request) => request,
+        Err(error) => return error_result(&format!("call_peer send failed: {error}")),
+    };
+    let common = json!({
+        "sent": true,
+        "selected_peer": selection.peer,
+        "selection_reason": selection.reason,
+        "expanded_skill": expanded_skill,
+        "spawned": spawned,
+        "request_id": sent.id,
+        "kind": kind,
+        "work_mode": work_mode,
+    });
+    if !args.get("wait").and_then(Value::as_bool).unwrap_or(true) {
+        let mut payload = common;
+        payload["completed"] = json!(false);
+        payload["reason"] = json!("sent_without_waiting");
+        payload["request"] = json!(sent);
+        return json_result(&payload);
+    }
+
+    let timeout_secs = args
+        .get("timeout_secs")
+        .and_then(Value::as_u64)
+        .unwrap_or(300)
+        .clamp(1, MAX_WAIT_SECS);
+    match await_collaboration_reply(client, &origin, &sent.id, timeout_secs).await {
+        Ok(Some(request)) => {
+            let mut payload = common;
+            payload["completed"] = json!(true);
+            payload["request"] = json!(request);
+            json_result(&payload)
+        }
+        Ok(None) => {
+            let mut payload = common;
+            payload["completed"] = json!(false);
+            payload["reason"] = json!("timeout");
+            payload["timeout_secs"] = json!(timeout_secs);
+            payload["request"] = json!(sent);
+            json_result(&payload)
+        }
+        Err(error) => error_result(&format!("call_peer wait failed: {error}")),
+    }
+}
+
+fn peer_call_contract(args: &Value) -> std::result::Result<(RequestKind, WorkMode), &'static str> {
+    let kind = match args
+        .get("intent")
+        .and_then(Value::as_str)
+        .unwrap_or("review")
+    {
+        "review" => RequestKind::Review,
+        "question" => RequestKind::Question,
+        "task" => RequestKind::Task,
+        _ => return Err("call_peer intent must be review, question, or task"),
+    };
+    let execute = args
+        .get("execute")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if execute && kind != RequestKind::Task {
+        return Err("call_peer execute=true requires intent=task");
+    }
+    Ok((
+        kind,
+        if execute {
+            WorkMode::Execute
+        } else {
+            WorkMode::ReadOnly
+        },
+    ))
+}
+
+fn peer_call_body(
+    args: &Value,
+    message_skills: &BTreeMap<String, String>,
+) -> std::result::Result<(String, Option<String>), String> {
+    let skill_name = args
+        .get("skill")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(|name| name.trim_start_matches('/'));
+    let skill = if let Some(name) = skill_name {
+        let found = message_skills
+            .get(name)
+            .or_else(|| {
+                message_skills
+                    .iter()
+                    .find(|(candidate, _)| candidate.eq_ignore_ascii_case(name))
+                    .map(|(_, prompt)| prompt)
+            })
+            .ok_or_else(|| {
+                let available = message_skills
+                    .keys()
+                    .map(|name| format!("/{name}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "message skill /{name} is not registered{}",
+                    if available.is_empty() {
+                        String::new()
+                    } else {
+                        format!("; available: {available}")
+                    }
+                )
+            })?;
+        Some((name.to_string(), found.trim()))
+    } else {
+        None
+    };
+    let body = args
+        .get("body")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|body| !body.is_empty());
+    let context = args
+        .get("context")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|context| !context.is_empty());
+    let mut sections = Vec::new();
+    if let Some((_, prompt)) = skill.as_ref() {
+        sections.push((*prompt).to_string());
+    }
+    if let Some(body) = body {
+        sections.push(body.to_string());
+    }
+    if let Some(context) = context {
+        sections.push(format!("Invocation context:\n{context}"));
+    }
+    if sections.is_empty() {
+        return Err("call_peer requires body, skill, or context".into());
+    }
+    Ok((
+        sections.join("\n\n"),
+        skill.map(|(name, _)| format!("/{name}")),
+    ))
+}
+
+fn select_peer(
+    room: &RoomContext,
+    target: &str,
+) -> std::result::Result<Option<PeerSelection>, String> {
+    let target = target.trim();
+    let live = room
+        .peers
+        .iter()
+        .filter(|peer| peer_is_eligible(peer))
+        .collect::<Vec<_>>();
+    if target.is_empty()
+        || target.eq_ignore_ascii_case("auto")
+        || target.eq_ignore_ascii_case("@peer")
+        || target.eq_ignore_ascii_case("@muxa-peer")
+        || target.eq_ignore_ascii_case("peer")
+    {
+        return Ok(best_peer(&live, &room.current).map(|peer| PeerSelection {
+            peer: peer.clone(),
+            reason:
+                "auto: healthy different-provider preference, then state and numeric pane order"
+                    .into(),
+        }));
+    }
+    let pane_target = target.strip_prefix("pane:").unwrap_or(target);
+    if let Some(peer) = live.iter().copied().find(|peer| peer.pane == pane_target) {
+        return Ok(Some(PeerSelection {
+            peer: peer.clone(),
+            reason: format!("explicit pane {}", peer.pane),
+        }));
+    }
+    if let Some(kind) = provider_kind(target) {
+        let candidates = live
+            .iter()
+            .copied()
+            .filter(|peer| peer.agent_kind == kind)
+            .collect::<Vec<_>>();
+        return Ok(
+            best_peer(&candidates, &room.current).map(|peer| PeerSelection {
+                peer: peer.clone(),
+                reason: format!("explicit provider {kind}"),
+            }),
+        );
+    }
+    if let Some(role) = target.strip_prefix("role:") {
+        let matches = live
+            .iter()
+            .copied()
+            .filter(|peer| {
+                peer.roles
+                    .iter()
+                    .any(|value| value.eq_ignore_ascii_case(role))
+            })
+            .collect::<Vec<_>>();
+        return match matches.as_slice() {
+            [] => Err(format!("no eligible peer has role {role:?}")),
+            [peer] => Ok(Some(PeerSelection {
+                peer: (*peer).clone(),
+                reason: format!("explicit role {role}"),
+            })),
+            _ => Err(format!(
+                "role {role:?} matches multiple peers; use @alias or pane id"
+            )),
+        };
+    }
+    let alias = target
+        .strip_prefix('@')
+        .or_else(|| target.strip_prefix("alias:"))
+        .unwrap_or(target);
+    let matches = live
+        .iter()
+        .copied()
+        .filter(|peer| {
+            peer.alias
+                .as_deref()
+                .is_some_and(|value| value.eq_ignore_ascii_case(alias))
+        })
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [] => Err(format!(
+            "no eligible peer matches {target:?}; use auto, a provider, @alias, role:<name>, or pane id"
+        )),
+        [peer] => Ok(Some(PeerSelection {
+            peer: (*peer).clone(),
+            reason: format!("explicit alias @{alias}"),
+        })),
+        _ => Err(format!(
+            "alias @{alias} matches multiple peers; use an exact pane id"
+        )),
+    }
+}
+
+fn peer_is_eligible(peer: &Participant) -> bool {
+    !matches!(peer.agent_kind, AgentKind::Task | AgentKind::Unknown)
+        && !matches!(peer.state, AgentState::Error | AgentState::Stopped)
+}
+
+fn best_peer<'a>(peers: &[&'a Participant], current: &Participant) -> Option<&'a Participant> {
+    peers.iter().copied().min_by(|left, right| {
+        peer_sort_key(left, current)
+            .cmp(&peer_sort_key(right, current))
+            .then_with(|| left.pane.cmp(&right.pane))
+    })
+}
+
+fn peer_sort_key(peer: &Participant, current: &Participant) -> (bool, u8, u8, u64) {
+    (
+        peer.agent_kind == current.agent_kind,
+        peer_state_rank(peer.state),
+        provider_rank(peer.agent_kind),
+        numeric_pane_index(&peer.pane).unwrap_or(u64::MAX),
+    )
+}
+
+fn peer_state_rank(state: AgentState) -> u8 {
+    match state {
+        AgentState::Idle => 0,
+        AgentState::Working => 1,
+        AgentState::Starting => 2,
+        AgentState::WaitingInput | AgentState::WaitingChoice => 3,
+        AgentState::Error => 4,
+        AgentState::Stopped => 5,
+    }
+}
+
+fn provider_rank(kind: AgentKind) -> u8 {
+    match kind {
+        AgentKind::Codex => 0,
+        AgentKind::ClaudeCode => 1,
+        AgentKind::GeminiCli => 2,
+        AgentKind::Opencode => 3,
+        AgentKind::Task => 4,
+        AgentKind::Unknown => 5,
+    }
+}
+
+fn numeric_pane_index(pane: &str) -> Option<u64> {
+    pane.rsplit_once('%')?.1.parse().ok()
+}
+
+fn provider_kind(target: &str) -> Option<AgentKind> {
+    match target
+        .trim()
+        .trim_start_matches('@')
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "claude" | "claude_code" | "claude-code" => Some(AgentKind::ClaudeCode),
+        "codex" | "cx" => Some(AgentKind::Codex),
+        "gemini" | "gemini_cli" | "gemini-cli" => Some(AgentKind::GeminiCli),
+        "opencode" => Some(AgentKind::Opencode),
+        _ => None,
+    }
+}
+
+fn peer_spawn_program(
+    args: &Value,
+    current: &Participant,
+    target: &str,
+) -> std::result::Result<crate::agent_launch::AgentProgram, String> {
+    let requested = args
+        .get("spawn_agent")
+        .and_then(Value::as_str)
+        .map(crate::agent_launch::AgentProgram::parse)
+        .transpose()?;
+    let targeted = provider_kind(target).map(agent_program_for_kind);
+    if let (Some(requested), Some(targeted)) = (requested, targeted) {
+        if requested != targeted {
+            return Err(format!(
+                "spawn_agent={} conflicts with target={target:?}",
+                agent_program_label(requested)
+            ));
+        }
+    }
+    Ok(requested.or(targeted).unwrap_or(match current.agent_kind {
+        AgentKind::ClaudeCode => crate::agent_launch::AgentProgram::Codex,
+        AgentKind::Codex => crate::agent_launch::AgentProgram::Claude,
+        AgentKind::GeminiCli | AgentKind::Opencode | AgentKind::Task | AgentKind::Unknown => {
+            crate::agent_launch::AgentProgram::Codex
+        }
+    }))
+}
+
+fn agent_program_for_kind(kind: AgentKind) -> crate::agent_launch::AgentProgram {
+    match kind {
+        AgentKind::ClaudeCode => crate::agent_launch::AgentProgram::Claude,
+        AgentKind::Codex | AgentKind::Task | AgentKind::Unknown => {
+            crate::agent_launch::AgentProgram::Codex
+        }
+        AgentKind::GeminiCli => crate::agent_launch::AgentProgram::Gemini,
+        AgentKind::Opencode => crate::agent_launch::AgentProgram::Opencode,
+    }
+}
+
+fn agent_program_label(program: crate::agent_launch::AgentProgram) -> &'static str {
+    match program {
+        crate::agent_launch::AgentProgram::Claude => "claude",
+        crate::agent_launch::AgentProgram::Codex => "codex",
+        crate::agent_launch::AgentProgram::Gemini => "gemini",
+        crate::agent_launch::AgentProgram::Opencode => "opencode",
+    }
+}
+
+async fn spawn_peer(
+    client: &Client,
+    origin: &CollaborationOrigin,
+    room: &RoomContext,
+    args: &Value,
+    target: &str,
+    program: crate::agent_launch::AgentProgram,
+) -> std::result::Result<(PeerSelection, crate::agent_launch::StartResult), String> {
+    if room.current.room.host != "tmux" || !room.current.pane.starts_with('%') {
+        return Err("call_peer automatic spawn currently requires a native tmux agent pane".into());
+    }
+    let request = crate::agent_launch::StartRequest {
+        agent: program,
+        placement: crate::agent_launch::Placement::Pane,
+        target: Some(room.current.pane.clone()),
+        cwd: room.current.cwd.as_deref().map(std::path::PathBuf::from),
+        prompt: None,
+        name: None,
+        workspace: None,
+        work: None,
+        role: Some("peer".into()),
+        task: Some("muxa peer call".into()),
+        direction: crate::agent_launch::SplitDirection::Right,
+    };
+    let started = tokio::task::spawn_blocking(move || crate::agent_launch::start(request))
+        .await
+        .map_err(|error| format!("call_peer spawn worker failed: {error}"))?
+        .map_err(|error| format!("call_peer spawn failed: {error}"))?;
+    let timeout_secs = args
+        .get("spawn_timeout_secs")
+        .and_then(Value::as_u64)
+        .unwrap_or(30)
+        .clamp(1, 60);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        let refreshed = client
+            .collaboration_context(origin)
+            .await
+            .map_err(|error| format!("call_peer context after spawn failed: {error}"))?;
+        if let Some(peer) = refreshed
+            .peers
+            .iter()
+            .find(|peer| peer.pane == started.pane && peer_is_eligible(peer))
+        {
+            return Ok((
+                PeerSelection {
+                    peer: peer.clone(),
+                    reason: format!(
+                        "spawned {} in {} after explicit confirmation for target {target:?}",
+                        agent_program_label(program),
+                        started.pane
+                    ),
+                },
+                started,
+            ));
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!(
+                "created {} peer pane {} but it did not register for collaboration within {timeout_secs}s; keep the pane, verify its hooks/MCP setup, then call again with target=\"pane:{}\"",
+                agent_program_label(program),
+                started.pane,
+                started.pane
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+async fn await_collaboration_reply(
+    client: &Client,
+    origin: &CollaborationOrigin,
+    request_id: &str,
+    timeout_secs: u64,
+) -> std::result::Result<Option<CollaborationRequest>, String> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        match client.collaboration_get(origin, request_id).await {
+            Ok(request) if request.status.is_terminal() => return Ok(Some(request)),
+            Ok(_) => {}
+            Err(error) => return Err(error.to_string()),
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Ok(None);
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
 }
 
 fn current_collaboration_origin() -> std::result::Result<CollaborationOrigin, String> {
@@ -1708,6 +2413,15 @@ mod tests {
         assert!(instructions.contains("review + read_only"));
         assert!(instructions.contains("task + execute + narrow paths"));
         assert!(instructions.contains("verify and integrate the result yourself"));
+        assert!(instructions.contains("@peer"));
+        assert!(instructions.contains("@muxa-peer"));
+        assert!(instructions.contains("muxa_call_peer"));
+        assert!(instructions.contains("muxa_peer_report"));
+        assert!(instructions.contains("never substitute a GitHub workflow"));
+        assert!(instructions.contains("a repository or cwd alone is not enough"));
+        assert!(instructions.contains("Never invent a PR"));
+        assert!(instructions.contains("execute=true"));
+        assert!(instructions.contains("spawn_if_missing=true"));
 
         let list = dispatch(
             &client,
@@ -1729,6 +2443,8 @@ mod tests {
                 "muxa_wait_for_change",
                 "muxa_collaboration_guide",
                 "muxa_room_context",
+                "muxa_call_peer",
+                "muxa_peer_report",
                 "muxa_set_identity",
                 "muxa_send_message",
                 "muxa_inbox",
@@ -1763,9 +2479,34 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("reviewer/subagent workflows"));
+        assert_peer_tool_definitions(tools);
 
         tx.send(()).unwrap();
         handle.await.unwrap();
+    }
+
+    fn assert_peer_tool_definitions(tools: &[Value]) {
+        let call_peer = tools
+            .iter()
+            .find(|tool| tool["name"] == "muxa_call_peer")
+            .unwrap();
+        assert_eq!(
+            call_peer["inputSchema"]["properties"]["intent"]["enum"],
+            json!(["review", "question", "task"])
+        );
+        assert!(call_peer["description"]
+            .as_str()
+            .unwrap()
+            .contains("Defaults to review + read_only"));
+        let peer_report = tools
+            .iter()
+            .find(|tool| tool["name"] == "muxa_peer_report")
+            .unwrap();
+        assert!(peer_report["description"]
+            .as_str()
+            .unwrap()
+            .contains("not a GitHub PR review"));
+        assert!(peer_report["inputSchema"]["properties"]["request_id"].is_object());
     }
 
     #[test]
@@ -1807,6 +2548,159 @@ mod tests {
             .unwrap()
             .iter()
             .any(|rule| rule.as_str().unwrap().contains("separate worktrees")));
+    }
+
+    #[test]
+    fn initialize_surfaces_registered_peer_call_skills() {
+        let skills = BTreeMap::from([
+            ("review-plan-feedback".into(), "review it".into()),
+            ("summarize".into(), "summarize it".into()),
+        ]);
+        let result = initialize_result(&skills);
+        let instructions = result["instructions"].as_str().unwrap();
+        assert!(instructions.contains("/review-plan-feedback"));
+        assert!(instructions.contains("/summarize"));
+    }
+
+    fn peer_participant(kind: AgentKind, pane: &str, state: AgentState) -> Participant {
+        serde_json::from_value(json!({
+            "agent_kind": kind,
+            "agent_session_id": format!("session-{pane}"),
+            "pane": pane,
+            "room": { "host": "tmux", "window_id": "@1" },
+            "tmux_session_name": "cal-7000",
+            "window_name": "agents",
+            "state": state,
+            "cwd": "/tmp/project"
+        }))
+        .unwrap()
+    }
+
+    fn peer_room(current: Participant, peers: Vec<Participant>) -> RoomContext {
+        RoomContext {
+            current,
+            peers,
+            unread: 0,
+            unread_replies: 0,
+        }
+    }
+
+    #[test]
+    fn peer_call_expands_a_registered_skill_without_losing_context() {
+        let skills = BTreeMap::from([(
+            "review-plan-feedback".into(),
+            "Run the iterative peer review workflow.".into(),
+        )]);
+        let (body, skill) = peer_call_body(
+            &json!({
+                "skill": "/review-plan-feedback",
+                "body": "Review commit abc123.",
+                "context": "Tests already passed."
+            }),
+            &skills,
+        )
+        .unwrap();
+
+        assert_eq!(skill.as_deref(), Some("/review-plan-feedback"));
+        assert_eq!(
+            body,
+            "Run the iterative peer review workflow.\n\nReview commit abc123.\n\nInvocation context:\nTests already passed."
+        );
+    }
+
+    #[test]
+    fn peer_call_unknown_skill_lists_available_names() {
+        let skills = BTreeMap::from([("review".into(), "review it".into())]);
+        let error = peer_call_body(&json!({ "skill": "missing" }), &skills).unwrap_err();
+        assert!(error.contains("/missing"), "{error}");
+        assert!(error.contains("/review"), "{error}");
+    }
+
+    #[test]
+    fn peer_call_requires_explicit_task_contract_for_execute() {
+        assert_eq!(
+            peer_call_contract(&json!({})).unwrap(),
+            (RequestKind::Review, WorkMode::ReadOnly)
+        );
+        assert!(peer_call_contract(&json!({ "execute": true })).is_err());
+        assert_eq!(
+            peer_call_contract(&json!({ "intent": "task", "execute": true })).unwrap(),
+            (RequestKind::Task, WorkMode::Execute)
+        );
+    }
+
+    #[test]
+    fn auto_peer_prefers_a_different_provider_then_numeric_pane_order() {
+        let current = peer_participant(AgentKind::ClaudeCode, "%1", AgentState::Idle);
+        let room = peer_room(
+            current,
+            vec![
+                peer_participant(AgentKind::ClaudeCode, "%2", AgentState::Idle),
+                peer_participant(AgentKind::Codex, "%12", AgentState::Idle),
+                peer_participant(AgentKind::Codex, "%3", AgentState::Idle),
+            ],
+        );
+
+        let selected = select_peer(&room, "auto").unwrap().unwrap();
+        assert_eq!(selected.peer.pane, "%3");
+        assert_eq!(
+            select_peer(&room, "@claude").unwrap().unwrap().peer.pane,
+            "%2"
+        );
+        assert_eq!(
+            select_peer(&room, "@muxa-peer").unwrap().unwrap().peer.pane,
+            "%3"
+        );
+    }
+
+    #[test]
+    fn peer_report_filters_provider_alias_role_and_pane_without_github_inference() {
+        let mut peer = peer_participant(AgentKind::ClaudeCode, "%12", AgentState::Idle);
+        peer.alias = Some("reviewer".into());
+        peer.roles = vec!["rust".into()];
+
+        assert!(peer_report_target_matches(&peer, "peer"));
+        assert!(peer_report_target_matches(&peer, "@muxa-peer"));
+        assert!(peer_report_target_matches(&peer, "@claude"));
+        assert!(peer_report_target_matches(&peer, "pane:%12"));
+        assert!(peer_report_target_matches(&peer, "@reviewer"));
+        assert!(peer_report_target_matches(&peer, "role:RUST"));
+        assert!(!peer_report_target_matches(&peer, "@codex"));
+        assert!(!peer_report_target_matches(&peer, "#2774"));
+    }
+
+    #[test]
+    fn peer_alias_and_role_selection_refuse_ambiguity() {
+        let current = peer_participant(AgentKind::ClaudeCode, "%1", AgentState::Idle);
+        let mut reviewer = peer_participant(AgentKind::Codex, "%2", AgentState::Idle);
+        reviewer.alias = Some("reviewer".into());
+        reviewer.roles = vec!["rust".into()];
+        let mut other = peer_participant(AgentKind::GeminiCli, "%3", AgentState::Idle);
+        other.roles = vec!["rust".into()];
+        let room = peer_room(current, vec![reviewer, other]);
+
+        assert_eq!(
+            select_peer(&room, "@reviewer").unwrap().unwrap().peer.pane,
+            "%2"
+        );
+        assert!(select_peer(&room, "role:rust")
+            .unwrap_err()
+            .contains("multiple peers"));
+    }
+
+    #[test]
+    fn missing_peer_spawn_defaults_to_the_opposite_provider() {
+        let claude = peer_participant(AgentKind::ClaudeCode, "%1", AgentState::Idle);
+        let codex = peer_participant(AgentKind::Codex, "%2", AgentState::Idle);
+        assert_eq!(
+            peer_spawn_program(&json!({}), &claude, "auto").unwrap(),
+            crate::agent_launch::AgentProgram::Codex
+        );
+        assert_eq!(
+            peer_spawn_program(&json!({}), &codex, "auto").unwrap(),
+            crate::agent_launch::AgentProgram::Claude
+        );
+        assert!(peer_spawn_program(&json!({ "spawn_agent": "claude" }), &codex, "@codex").is_err());
     }
 
     #[test]

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -91,7 +91,8 @@ const MCP_SERVER_INSTRUCTIONS: &str = "muxa is your same-tmux-window peer team c
     When work is already represented by a validated AIR 1 workflow, plan, or trace, \
     attach its typed air_artifacts reference for shared identity and visualization; \
     AIR Workbench remains the validator/editor and muxa never implies conformance. \
-    SSH fleet operations are a separate physical-host control plane: discover hosts \
+    Fleet operations are a separate physical-host control plane whose always-present \
+    local host needs no SSH configuration: discover hosts \
     with muxa_fleet_status, always name the host and pane explicitly for capture or \
     prompt delivery, and remember that observe-mode hosts reject control actions.";
 
@@ -487,7 +488,7 @@ fn tool_definitions() -> Vec<Value> {
         }),
         json!({
             "name": "muxa_fleet_status",
-            "description": "Read the cached SSH fleet hierarchy and health for physical hosts. Optionally filter hosts with a Kubernetes-style label selector. This does not open a new SSH connection per call.",
+            "description": "Read the cached physical-host Fleet hierarchy and health, including the always-present local controller node. Optionally filter hosts with a Kubernetes-style label selector. This does not open a new SSH connection per call.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -498,11 +499,11 @@ fn tool_definitions() -> Vec<Value> {
         }),
         json!({
             "name": "muxa_fleet_capture",
-            "description": "Capture one exact pane from a named SSH fleet host. The host must have a live cached topology; pane accepts a backend pane id or session/window/pane path and ambiguity is rejected.",
+            "description": "Capture one exact pane from a named Fleet host, including local. The host must have a live cached topology; pane accepts a backend pane id or session/window/pane path and ambiguity is rejected.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "host": { "type": "string", "description": "Configured fleet host alias." },
+                    "host": { "type": "string", "description": "Fleet host alias; local always names the controller node." },
                     "pane": { "type": "string", "description": "Pane id such as %12 or session/window/%12." }
                 },
                 "required": ["host", "pane"],
@@ -511,11 +512,11 @@ fn tool_definitions() -> Vec<Value> {
         }),
         json!({
             "name": "muxa_fleet_send_prompt",
-            "description": "Send literal text to one exact pane on a named control-mode SSH fleet host. The daemon enforces host authorization and never retries this mutation.",
+            "description": "Send literal text to one exact pane on a named Fleet host. Local is always control-capable; remote hosts must use control mode. The daemon never retries this mutation.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "host": { "type": "string", "description": "Configured fleet host alias." },
+                    "host": { "type": "string", "description": "Fleet host alias; local always names the controller node." },
                     "pane": { "type": "string", "description": "Pane id such as %12 or session/window/%12." },
                     "text": { "type": "string", "description": "Literal prompt text." },
                     "submit": { "type": "boolean", "description": "Press Enter after delivery. Default true." }

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -90,7 +90,10 @@ const MCP_SERVER_INSTRUCTIONS: &str = "muxa is your same-tmux-window peer team c
     always finish with muxa_reply using completed, blocked, declined, or failed. \
     When work is already represented by a validated AIR 1 workflow, plan, or trace, \
     attach its typed air_artifacts reference for shared identity and visualization; \
-    AIR Workbench remains the validator/editor and muxa never implies conformance.";
+    AIR Workbench remains the validator/editor and muxa never implies conformance. \
+    SSH fleet operations are a separate physical-host control plane: discover hosts \
+    with muxa_fleet_status, always name the host and pane explicitly for capture or \
+    prompt delivery, and remember that observe-mode hosts reject control actions.";
 
 /// How often `muxa_wait_for_change` reconciles against a fresh daemon
 /// snapshot while blocking on the transition stream. A broadcast lag on the
@@ -483,6 +486,45 @@ fn tool_definitions() -> Vec<Value> {
             },
         }),
         json!({
+            "name": "muxa_fleet_status",
+            "description": "Read the cached SSH fleet hierarchy and health for physical hosts. Optionally filter hosts with a Kubernetes-style label selector. This does not open a new SSH connection per call.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "selector": { "type": "string", "description": "Optional label selector, for example environment=production,region in (icn,nrt)." }
+                },
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "muxa_fleet_capture",
+            "description": "Capture one exact pane from a named SSH fleet host. The host must have a live cached topology; pane accepts a backend pane id or session/window/pane path and ambiguity is rejected.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "host": { "type": "string", "description": "Configured fleet host alias." },
+                    "pane": { "type": "string", "description": "Pane id such as %12 or session/window/%12." }
+                },
+                "required": ["host", "pane"],
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "muxa_fleet_send_prompt",
+            "description": "Send literal text to one exact pane on a named control-mode SSH fleet host. The daemon enforces host authorization and never retries this mutation.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "host": { "type": "string", "description": "Configured fleet host alias." },
+                    "pane": { "type": "string", "description": "Pane id such as %12 or session/window/%12." },
+                    "text": { "type": "string", "description": "Literal prompt text." },
+                    "submit": { "type": "boolean", "description": "Press Enter after delivery. Default true." }
+                },
+                "required": ["host", "pane", "text"],
+                "additionalProperties": false
+            }
+        }),
+        json!({
             "name": "muxa_wait_for_change",
             "description": "Block until an agent changes state. Set until=settled \
                 to ignore intermediate working transitions and return only when the \
@@ -870,6 +912,75 @@ async fn call_tool(
                 )),
                 Err(e) => error_result(&format!("capture failed: {e}")),
             })
+        }
+        "muxa_fleet_status" => {
+            let selector = args.get("selector").and_then(Value::as_str);
+            Ok(match client.fleet_snapshot(selector).await {
+                Ok(snapshot) => json_result(&json!(snapshot)),
+                Err(error) => error_result(&format!("fleet status failed: {error}")),
+            })
+        }
+        "muxa_fleet_capture" => {
+            let Some(host) = args.get("host").and_then(Value::as_str) else {
+                return Ok(error_result("fleet_capture requires a `host` argument"));
+            };
+            let Some(pane) = args.get("pane").and_then(Value::as_str) else {
+                return Ok(error_result("fleet_capture requires a `pane` argument"));
+            };
+            let target = match crate::fleet_cli::resolve_pane(client, host, pane).await {
+                Ok(target) => target,
+                Err(error) => return Ok(error_result(&format!("fleet capture failed: {error}"))),
+            };
+            Ok(
+                match client
+                    .fleet_execute(host, &muxa::FleetOperation::Capture { pane: target })
+                    .await
+                {
+                    Ok(result) => match result.capture {
+                        Some(capture) => text_result(&capture),
+                        None => error_result("fleet capture returned no pane contents"),
+                    },
+                    Err(error) => error_result(&format!("fleet capture failed: {error}")),
+                },
+            )
+        }
+        "muxa_fleet_send_prompt" => {
+            let Some(host) = args.get("host").and_then(Value::as_str) else {
+                return Ok(error_result("fleet_send_prompt requires a `host` argument"));
+            };
+            let Some(pane) = args.get("pane").and_then(Value::as_str) else {
+                return Ok(error_result("fleet_send_prompt requires a `pane` argument"));
+            };
+            let Some(text) = args.get("text").and_then(Value::as_str) else {
+                return Ok(error_result("fleet_send_prompt requires a `text` argument"));
+            };
+            let submit = args.get("submit").and_then(Value::as_bool).unwrap_or(true);
+            let target = match crate::fleet_cli::resolve_pane(client, host, pane).await {
+                Ok(target) => target,
+                Err(error) => {
+                    return Ok(error_result(&format!("fleet send prompt failed: {error}")));
+                }
+            };
+            Ok(
+                match client
+                    .fleet_execute(
+                        host,
+                        &muxa::FleetOperation::SendPrompt {
+                            pane: target,
+                            text: text.to_string(),
+                            submit,
+                        },
+                    )
+                    .await
+                {
+                    Ok(result) => json_result(&json!({
+                        "host": host,
+                        "pane": pane,
+                        "send": result.send,
+                    })),
+                    Err(error) => error_result(&format!("fleet send prompt failed: {error}")),
+                },
+            )
         }
         "muxa_wait_for_change" => Ok(wait_for_change(client, &args).await),
         "muxa_collaboration_guide" => {
@@ -2422,6 +2533,8 @@ mod tests {
         assert!(instructions.contains("Never invent a PR"));
         assert!(instructions.contains("execute=true"));
         assert!(instructions.contains("spawn_if_missing=true"));
+        assert!(instructions.contains("muxa_fleet_status"));
+        assert!(instructions.contains("observe-mode hosts"));
 
         let list = dispatch(
             &client,
@@ -2440,6 +2553,9 @@ mod tests {
                 "muxa_manage_tmux",
                 "muxa_send_prompt",
                 "muxa_capture_pane",
+                "muxa_fleet_status",
+                "muxa_fleet_capture",
+                "muxa_fleet_send_prompt",
                 "muxa_wait_for_change",
                 "muxa_collaboration_guide",
                 "muxa_room_context",

--- a/crates/muxa-cli/src/relay.rs
+++ b/crates/muxa-cli/src/relay.rs
@@ -1,0 +1,537 @@
+//! SSH stdio relay used by Muxa Fleet.
+//!
+//! The remote shell sees only a fixed `muxa relay --stdio` command. Prompt
+//! text and pane metadata travel as length-bounded JSON lines on stdin, never
+//! as shell arguments. Every pane action is revalidated against its complete
+//! backend/socket/session/window/pane key before it can run.
+
+use std::fmt::Write as _;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use muxa::fleet::{
+    load_or_create_node_id, read_bounded_line, sanitize_capture_text, FleetBackendInfo,
+    FleetCapturedWindowPane, FleetCommandResult, FleetWindowCapture, GlobalPaneRef, RelayFrame,
+    RelayHello, RelayRequest, RemoteSnapshot, FLEET_CAPABILITIES, FLEET_MAX_FRAME_BYTES,
+    FLEET_MIN_PROTOCOL_VERSION, FLEET_PROTOCOL_VERSION,
+};
+use muxa::ipc::Client;
+use muxa::tmux::SessionInfo;
+use muxa::{HostKind, PaneKey, SharedBackend};
+use time::OffsetDateTime;
+use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::sync::{mpsc, Semaphore};
+
+const RELAY_OUTPUT_CAPACITY: usize = 256;
+const RELAY_REQUEST_CONCURRENCY: usize = 32;
+const RELAY_KEEPALIVE: Duration = Duration::from_secs(10);
+
+#[allow(clippy::too_many_lines)] // relay lifecycle and its owned tasks are one protocol boundary
+pub(crate) async fn run(client: Client) -> Result<()> {
+    let id_path = muxa::paths::default_node_id_file()
+        .context("no data directory is available for the fleet host id")?;
+    let node_id = load_or_create_node_id(&id_path)
+        .with_context(|| format!("loading fleet host identity from {}", id_path.display()))?;
+    let daemon = client
+        .hello(Duration::from_secs(3))
+        .await
+        .context("local muxad is unavailable")?;
+    let backends = muxa::active_backends();
+    let backend_info = backend_info(&backends);
+    let mut transitions = client
+        .subscribe()
+        .await
+        .context("subscribing to local muxad")?;
+    let revision = Arc::new(AtomicU64::new(0));
+    let (output_tx, mut output_rx) = mpsc::channel::<RelayFrame>(RELAY_OUTPUT_CAPACITY);
+
+    let writer = tokio::spawn(async move {
+        let mut stdout = tokio::io::stdout();
+        while let Some(frame) = output_rx.recv().await {
+            let mut encoded = serde_json::to_vec(&frame)?;
+            if encoded.len() > FLEET_MAX_FRAME_BYTES {
+                bail!("relay response exceeds {FLEET_MAX_FRAME_BYTES} bytes");
+            }
+            encoded.push(b'\n');
+            stdout.write_all(&encoded).await?;
+            stdout.flush().await?;
+        }
+        Ok::<(), anyhow::Error>(())
+    });
+
+    output_tx
+        .send(RelayFrame::Hello {
+            hello: RelayHello {
+                fleet_protocol: FLEET_PROTOCOL_VERSION,
+                min_fleet_protocol: FLEET_MIN_PROTOCOL_VERSION,
+                node_id,
+                hostname: hostname(),
+                os: std::env::consts::OS.into(),
+                arch: std::env::consts::ARCH.into(),
+                muxa_version: env!("CARGO_PKG_VERSION").into(),
+                capabilities: FLEET_CAPABILITIES
+                    .iter()
+                    .map(|capability| (*capability).to_string())
+                    .collect(),
+                daemon_generation: daemon.generation,
+                boot_id: boot_id(),
+                backends: backend_info,
+                server_time: OffsetDateTime::now_utc(),
+            },
+        })
+        .await
+        .context("relay output closed")?;
+
+    let transition_tx = output_tx.clone();
+    let transition_revision = Arc::clone(&revision);
+    let transition_task = tokio::spawn(async move {
+        loop {
+            match transitions.recv().await {
+                Ok(Some(transition)) => {
+                    let next = transition_revision.fetch_add(1, Ordering::SeqCst) + 1;
+                    if transition_tx
+                        .send(RelayFrame::Transition {
+                            revision: next,
+                            transition,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Ok(None) => {
+                    let _ = transition_tx
+                        .send(RelayFrame::ResyncRequired {
+                            reason: "local muxad subscription closed".into(),
+                        })
+                        .await;
+                    break;
+                }
+                Err(error) => {
+                    let _ = transition_tx
+                        .send(RelayFrame::ResyncRequired {
+                            reason: format!("local muxad subscription failed: {error}"),
+                        })
+                        .await;
+                    break;
+                }
+            }
+        }
+    });
+
+    let keepalive_tx = output_tx.clone();
+    let keepalive_revision = Arc::clone(&revision);
+    let keepalive_task = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(RELAY_KEEPALIVE);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            if keepalive_tx
+                .send(RelayFrame::Keepalive {
+                    revision: keepalive_revision.load(Ordering::SeqCst),
+                    observed_at: OffsetDateTime::now_utc(),
+                })
+                .await
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    let mut stdin = BufReader::new(tokio::io::stdin());
+    let mut line = String::new();
+    let request_permits = Arc::new(Semaphore::new(RELAY_REQUEST_CONCURRENCY));
+    loop {
+        line.clear();
+        let read = read_bounded_line(&mut stdin, &mut line, FLEET_MAX_FRAME_BYTES).await?;
+        if read == 0 {
+            break;
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let request = match serde_json::from_str::<RelayRequest>(trimmed) {
+            Ok(request) => request,
+            Err(error) => {
+                output_tx
+                    .send(RelayFrame::Error {
+                        request_id: String::new(),
+                        code: "bad_request".into(),
+                        message: error.to_string(),
+                    })
+                    .await
+                    .ok();
+                continue;
+            }
+        };
+        let tx = output_tx.clone();
+        let request_client = client.clone();
+        let request_backends = backends.clone();
+        let request_revision = Arc::clone(&revision);
+        let permit = Arc::clone(&request_permits)
+            .acquire_owned()
+            .await
+            .context("relay request semaphore closed")?;
+        tokio::spawn(async move {
+            let _permit = permit;
+            let request_id = request.request_id().to_string();
+            let frame =
+                match handle_request(request, request_client, request_backends, request_revision)
+                    .await
+                {
+                    Ok(frame) => frame,
+                    Err(error) => RelayFrame::Error {
+                        request_id,
+                        code: "request_failed".into(),
+                        message: error.to_string(),
+                    },
+                };
+            let _ = tx.send(frame).await;
+        });
+    }
+
+    drop(output_tx);
+    transition_task.abort();
+    keepalive_task.abort();
+    writer.await.context("joining relay writer")??;
+    Ok(())
+}
+
+#[allow(clippy::too_many_lines)] // exhaustive relay request dispatch
+async fn handle_request(
+    request: RelayRequest,
+    client: Client,
+    backends: Vec<SharedBackend>,
+    revision: Arc<AtomicU64>,
+) -> Result<RelayFrame> {
+    match request {
+        RelayRequest::Snapshot { request_id } => {
+            let snapshot = collect_snapshot(&client, &backends, revision).await?;
+            Ok(RelayFrame::Snapshot {
+                request_id,
+                snapshot,
+            })
+        }
+        RelayRequest::Ping { request_id } => Ok(RelayFrame::Result {
+            request_id,
+            result: FleetCommandResult::accepted("pong"),
+        }),
+        RelayRequest::Capture { request_id, pane } => {
+            let backend = exact_backend(&backends, &pane).await?;
+            let socket = pane.window.session.endpoint.socket.clone();
+            let pane_id = pane.pane_id.clone();
+            let capture = tokio::task::spawn_blocking(move || {
+                backend
+                    .capture_pane_on(Some(&socket), &pane_id)
+                    .map(sanitize_capture_text)
+            })
+            .await
+            .context("capture task panicked")?;
+            Ok(RelayFrame::Result {
+                request_id,
+                result: FleetCommandResult::capture(capture),
+            })
+        }
+        RelayRequest::CaptureWindow { request_id, window } => {
+            if window.session.endpoint.host != HostKind::Tmux {
+                bail!("window geometry is currently available only for tmux backends");
+            }
+            let backend = backends
+                .iter()
+                .find(|backend| backend.kind() == HostKind::Tmux)
+                .cloned()
+                .context("tmux backend is unavailable")?;
+            let verify_backend = backend.clone();
+            let verify_window = window.clone();
+            let exists = tokio::task::spawn_blocking(move || {
+                verify_backend.list_panes().iter().any(|pane| {
+                    PaneKey::from_pane(verify_backend.kind(), pane).window == verify_window
+                })
+            })
+            .await
+            .context("window verification task panicked")?;
+            if !exists {
+                bail!("exact window target is stale or no longer exists");
+            }
+            let capture_window = window.clone();
+            let capture = tokio::task::spawn_blocking(move || {
+                let socket = capture_window.session.endpoint.socket.clone();
+                let (geometries, zoomed) =
+                    muxa::tmux::layout::window_panes_on(Some(&socket), &capture_window.window_id);
+                let visible = geometries
+                    .into_iter()
+                    .filter(|geometry| !zoomed || geometry.active)
+                    .collect::<Vec<_>>();
+                let mut panes = Vec::with_capacity(visible.len());
+                for batch in visible.chunks(8) {
+                    panes.extend(std::thread::scope(|scope| {
+                        let handles = batch
+                            .iter()
+                            .cloned()
+                            .map(|geometry| {
+                                let backend = backend.clone();
+                                let socket = socket.clone();
+                                scope.spawn(move || {
+                                    let text = backend
+                                        .capture_pane_on(Some(&socket), &geometry.pane_id)
+                                        .map(sanitize_capture_text);
+                                    FleetCapturedWindowPane { geometry, text }
+                                })
+                            })
+                            .collect::<Vec<_>>();
+                        handles
+                            .into_iter()
+                            .filter_map(|handle| handle.join().ok())
+                            .collect::<Vec<_>>()
+                    }));
+                }
+                FleetWindowCapture {
+                    window: capture_window,
+                    panes,
+                    zoomed,
+                    observed_at: OffsetDateTime::now_utc(),
+                }
+            })
+            .await
+            .context("window capture task panicked")?;
+            Ok(RelayFrame::Result {
+                request_id,
+                result: FleetCommandResult::window_capture(capture),
+            })
+        }
+        RelayRequest::SendPrompt {
+            request_id,
+            pane,
+            text,
+            submit,
+        } => {
+            let backend = exact_backend(&backends, &pane).await?;
+            if !backend.caps().send_text {
+                bail!("{} backend does not support text injection", backend.kind());
+            }
+            let socket = pane.window.session.endpoint.socket.clone();
+            let pane_id = pane.pane_id.clone();
+            let outcome = tokio::task::spawn_blocking(move || {
+                if !backend.send_text_on(Some(&socket), &pane_id, &text) {
+                    return None;
+                }
+                let submitted = if submit {
+                    std::thread::sleep(muxa::backend::PROMPT_SUBMIT_GRACE);
+                    backend.send_text_on(Some(&socket), &pane_id, "\r")
+                } else {
+                    false
+                };
+                Some(muxa::ipc::SendPromptOutcome {
+                    sent: true,
+                    submitted,
+                })
+            })
+            .await
+            .context("send task panicked")?
+            .context("backend refused text injection")?;
+            Ok(RelayFrame::Result {
+                request_id,
+                result: FleetCommandResult::sent(outcome),
+            })
+        }
+    }
+}
+
+async fn exact_backend(backends: &[SharedBackend], key: &PaneKey) -> Result<SharedBackend> {
+    let backend = backends
+        .iter()
+        .find(|backend| backend.kind() == key.window.session.endpoint.host)
+        .cloned()
+        .with_context(|| {
+            format!(
+                "{} backend is unavailable",
+                key.window.session.endpoint.host
+            )
+        })?;
+    let scan_backend = backend.clone();
+    let panes = tokio::task::spawn_blocking(move || scan_backend.list_panes())
+        .await
+        .context("pane scan task panicked")?;
+    if !panes
+        .iter()
+        .any(|pane| PaneKey::from_pane(backend.kind(), pane) == *key)
+    {
+        bail!("exact pane target is stale or no longer exists");
+    }
+    Ok(backend)
+}
+
+async fn collect_snapshot(
+    client: &Client,
+    backends: &[SharedBackend],
+    revision: Arc<AtomicU64>,
+) -> Result<RemoteSnapshot> {
+    // Pin before any scans. Transitions that happen during collection receive
+    // a strictly newer revision and therefore remain applicable regardless of
+    // whether their frame is queued before or after this snapshot frame.
+    let snapshot_revision = revision.load(Ordering::SeqCst);
+    let pane_tasks: Vec<_> = backends
+        .iter()
+        .map(|backend| {
+            let backend = backend.clone();
+            tokio::task::spawn_blocking(move || backend.list_panes())
+        })
+        .collect();
+    let session_tasks: Vec<_> = backends
+        .iter()
+        .map(|backend| {
+            let kind = backend.kind();
+            tokio::task::spawn_blocking(move || sessions_for_backend(kind))
+        })
+        .collect();
+    let agents = client
+        .snapshot()
+        .await
+        .context("reading local agent snapshot")?;
+    let mut panes = Vec::new();
+    for task in pane_tasks {
+        panes.extend(task.await.context("pane scan task panicked")?);
+    }
+    let mut sessions = Vec::new();
+    for task in session_tasks {
+        sessions.extend(task.await.context("session scan task panicked")?);
+    }
+    Ok(RemoteSnapshot {
+        revision: snapshot_revision,
+        observed_at: OffsetDateTime::now_utc(),
+        agents,
+        panes,
+        sessions,
+        backends: backend_info(backends),
+    })
+}
+
+fn sessions_for_backend(kind: HostKind) -> Vec<SessionInfo> {
+    match kind {
+        HostKind::Tmux => muxa::tmux::list_sessions().unwrap_or_default(),
+        HostKind::Herdr => {
+            let socket = muxa::backend::herdr::default_socket_path();
+            muxa::backend::herdr::herdr_list_workspaces(&socket)
+                .into_iter()
+                .map(|workspace| SessionInfo {
+                    session_id: workspace.id,
+                    name: workspace.label,
+                    attached_clients: 0,
+                })
+                .collect()
+        }
+        HostKind::Rmux | HostKind::Zellij => Vec::new(),
+    }
+}
+
+fn backend_info(backends: &[SharedBackend]) -> Vec<FleetBackendInfo> {
+    backends
+        .iter()
+        .map(|backend| FleetBackendInfo::new(backend.kind(), backend.caps()))
+        .collect()
+}
+
+fn hostname() -> String {
+    std::fs::read_to_string("/etc/hostname")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var("HOSTNAME").ok())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+fn boot_id() -> String {
+    std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| format!("relay-{}", muxa::NodeId::generate()))
+}
+
+/// Encode an exact target into a shell-token-safe hexadecimal argument for a
+/// separate `ssh -t` attach channel. The target remains validated remotely.
+pub(crate) fn encode_attach_token(target: &GlobalPaneRef) -> Result<String> {
+    let bytes = serde_json::to_vec(target)?;
+    let mut token = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut token, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    Ok(token)
+}
+
+fn decode_attach_token(token: &str) -> Result<GlobalPaneRef> {
+    if token.is_empty() || !token.len().is_multiple_of(2) || token.len() > 64 * 1024 {
+        bail!("invalid remote attach token length");
+    }
+    let bytes = token
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let pair = std::str::from_utf8(pair)?;
+            u8::from_str_radix(pair, 16).map_err(anyhow::Error::from)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    serde_json::from_slice(&bytes).context("decoding remote attach target")
+}
+
+pub(crate) fn remote_attach(token: &str) -> Result<()> {
+    let target = decode_attach_token(token)?;
+    let id_path = muxa::paths::default_node_id_file()
+        .context("no data directory is available for the fleet host id")?;
+    let local = load_or_create_node_id(&id_path)?;
+    if target.node_id != local {
+        bail!(
+            "attach target belongs to node {}, not this node {local}",
+            target.node_id
+        );
+    }
+    let backend = muxa::active_backends()
+        .into_iter()
+        .find(|backend| backend.kind() == target.pane.window.session.endpoint.host)
+        .context("target backend is unavailable")?;
+    if !backend
+        .list_panes()
+        .iter()
+        .any(|pane| PaneKey::from_pane(backend.kind(), pane) == target.pane)
+    {
+        bail!("exact pane target is stale or no longer exists");
+    }
+    crate::jump_to_topology_pane(&target.pane);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use muxa::{BackendEndpoint, SessionKey, WindowKey};
+
+    #[test]
+    fn attach_token_is_shell_safe_and_round_trips() {
+        let target = GlobalPaneRef {
+            node_id: muxa::NodeId::generate(),
+            pane: PaneKey {
+                window: WindowKey {
+                    session: SessionKey {
+                        endpoint: BackendEndpoint {
+                            host: HostKind::Tmux,
+                            socket: "default".into(),
+                        },
+                        session_id: "$1".into(),
+                    },
+                    window_id: "@2".into(),
+                },
+                pane_id: "%3".into(),
+            },
+            agent_session_id: Some("agent;$(bad)".into()),
+        };
+        let token = encode_attach_token(&target).unwrap();
+        assert!(token.chars().all(|ch| ch.is_ascii_hexdigit()));
+        assert_eq!(decode_attach_token(&token).unwrap(), target);
+    }
+}

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -142,7 +142,7 @@ const WAKE_CAPACITY: usize = 1;
 const OUTCOME_CAPACITY: usize = 2;
 
 #[derive(Debug, Clone, Copy)]
-struct WatchThemeSpec {
+pub(crate) struct WatchThemeSpec {
     title: &'static str,
     accent: Color,
     accent_fg: Color,
@@ -161,40 +161,40 @@ struct WatchThemeSpec {
     state_choice: Color,
     state_error: Color,
     state_starting: Color,
-    border_type: BorderType,
+    pub(crate) border_type: BorderType,
 }
 
 impl WatchThemeSpec {
-    fn accent_badge(self) -> Style {
+    pub(crate) fn accent_badge(self) -> Style {
         Style::default()
             .fg(self.accent_fg)
             .bg(self.accent)
             .add_modifier(Modifier::BOLD)
     }
 
-    fn action_badge(self) -> Style {
+    pub(crate) fn action_badge(self) -> Style {
         Style::default().fg(self.action_fg).bg(self.action)
     }
 
-    fn key_badge(self) -> Style {
+    pub(crate) fn key_badge(self) -> Style {
         Style::default().fg(self.key_fg).bg(self.key_bg)
     }
 
-    fn border_style(self) -> Style {
+    pub(crate) fn border_style(self) -> Style {
         Style::default().fg(self.border)
     }
 
-    fn dim_style(self) -> Style {
+    pub(crate) fn dim_style(self) -> Style {
         Style::default().fg(self.dim)
     }
 
-    fn table_header_style(self) -> Style {
+    pub(crate) fn table_header_style(self) -> Style {
         Style::default()
             .fg(self.table_header)
             .add_modifier(Modifier::BOLD)
     }
 
-    fn selected_style(self) -> Style {
+    pub(crate) fn selected_style(self) -> Style {
         let style = Style::default()
             .bg(self.selected_bg)
             .add_modifier(Modifier::BOLD);
@@ -205,7 +205,7 @@ impl WatchThemeSpec {
         }
     }
 
-    fn state_style(self, state: AgentState) -> Style {
+    pub(crate) fn state_style(self, state: AgentState) -> Style {
         match state {
             AgentState::Idle => Style::default()
                 .fg(self.state_idle)
@@ -228,7 +228,7 @@ impl WatchThemeSpec {
     }
 }
 
-fn watch_theme(theme: WatchTheme) -> WatchThemeSpec {
+pub(crate) fn watch_theme(theme: WatchTheme) -> WatchThemeSpec {
     match theme {
         WatchTheme::Classic => classic_watch_theme(),
         WatchTheme::OhMyMuxa => oh_my_muxa_watch_theme(),

--- a/crates/muxa/Cargo.toml
+++ b/crates/muxa/Cargo.toml
@@ -29,6 +29,7 @@ reqwest = { workspace = true }
 url = { workspace = true }
 notify-rust = "4"
 portable-pty = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "test-util"] }

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -5,6 +5,7 @@
 
 use crate::collaboration::RequestKind;
 use crate::error::{CoreError, Result};
+use crate::fleet::{validate_label_key, validate_label_value, HostAccessMode};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::net::{AddrParseError, SocketAddr};
@@ -95,6 +96,9 @@ pub enum ConfigError {
          nor [sinks.webhook].endpoint_env is set (one of the two is required)"
     )]
     WebhookMissingEndpoint,
+
+    #[error("{path}: {message}")]
+    InvalidFleet { path: String, message: String },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -107,6 +111,8 @@ pub struct Config {
     pub notifier: NotifierConfig,
     pub watch: WatchConfig,
     pub dashboard: DashboardTomlConfig,
+    /// SSH-connected physical hosts aggregated by the local daemon.
+    pub fleet: FleetConfig,
     pub discovery: DiscoveryConfig,
     pub reconciler: ReconcilerConfig,
     pub screen_detect: ScreenDetectConfig,
@@ -121,6 +127,86 @@ pub struct Config {
     pub session_activity: SessionActivityConfig,
     pub sinks: SinksConfig,
     pub stats: StatsConfig,
+}
+
+/// Fleet-wide connection and refresh policy. Inventory keys are stable local
+/// aliases; the remote relay supplies the durable physical [`NodeId`](crate::fleet::NodeId).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct FleetConfig {
+    pub enabled: bool,
+    pub refresh_secs: u64,
+    pub keepalive_secs: u64,
+    pub offline_after_secs: u64,
+    pub connect_timeout_secs: u64,
+    pub command_timeout_secs: u64,
+    pub max_parallel_connects: usize,
+    pub capture_policy: FleetCapturePolicy,
+    pub hosts: BTreeMap<String, FleetHostConfig>,
+}
+
+impl Default for FleetConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            refresh_secs: 15,
+            keepalive_secs: 10,
+            offline_after_secs: 30,
+            connect_timeout_secs: 10,
+            command_timeout_secs: 10,
+            max_parallel_connects: 6,
+            capture_policy: FleetCapturePolicy::Selected,
+            hosts: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetCapturePolicy {
+    Never,
+    #[default]
+    Selected,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetConnectPolicy {
+    #[default]
+    Auto,
+    OnDemand,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct FleetHostConfig {
+    /// OpenSSH destination or Host alias. User/port/key/ProxyJump stay in
+    /// `~/.ssh/config` rather than being duplicated in muxa configuration.
+    pub ssh: String,
+    /// Remote binary invoked as a fixed command. Kept shell-token-safe because
+    /// OpenSSH ultimately passes a command string to the remote login shell.
+    pub muxa_path: String,
+    pub remote_socket: Option<PathBuf>,
+    pub enabled: bool,
+    pub connect: FleetConnectPolicy,
+    pub mode: HostAccessMode,
+    pub labels: BTreeMap<String, String>,
+    pub annotations: BTreeMap<String, String>,
+}
+
+impl Default for FleetHostConfig {
+    fn default() -> Self {
+        Self {
+            ssh: String::new(),
+            muxa_path: "muxa".into(),
+            remote_socket: None,
+            enabled: true,
+            connect: FleetConnectPolicy::Auto,
+            mode: HostAccessMode::Observe,
+            labels: BTreeMap::new(),
+            annotations: BTreeMap::new(),
+        }
+    }
 }
 
 /// `[message.skills]` config — reusable prompt templates for message
@@ -868,7 +954,7 @@ impl Config {
     /// home, and so the always-on / daemon-only split stays legible to
     /// callers.
     pub fn validate(&self) -> std::result::Result<(), ConfigError> {
-        Ok(())
+        validate_fleet(&self.fleet)
     }
 
     /// Run hard semantic checks that only matter when the daemon is
@@ -922,6 +1008,97 @@ impl Config {
             );
         }
     }
+}
+
+fn validate_fleet(cfg: &FleetConfig) -> std::result::Result<(), ConfigError> {
+    let invalid = |path: String, message: String| ConfigError::InvalidFleet { path, message };
+    if cfg.refresh_secs == 0 {
+        return Err(invalid(
+            "fleet.refresh_secs".into(),
+            "must be greater than zero".into(),
+        ));
+    }
+    if cfg.keepalive_secs == 0 {
+        return Err(invalid(
+            "fleet.keepalive_secs".into(),
+            "must be greater than zero".into(),
+        ));
+    }
+    if cfg.offline_after_secs < cfg.keepalive_secs.saturating_mul(2) {
+        return Err(invalid(
+            "fleet.offline_after_secs".into(),
+            "must allow at least two keepalive intervals".into(),
+        ));
+    }
+    if cfg.connect_timeout_secs == 0 || cfg.command_timeout_secs == 0 {
+        return Err(invalid(
+            "fleet".into(),
+            "connect_timeout_secs and command_timeout_secs must be greater than zero".into(),
+        ));
+    }
+    if cfg.max_parallel_connects == 0 || cfg.max_parallel_connects > 128 {
+        return Err(invalid(
+            "fleet.max_parallel_connects".into(),
+            "must be between 1 and 128".into(),
+        ));
+    }
+    for (alias, host) in &cfg.hosts {
+        validate_label_value(alias).map_err(|message| {
+            invalid(
+                format!("fleet.hosts.{alias}"),
+                format!("invalid host alias: {message}"),
+            )
+        })?;
+        if host.ssh.is_empty()
+            || host.ssh.starts_with('-')
+            || host
+                .ssh
+                .chars()
+                .any(|ch| ch.is_control() || ch.is_whitespace())
+        {
+            return Err(invalid(
+                format!("fleet.hosts.{alias}.ssh"),
+                "must be a non-empty OpenSSH destination without whitespace and must not start with '-'"
+                    .into(),
+            ));
+        }
+        if host.muxa_path.is_empty()
+            || !host
+                .muxa_path
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-' | '+'))
+        {
+            return Err(invalid(
+                format!("fleet.hosts.{alias}.muxa_path"),
+                "must be a shell-token-safe binary name or path".into(),
+            ));
+        }
+        if let Some(socket) = &host.remote_socket {
+            let value = socket.to_string_lossy();
+            if value.is_empty()
+                || value.chars().any(|ch| {
+                    ch.is_control() || ch.is_whitespace() || "'\"`;|&<>$(){}[]".contains(ch)
+                })
+            {
+                return Err(invalid(
+                    format!("fleet.hosts.{alias}.remote_socket"),
+                    "must be a shell-token-safe remote path without whitespace".into(),
+                ));
+            }
+        }
+        for (key, value) in &host.labels {
+            validate_label_key(key)
+                .map_err(|message| invalid(format!("fleet.hosts.{alias}.labels.{key}"), message))?;
+            validate_label_value(value)
+                .map_err(|message| invalid(format!("fleet.hosts.{alias}.labels.{key}"), message))?;
+        }
+        for key in host.annotations.keys() {
+            validate_label_key(key).map_err(|message| {
+                invalid(format!("fleet.hosts.{alias}.annotations.{key}"), message)
+            })?;
+        }
+    }
+    Ok(())
 }
 
 fn validate_dashboard(cfg: &DashboardTomlConfig) -> std::result::Result<(), ConfigError> {
@@ -2330,5 +2507,73 @@ template = "{nope} {last_prompt}"
     fn unknown_detail_placeholders_flags_each_unknown_alternative() {
         let unknown = unknown_detail_placeholders("{nope|also_nope|last_prompt}");
         assert_eq!(unknown, vec!["nope".to_string(), "also_nope".to_string()]);
+    }
+
+    #[test]
+    fn parses_fleet_inventory_labels_annotations_and_policy() {
+        let input = r#"
+[fleet]
+enabled = true
+refresh_secs = 12
+keepalive_secs = 5
+offline_after_secs = 15
+
+[fleet.hosts.dev]
+ssh = "devbox"
+mode = "control"
+connect = "on_demand"
+
+[fleet.hosts.dev.labels]
+"muxa.dev/environment" = "development"
+accelerator = "gpu"
+
+[fleet.hosts.dev.annotations]
+"muxa.dev/owner" = "June <june@example.com>"
+"#;
+        let cfg: Config = toml::from_str(input).unwrap();
+        cfg.validate().unwrap();
+        assert!(cfg.fleet.enabled);
+        assert_eq!(cfg.fleet.hosts["dev"].mode, HostAccessMode::Control);
+        assert_eq!(cfg.fleet.hosts["dev"].connect, FleetConnectPolicy::OnDemand);
+        assert_eq!(cfg.fleet.hosts["dev"].labels["accelerator"], "gpu");
+        assert_eq!(
+            cfg.fleet.hosts["dev"].annotations["muxa.dev/owner"],
+            "June <june@example.com>"
+        );
+    }
+
+    #[test]
+    fn fleet_validation_rejects_unsafe_ssh_and_remote_shell_tokens() {
+        let mut cfg = Config::default();
+        cfg.fleet.hosts.insert(
+            "dev".into(),
+            FleetHostConfig {
+                ssh: "-oProxyCommand=bad".into(),
+                ..FleetHostConfig::default()
+            },
+        );
+        assert!(matches!(
+            cfg.validate(),
+            Err(ConfigError::InvalidFleet { .. })
+        ));
+        cfg.fleet.hosts.get_mut("dev").unwrap().ssh = "devbox".into();
+        cfg.fleet.hosts.get_mut("dev").unwrap().muxa_path = "muxa;bad".into();
+        assert!(matches!(
+            cfg.validate(),
+            Err(ConfigError::InvalidFleet { .. })
+        ));
+    }
+
+    #[test]
+    fn fleet_validation_requires_two_keepalive_windows_before_offline() {
+        let mut cfg = Config::default();
+        cfg.fleet.keepalive_secs = 10;
+        cfg.fleet.offline_after_secs = 19;
+        assert!(matches!(
+            cfg.validate(),
+            Err(ConfigError::InvalidFleet { .. })
+        ));
+        cfg.fleet.offline_after_secs = 20;
+        assert!(cfg.validate().is_ok());
     }
 }

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -134,7 +134,12 @@ pub struct Config {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct FleetConfig {
+    /// Enable persistent outbound SSH connections. The controller's local
+    /// node is published regardless of this flag.
     pub enabled: bool,
+    /// Metadata for the controller node. It is always visible; `enabled`
+    /// controls only outbound SSH host connections.
+    pub local: FleetLocalConfig,
     pub refresh_secs: u64,
     pub keepalive_secs: u64,
     pub offline_after_secs: u64,
@@ -149,6 +154,7 @@ impl Default for FleetConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            local: FleetLocalConfig::default(),
             refresh_secs: 15,
             keepalive_secs: 10,
             offline_after_secs: 30,
@@ -159,6 +165,14 @@ impl Default for FleetConfig {
             hosts: BTreeMap::new(),
         }
     }
+}
+
+/// User-managed metadata layered onto the always-present local Fleet node.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct FleetLocalConfig {
+    pub labels: BTreeMap<String, String>,
+    pub annotations: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -1042,7 +1056,20 @@ fn validate_fleet(cfg: &FleetConfig) -> std::result::Result<(), ConfigError> {
             "must be between 1 and 128".into(),
         ));
     }
+    validate_fleet_metadata(
+        &cfg.local.labels,
+        &cfg.local.annotations,
+        "fleet.local",
+        crate::fleet::LOCAL_MANAGED_LABELS,
+    )?;
     for (alias, host) in &cfg.hosts {
+        if alias == crate::fleet::LOCAL_HOST_ALIAS {
+            return Err(invalid(
+                format!("fleet.hosts.{alias}"),
+                "the alias 'local' is reserved for this muxad node; configure its metadata under [fleet.local]"
+                    .into(),
+            ));
+        }
         validate_label_value(alias).map_err(|message| {
             invalid(
                 format!("fleet.hosts.{alias}"),
@@ -1086,17 +1113,43 @@ fn validate_fleet(cfg: &FleetConfig) -> std::result::Result<(), ConfigError> {
                 ));
             }
         }
-        for (key, value) in &host.labels {
-            validate_label_key(key)
-                .map_err(|message| invalid(format!("fleet.hosts.{alias}.labels.{key}"), message))?;
-            validate_label_value(value)
-                .map_err(|message| invalid(format!("fleet.hosts.{alias}.labels.{key}"), message))?;
+        validate_fleet_metadata(
+            &host.labels,
+            &host.annotations,
+            &format!("fleet.hosts.{alias}"),
+            &[],
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_fleet_metadata(
+    labels: &BTreeMap<String, String>,
+    annotations: &BTreeMap<String, String>,
+    path: &str,
+    managed_labels: &[&str],
+) -> std::result::Result<(), ConfigError> {
+    for (key, value) in labels {
+        if managed_labels.contains(&key.as_str()) {
+            return Err(ConfigError::InvalidFleet {
+                path: format!("{path}.labels.{key}"),
+                message: "is managed by muxad and cannot be overridden".into(),
+            });
         }
-        for key in host.annotations.keys() {
-            validate_label_key(key).map_err(|message| {
-                invalid(format!("fleet.hosts.{alias}.annotations.{key}"), message)
-            })?;
-        }
+        validate_label_key(key).map_err(|message| ConfigError::InvalidFleet {
+            path: format!("{path}.labels.{key}"),
+            message,
+        })?;
+        validate_label_value(value).map_err(|message| ConfigError::InvalidFleet {
+            path: format!("{path}.labels.{key}"),
+            message,
+        })?;
+    }
+    for key in annotations.keys() {
+        validate_label_key(key).map_err(|message| ConfigError::InvalidFleet {
+            path: format!("{path}.annotations.{key}"),
+            message,
+        })?;
     }
     Ok(())
 }
@@ -2575,5 +2628,53 @@ accelerator = "gpu"
         ));
         cfg.fleet.offline_after_secs = 20;
         assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn fleet_local_metadata_is_independent_of_remote_enablement() {
+        let input = r#"
+[fleet]
+enabled = false
+
+[fleet.local.labels]
+environment = "development"
+
+[fleet.local.annotations]
+"muxa.dev/owner" = "June <june@example.com>"
+"#;
+        let cfg: Config = toml::from_str(input).unwrap();
+        cfg.validate().unwrap();
+        assert!(!cfg.fleet.enabled);
+        assert_eq!(cfg.fleet.local.labels["environment"], "development");
+        assert_eq!(
+            cfg.fleet.local.annotations["muxa.dev/owner"],
+            "June <june@example.com>"
+        );
+    }
+
+    #[test]
+    fn fleet_reserves_local_alias_and_managed_labels() {
+        let mut cfg = Config::default();
+        cfg.fleet.hosts.insert(
+            crate::fleet::LOCAL_HOST_ALIAS.into(),
+            FleetHostConfig {
+                ssh: "other-machine".into(),
+                ..FleetHostConfig::default()
+            },
+        );
+        assert!(matches!(
+            cfg.validate(),
+            Err(ConfigError::InvalidFleet { .. })
+        ));
+
+        cfg.fleet.hosts.clear();
+        cfg.fleet
+            .local
+            .labels
+            .insert("muxa.io/local".into(), "false".into());
+        assert!(matches!(
+            cfg.validate(),
+            Err(ConfigError::InvalidFleet { .. })
+        ));
     }
 }

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -42,6 +42,7 @@ use crate::backend::{HostKind, SharedBackend};
 use crate::config::{DashboardAuthMode, StatsConfig};
 use crate::dashboard::{assets, auth, DashboardConfig};
 use crate::event::{AgentKind, AgentState, PROTOCOL_VERSION};
+use crate::fleet::{FleetOperation, FleetRuntime, LabelSelector};
 use crate::metrics::Metrics;
 use crate::scope_filter::ScopeExclusions;
 use crate::session::{SessionBackend, SharedSessionBackend};
@@ -118,6 +119,9 @@ pub struct AppState {
     pub session_activity_path: Option<PathBuf>,
     /// ACTIVE estimate tuning shared with `muxa stats`.
     pub stats_config: StatsConfig,
+    /// Optional SSH fleet runtime. Fleet reads reuse muxad's per-host cache;
+    /// dashboard requests never launch their own SSH processes.
+    pub fleet: Option<FleetRuntime>,
     /// 1-second cache for the `agents_by_state` histogram. See the
     /// [`AGENTS_BY_STATE_CACHE_TTL`] doc-comment for the perf rationale
     /// and the eventual plan to replace this with per-state atomics.
@@ -131,11 +135,12 @@ pub struct AppState {
     timeline_summary_cache: Arc<tokio::sync::Mutex<TimelineSummaryCache>>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct DashboardRuntimeConfig {
     pub activity_path: Option<PathBuf>,
     pub session_activity_path: Option<PathBuf>,
     pub stats_config: StatsConfig,
+    pub fleet: Option<FleetRuntime>,
 }
 
 impl AppState {
@@ -158,6 +163,7 @@ impl AppState {
             activity_path: None,
             session_activity_path: None,
             stats_config: StatsConfig::default(),
+            fleet: None,
             agents_by_state_cache: Arc::new(tokio::sync::Mutex::new(AgentsByStateCache::default())),
             activity_ledger_cache: Arc::new(tokio::sync::Mutex::new(
                 crate::activity::ActivityCache::default(),
@@ -182,6 +188,12 @@ impl AppState {
     #[must_use]
     pub fn with_stats_config(mut self, stats_config: StatsConfig) -> Self {
         self.stats_config = stats_config;
+        self
+    }
+
+    #[must_use]
+    pub fn with_fleet(mut self, fleet: Option<FleetRuntime>) -> Self {
+        self.fleet = fleet;
         self
     }
 
@@ -305,6 +317,7 @@ pub fn router(state: AppState) -> Router {
         .route("/api/health", get(health_handler))
         .route("/api/access", get(access_handler))
         .route("/api/agents", get(agents_handler))
+        .route("/api/fleet", get(fleet_handler))
         .route("/api/panes", get(panes_handler))
         .route("/api/terminal-sessions", get(terminal_sessions_handler))
         .route(
@@ -321,6 +334,7 @@ pub fn router(state: AppState) -> Router {
     };
     let write_api = Router::new()
         .route("/api/panes/{pane}/prompt", post(pane_prompt_handler))
+        .route("/api/fleet/{host}/command", post(fleet_command_handler))
         .route("/api/panes/{pane}/abort", post(pane_abort_handler))
         .route(
             "/api/terminal-sessions/{id}/input",
@@ -391,7 +405,8 @@ pub async fn serve(
     let state = AppState::new(store, config.clone(), pane_cache, sessions)
         .with_backends(backends)
         .with_activity_paths(runtime.activity_path, runtime.session_activity_path)
-        .with_stats_config(runtime.stats_config);
+        .with_stats_config(runtime.stats_config)
+        .with_fleet(runtime.fleet);
     let app = router(state);
     let listener = TcpListener::bind(config.bind).await?;
     let local = listener.local_addr()?;
@@ -592,6 +607,59 @@ async fn agents_handler(State(state): State<AppState>) -> impl IntoResponse {
     Json(AgentsResponse {
         agents: state.store.snapshot().await,
     })
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct FleetQuery {
+    selector: Option<String>,
+}
+
+async fn fleet_handler(State(state): State<AppState>, Query(query): Query<FleetQuery>) -> Response {
+    let Some(fleet) = &state.fleet else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "fleet manager is not enabled" })),
+        )
+            .into_response();
+    };
+    let selector = match query
+        .selector
+        .as_deref()
+        .map(str::parse::<LabelSelector>)
+        .transpose()
+    {
+        Ok(selector) => selector,
+        Err(error) => {
+            return (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))).into_response();
+        }
+    };
+    Json(fleet.store.snapshot_selected(selector.as_ref()).await).into_response()
+}
+
+#[derive(Debug, Deserialize)]
+struct FleetCommandRequest {
+    operation: FleetOperation,
+}
+
+async fn fleet_command_handler(
+    State(state): State<AppState>,
+    Path(host): Path<String>,
+    Json(request): Json<FleetCommandRequest>,
+) -> Response {
+    let Some(fleet) = &state.fleet else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "fleet manager is not enabled" })),
+        )
+            .into_response();
+    };
+    match fleet
+        .execute(host, request.operation, Duration::from_secs(20))
+        .await
+    {
+        Ok(result) => Json(result).into_response(),
+        Err(error) => (StatusCode::CONFLICT, Json(json!({ "error": error }))).into_response(),
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -1600,7 +1668,7 @@ mod tests {
     use axum::http::Request;
     use http_body_util::BodyExt;
     use serde_json::Value;
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::sync::Mutex;
     use tower::ServiceExt;
 
@@ -1759,6 +1827,97 @@ mod tests {
         assert_eq!(v["ok"], true);
         assert_eq!(v["protocol"], i64::from(PROTOCOL_VERSION));
         assert!(v["version"].is_string());
+    }
+
+    fn fleet_host(alias: &str, environment: &str) -> crate::fleet::FleetHostSnapshot {
+        crate::fleet::FleetHostSnapshot {
+            alias: alias.into(),
+            ssh_target: alias.into(),
+            labels: BTreeMap::from([("environment".into(), environment.into())]),
+            annotations: BTreeMap::new(),
+            mode: crate::fleet::HostAccessMode::Observe,
+            state: crate::fleet::FleetHostState::Online,
+            node_id: None,
+            hostname: None,
+            os: None,
+            arch: None,
+            muxa_version: None,
+            protocol: None,
+            capabilities: Vec::new(),
+            daemon_generation: None,
+            boot_id: None,
+            latency_ms: None,
+            last_seen_at: None,
+            received_at: None,
+            error: None,
+            remote: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn fleet_endpoint_reads_cache_and_applies_label_selector() {
+        let store = Arc::new(crate::fleet::FleetStore::new());
+        store.upsert_host(fleet_host("dev", "development")).await;
+        store.upsert_host(fleet_host("prod", "production")).await;
+        let (runtime, _commands) = FleetRuntime::new(store);
+        let app = router(fresh_state().with_fleet(Some(runtime)));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/fleet?selector=environment%3Dproduction")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["hosts"].as_array().unwrap().len(), 1);
+        assert_eq!(body["hosts"][0]["alias"], "prod");
+    }
+
+    #[tokio::test]
+    async fn fleet_command_endpoint_is_pat_gated_and_dispatches() {
+        let (runtime, mut commands) = FleetRuntime::new(Arc::new(crate::fleet::FleetStore::new()));
+        let app = router(state_with_token("secret").with_fleet(Some(runtime)));
+        let unauthorized = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/fleet/dev/command")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"operation":{"kind":"refresh"}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+        let responder = tokio::spawn(async move {
+            let command = commands.recv().await.unwrap();
+            assert_eq!(command.host, "dev");
+            assert!(matches!(command.operation, FleetOperation::Refresh));
+            command
+                .reply
+                .send(Ok(crate::fleet::FleetCommandResult::accepted("refreshed")))
+                .unwrap();
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/fleet/dev/command")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::AUTHORIZATION, "Bearer secret")
+                    .body(Body::from(r#"{"operation":{"kind":"refresh"}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_json(response).await["message"], "refreshed");
+        responder.await.unwrap();
     }
 
     #[test]

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -1832,6 +1832,7 @@ mod tests {
     fn fleet_host(alias: &str, environment: &str) -> crate::fleet::FleetHostSnapshot {
         crate::fleet::FleetHostSnapshot {
             alias: alias.into(),
+            local: false,
             ssh_target: alias.into(),
             labels: BTreeMap::from([("environment".into(), environment.into())]),
             annotations: BTreeMap::new(),

--- a/crates/muxa/src/fleet.rs
+++ b/crates/muxa/src/fleet.rs
@@ -1,0 +1,1046 @@
+//! Remote-host fleet model shared by muxad, the SSH relay, and clients.
+//!
+//! A fleet host is a physical machine. This is deliberately distinct from
+//! [`crate::backend::HostKind`], whose historical name describes a local
+//! multiplexer backend (tmux/rmux/zellij/herdr). Every remote target is keyed
+//! by [`NodeId`] first, then by its backend endpoint and native topology ids.
+
+use std::collections::{BTreeMap, HashSet};
+use std::fmt;
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt};
+use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
+use uuid::Uuid;
+
+use crate::backend::{BackendCaps, HostKind};
+use crate::event::AgentState;
+use crate::ipc::SendPromptOutcome;
+use crate::state::{Agent, Transition};
+use crate::tmux::layout::PaneGeometry;
+use crate::tmux::{PaneInfo, SessionInfo};
+use crate::topology::{PaneKey, WindowKey};
+
+pub const FLEET_PROTOCOL_VERSION: u32 = 1;
+pub const FLEET_MIN_PROTOCOL_VERSION: u32 = 1;
+pub const FLEET_MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
+pub const FLEET_MAX_DIAGNOSTIC_BYTES: usize = 1024;
+pub const FLEET_MAX_CAPTURE_BYTES: usize = 256 * 1024;
+pub const FLEET_CAPABILITIES: &[&str] = &[
+    "snapshot_watch",
+    "capture",
+    "window_capture",
+    "send_prompt",
+    "exact_pane_ref",
+    "labels_v1",
+];
+
+/// Read one UTF-8 line without allowing a peer that withholds `\n` to grow
+/// memory past `limit`. The terminator is retained, matching `read_line`.
+pub async fn read_bounded_line<R>(
+    reader: &mut R,
+    line: &mut String,
+    limit: usize,
+) -> std::io::Result<usize>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut bytes = Vec::new();
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            if bytes.is_empty() {
+                return Ok(0);
+            }
+            break;
+        }
+        let take = available
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(available.len(), |position| position + 1);
+        if bytes.len().saturating_add(take) > limit {
+            return Err(std::io::Error::other(format!(
+                "fleet frame exceeds {limit} bytes"
+            )));
+        }
+        bytes.extend_from_slice(&available[..take]);
+        reader.consume(take);
+        if bytes.last() == Some(&b'\n') {
+            break;
+        }
+    }
+    *line = String::from_utf8(bytes)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    Ok(line.len())
+}
+
+/// Drain a stream to EOF so the child process cannot block on a full pipe,
+/// retaining at most `limit` bytes for diagnostics.
+pub async fn drain_bounded<R>(reader: &mut R, limit: usize) -> std::io::Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut retained = Vec::with_capacity(limit.min(4096));
+    let mut chunk = [0_u8; 4096];
+    loop {
+        let read = reader.read(&mut chunk).await?;
+        if read == 0 {
+            break;
+        }
+        let remaining = limit.saturating_sub(retained.len());
+        retained.extend_from_slice(&chunk[..read.min(remaining)]);
+    }
+    Ok(retained)
+}
+
+/// Remove terminal control sequences from data that may originate on a
+/// compromised remote node before rendering it in a trusted terminal.
+#[must_use]
+pub fn sanitize_terminal_text(value: &str) -> String {
+    #[derive(Clone, Copy)]
+    enum Escape {
+        Text,
+        Esc,
+        Csi,
+        Osc,
+        OscEsc,
+    }
+    let mut state = Escape::Text;
+    let mut output = String::with_capacity(value.len());
+    for character in value.chars() {
+        state = match state {
+            Escape::Text if character == '\u{1b}' => Escape::Esc,
+            Escape::Text => {
+                if !character.is_control() || matches!(character, '\n' | '\t') {
+                    output.push(character);
+                }
+                Escape::Text
+            }
+            Escape::Esc if character == '[' => Escape::Csi,
+            Escape::Esc if character == ']' => Escape::Osc,
+            Escape::Esc => Escape::Text,
+            Escape::Csi if ('@'..='~').contains(&character) => Escape::Text,
+            Escape::Csi => Escape::Csi,
+            Escape::Osc if character == '\u{7}' => Escape::Text,
+            Escape::Osc if character == '\u{1b}' => Escape::OscEsc,
+            Escape::OscEsc if character == '\\' => Escape::Text,
+            Escape::Osc | Escape::OscEsc => Escape::Osc,
+        };
+    }
+    output
+}
+
+/// Sanitize and retain only the newest bounded portion of a terminal capture.
+#[must_use]
+pub fn sanitize_capture_text(value: String) -> String {
+    let mut text = sanitize_terminal_text(&value);
+    if text.len() <= FLEET_MAX_CAPTURE_BYTES {
+        return text;
+    }
+    let mut start = text.len() - FLEET_MAX_CAPTURE_BYTES;
+    while !text.is_char_boundary(start) {
+        start += 1;
+    }
+    text.drain(..start);
+    text
+}
+
+/// Durable UUID belonging to a physical machine.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct NodeId(String);
+
+impl NodeId {
+    #[must_use]
+    pub fn generate() -> Self {
+        Self(Uuid::new_v4().to_string())
+    }
+
+    pub fn parse(value: impl Into<String>) -> Result<Self, String> {
+        let value = value.into();
+        Uuid::parse_str(&value).map_err(|error| format!("invalid node id: {error}"))?;
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for NodeId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl FromStr for NodeId {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+/// Read a node id, or atomically create an owner-only identity file.
+pub fn load_or_create_node_id(path: &Path) -> std::io::Result<NodeId> {
+    match std::fs::read_to_string(path) {
+        Ok(value) => NodeId::parse(value.trim()).map_err(std::io::Error::other),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            if let Some(parent) = path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+            {
+                std::fs::create_dir_all(parent)?;
+            }
+            let generated = NodeId::generate();
+            let mut options = std::fs::OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            match options.open(path) {
+                Ok(mut file) => {
+                    use std::io::Write as _;
+                    writeln!(file, "{generated}")?;
+                    file.sync_all()?;
+                    Ok(generated)
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    let value = std::fs::read_to_string(path)?;
+                    NodeId::parse(value.trim()).map_err(std::io::Error::other)
+                }
+                Err(error) => Err(error),
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Per-host authorization at the central manager.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostAccessMode {
+    #[default]
+    Observe,
+    Control,
+}
+
+/// Complete collision-free pane address across physical nodes and local
+/// multiplexer endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GlobalPaneRef {
+    pub node_id: NodeId,
+    pub pane: PaneKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FleetCapturedWindowPane {
+    pub geometry: PaneGeometry,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FleetWindowCapture {
+    pub window: WindowKey,
+    pub panes: Vec<FleetCapturedWindowPane>,
+    pub zoomed: bool,
+    #[serde(with = "time::serde::rfc3339")]
+    pub observed_at: OffsetDateTime,
+}
+
+/// Serializable subset of backend capabilities advertised by a relay.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetBackendInfo {
+    pub kind: HostKind,
+    pub current_command: bool,
+    pub pane_pid_map: bool,
+    pub capture_pane: bool,
+    pub focus_pane: bool,
+    pub send_text: bool,
+}
+
+impl FleetBackendInfo {
+    #[must_use]
+    pub fn new(kind: HostKind, caps: BackendCaps) -> Self {
+        Self {
+            kind,
+            current_command: caps.current_command,
+            pane_pid_map: caps.pane_pid_map,
+            capture_pane: caps.capture_pane,
+            focus_pane: caps.focus_pane,
+            send_text: caps.send_text,
+        }
+    }
+}
+
+/// One coherent remote observation. Detailed terminal contents and retained
+/// prompt history are intentionally absent; callers fetch a selected capture
+/// on demand instead of centralizing every PTY.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoteSnapshot {
+    pub revision: u64,
+    #[serde(with = "time::serde::rfc3339")]
+    pub observed_at: OffsetDateTime,
+    pub agents: Vec<Agent>,
+    pub panes: Vec<PaneInfo>,
+    pub sessions: Vec<SessionInfo>,
+    pub backends: Vec<FleetBackendInfo>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetHostState {
+    Disabled,
+    #[default]
+    Connecting,
+    Online,
+    Degraded,
+    Offline,
+    AuthFailed,
+    VersionSkew,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FleetHostSnapshot {
+    pub alias: String,
+    pub ssh_target: String,
+    pub labels: BTreeMap<String, String>,
+    pub annotations: BTreeMap<String, String>,
+    pub mode: HostAccessMode,
+    pub state: FleetHostState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<NodeId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub os: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub arch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub muxa_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<u32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_generation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub boot_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u64>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::rfc3339::option"
+    )]
+    pub last_seen_at: Option<OffsetDateTime>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::rfc3339::option"
+    )]
+    pub received_at: Option<OffsetDateTime>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote: Option<RemoteSnapshot>,
+}
+
+impl FleetHostSnapshot {
+    #[must_use]
+    pub fn agent_count(&self) -> usize {
+        self.remote.as_ref().map_or(0, |remote| remote.agents.len())
+    }
+
+    #[must_use]
+    pub fn pane_count(&self) -> usize {
+        self.remote.as_ref().map_or(0, |remote| remote.panes.len())
+    }
+
+    #[must_use]
+    pub fn needs_attention(&self) -> usize {
+        self.remote.as_ref().map_or(0, |remote| {
+            remote
+                .agents
+                .iter()
+                .filter(|agent| {
+                    matches!(
+                        agent.state,
+                        AgentState::WaitingInput | AgentState::WaitingChoice | AgentState::Error
+                    )
+                })
+                .count()
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FleetSnapshot {
+    #[serde(with = "time::serde::rfc3339")]
+    pub generated_at: OffsetDateTime,
+    pub hosts: Vec<FleetHostSnapshot>,
+}
+
+impl FleetSnapshot {
+    #[must_use]
+    pub fn select(mut self, selector: Option<&LabelSelector>) -> Self {
+        if let Some(selector) = selector {
+            self.hosts.retain(|host| selector.matches(&host.labels));
+        }
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayHello {
+    pub fleet_protocol: u32,
+    pub min_fleet_protocol: u32,
+    pub node_id: NodeId,
+    pub hostname: String,
+    pub os: String,
+    pub arch: String,
+    pub muxa_version: String,
+    pub capabilities: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_generation: Option<u64>,
+    pub boot_id: String,
+    pub backends: Vec<FleetBackendInfo>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub server_time: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RelayRequest {
+    Snapshot {
+        request_id: String,
+    },
+    Ping {
+        request_id: String,
+    },
+    Capture {
+        request_id: String,
+        pane: PaneKey,
+    },
+    CaptureWindow {
+        request_id: String,
+        window: WindowKey,
+    },
+    SendPrompt {
+        request_id: String,
+        pane: PaneKey,
+        text: String,
+        submit: bool,
+    },
+}
+
+impl RelayRequest {
+    #[must_use]
+    pub fn request_id(&self) -> &str {
+        match self {
+            Self::Snapshot { request_id }
+            | Self::Ping { request_id }
+            | Self::Capture { request_id, .. }
+            | Self::CaptureWindow { request_id, .. }
+            | Self::SendPrompt { request_id, .. } => request_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RelayFrame {
+    Hello {
+        hello: RelayHello,
+    },
+    Snapshot {
+        request_id: String,
+        snapshot: RemoteSnapshot,
+    },
+    Transition {
+        revision: u64,
+        transition: Transition,
+    },
+    Keepalive {
+        revision: u64,
+        #[serde(with = "time::serde::rfc3339")]
+        observed_at: OffsetDateTime,
+    },
+    Result {
+        request_id: String,
+        result: FleetCommandResult,
+    },
+    Error {
+        request_id: String,
+        code: String,
+        message: String,
+    },
+    ResyncRequired {
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FleetOperation {
+    Connect,
+    Disconnect,
+    Refresh,
+    Capture {
+        pane: PaneKey,
+    },
+    CaptureWindow {
+        window: WindowKey,
+    },
+    SendPrompt {
+        pane: PaneKey,
+        text: String,
+        #[serde(default)]
+        submit: bool,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FleetCommandResult {
+    pub accepted: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub send: Option<SendPromptOutcomeWire>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_capture: Option<FleetWindowCapture>,
+}
+
+impl FleetCommandResult {
+    #[must_use]
+    pub fn accepted(message: impl Into<String>) -> Self {
+        Self {
+            accepted: true,
+            message: Some(message.into()),
+            capture: None,
+            send: None,
+            window_capture: None,
+        }
+    }
+
+    #[must_use]
+    pub fn capture(capture: Option<String>) -> Self {
+        Self {
+            accepted: true,
+            message: None,
+            capture,
+            send: None,
+            window_capture: None,
+        }
+    }
+
+    #[must_use]
+    pub fn sent(outcome: SendPromptOutcome) -> Self {
+        Self {
+            accepted: true,
+            message: None,
+            capture: None,
+            send: Some(outcome.into()),
+            window_capture: None,
+        }
+    }
+
+    #[must_use]
+    pub fn window_capture(capture: FleetWindowCapture) -> Self {
+        Self {
+            accepted: true,
+            message: None,
+            capture: None,
+            send: None,
+            window_capture: Some(capture),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct SendPromptOutcomeWire {
+    pub sent: bool,
+    pub submitted: bool,
+}
+
+impl From<SendPromptOutcome> for SendPromptOutcomeWire {
+    fn from(value: SendPromptOutcome) -> Self {
+        Self {
+            sent: value.sent,
+            submitted: value.submitted,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FleetUpdate {
+    pub host: String,
+    pub state: FleetHostState,
+    pub revision: Option<u64>,
+}
+
+/// Central cache. Remote snapshots remain isolated per node and are never
+/// inserted into the local agent Store, preventing pane-id collisions and
+/// local reconciler/GC activity from mutating remote truth.
+pub struct FleetStore {
+    hosts: RwLock<BTreeMap<String, FleetHostSnapshot>>,
+    updates: broadcast::Sender<FleetUpdate>,
+}
+
+impl Default for FleetStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FleetStore {
+    #[must_use]
+    pub fn new() -> Self {
+        let (updates, _) = broadcast::channel(512);
+        Self {
+            hosts: RwLock::new(BTreeMap::new()),
+            updates,
+        }
+    }
+
+    pub async fn snapshot(&self) -> FleetSnapshot {
+        self.snapshot_selected(None).await
+    }
+
+    pub async fn snapshot_selected(&self, selector: Option<&LabelSelector>) -> FleetSnapshot {
+        FleetSnapshot {
+            generated_at: OffsetDateTime::now_utc(),
+            hosts: self
+                .hosts
+                .read()
+                .await
+                .values()
+                .filter(|host| selector.is_none_or(|selector| selector.matches(&host.labels)))
+                .cloned()
+                .collect(),
+        }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<FleetUpdate> {
+        self.updates.subscribe()
+    }
+
+    pub async fn upsert_host(&self, host: FleetHostSnapshot) {
+        let alias = host.alias.clone();
+        let state = host.state;
+        let revision = host.remote.as_ref().map(|remote| remote.revision);
+        self.hosts.write().await.insert(alias.clone(), host);
+        let _ = self.updates.send(FleetUpdate {
+            host: alias,
+            state,
+            revision,
+        });
+    }
+
+    pub async fn mutate_host(&self, alias: &str, mutate: impl FnOnce(&mut FleetHostSnapshot)) {
+        let mut hosts = self.hosts.write().await;
+        let Some(host) = hosts.get_mut(alias) else {
+            return;
+        };
+        mutate(host);
+        let update = FleetUpdate {
+            host: alias.to_string(),
+            state: host.state,
+            revision: host.remote.as_ref().map(|remote| remote.revision),
+        };
+        drop(hosts);
+        let _ = self.updates.send(update);
+    }
+
+    pub async fn apply_transition(&self, alias: &str, revision: u64, transition: Transition) {
+        self.mutate_host(alias, |host| {
+            let Some(remote) = host.remote.as_mut() else {
+                host.state = FleetHostState::Degraded;
+                host.error = Some("transition arrived before initial snapshot".into());
+                return;
+            };
+            if revision <= remote.revision {
+                return;
+            }
+            if revision != remote.revision.saturating_add(1) {
+                host.state = FleetHostState::Degraded;
+                host.error = Some(format!(
+                    "remote event gap: expected {}, received {revision}",
+                    remote.revision.saturating_add(1)
+                ));
+            }
+            let incoming = transition.agent.as_ref();
+            if let Some(existing) = remote.agents.iter_mut().find(|agent| {
+                agent.kind == incoming.kind && agent.session_id == incoming.session_id
+            }) {
+                *existing = incoming.clone();
+            } else {
+                remote.agents.push(incoming.clone());
+            }
+            remote.revision = revision;
+            remote.observed_at = OffsetDateTime::now_utc();
+            host.last_seen_at = Some(remote.observed_at);
+            host.received_at = Some(OffsetDateTime::now_utc());
+        })
+        .await;
+    }
+}
+
+struct FleetDispatch {
+    host: String,
+    operation: FleetOperation,
+    reply: oneshot::Sender<Result<FleetCommandResult, String>>,
+}
+
+#[derive(Clone)]
+pub struct FleetRuntime {
+    pub store: Arc<FleetStore>,
+    commands: mpsc::Sender<FleetDispatch>,
+}
+
+impl FleetRuntime {
+    #[must_use]
+    pub fn new(store: Arc<FleetStore>) -> (Self, FleetCommandReceiver) {
+        let (commands, receiver) = mpsc::channel(128);
+        (Self { store, commands }, FleetCommandReceiver(receiver))
+    }
+
+    pub async fn execute(
+        &self,
+        host: impl Into<String>,
+        operation: FleetOperation,
+        timeout: Duration,
+    ) -> Result<FleetCommandResult, String> {
+        let (reply, response) = oneshot::channel();
+        self.commands
+            .send(FleetDispatch {
+                host: host.into(),
+                operation,
+                reply,
+            })
+            .await
+            .map_err(|_| "fleet manager is not running".to_string())?;
+        tokio::time::timeout(timeout, response)
+            .await
+            .map_err(|_| format!("fleet command timed out after {timeout:?}"))?
+            .map_err(|_| "fleet manager dropped the command".to_string())?
+    }
+}
+
+pub struct FleetCommandEnvelope {
+    pub host: String,
+    pub operation: FleetOperation,
+    pub reply: oneshot::Sender<Result<FleetCommandResult, String>>,
+}
+
+pub struct FleetCommandReceiver(mpsc::Receiver<FleetDispatch>);
+
+impl FleetCommandReceiver {
+    pub async fn recv(&mut self) -> Option<FleetCommandEnvelope> {
+        self.0.recv().await.map(|dispatch| FleetCommandEnvelope {
+            host: dispatch.host,
+            operation: dispatch.operation,
+            reply: dispatch.reply,
+        })
+    }
+}
+
+/// Kubernetes-style label selector. Supported requirements are equality,
+/// inequality, set membership, non-membership, existence, and non-existence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabelSelector(Vec<LabelRequirement>);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LabelRequirement {
+    Exists(String),
+    NotExists(String),
+    Eq(String, String),
+    NotEq(String, String),
+    In(String, HashSet<String>),
+    NotIn(String, HashSet<String>),
+}
+
+impl LabelSelector {
+    #[must_use]
+    pub fn all() -> Self {
+        Self(Vec::new())
+    }
+
+    #[must_use]
+    pub fn matches(&self, labels: &BTreeMap<String, String>) -> bool {
+        self.0.iter().all(|requirement| match requirement {
+            LabelRequirement::Exists(key) => labels.contains_key(key),
+            LabelRequirement::NotExists(key) => !labels.contains_key(key),
+            LabelRequirement::Eq(key, value) => labels.get(key) == Some(value),
+            LabelRequirement::NotEq(key, value) => labels.get(key) != Some(value),
+            LabelRequirement::In(key, values) => {
+                labels.get(key).is_some_and(|value| values.contains(value))
+            }
+            LabelRequirement::NotIn(key, values) => {
+                labels.get(key).is_none_or(|value| !values.contains(value))
+            }
+        })
+    }
+}
+
+impl FromStr for LabelSelector {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let input = input.trim();
+        if input.is_empty() {
+            return Ok(Self::all());
+        }
+        split_selector(input)?
+            .into_iter()
+            .map(parse_requirement)
+            .collect::<Result<Vec<_>, _>>()
+            .map(Self)
+    }
+}
+
+fn split_selector(input: &str) -> Result<Vec<&str>, String> {
+    let mut depth = 0_u32;
+    let mut start = 0;
+    let mut parts = Vec::new();
+    for (index, ch) in input.char_indices() {
+        match ch {
+            '(' => depth = depth.saturating_add(1),
+            ')' => {
+                if depth == 0 {
+                    return Err("label selector has an unmatched ')'".into());
+                }
+                depth -= 1;
+            }
+            ',' if depth == 0 => {
+                let part = input[start..index].trim();
+                if part.is_empty() {
+                    return Err("label selector contains an empty requirement".into());
+                }
+                parts.push(part);
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+    if depth != 0 {
+        return Err("label selector has an unmatched '('".into());
+    }
+    let tail = input[start..].trim();
+    if tail.is_empty() {
+        return Err("label selector contains an empty requirement".into());
+    }
+    parts.push(tail);
+    Ok(parts)
+}
+
+fn parse_requirement(input: &str) -> Result<LabelRequirement, String> {
+    let input = input.trim();
+    if let Some(key) = input.strip_prefix('!') {
+        validate_label_key(key.trim())?;
+        return Ok(LabelRequirement::NotExists(key.trim().to_string()));
+    }
+    for (operator, is_not) in [(" notin ", true), (" in ", false)] {
+        if let Some((key, values)) = input.split_once(operator) {
+            let key = key.trim();
+            validate_label_key(key)?;
+            let values = values.trim();
+            let inner = values
+                .strip_prefix('(')
+                .and_then(|value| value.strip_suffix(')'))
+                .ok_or_else(|| format!("selector '{input}' requires parenthesized values"))?;
+            let parsed = inner
+                .split(',')
+                .map(str::trim)
+                .map(|value| {
+                    validate_label_value(value)?;
+                    Ok(value.to_string())
+                })
+                .collect::<Result<HashSet<_>, String>>()?;
+            if parsed.is_empty() {
+                return Err(format!("selector '{input}' has no values"));
+            }
+            return Ok(if is_not {
+                LabelRequirement::NotIn(key.to_string(), parsed)
+            } else {
+                LabelRequirement::In(key.to_string(), parsed)
+            });
+        }
+    }
+    if let Some((key, value)) = input.split_once("!=") {
+        let (key, value) = (key.trim(), value.trim());
+        validate_label_key(key)?;
+        validate_label_value(value)?;
+        return Ok(LabelRequirement::NotEq(key.to_string(), value.to_string()));
+    }
+    let equality = input.split_once("==").or_else(|| input.split_once('='));
+    if let Some((key, value)) = equality {
+        let (key, value) = (key.trim(), value.trim());
+        validate_label_key(key)?;
+        validate_label_value(value)?;
+        return Ok(LabelRequirement::Eq(key.to_string(), value.to_string()));
+    }
+    validate_label_key(input)?;
+    Ok(LabelRequirement::Exists(input.to_string()))
+}
+
+/// Validate the Kubernetes label-key shape: optional DNS prefix plus a
+/// 63-character name with alphanumeric endpoints and `-_.` in the middle.
+pub fn validate_label_key(key: &str) -> Result<(), String> {
+    if key.is_empty() {
+        return Err("label key cannot be empty".into());
+    }
+    let (prefix, name) = key
+        .rsplit_once('/')
+        .map_or((None, key), |(prefix, name)| (Some(prefix), name));
+    if let Some(prefix) = prefix {
+        if prefix.len() > 253 || !valid_dns_subdomain(prefix) {
+            return Err(format!("invalid label DNS prefix '{prefix}'"));
+        }
+    }
+    validate_label_name(name, false)
+        .map_err(|message| format!("invalid label key '{key}': {message}"))
+}
+
+pub fn validate_label_value(value: &str) -> Result<(), String> {
+    validate_label_name(value, true)
+        .map_err(|message| format!("invalid label value '{value}': {message}"))
+}
+
+fn validate_label_name(value: &str, allow_empty: bool) -> Result<(), String> {
+    if value.is_empty() {
+        return allow_empty
+            .then_some(())
+            .ok_or_else(|| "name cannot be empty".into());
+    }
+    if value.len() > 63 {
+        return Err("must be at most 63 bytes".into());
+    }
+    let valid_edge = |byte: u8| byte.is_ascii_alphanumeric();
+    let bytes = value.as_bytes();
+    if !valid_edge(bytes[0]) || !valid_edge(bytes[bytes.len() - 1]) {
+        return Err("must begin and end with an alphanumeric character".into());
+    }
+    if !bytes
+        .iter()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return Err("may contain only alphanumeric characters, '-', '_' or '.'".into());
+    }
+    Ok(())
+}
+
+fn valid_dns_subdomain(value: &str) -> bool {
+    !value.is_empty()
+        && value.split('.').all(|part| {
+            !part.is_empty()
+                && part.len() <= 63
+                && part.as_bytes()[0].is_ascii_alphanumeric()
+                && part.as_bytes()[part.len() - 1].is_ascii_alphanumeric()
+                && part
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use tokio::io::{AsyncWriteExt, BufReader};
+
+    #[test]
+    fn node_id_is_stable_and_owner_scoped() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("muxa/host-id");
+        let first = load_or_create_node_id(&path).unwrap();
+        let second = load_or_create_node_id(&path).unwrap();
+        assert_eq!(first, second);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn selector_supports_kubernetes_operators() {
+        let labels = BTreeMap::from([
+            ("environment".into(), "production".into()),
+            ("tier".into(), "worker".into()),
+            ("accelerator".into(), "gpu".into()),
+        ]);
+        assert!("environment=production,tier in (worker,api),accelerator"
+            .parse::<LabelSelector>()
+            .unwrap()
+            .matches(&labels));
+        assert!("environment!=qa,!draining,tier notin (frontend)"
+            .parse::<LabelSelector>()
+            .unwrap()
+            .matches(&labels));
+        assert!(!"environment=qa"
+            .parse::<LabelSelector>()
+            .unwrap()
+            .matches(&labels));
+    }
+
+    #[test]
+    fn selector_rejects_invalid_keys_and_parentheses() {
+        assert!("UPPER/key=value".parse::<LabelSelector>().is_err());
+        assert!("tier in worker".parse::<LabelSelector>().is_err());
+        assert!("tier in (worker,api".parse::<LabelSelector>().is_err());
+        assert!("a,,b".parse::<LabelSelector>().is_err());
+    }
+
+    #[tokio::test]
+    async fn bounded_line_rejects_an_unterminated_oversized_frame() {
+        let (mut writer, reader) = tokio::io::duplex(64);
+        let sender = tokio::spawn(async move {
+            writer.write_all(b"123456789").await.unwrap();
+            writer.shutdown().await.unwrap();
+        });
+        let mut reader = BufReader::new(reader);
+        let mut line = String::new();
+        let error = read_bounded_line(&mut reader, &mut line, 8)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("exceeds 8 bytes"));
+        sender.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn bounded_drain_discards_excess_but_reaches_eof() {
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        let sender = tokio::spawn(async move {
+            writer.write_all(b"abcdefgh").await.unwrap();
+            writer.shutdown().await.unwrap();
+        });
+        assert_eq!(drain_bounded(&mut reader, 4).await.unwrap(), b"abcd");
+        sender.await.unwrap();
+    }
+
+    #[test]
+    fn terminal_sanitizer_removes_csi_osc_and_c0_controls() {
+        assert_eq!(
+            sanitize_terminal_text("ok\u{1b}[31mred\u{1b}[0m\u{1b}]0;bad\u{7}\u{0}done"),
+            "okreddone"
+        );
+    }
+}

--- a/crates/muxa/src/fleet.rs
+++ b/crates/muxa/src/fleet.rs
@@ -607,6 +607,10 @@ pub struct FleetUpdate {
     pub host: String,
     pub state: FleetHostState,
     pub revision: Option<u64>,
+    /// The broadcast receiver lagged and the client must reconcile the whole
+    /// selected snapshot rather than infer anything from `host`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub resync: bool,
 }
 
 /// Central cache. Remote snapshots remain isolated per node and are never
@@ -664,6 +668,21 @@ impl FleetStore {
         self.updates.subscribe()
     }
 
+    /// Return whether the current cached host matches `selector`. A missing
+    /// host never matches. Fleet streams use this after receiving an update
+    /// so selector-scoped watchers are not woken by unrelated hosts.
+    pub async fn host_matches_selector(
+        &self,
+        alias: &str,
+        selector: Option<&LabelSelector>,
+    ) -> bool {
+        self.hosts
+            .read()
+            .await
+            .get(alias)
+            .is_some_and(|host| selector.is_none_or(|selector| selector.matches(&host.labels)))
+    }
+
     pub async fn upsert_host(&self, host: FleetHostSnapshot) {
         let alias = host.alias.clone();
         let state = host.state;
@@ -673,6 +692,7 @@ impl FleetStore {
             host: alias,
             state,
             revision,
+            resync: false,
         });
     }
 
@@ -686,6 +706,7 @@ impl FleetStore {
             host: alias.to_string(),
             state: host.state,
             revision: host.remote.as_ref().map(|remote| remote.revision),
+            resync: false,
         };
         drop(hosts);
         let _ = self.updates.send(update);

--- a/crates/muxa/src/fleet.rs
+++ b/crates/muxa/src/fleet.rs
@@ -28,6 +28,17 @@ use crate::topology::{PaneKey, WindowKey};
 
 pub const FLEET_PROTOCOL_VERSION: u32 = 1;
 pub const FLEET_MIN_PROTOCOL_VERSION: u32 = 1;
+/// Reserved inventory alias for the daemon's own physical node.
+pub const LOCAL_HOST_ALIAS: &str = "local";
+/// Truth-bearing labels populated by muxad for the controller node. Users may
+/// add metadata alongside these keys but cannot override them.
+pub const LOCAL_MANAGED_LABELS: &[&str] = &[
+    "muxa.io/local",
+    "muxa.io/transport",
+    "kubernetes.io/hostname",
+    "kubernetes.io/os",
+    "kubernetes.io/arch",
+];
 pub const FLEET_MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
 pub const FLEET_MAX_DIAGNOSTIC_BYTES: usize = 1024;
 pub const FLEET_MAX_CAPTURE_BYTES: usize = 256 * 1024;
@@ -315,6 +326,11 @@ pub enum FleetHostState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FleetHostSnapshot {
     pub alias: String,
+    /// True for the controller node itself. The local node is always present
+    /// and never traverses SSH, even when remote Fleet connections are
+    /// disabled.
+    #[serde(default)]
+    pub local: bool,
     pub ssh_target: String,
     pub labels: BTreeMap<String, String>,
     pub annotations: BTreeMap<String, String>,
@@ -622,16 +638,25 @@ impl FleetStore {
     }
 
     pub async fn snapshot_selected(&self, selector: Option<&LabelSelector>) -> FleetSnapshot {
+        let mut hosts = self
+            .hosts
+            .read()
+            .await
+            .values()
+            .filter(|host| selector.is_none_or(|selector| selector.matches(&host.labels)))
+            .cloned()
+            .collect::<Vec<_>>();
+        // The controller is the operator's anchor and should not disappear
+        // below alphabetically-earlier SSH aliases.
+        hosts.sort_by(|left, right| {
+            right
+                .local
+                .cmp(&left.local)
+                .then(left.alias.cmp(&right.alias))
+        });
         FleetSnapshot {
             generated_at: OffsetDateTime::now_utc(),
-            hosts: self
-                .hosts
-                .read()
-                .await
-                .values()
-                .filter(|host| selector.is_none_or(|selector| selector.matches(&host.labels)))
-                .cloned()
-                .collect(),
+            hosts,
         }
     }
 
@@ -963,6 +988,36 @@ mod tests {
     use tempfile::tempdir;
     use tokio::io::{AsyncWriteExt, BufReader};
 
+    fn host(alias: &str, local: bool, labels: BTreeMap<String, String>) -> FleetHostSnapshot {
+        FleetHostSnapshot {
+            alias: alias.into(),
+            local,
+            ssh_target: alias.into(),
+            labels,
+            annotations: BTreeMap::new(),
+            mode: if local {
+                HostAccessMode::Control
+            } else {
+                HostAccessMode::Observe
+            },
+            state: FleetHostState::Online,
+            node_id: None,
+            hostname: None,
+            os: None,
+            arch: None,
+            muxa_version: None,
+            protocol: None,
+            capabilities: Vec::new(),
+            daemon_generation: None,
+            boot_id: None,
+            latency_ms: None,
+            last_seen_at: None,
+            received_at: None,
+            error: None,
+            remote: None,
+        }
+    }
+
     #[test]
     fn node_id_is_stable_and_owner_scoped() {
         let dir = tempdir().unwrap();
@@ -1042,5 +1097,30 @@ mod tests {
             sanitize_terminal_text("ok\u{1b}[31mred\u{1b}[0m\u{1b}]0;bad\u{7}\u{0}done"),
             "okreddone"
         );
+    }
+
+    #[tokio::test]
+    async fn fleet_store_keeps_local_first_and_applies_selectors() {
+        let store = FleetStore::new();
+        store
+            .upsert_host(host(
+                "alpha",
+                false,
+                BTreeMap::from([("environment".into(), "production".into())]),
+            ))
+            .await;
+        store
+            .upsert_host(host(
+                LOCAL_HOST_ALIAS,
+                true,
+                BTreeMap::from([("muxa.io/local".into(), "true".into())]),
+            ))
+            .await;
+        let all = store.snapshot().await;
+        assert_eq!(all.hosts[0].alias, LOCAL_HOST_ALIAS);
+        let selector = "muxa.io/local=true".parse::<LabelSelector>().unwrap();
+        let selected = store.snapshot_selected(Some(&selector)).await;
+        assert_eq!(selected.hosts.len(), 1);
+        assert!(selected.hosts[0].local);
     }
 }

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -4963,6 +4963,7 @@ mod tests {
         fleet_store
             .upsert_host(FleetHostSnapshot {
                 alias: "dev".into(),
+                local: false,
                 ssh_target: "devbox".into(),
                 labels: std::collections::BTreeMap::from([(
                     "environment".into(),

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -41,6 +41,7 @@ use crate::session::{
 use crate::state::{Agent, SharedStore};
 use crate::tmux::PaneInfo;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU8, Ordering as AtomicOrdering};
@@ -139,7 +140,10 @@ enum RequestBody {
     /// Long-lived notification stream for changes to the central Fleet cache.
     /// Payloads are deliberately tiny; clients fetch one coherent filtered
     /// snapshot after coalescing notifications.
-    FleetSubscribe,
+    FleetSubscribe {
+        #[serde(default)]
+        selector: Option<String>,
+    },
     /// Route one exact operation through the per-host persistent SSH relay.
     FleetCommand {
         host: String,
@@ -1169,9 +1173,11 @@ async fn stream_transitions(
 async fn stream_fleet_updates(
     mut writer: tokio::net::unix::OwnedWriteHalf,
     store: Arc<crate::fleet::FleetStore>,
+    mut rx: broadcast::Receiver<FleetUpdate>,
     protocol: u32,
+    selector: Option<LabelSelector>,
+    mut visible_hosts: HashSet<String>,
 ) -> Result<(), RuntimeError> {
-    let mut rx = store.subscribe();
     let mut keepalive = tokio::time::interval(STREAM_KEEPALIVE_INTERVAL);
     keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     keepalive.tick().await;
@@ -1179,6 +1185,24 @@ async fn stream_fleet_updates(
         tokio::select! {
             recv = rx.recv() => match recv {
                 Ok(update) => {
+                    let was_visible = visible_hosts.contains(&update.host);
+                    let is_visible = if selector.is_none() {
+                        true
+                    } else {
+                        store
+                            .host_matches_selector(&update.host, selector.as_ref())
+                            .await
+                    };
+                    if is_visible {
+                        visible_hosts.insert(update.host.clone());
+                    } else {
+                        visible_hosts.remove(&update.host);
+                    }
+                    // A host entering or leaving the selector must invalidate
+                    // the filtered snapshot. Unrelated hosts remain silent.
+                    if !was_visible && !is_visible {
+                        continue;
+                    }
                     let bytes = encode_line(&update, protocol)?;
                     if writer.write_all(&bytes).await.is_err()
                         || writer.flush().await.is_err()
@@ -1189,6 +1213,24 @@ async fn stream_fleet_updates(
                 Err(broadcast::error::RecvError::Closed) => return Ok(()),
                 Err(broadcast::error::RecvError::Lagged(dropped)) => {
                     tracing::warn!(dropped, "fleet subscribe lagged; fallback snapshot will reconcile");
+                    let selected = store.snapshot_selected(selector.as_ref()).await;
+                    visible_hosts = selected
+                        .hosts
+                        .into_iter()
+                        .map(|host| host.alias)
+                        .collect();
+                    let update = FleetUpdate {
+                        host: "*".into(),
+                        state: crate::fleet::FleetHostState::Degraded,
+                        revision: None,
+                        resync: true,
+                    };
+                    let bytes = encode_line(&update, protocol)?;
+                    if writer.write_all(&bytes).await.is_err()
+                        || writer.flush().await.is_err()
+                    {
+                        return Ok(());
+                    }
                 }
             },
             _ = keepalive.tick() => {
@@ -1728,7 +1770,7 @@ async fn handle(
                         None => Response::err("fleet is not enabled in muxad"),
                     }
                 }
-                RequestBody::FleetSubscribe => {
+                RequestBody::FleetSubscribe { selector } => {
                     kind = "fleet_subscribe";
                     let Some(fleet) = &fleet else {
                         let response = Response::err("fleet is not enabled in muxad");
@@ -1736,6 +1778,34 @@ async fn handle(
                         let _ = write_line_or_closed(&mut writer, &bytes).await?;
                         return Ok(());
                     };
+                    let selector = match selector
+                        .as_deref()
+                        .map(str::parse::<LabelSelector>)
+                        .transpose()
+                    {
+                        Ok(selector) => selector,
+                        Err(error) => {
+                            let response =
+                                Response::err(format!("invalid label selector: {error}"));
+                            let bytes =
+                                encode_line(&response, negotiated.unwrap_or(PROTOCOL_VERSION))?;
+                            let _ = write_line_or_closed(&mut writer, &bytes).await?;
+                            return Ok(());
+                        }
+                    };
+                    // Subscribe before observing the initial membership and
+                    // before ACK. The client fetches a fresh snapshot after
+                    // ACK, so every mutation is represented either there or
+                    // in this already-live receiver (duplicates are harmless).
+                    let updates = fleet.store.subscribe();
+                    let visible_hosts = fleet
+                        .store
+                        .snapshot_selected(selector.as_ref())
+                        .await
+                        .hosts
+                        .into_iter()
+                        .map(|host| host.alias)
+                        .collect::<HashSet<_>>();
                     let stream_proto = negotiated.unwrap_or(PROTOCOL_VERSION);
                     let ack_bytes = encode_line(&Response::ok(), stream_proto)?;
                     if !write_line_or_closed(&mut writer, &ack_bytes).await? {
@@ -1747,7 +1817,15 @@ async fn handle(
                         kind,
                         "ipc.handle (fleet stream takeover)",
                     );
-                    return stream_fleet_updates(writer, fleet.store.clone(), stream_proto).await;
+                    return stream_fleet_updates(
+                        writer,
+                        fleet.store.clone(),
+                        updates,
+                        stream_proto,
+                        selector,
+                        visible_hosts,
+                    )
+                    .await;
                 }
                 RequestBody::FleetCommand { host, operation } => {
                     kind = "fleet_command";
@@ -2562,13 +2640,19 @@ impl Client {
     /// Subscribe to compact Fleet cache invalidations. The stream carries no
     /// remote terminal contents and grants no additional authority; callers
     /// fetch a normal selector-filtered snapshot after coalescing updates.
-    pub async fn fleet_subscribe(&self) -> Result<FleetUpdateStream, RuntimeError> {
-        tokio::time::timeout(CLIENT_CALL_TIMEOUT, self.fleet_subscribe_inner())
+    pub async fn fleet_subscribe(
+        &self,
+        selector: Option<&str>,
+    ) -> Result<FleetUpdateStream, RuntimeError> {
+        tokio::time::timeout(CLIENT_CALL_TIMEOUT, self.fleet_subscribe_inner(selector))
             .await
             .map_err(|_| RuntimeError::Timeout(CLIENT_CALL_TIMEOUT))?
     }
 
-    async fn fleet_subscribe_inner(&self) -> Result<FleetUpdateStream, RuntimeError> {
+    async fn fleet_subscribe_inner(
+        &self,
+        selector: Option<&str>,
+    ) -> Result<FleetUpdateStream, RuntimeError> {
         let stream = UnixStream::connect(&self.socket_path)
             .await
             .map_err(|error| match error.kind() {
@@ -2584,6 +2668,7 @@ impl Client {
         let mut request = serde_json::to_vec(&serde_json::json!({
             "protocol": PROTOCOL_VERSION,
             "kind": "fleet_subscribe",
+            "selector": selector,
         }))?;
         request.push(b'\n');
         writer.write_all(&request).await?;
@@ -5090,6 +5175,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::too_many_lines)] // one end-to-end flow verifies selector stream membership
     async fn fleet_snapshot_selector_and_command_round_trip_over_ipc() {
         use crate::fleet::{
             FleetHostSnapshot, FleetHostState, FleetOperation, FleetRuntime, FleetStore,
@@ -5127,6 +5213,13 @@ mod tests {
                 remote: None,
             })
             .await;
+        let mut production = fleet_store.snapshot().await.hosts[0].clone();
+        production.alias = "prod".into();
+        production.ssh_target = "prodbox".into();
+        production
+            .labels
+            .insert("environment".into(), "production".into());
+        fleet_store.upsert_host(production).await;
         let (runtime, mut commands) = FleetRuntime::new(fleet_store.clone());
         let command_task = tokio::spawn(async move {
             let command = commands.recv().await.expect("fleet command");
@@ -5143,9 +5236,17 @@ mod tests {
 
         let client = Client::new(socket);
         let mut updates = client
-            .fleet_subscribe()
+            .fleet_subscribe(Some("environment=development"))
             .await
             .expect("fleet update subscription");
+        fleet_store
+            .mutate_host("prod", |host| host.latency_ms = Some(8))
+            .await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), updates.recv())
+                .await
+                .is_err()
+        );
         fleet_store
             .mutate_host("dev", |host| host.latency_ms = Some(4))
             .await;
@@ -5156,13 +5257,45 @@ mod tests {
             .expect("fleet update stream closed");
         assert_eq!(update.host, "dev");
         assert_eq!(update.state, FleetHostState::Online);
+        fleet_store
+            .mutate_host("dev", |host| {
+                host.labels
+                    .insert("environment".into(), "production".into());
+            })
+            .await;
+        let leaving = tokio::time::timeout(Duration::from_secs(1), updates.recv())
+            .await
+            .expect("selector leaving update timeout")
+            .expect("selector leaving update read")
+            .expect("fleet update stream closed");
+        assert_eq!(leaving.host, "dev");
+        fleet_store
+            .mutate_host("dev", |host| host.latency_ms = Some(5))
+            .await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), updates.recv())
+                .await
+                .is_err()
+        );
+        fleet_store
+            .mutate_host("dev", |host| {
+                host.labels
+                    .insert("environment".into(), "development".into());
+            })
+            .await;
+        let entering = tokio::time::timeout(Duration::from_secs(1), updates.recv())
+            .await
+            .expect("selector entering update timeout")
+            .expect("selector entering update read")
+            .expect("fleet update stream closed");
+        assert_eq!(entering.host, "dev");
         let selected = client
             .fleet_snapshot(Some("environment=development"))
             .await
             .expect("fleet snapshot");
         assert_eq!(selected.hosts.len(), 1);
         let excluded = client
-            .fleet_snapshot(Some("environment=production"))
+            .fleet_snapshot(Some("environment=staging"))
             .await
             .expect("filtered fleet snapshot");
         assert!(excluded.hosts.is_empty());
@@ -5175,7 +5308,7 @@ mod tests {
         command_task.await.unwrap();
         drop(updates);
         fleet_store
-            .mutate_host("dev", |host| host.latency_ms = Some(5))
+            .mutate_host("dev", |host| host.latency_ms = Some(6))
             .await;
         tokio::task::yield_now().await;
         let _ = shutdown_tx.send(());

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -32,7 +32,7 @@ use crate::collaboration_audit::{
 };
 use crate::event::{AgentEvent, PROTOCOL_VERSION};
 use crate::fleet::{
-    FleetCommandResult, FleetOperation, FleetRuntime, FleetSnapshot, LabelSelector,
+    FleetCommandResult, FleetOperation, FleetRuntime, FleetSnapshot, FleetUpdate, LabelSelector,
 };
 use crate::session::{
     PtySessionBackend, SessionBackend, SessionOutput, SessionRef, SharedSessionBackend,
@@ -136,6 +136,10 @@ enum RequestBody {
         #[serde(default)]
         selector: Option<String>,
     },
+    /// Long-lived notification stream for changes to the central Fleet cache.
+    /// Payloads are deliberately tiny; clients fetch one coherent filtered
+    /// snapshot after coalescing notifications.
+    FleetSubscribe,
     /// Route one exact operation through the per-host persistent SSH relay.
     FleetCommand {
         host: String,
@@ -378,6 +382,7 @@ const CAPABILITIES: &[&str] = &[
     "collaboration_identity",
     "collaboration_provenance",
     "fleet_v1",
+    "fleet_subscribe",
 ];
 
 /// Advertised only when the server has the controller required to come back
@@ -1157,6 +1162,46 @@ async fn stream_transitions(
     }
 }
 
+/// Stream compact Fleet cache invalidations. A notification names the host and
+/// revision but is not itself a snapshot; clients coalesce bursts and fetch a
+/// coherent selector-filtered snapshot. This keeps one busy remote agent from
+/// making the central TUI clone and redraw every host on a fixed timer.
+async fn stream_fleet_updates(
+    mut writer: tokio::net::unix::OwnedWriteHalf,
+    store: Arc<crate::fleet::FleetStore>,
+    protocol: u32,
+) -> Result<(), RuntimeError> {
+    let mut rx = store.subscribe();
+    let mut keepalive = tokio::time::interval(STREAM_KEEPALIVE_INTERVAL);
+    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    keepalive.tick().await;
+    loop {
+        tokio::select! {
+            recv = rx.recv() => match recv {
+                Ok(update) => {
+                    let bytes = encode_line(&update, protocol)?;
+                    if writer.write_all(&bytes).await.is_err()
+                        || writer.flush().await.is_err()
+                    {
+                        return Ok(());
+                    }
+                }
+                Err(broadcast::error::RecvError::Closed) => return Ok(()),
+                Err(broadcast::error::RecvError::Lagged(dropped)) => {
+                    tracing::warn!(dropped, "fleet subscribe lagged; fallback snapshot will reconcile");
+                }
+            },
+            _ = keepalive.tick() => {
+                if writer.write_all(b"\n").await.is_err()
+                    || writer.flush().await.is_err()
+                {
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+
 /// Resolve the backend that governs `pane`'s id namespace (`%…` → tmux,
 /// `herdr:…` → herdr, `zellij:…` → zellij).
 ///
@@ -1682,6 +1727,27 @@ async fn handle(
                         },
                         None => Response::err("fleet is not enabled in muxad"),
                     }
+                }
+                RequestBody::FleetSubscribe => {
+                    kind = "fleet_subscribe";
+                    let Some(fleet) = &fleet else {
+                        let response = Response::err("fleet is not enabled in muxad");
+                        let bytes = encode_line(&response, negotiated.unwrap_or(PROTOCOL_VERSION))?;
+                        let _ = write_line_or_closed(&mut writer, &bytes).await?;
+                        return Ok(());
+                    };
+                    let stream_proto = negotiated.unwrap_or(PROTOCOL_VERSION);
+                    let ack_bytes = encode_line(&Response::ok(), stream_proto)?;
+                    if !write_line_or_closed(&mut writer, &ack_bytes).await? {
+                        return Ok(());
+                    }
+                    tracing::debug!(
+                        elapsed_us =
+                            u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX),
+                        kind,
+                        "ipc.handle (fleet stream takeover)",
+                    );
+                    return stream_fleet_updates(writer, fleet.store.clone(), stream_proto).await;
                 }
                 RequestBody::FleetCommand { host, operation } => {
                     kind = "fleet_command";
@@ -2346,6 +2412,14 @@ pub struct TransitionStream {
     line: String,
 }
 
+/// Long-lived compact invalidation stream returned by
+/// [`Client::fleet_subscribe`]. Callers fetch a coherent snapshot after
+/// coalescing one or more updates.
+pub struct FleetUpdateStream {
+    reader: BufReader<tokio::net::unix::OwnedReadHalf>,
+    line: String,
+}
+
 /// Whether a subscribe-stream line is the daemon's `lagged` control marker
 /// (`{"event":"lagged",…}`) rather than a `Transition`. Kept cheap: a real
 /// `Transition` is tagged by `from`/`to`, never an `event` field, so a
@@ -2399,6 +2473,25 @@ impl TransitionStream {
             }
             let t: crate::state::Transition = serde_json::from_str(trimmed)?;
             return Ok(Some(t));
+        }
+    }
+}
+
+impl FleetUpdateStream {
+    pub async fn recv(&mut self) -> Result<Option<FleetUpdate>, RuntimeError> {
+        loop {
+            self.line.clear();
+            let n = read_limited_line(&mut self.reader, &mut self.line).await?;
+            if n == 0 {
+                return Ok(None);
+            }
+            let trimmed = self.line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            return serde_json::from_str(trimmed)
+                .map(Some)
+                .map_err(RuntimeError::Json);
         }
     }
 }
@@ -2464,6 +2557,52 @@ impl Client {
         });
         let response = self.call_checked(&req).await?;
         serde_json::from_value(response["fleet"].clone()).map_err(RuntimeError::Json)
+    }
+
+    /// Subscribe to compact Fleet cache invalidations. The stream carries no
+    /// remote terminal contents and grants no additional authority; callers
+    /// fetch a normal selector-filtered snapshot after coalescing updates.
+    pub async fn fleet_subscribe(&self) -> Result<FleetUpdateStream, RuntimeError> {
+        tokio::time::timeout(CLIENT_CALL_TIMEOUT, self.fleet_subscribe_inner())
+            .await
+            .map_err(|_| RuntimeError::Timeout(CLIENT_CALL_TIMEOUT))?
+    }
+
+    async fn fleet_subscribe_inner(&self) -> Result<FleetUpdateStream, RuntimeError> {
+        let stream = UnixStream::connect(&self.socket_path)
+            .await
+            .map_err(|error| match error.kind() {
+                std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound => {
+                    RuntimeError::NotConnected(self.socket_path.clone())
+                }
+                _ => RuntimeError::Io(error),
+            })?;
+        let (reader, mut writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+        self.send_hello(&mut reader, &mut writer).await?;
+
+        let mut request = serde_json::to_vec(&serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "fleet_subscribe",
+        }))?;
+        request.push(b'\n');
+        writer.write_all(&request).await?;
+        writer.flush().await?;
+
+        let mut ack = String::new();
+        read_limited_line(&mut reader, &mut ack).await?;
+        let ack: serde_json::Value = serde_json::from_str(ack.trim())?;
+        if !ack["ok"].as_bool().unwrap_or(false) {
+            return Err(RuntimeError::Json(serde::de::Error::custom(format!(
+                "fleet subscribe rejected: {}",
+                ack["error"].as_str().unwrap_or("(no error message)")
+            ))));
+        }
+        drop(writer);
+        Ok(FleetUpdateStream {
+            reader,
+            line: String::new(),
+        })
     }
 
     /// Execute an exact operation on one configured host. Mutations are
@@ -4988,7 +5127,7 @@ mod tests {
                 remote: None,
             })
             .await;
-        let (runtime, mut commands) = FleetRuntime::new(fleet_store);
+        let (runtime, mut commands) = FleetRuntime::new(fleet_store.clone());
         let command_task = tokio::spawn(async move {
             let command = commands.recv().await.expect("fleet command");
             assert_eq!(command.host, "dev");
@@ -5003,6 +5142,20 @@ mod tests {
         wait_for_socket(&socket).await;
 
         let client = Client::new(socket);
+        let mut updates = client
+            .fleet_subscribe()
+            .await
+            .expect("fleet update subscription");
+        fleet_store
+            .mutate_host("dev", |host| host.latency_ms = Some(4))
+            .await;
+        let update = tokio::time::timeout(Duration::from_secs(1), updates.recv())
+            .await
+            .expect("fleet update timeout")
+            .expect("fleet update read")
+            .expect("fleet update stream closed");
+        assert_eq!(update.host, "dev");
+        assert_eq!(update.state, FleetHostState::Online);
         let selected = client
             .fleet_snapshot(Some("environment=development"))
             .await
@@ -5020,6 +5173,11 @@ mod tests {
         assert_eq!(result.message.as_deref(), Some("refreshed"));
 
         command_task.await.unwrap();
+        drop(updates);
+        fleet_store
+            .mutate_host("dev", |host| host.latency_ms = Some(5))
+            .await;
+        tokio::task::yield_now().await;
         let _ = shutdown_tx.send(());
         server_task.await.unwrap();
     }

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -31,6 +31,9 @@ use crate::collaboration_audit::{
     CollaborationAuditContext, CollaborationAuditLog, CollaborationAuditOperation,
 };
 use crate::event::{AgentEvent, PROTOCOL_VERSION};
+use crate::fleet::{
+    FleetCommandResult, FleetOperation, FleetRuntime, FleetSnapshot, LabelSelector,
+};
 use crate::session::{
     PtySessionBackend, SessionBackend, SessionOutput, SessionRef, SharedSessionBackend,
     SpawnSession, TerminalSnapshot,
@@ -126,6 +129,18 @@ enum RequestBody {
         event: AgentEvent,
     },
     Snapshot,
+    /// Snapshot of every configured physical SSH host. `selector` follows
+    /// Kubernetes label-selector syntax and is evaluated against central
+    /// inventory metadata, never against untrusted remote data.
+    FleetSnapshot {
+        #[serde(default)]
+        selector: Option<String>,
+    },
+    /// Route one exact operation through the per-host persistent SSH relay.
+    FleetCommand {
+        host: String,
+        operation: FleetOperation,
+    },
     ByPane {
         pane: String,
     },
@@ -362,6 +377,7 @@ const CAPABILITIES: &[&str] = &[
     "collaboration_lifecycle",
     "collaboration_identity",
     "collaboration_provenance",
+    "fleet_v1",
 ];
 
 /// Advertised only when the server has the controller required to come back
@@ -431,6 +447,10 @@ pub struct Response {
     pub ask_entry: Option<AskEntry>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ask_agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fleet: Option<FleetSnapshot>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fleet_result: Option<FleetCommandResult>,
 }
 
 #[derive(Debug, Serialize)]
@@ -466,6 +486,8 @@ impl Response {
             ask_entries: None,
             ask_entry: None,
             ask_agent: None,
+            fleet: None,
+            fleet_result: None,
         }
     }
     fn err(msg: impl Into<String>) -> Self {
@@ -478,6 +500,16 @@ impl Response {
         let mut r = Self::ok();
         r.agents = Some(agents);
         r
+    }
+    fn with_fleet(fleet: FleetSnapshot) -> Self {
+        let mut response = Self::ok();
+        response.fleet = Some(fleet);
+        response
+    }
+    fn with_fleet_result(result: FleetCommandResult) -> Self {
+        let mut response = Self::ok();
+        response.fleet_result = Some(result);
+        response
     }
     fn with_prompts(prompts: Vec<crate::history::HistoryEntry>) -> Self {
         let mut r = Self::ok();
@@ -657,6 +689,7 @@ pub struct Server {
     collaboration_audit: Arc<CollaborationAuditLog>,
     ask: Arc<AskStore>,
     restart: Option<Arc<RestartController>>,
+    fleet: Option<FleetRuntime>,
     handler_limit: usize,
 }
 
@@ -673,6 +706,7 @@ impl Server {
             collaboration_audit: CollaborationAuditLog::in_memory(),
             ask: crate::ask::AskStore::in_memory(crate::ask::AskOptions::default()),
             restart: None,
+            fleet: None,
             handler_limit: MAX_INFLIGHT_HANDLERS,
         }
     }
@@ -732,6 +766,15 @@ impl Server {
     #[must_use]
     pub fn with_restart_controller(mut self, restart: Arc<RestartController>) -> Self {
         self.restart = Some(restart);
+        self
+    }
+
+    /// Install the physical-host fleet cache and command router. Keeping this
+    /// optional preserves embedders/tests and makes a disabled fleet consume
+    /// no SSH processes or background resources.
+    #[must_use]
+    pub fn with_fleet(mut self, fleet: FleetRuntime) -> Self {
+        self.fleet = Some(fleet);
         self
     }
 
@@ -828,6 +871,7 @@ impl Server {
                     let collaboration_audit = self.collaboration_audit.clone();
                     let ask = self.ask.clone();
                     let restart = self.restart.clone();
+                    let fleet = self.fleet.clone();
                     handlers.spawn(async move {
                         // Held for the handler's lifetime; released here on exit.
                         let _permit = permit;
@@ -842,6 +886,7 @@ impl Server {
                                 collaboration_audit,
                                 ask,
                                 restart,
+                                fleet,
                             ))
                             .await
                         {
@@ -1446,7 +1491,8 @@ async fn record_collaboration_audit(
         collaboration,
         collaboration_audit,
         ask,
-        restart
+        restart,
+        fleet
     )
 )]
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)] // IPC dispatch table and its shared daemon state
@@ -1460,6 +1506,7 @@ async fn handle(
     collaboration_audit: Arc<CollaborationAuditLog>,
     ask: Arc<AskStore>,
     restart: Option<Arc<RestartController>>,
+    fleet: Option<FleetRuntime>,
 ) -> Result<(), RuntimeError> {
     let mut collaboration_actor = observe_collaboration_actor(&stream);
     let (reader, mut writer) = stream.into_split();
@@ -1619,6 +1666,35 @@ async fn handle(
                 RequestBody::Snapshot => {
                     kind = "snapshot";
                     Response::with_agents(store.snapshot().await)
+                }
+                RequestBody::FleetSnapshot { selector } => {
+                    kind = "fleet_snapshot";
+                    match &fleet {
+                        Some(fleet) => match selector
+                            .as_deref()
+                            .map(str::parse::<LabelSelector>)
+                            .transpose()
+                        {
+                            Ok(selector) => Response::with_fleet(
+                                fleet.store.snapshot_selected(selector.as_ref()).await,
+                            ),
+                            Err(error) => Response::err(format!("invalid label selector: {error}")),
+                        },
+                        None => Response::err("fleet is not enabled in muxad"),
+                    }
+                }
+                RequestBody::FleetCommand { host, operation } => {
+                    kind = "fleet_command";
+                    match &fleet {
+                        Some(fleet) => match fleet
+                            .execute(host, operation, Duration::from_secs(20))
+                            .await
+                        {
+                            Ok(result) => Response::with_fleet_result(result),
+                            Err(error) => Response::err(error),
+                        },
+                        None => Response::err("fleet is not enabled in muxad"),
+                    }
                 }
                 RequestBody::ByPane { pane } => {
                     kind = "by_pane";
@@ -2373,6 +2449,48 @@ impl Client {
         let req = serde_json::json!({ "protocol": PROTOCOL_VERSION, "kind": "snapshot" });
         let resp = self.call(&req).await?;
         Ok(decode_agents(&resp))
+    }
+
+    /// Read the central physical-host cache. This is a local Unix-socket
+    /// operation; SSH collection runs continuously in muxad's `FleetManager`.
+    pub async fn fleet_snapshot(
+        &self,
+        selector: Option<&str>,
+    ) -> Result<FleetSnapshot, RuntimeError> {
+        let req = serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "fleet_snapshot",
+            "selector": selector,
+        });
+        let response = self.call_checked(&req).await?;
+        serde_json::from_value(response["fleet"].clone()).map_err(RuntimeError::Json)
+    }
+
+    /// Execute an exact operation on one configured host. Mutations are
+    /// authorized again by the manager's per-host access mode.
+    pub async fn fleet_execute(
+        &self,
+        host: &str,
+        operation: &FleetOperation,
+    ) -> Result<FleetCommandResult, RuntimeError> {
+        let req = serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "fleet_command",
+            "host": host,
+            "operation": operation,
+        });
+        let response = self
+            .call_with_timeout(&req, Duration::from_secs(25))
+            .await?;
+        if !response["ok"].as_bool().unwrap_or(false) {
+            return Err(RuntimeError::Json(serde::de::Error::custom(
+                response["error"]
+                    .as_str()
+                    .unwrap_or("fleet command failed")
+                    .to_string(),
+            )));
+        }
+        serde_json::from_value(response["fleet_result"].clone()).map_err(RuntimeError::Json)
     }
 
     /// Ask the daemon which additive features it supports and, when it can
@@ -3666,6 +3784,7 @@ mod tests {
             CollaborationAuditLog::in_memory(),
             crate::ask::AskStore::in_memory(crate::ask::AskOptions::default()),
             None,
+            None,
         ));
 
         let req = serde_json::json!({
@@ -4829,5 +4948,78 @@ mod tests {
             .expect("a transition after the skipped marker");
         assert_eq!(got.to, transition.to);
         assert_eq!(got.agent.session_id, "lag");
+    }
+
+    #[tokio::test]
+    async fn fleet_snapshot_selector_and_command_round_trip_over_ipc() {
+        use crate::fleet::{
+            FleetHostSnapshot, FleetHostState, FleetOperation, FleetRuntime, FleetStore,
+            HostAccessMode, FLEET_PROTOCOL_VERSION,
+        };
+
+        let dir = tempdir().unwrap();
+        let socket = dir.path().join("fleet-ipc.sock");
+        let fleet_store = Arc::new(FleetStore::new());
+        fleet_store
+            .upsert_host(FleetHostSnapshot {
+                alias: "dev".into(),
+                ssh_target: "devbox".into(),
+                labels: std::collections::BTreeMap::from([(
+                    "environment".into(),
+                    "development".into(),
+                )]),
+                annotations: std::collections::BTreeMap::new(),
+                mode: HostAccessMode::Control,
+                state: FleetHostState::Online,
+                node_id: None,
+                hostname: Some("devbox".into()),
+                os: Some("linux".into()),
+                arch: Some("x86_64".into()),
+                muxa_version: Some(env!("CARGO_PKG_VERSION").into()),
+                protocol: Some(FLEET_PROTOCOL_VERSION),
+                capabilities: Vec::new(),
+                daemon_generation: Some(0),
+                boot_id: Some("boot".into()),
+                latency_ms: Some(3),
+                last_seen_at: Some(OffsetDateTime::now_utc()),
+                received_at: Some(OffsetDateTime::now_utc()),
+                error: None,
+                remote: None,
+            })
+            .await;
+        let (runtime, mut commands) = FleetRuntime::new(fleet_store);
+        let command_task = tokio::spawn(async move {
+            let command = commands.recv().await.expect("fleet command");
+            assert_eq!(command.host, "dev");
+            assert!(matches!(command.operation, FleetOperation::Refresh));
+            let _ = command
+                .reply
+                .send(Ok(FleetCommandResult::accepted("refreshed")));
+        });
+        let (shutdown_tx, shutdown_rx) = broadcast::channel(1);
+        let server = Server::new(socket.clone(), Store::shared()).with_fleet(runtime);
+        let server_task = tokio::spawn(async move { server.run(shutdown_rx).await.unwrap() });
+        wait_for_socket(&socket).await;
+
+        let client = Client::new(socket);
+        let selected = client
+            .fleet_snapshot(Some("environment=development"))
+            .await
+            .expect("fleet snapshot");
+        assert_eq!(selected.hosts.len(), 1);
+        let excluded = client
+            .fleet_snapshot(Some("environment=production"))
+            .await
+            .expect("filtered fleet snapshot");
+        assert!(excluded.hosts.is_empty());
+        let result = client
+            .fleet_execute("dev", &FleetOperation::Refresh)
+            .await
+            .expect("fleet command");
+        assert_eq!(result.message.as_deref(), Some("refreshed"));
+
+        command_task.await.unwrap();
+        let _ = shutdown_tx.send(());
+        server_task.await.unwrap();
     }
 }

--- a/crates/muxa/src/lib.rs
+++ b/crates/muxa/src/lib.rs
@@ -44,6 +44,7 @@ pub mod dashboard;
 pub mod discovery;
 pub mod error;
 pub mod event;
+pub mod fleet;
 pub mod history;
 pub mod ipc;
 pub mod metrics;
@@ -75,6 +76,11 @@ pub use config::Config;
 pub use error::CoreError as Error;
 pub use event::{
     AgentEvent, AgentId, AgentKind, AgentState, NotificationLevel, SurfaceKind, SurfaceRef,
+};
+pub use fleet::{
+    FleetCommandResult, FleetHostSnapshot, FleetHostState, FleetOperation, FleetRuntime,
+    FleetSnapshot, FleetStore, GlobalPaneRef, HostAccessMode, LabelSelector, NodeId,
+    RemoteSnapshot,
 };
 pub use history::{HistoryEntry, PromptHistory};
 pub use process_tree::{WorkloadProcess, WorkloadProcessKind, WorkloadSummary};

--- a/crates/muxa/src/paths.rs
+++ b/crates/muxa/src/paths.rs
@@ -12,6 +12,7 @@ pub const SESSION_ACTIVITY_FILENAME: &str = "session-activity.json";
 pub const COLLABORATION_FILENAME: &str = "collaboration.json";
 pub const COLLABORATION_AUDIT_FILENAME: &str = "collaboration-audit.ndjson";
 pub const ASK_FILENAME: &str = "ask.json";
+pub const NODE_ID_FILENAME: &str = "host-id";
 
 /// Default daemon socket path. Prefers `$XDG_RUNTIME_DIR/muxa.sock`; falls
 /// back to `/tmp/muxa-<uid>.sock` when the runtime dir is unset.
@@ -48,6 +49,13 @@ pub fn default_activity_file() -> Option<PathBuf> {
 /// the prompt history so a single backup or rotation policy covers both.
 pub fn default_state_file() -> Option<PathBuf> {
     dirs::data_dir().map(|d| d.join(CONFIG_DIRNAME).join(STATE_FILENAME))
+}
+
+/// Stable physical-node identity used by Muxa Fleet. It intentionally lives
+/// in the data directory rather than config: SSH aliases, host names, labels,
+/// and even the config file can change without creating a different node.
+pub fn default_node_id_file() -> Option<PathBuf> {
+    dirs::data_dir().map(|d| d.join(CONFIG_DIRNAME).join(NODE_ID_FILENAME))
 }
 
 /// Default tmux session activity file: `$XDG_DATA_HOME/muxa/session-activity.json`.

--- a/crates/muxa/src/tmux/layout.rs
+++ b/crates/muxa/src/tmux/layout.rs
@@ -41,7 +41,7 @@ const FRAME_FMT: &str =
 
 /// Where one pane sits on screen, plus the little bit of identity the
 /// overlay needs to label it when no agent is attached.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PaneGeometry {
     pub pane_id: String,
     /// tmux's per-window pane index — the digit `display-panes` shows, and

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -511,7 +511,7 @@ pub fn socket_short_name(path: &str) -> String {
         .to_string()
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct SessionInfo {
     /// tmux's stable session id (e.g. `$3`). Prefer this over the mutable
     /// session name for persisted counters.

--- a/crates/muxad/Cargo.toml
+++ b/crates/muxad/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 time = { workspace = true }
+uuid = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/muxad/src/fleet_manager.rs
+++ b/crates/muxad/src/fleet_manager.rs
@@ -3,17 +3,21 @@
 use std::collections::{BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use muxa::config::{FleetCapturePolicy, FleetConfig, FleetConnectPolicy, FleetHostConfig};
 use muxa::fleet::{
-    drain_bounded, read_bounded_line, sanitize_capture_text, sanitize_terminal_text,
-    FleetCommandEnvelope, FleetCommandReceiver, FleetCommandResult, FleetHostSnapshot,
-    FleetHostState, FleetOperation, FleetRuntime, FleetStore, HostAccessMode, NodeId, RelayFrame,
-    RelayHello, RelayRequest, FLEET_MAX_DIAGNOSTIC_BYTES, FLEET_MAX_FRAME_BYTES,
-    FLEET_PROTOCOL_VERSION,
+    drain_bounded, load_or_create_node_id, read_bounded_line, sanitize_capture_text,
+    sanitize_terminal_text, validate_label_value, FleetCapturedWindowPane, FleetCommandEnvelope,
+    FleetCommandReceiver, FleetCommandResult, FleetHostSnapshot, FleetHostState, FleetOperation,
+    FleetRuntime, FleetStore, FleetWindowCapture, HostAccessMode, NodeId, RelayFrame, RelayHello,
+    RelayRequest, RemoteSnapshot, FLEET_CAPABILITIES, FLEET_MAX_DIAGNOSTIC_BYTES,
+    FLEET_MAX_FRAME_BYTES, FLEET_PROTOCOL_VERSION, LOCAL_HOST_ALIAS,
 };
+use muxa::tmux::SessionInfo;
+use muxa::{HostKind, PaneKey, SharedBackend, SharedStore, WindowKey};
 use time::OffsetDateTime;
 use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
@@ -25,32 +29,60 @@ const MAX_PENDING_REQUESTS: usize = 64;
 
 pub(crate) async fn start(
     cfg: &FleetConfig,
+    local_agents: SharedStore,
+    backends: Vec<SharedBackend>,
+    daemon_generation: u64,
     shutdown: broadcast::Receiver<()>,
-) -> (Option<FleetRuntime>, Option<tokio::task::JoinHandle<()>>) {
-    if !cfg.enabled {
-        return (None, None);
-    }
-
+) -> (FleetRuntime, tokio::task::JoinHandle<()>) {
     let store = Arc::new(FleetStore::new());
     let (runtime, receiver) = FleetRuntime::new(Arc::clone(&store));
+    let local_transitions = local_agents.subscribe();
+    let local_revision = Arc::new(AtomicU64::new(0));
+    let (node_id, identity_error) = local_node_id();
+    let local_snapshot =
+        collect_local_snapshot(&local_agents, &backends, Arc::clone(&local_revision)).await;
+    store
+        .upsert_host(local_host(
+            cfg,
+            node_id.clone(),
+            daemon_generation,
+            local_snapshot,
+            identity_error.clone(),
+        ))
+        .await;
     for (alias, host) in &cfg.hosts {
-        store.upsert_host(base_host(alias, host)).await;
+        store.upsert_host(base_host(alias, host, cfg.enabled)).await;
     }
     let config = cfg.clone();
     let handle = tokio::spawn(async move {
-        run_manager(config, store, receiver, shutdown).await;
+        run_manager(ManagerInput {
+            cfg: config,
+            store,
+            commands: receiver,
+            local: LocalManagerInput {
+                agents: local_agents,
+                backends,
+                transitions: local_transitions,
+                revision: local_revision,
+                identity_error,
+                node_id,
+            },
+            shutdown,
+        })
+        .await;
     });
-    (Some(runtime), Some(handle))
+    (runtime, handle)
 }
 
-fn base_host(alias: &str, cfg: &FleetHostConfig) -> FleetHostSnapshot {
+fn base_host(alias: &str, cfg: &FleetHostConfig, fleet_enabled: bool) -> FleetHostSnapshot {
     FleetHostSnapshot {
         alias: alias.into(),
+        local: false,
         ssh_target: cfg.ssh.clone(),
         labels: cfg.labels.clone(),
         annotations: cfg.annotations.clone(),
         mode: cfg.mode,
-        state: if cfg.enabled {
+        state: if fleet_enabled && cfg.enabled {
             FleetHostState::Connecting
         } else {
             FleetHostState::Disabled
@@ -72,19 +104,58 @@ fn base_host(alias: &str, cfg: &FleetHostConfig) -> FleetHostSnapshot {
     }
 }
 
-async fn run_manager(
+struct ManagerInput {
     cfg: FleetConfig,
     store: Arc<FleetStore>,
-    mut commands: FleetCommandReceiver,
-    mut shutdown: broadcast::Receiver<()>,
-) {
+    commands: FleetCommandReceiver,
+    local: LocalManagerInput,
+    shutdown: broadcast::Receiver<()>,
+}
+
+struct LocalManagerInput {
+    agents: SharedStore,
+    backends: Vec<SharedBackend>,
+    transitions: broadcast::Receiver<muxa::Transition>,
+    revision: Arc<AtomicU64>,
+    identity_error: Option<String>,
+    node_id: NodeId,
+}
+
+async fn run_manager(input: ManagerInput) {
+    let ManagerInput {
+        cfg,
+        store,
+        mut commands,
+        local,
+        mut shutdown,
+    } = input;
     let permits = Arc::new(Semaphore::new(cfg.max_parallel_connects));
-    let node_registry = Arc::new(RwLock::new(BTreeMap::<NodeId, String>::new()));
+    let node_registry = Arc::new(RwLock::new(BTreeMap::from([(
+        local.node_id,
+        LOCAL_HOST_ALIAS.to_string(),
+    )])));
     let mut routes = HashMap::new();
     let mut handles = Vec::new();
 
+    let (local_tx, local_rx) = mpsc::channel(64);
+    routes.insert(LOCAL_HOST_ALIAS.to_string(), local_tx);
+    handles.push(tokio::spawn(
+        LocalTask {
+            fleet: cfg.clone(),
+            store: Arc::clone(&store),
+            agents: local.agents,
+            backends: local.backends,
+            commands: local_rx,
+            transitions: local.transitions,
+            revision: local.revision,
+            identity_error: local.identity_error,
+            shutdown: shutdown.resubscribe(),
+        }
+        .run(),
+    ));
+
     for (alias, host) in &cfg.hosts {
-        if !host.enabled {
+        if !cfg.enabled || !host.enabled {
             continue;
         }
         let (tx, rx) = mpsc::channel(64);
@@ -127,6 +198,436 @@ async fn run_manager(
     for handle in handles {
         let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
     }
+}
+
+fn local_node_id() -> (NodeId, Option<String>) {
+    let Some(path) = muxa::paths::default_node_id_file() else {
+        return (
+            NodeId::generate(),
+            Some("no data directory is available; local NodeId is ephemeral".into()),
+        );
+    };
+    match load_or_create_node_id(&path) {
+        Ok(node_id) => (node_id, None),
+        Err(error) => (
+            NodeId::generate(),
+            Some(format!(
+                "could not persist local NodeId at {}: {error}; identity is ephemeral",
+                path.display()
+            )),
+        ),
+    }
+}
+
+fn local_host(
+    cfg: &FleetConfig,
+    node_id: NodeId,
+    daemon_generation: u64,
+    remote: RemoteSnapshot,
+    identity_error: Option<String>,
+) -> FleetHostSnapshot {
+    let hostname = local_hostname();
+    let mut labels = cfg.local.labels.clone();
+    labels.insert("muxa.io/local".into(), "true".into());
+    labels.insert("muxa.io/transport".into(), "local".into());
+    labels.insert("kubernetes.io/os".into(), std::env::consts::OS.into());
+    labels.insert("kubernetes.io/arch".into(), std::env::consts::ARCH.into());
+    if validate_label_value(&hostname).is_ok() {
+        labels.insert("kubernetes.io/hostname".into(), hostname.clone());
+    }
+    let now = OffsetDateTime::now_utc();
+    FleetHostSnapshot {
+        alias: LOCAL_HOST_ALIAS.into(),
+        local: true,
+        ssh_target: "local://".into(),
+        labels,
+        annotations: cfg.local.annotations.clone(),
+        mode: HostAccessMode::Control,
+        state: if identity_error.is_some() {
+            FleetHostState::Degraded
+        } else {
+            FleetHostState::Online
+        },
+        node_id: Some(node_id),
+        hostname: Some(hostname),
+        os: Some(std::env::consts::OS.into()),
+        arch: Some(std::env::consts::ARCH.into()),
+        muxa_version: Some(env!("CARGO_PKG_VERSION").into()),
+        protocol: Some(FLEET_PROTOCOL_VERSION),
+        capabilities: FLEET_CAPABILITIES
+            .iter()
+            .map(|capability| (*capability).to_string())
+            .collect(),
+        daemon_generation: Some(daemon_generation),
+        boot_id: Some(local_boot_id()),
+        latency_ms: Some(0),
+        last_seen_at: Some(remote.observed_at),
+        received_at: Some(now),
+        error: identity_error,
+        remote: Some(remote),
+    }
+}
+
+struct LocalTask {
+    fleet: FleetConfig,
+    store: Arc<FleetStore>,
+    agents: SharedStore,
+    backends: Vec<SharedBackend>,
+    commands: mpsc::Receiver<HostCommand>,
+    transitions: broadcast::Receiver<muxa::Transition>,
+    revision: Arc<AtomicU64>,
+    identity_error: Option<String>,
+    shutdown: broadcast::Receiver<()>,
+}
+
+impl LocalTask {
+    async fn run(mut self) {
+        let mut refresh = tokio::time::interval(Duration::from_secs(self.fleet.refresh_secs));
+        refresh.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // The initial snapshot was collected before the manager was exposed.
+        refresh.tick().await;
+        loop {
+            tokio::select! {
+                _ = self.shutdown.recv() => break,
+                _ = refresh.tick() => self.refresh().await,
+                transition = self.transitions.recv() => {
+                    match transition {
+                        Ok(transition) => {
+                            let revision = self.revision.fetch_add(1, Ordering::SeqCst) + 1;
+                            self.store.apply_transition(LOCAL_HOST_ALIAS, revision, transition).await;
+                        }
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            self.revision.fetch_add(skipped, Ordering::SeqCst);
+                            self.refresh().await;
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            self.store.mutate_host(LOCAL_HOST_ALIAS, |host| {
+                                host.state = FleetHostState::Degraded;
+                                host.error = Some("local agent transition stream closed".into());
+                            }).await;
+                            break;
+                        }
+                    }
+                }
+                command = self.commands.recv() => {
+                    let Some(command) = command else { break; };
+                    let result = self.execute(command.operation).await;
+                    let _ = command.reply.send(result);
+                }
+            }
+        }
+    }
+
+    async fn refresh(&self) {
+        let snapshot =
+            collect_local_snapshot(&self.agents, &self.backends, Arc::clone(&self.revision)).await;
+        let observed = snapshot.observed_at;
+        let identity_error = self.identity_error.clone();
+        self.store
+            .mutate_host(LOCAL_HOST_ALIAS, |host| {
+                host.remote = Some(merge_remote_snapshot(host.remote.take(), snapshot));
+                host.state = if identity_error.is_some() {
+                    FleetHostState::Degraded
+                } else {
+                    FleetHostState::Online
+                };
+                host.last_seen_at = Some(observed);
+                host.received_at = Some(OffsetDateTime::now_utc());
+                host.error = identity_error;
+            })
+            .await;
+    }
+
+    async fn execute(&self, operation: FleetOperation) -> Result<FleetCommandResult, String> {
+        match operation {
+            FleetOperation::Connect => Ok(FleetCommandResult::accepted(
+                "local host is always connected",
+            )),
+            FleetOperation::Disconnect => {
+                Err("local host cannot be disconnected from its own muxad".into())
+            }
+            FleetOperation::Refresh => {
+                self.refresh().await;
+                let revision = self.revision.load(Ordering::SeqCst);
+                Ok(FleetCommandResult::accepted(format!(
+                    "refreshed local revision {revision}"
+                )))
+            }
+            FleetOperation::Capture { pane } => {
+                if self.fleet.capture_policy == FleetCapturePolicy::Never {
+                    return Err("fleet capture policy is 'never'".into());
+                }
+                audit_operation(LOCAL_HOST_ALIAS, "capture", 0);
+                local_capture(&self.backends, pane).await
+            }
+            FleetOperation::CaptureWindow { window } => {
+                if self.fleet.capture_policy == FleetCapturePolicy::Never {
+                    return Err("fleet capture policy is 'never'".into());
+                }
+                audit_operation(LOCAL_HOST_ALIAS, "capture_window", 0);
+                local_capture_window(&self.backends, window).await
+            }
+            FleetOperation::SendPrompt { pane, text, submit } => {
+                if text.len() > FLEET_MAX_FRAME_BYTES {
+                    return Err(format!(
+                        "local prompt exceeds {FLEET_MAX_FRAME_BYTES} bytes"
+                    ));
+                }
+                audit_operation(LOCAL_HOST_ALIAS, "send_prompt", text.len());
+                local_send_prompt(&self.backends, pane, text, submit).await
+            }
+        }
+    }
+}
+
+async fn collect_local_snapshot(
+    agents: &SharedStore,
+    backends: &[SharedBackend],
+    revision: Arc<AtomicU64>,
+) -> RemoteSnapshot {
+    // Pin before scans so transitions received while a backend is enumerating
+    // have a newer revision and are overlaid by `merge_remote_snapshot`.
+    let snapshot_revision = revision.load(Ordering::SeqCst);
+    let pane_tasks = backends
+        .iter()
+        .map(|backend| {
+            let backend = backend.clone();
+            tokio::task::spawn_blocking(move || backend.list_panes())
+        })
+        .collect::<Vec<_>>();
+    let session_tasks = backends
+        .iter()
+        .map(|backend| {
+            let kind = backend.kind();
+            tokio::task::spawn_blocking(move || local_sessions_for_backend(kind))
+        })
+        .collect::<Vec<_>>();
+    let agents = agents.snapshot().await;
+    let mut panes = Vec::new();
+    for task in pane_tasks {
+        match task.await {
+            Ok(observed) => panes.extend(observed),
+            Err(error) => tracing::warn!(%error, "local Fleet pane scan panicked"),
+        }
+    }
+    let mut sessions = Vec::new();
+    for task in session_tasks {
+        match task.await {
+            Ok(observed) => sessions.extend(observed),
+            Err(error) => tracing::warn!(%error, "local Fleet session scan panicked"),
+        }
+    }
+    RemoteSnapshot {
+        revision: snapshot_revision,
+        observed_at: OffsetDateTime::now_utc(),
+        agents,
+        panes,
+        sessions,
+        backends: local_backend_info(backends),
+    }
+}
+
+fn local_sessions_for_backend(kind: HostKind) -> Vec<SessionInfo> {
+    match kind {
+        HostKind::Tmux => muxa::tmux::list_sessions().unwrap_or_default(),
+        HostKind::Herdr => {
+            let socket = muxa::backend::herdr::default_socket_path();
+            muxa::backend::herdr::herdr_list_workspaces(&socket)
+                .into_iter()
+                .map(|workspace| SessionInfo {
+                    session_id: workspace.id,
+                    name: workspace.label,
+                    attached_clients: 0,
+                })
+                .collect()
+        }
+        HostKind::Rmux | HostKind::Zellij => Vec::new(),
+    }
+}
+
+fn local_backend_info(backends: &[SharedBackend]) -> Vec<muxa::fleet::FleetBackendInfo> {
+    backends
+        .iter()
+        .map(|backend| muxa::fleet::FleetBackendInfo::new(backend.kind(), backend.caps()))
+        .collect()
+}
+
+async fn exact_local_backend(
+    backends: &[SharedBackend],
+    key: &PaneKey,
+) -> Result<SharedBackend, String> {
+    let backend = backends
+        .iter()
+        .find(|backend| backend.kind() == key.window.session.endpoint.host)
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "{} backend is unavailable",
+                key.window.session.endpoint.host
+            )
+        })?;
+    let scanner = backend.clone();
+    let panes = tokio::task::spawn_blocking(move || scanner.list_panes())
+        .await
+        .map_err(|error| format!("local pane scan panicked: {error}"))?;
+    if !panes
+        .iter()
+        .any(|pane| PaneKey::from_pane(backend.kind(), pane) == *key)
+    {
+        return Err("exact local pane target is stale or no longer exists".into());
+    }
+    Ok(backend)
+}
+
+async fn local_capture(
+    backends: &[SharedBackend],
+    pane: PaneKey,
+) -> Result<FleetCommandResult, String> {
+    let backend = exact_local_backend(backends, &pane).await?;
+    if !backend.caps().capture_pane {
+        return Err(format!(
+            "{} backend does not support pane capture",
+            backend.kind()
+        ));
+    }
+    let socket = pane.window.session.endpoint.socket;
+    let pane_id = pane.pane_id;
+    let capture = tokio::task::spawn_blocking(move || {
+        backend
+            .capture_pane_on(Some(&socket), &pane_id)
+            .map(sanitize_capture_text)
+    })
+    .await
+    .map_err(|error| format!("local capture task panicked: {error}"))?;
+    Ok(FleetCommandResult::capture(capture))
+}
+
+async fn local_capture_window(
+    backends: &[SharedBackend],
+    window: WindowKey,
+) -> Result<FleetCommandResult, String> {
+    if window.session.endpoint.host != HostKind::Tmux {
+        return Err("window geometry is currently available only for tmux backends".into());
+    }
+    let backend = backends
+        .iter()
+        .find(|backend| backend.kind() == HostKind::Tmux)
+        .cloned()
+        .ok_or_else(|| "tmux backend is unavailable".to_string())?;
+    let verify_backend = backend.clone();
+    let verify_window = window.clone();
+    let exists = tokio::task::spawn_blocking(move || {
+        verify_backend
+            .list_panes()
+            .iter()
+            .any(|pane| PaneKey::from_pane(verify_backend.kind(), pane).window == verify_window)
+    })
+    .await
+    .map_err(|error| format!("local window verification panicked: {error}"))?;
+    if !exists {
+        return Err("exact local window target is stale or no longer exists".into());
+    }
+    let capture = tokio::task::spawn_blocking(move || {
+        let socket = window.session.endpoint.socket.clone();
+        let (geometries, zoomed) =
+            muxa::tmux::layout::window_panes_on(Some(&socket), &window.window_id);
+        let visible = geometries
+            .into_iter()
+            .filter(|geometry| !zoomed || geometry.active)
+            .collect::<Vec<_>>();
+        let mut panes = Vec::with_capacity(visible.len());
+        for batch in visible.chunks(8) {
+            panes.extend(std::thread::scope(|scope| {
+                batch
+                    .iter()
+                    .cloned()
+                    .map(|geometry| {
+                        let backend = backend.clone();
+                        let socket = socket.clone();
+                        scope.spawn(move || {
+                            let text = backend
+                                .capture_pane_on(Some(&socket), &geometry.pane_id)
+                                .map(sanitize_capture_text);
+                            FleetCapturedWindowPane { geometry, text }
+                        })
+                    })
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .filter_map(|handle| handle.join().ok())
+                    .collect::<Vec<_>>()
+            }));
+        }
+        FleetWindowCapture {
+            window,
+            panes,
+            zoomed,
+            observed_at: OffsetDateTime::now_utc(),
+        }
+    })
+    .await
+    .map_err(|error| format!("local window capture panicked: {error}"))?;
+    let result = FleetCommandResult::window_capture(capture);
+    let encoded = serde_json::to_vec(&result)
+        .map_err(|error| format!("encoding local window capture: {error}"))?;
+    if encoded.len() > FLEET_MAX_FRAME_BYTES {
+        return Err(format!(
+            "local window capture exceeds {FLEET_MAX_FRAME_BYTES} bytes"
+        ));
+    }
+    Ok(result)
+}
+
+async fn local_send_prompt(
+    backends: &[SharedBackend],
+    pane: PaneKey,
+    text: String,
+    submit: bool,
+) -> Result<FleetCommandResult, String> {
+    let backend = exact_local_backend(backends, &pane).await?;
+    if !backend.caps().send_text {
+        return Err(format!(
+            "{} backend does not support text injection",
+            backend.kind()
+        ));
+    }
+    let socket = pane.window.session.endpoint.socket;
+    let pane_id = pane.pane_id;
+    let outcome = tokio::task::spawn_blocking(move || {
+        if !backend.send_text_on(Some(&socket), &pane_id, &text) {
+            return None;
+        }
+        let submitted = if submit {
+            std::thread::sleep(muxa::backend::PROMPT_SUBMIT_GRACE);
+            backend.send_text_on(Some(&socket), &pane_id, "\r")
+        } else {
+            false
+        };
+        Some(muxa::ipc::SendPromptOutcome {
+            sent: true,
+            submitted,
+        })
+    })
+    .await
+    .map_err(|error| format!("local send task panicked: {error}"))?
+    .ok_or_else(|| "backend refused text injection".to_string())?;
+    Ok(FleetCommandResult::sent(outcome))
+}
+
+fn local_hostname() -> String {
+    std::fs::read_to_string("/etc/hostname")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var("HOSTNAME").ok())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+fn local_boot_id() -> String {
+    std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| format!("process-{}", std::process::id()))
 }
 
 struct HostCommand {
@@ -872,6 +1373,38 @@ mod tests {
     use super::*;
     use muxa::event::{AgentEvent, AgentId, AgentKind, AgentState};
     use muxa::state::Store;
+
+    #[test]
+    fn local_host_is_first_class_with_truthful_managed_labels() {
+        let mut cfg = FleetConfig::default();
+        cfg.local
+            .labels
+            .insert("environment".into(), "development".into());
+        cfg.local
+            .annotations
+            .insert("example.com/owner".into(), "June".into());
+        let observed_at = OffsetDateTime::now_utc();
+        let remote = RemoteSnapshot {
+            revision: 4,
+            observed_at,
+            agents: Vec::new(),
+            panes: Vec::new(),
+            sessions: Vec::new(),
+            backends: Vec::new(),
+        };
+        let host = local_host(&cfg, NodeId::generate(), 9, remote, None);
+        assert!(host.local);
+        assert_eq!(host.alias, LOCAL_HOST_ALIAS);
+        assert_eq!(host.ssh_target, "local://");
+        assert_eq!(host.mode, HostAccessMode::Control);
+        assert_eq!(host.state, FleetHostState::Online);
+        assert_eq!(host.labels["muxa.io/local"], "true");
+        assert_eq!(host.labels["muxa.io/transport"], "local");
+        assert_eq!(host.labels["environment"], "development");
+        assert_eq!(host.annotations["example.com/owner"], "June");
+        assert_eq!(host.daemon_generation, Some(9));
+        assert_eq!(host.remote.unwrap().revision, 4);
+    }
 
     #[test]
     fn ssh_errors_are_classified_without_ansi_controls() {

--- a/crates/muxad/src/fleet_manager.rs
+++ b/crates/muxad/src/fleet_manager.rs
@@ -1,0 +1,970 @@
+//! Persistent SSH connection manager for physical Muxa Fleet hosts.
+
+use std::collections::{BTreeMap, HashMap};
+use std::hash::{Hash, Hasher};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use muxa::config::{FleetCapturePolicy, FleetConfig, FleetConnectPolicy, FleetHostConfig};
+use muxa::fleet::{
+    drain_bounded, read_bounded_line, sanitize_capture_text, sanitize_terminal_text,
+    FleetCommandEnvelope, FleetCommandReceiver, FleetCommandResult, FleetHostSnapshot,
+    FleetHostState, FleetOperation, FleetRuntime, FleetStore, HostAccessMode, NodeId, RelayFrame,
+    RelayHello, RelayRequest, FLEET_MAX_DIAGNOSTIC_BYTES, FLEET_MAX_FRAME_BYTES,
+    FLEET_PROTOCOL_VERSION,
+};
+use time::OffsetDateTime;
+use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::{broadcast, mpsc, oneshot, RwLock, Semaphore};
+use uuid::Uuid;
+
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+const MAX_PENDING_REQUESTS: usize = 64;
+
+pub(crate) async fn start(
+    cfg: &FleetConfig,
+    shutdown: broadcast::Receiver<()>,
+) -> (Option<FleetRuntime>, Option<tokio::task::JoinHandle<()>>) {
+    if !cfg.enabled {
+        return (None, None);
+    }
+
+    let store = Arc::new(FleetStore::new());
+    let (runtime, receiver) = FleetRuntime::new(Arc::clone(&store));
+    for (alias, host) in &cfg.hosts {
+        store.upsert_host(base_host(alias, host)).await;
+    }
+    let config = cfg.clone();
+    let handle = tokio::spawn(async move {
+        run_manager(config, store, receiver, shutdown).await;
+    });
+    (Some(runtime), Some(handle))
+}
+
+fn base_host(alias: &str, cfg: &FleetHostConfig) -> FleetHostSnapshot {
+    FleetHostSnapshot {
+        alias: alias.into(),
+        ssh_target: cfg.ssh.clone(),
+        labels: cfg.labels.clone(),
+        annotations: cfg.annotations.clone(),
+        mode: cfg.mode,
+        state: if cfg.enabled {
+            FleetHostState::Connecting
+        } else {
+            FleetHostState::Disabled
+        },
+        node_id: None,
+        hostname: None,
+        os: None,
+        arch: None,
+        muxa_version: None,
+        protocol: None,
+        capabilities: Vec::new(),
+        daemon_generation: None,
+        boot_id: None,
+        latency_ms: None,
+        last_seen_at: None,
+        received_at: None,
+        error: None,
+        remote: None,
+    }
+}
+
+async fn run_manager(
+    cfg: FleetConfig,
+    store: Arc<FleetStore>,
+    mut commands: FleetCommandReceiver,
+    mut shutdown: broadcast::Receiver<()>,
+) {
+    let permits = Arc::new(Semaphore::new(cfg.max_parallel_connects));
+    let node_registry = Arc::new(RwLock::new(BTreeMap::<NodeId, String>::new()));
+    let mut routes = HashMap::new();
+    let mut handles = Vec::new();
+
+    for (alias, host) in &cfg.hosts {
+        if !host.enabled {
+            continue;
+        }
+        let (tx, rx) = mpsc::channel(64);
+        routes.insert(alias.clone(), tx);
+        let task = HostTask {
+            alias: alias.clone(),
+            config: host.clone(),
+            fleet: cfg.clone(),
+            store: Arc::clone(&store),
+            permits: Arc::clone(&permits),
+            node_registry: Arc::clone(&node_registry),
+            commands: rx,
+            shutdown: shutdown.resubscribe(),
+        };
+        handles.push(tokio::spawn(task.run()));
+    }
+
+    loop {
+        tokio::select! {
+            _ = shutdown.recv() => break,
+            command = commands.recv() => {
+                let Some(command) = command else { break; };
+                if let Some(route) = routes.get(&command.host) {
+                    if route.send(HostCommand::from(command)).await.is_err() {
+                        // The task disappeared between lookup and send.
+                        // There is no sender left to answer; the caller's
+                        // oneshot observes cancellation and reports it.
+                    }
+                } else {
+                    let _ = command.reply.send(Err(format!(
+                        "fleet host '{}' is not configured or is disabled",
+                        command.host
+                    )));
+                }
+            }
+        }
+    }
+
+    drop(routes);
+    for handle in handles {
+        let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    }
+}
+
+struct HostCommand {
+    operation: FleetOperation,
+    reply: oneshot::Sender<Result<FleetCommandResult, String>>,
+}
+
+impl From<FleetCommandEnvelope> for HostCommand {
+    fn from(value: FleetCommandEnvelope) -> Self {
+        Self {
+            operation: value.operation,
+            reply: value.reply,
+        }
+    }
+}
+
+struct HostTask {
+    alias: String,
+    config: FleetHostConfig,
+    fleet: FleetConfig,
+    store: Arc<FleetStore>,
+    permits: Arc<Semaphore>,
+    node_registry: Arc<RwLock<BTreeMap<NodeId, String>>>,
+    commands: mpsc::Receiver<HostCommand>,
+    shutdown: broadcast::Receiver<()>,
+}
+
+enum PendingReply {
+    Command(oneshot::Sender<Result<FleetCommandResult, String>>),
+    Refresh(oneshot::Sender<Result<FleetCommandResult, String>>),
+}
+
+struct PendingRequest {
+    reply: PendingReply,
+    deadline: Instant,
+}
+
+impl PendingRequest {
+    fn new(reply: PendingReply, timeout: Duration) -> Self {
+        Self {
+            reply,
+            deadline: Instant::now() + timeout,
+        }
+    }
+}
+
+impl HostTask {
+    async fn run(mut self) {
+        let mut desired = self.config.connect == FleetConnectPolicy::Auto;
+        let mut backoff = Duration::from_secs(1);
+        loop {
+            if !desired {
+                self.store
+                    .mutate_host(&self.alias, |host| {
+                        host.state = FleetHostState::Offline;
+                        host.error = Some("connection is on demand".into());
+                    })
+                    .await;
+                tokio::select! {
+                    _ = self.shutdown.recv() => break,
+                    command = self.commands.recv() => {
+                        let Some(command) = command else { break; };
+                        match command.operation {
+                            FleetOperation::Connect => {
+                                desired = true;
+                                let _ = command.reply.send(Ok(FleetCommandResult::accepted("connecting")));
+                            }
+                            _ => {
+                                let _ = command.reply.send(Err(format!(
+                                    "host '{}' is disconnected; run `muxa fleet connect {}` first",
+                                    self.alias, self.alias
+                                )));
+                            }
+                        }
+                    }
+                }
+                continue;
+            }
+
+            self.store
+                .mutate_host(&self.alias, |host| {
+                    host.state = FleetHostState::Connecting;
+                    host.error = None;
+                })
+                .await;
+
+            let permit = tokio::select! {
+                _ = self.shutdown.recv() => break,
+                permit = Arc::clone(&self.permits).acquire_owned() => match permit {
+                    Ok(permit) => permit,
+                    Err(_) => break,
+                },
+            };
+            let connection = self.connect().await;
+            drop(permit);
+
+            match connection {
+                Ok(connected) => {
+                    backoff = Duration::from_secs(1);
+                    let result = self.serve_connection(connected, &mut desired).await;
+                    if let Err(error) = result {
+                        self.record_disconnect(&error).await;
+                    }
+                }
+                Err(error) => self.record_disconnect(&error).await,
+            }
+
+            if !desired {
+                continue;
+            }
+            let delay = backoff + deterministic_jitter(&self.alias, backoff);
+            tokio::select! {
+                _ = self.shutdown.recv() => break,
+                () = tokio::time::sleep(delay) => {},
+                command = self.commands.recv() => {
+                    let Some(command) = command else { break; };
+                    match command.operation {
+                        FleetOperation::Disconnect => {
+                            desired = false;
+                            let _ = command.reply.send(Ok(FleetCommandResult::accepted("disconnected")));
+                        }
+                        FleetOperation::Connect | FleetOperation::Refresh => {
+                            let _ = command.reply.send(Ok(FleetCommandResult::accepted("reconnecting")));
+                        }
+                        _ => {
+                            let _ = command.reply.send(Err("host is offline; command was not sent".into()));
+                        }
+                    }
+                }
+            }
+            backoff = (backoff * 2).min(MAX_BACKOFF);
+        }
+    }
+
+    async fn connect(&self) -> Result<Connected, String> {
+        let started = Instant::now();
+        let mut command = Command::new("ssh");
+        command
+            .kill_on_drop(true)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args([
+                "-T",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ClearAllForwardings=yes",
+                "-o",
+                &format!("ConnectTimeout={}", self.fleet.connect_timeout_secs),
+                "--",
+                &self.config.ssh,
+                &self.config.muxa_path,
+            ]);
+        if let Some(socket) = &self.config.remote_socket {
+            command.arg("--socket").arg(socket);
+        }
+        command.args(["relay", "--stdio"]);
+
+        let mut child = command
+            .spawn()
+            .map_err(|error| format!("could not start OpenSSH: {error}"))?;
+        let stdin = child.stdin.take().ok_or("OpenSSH stdin is unavailable")?;
+        let stdout = child.stdout.take().ok_or("OpenSSH stdout is unavailable")?;
+        let stderr = child.stderr.take().ok_or("OpenSSH stderr is unavailable")?;
+        let stderr_task = tokio::spawn(async move {
+            let mut stderr = stderr;
+            let bytes = drain_bounded(&mut stderr, FLEET_MAX_DIAGNOSTIC_BYTES)
+                .await
+                .unwrap_or_default();
+            sanitize_remote_error(&String::from_utf8_lossy(&bytes))
+        });
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        let read = tokio::time::timeout(
+            Duration::from_secs(self.fleet.connect_timeout_secs),
+            read_relay_line(&mut reader, &mut line),
+        )
+        .await
+        .map_err(|_| "timed out waiting for the remote relay handshake".to_string())?
+        .map_err(|error| error.to_string())?;
+        if read == 0 {
+            let _ = child.wait().await;
+            let stderr = stderr_task.await.unwrap_or_default();
+            return Err(if stderr.is_empty() {
+                "remote relay exited before its handshake".into()
+            } else {
+                stderr
+            });
+        }
+        let frame: RelayFrame = serde_json::from_str(line.trim())
+            .map_err(|error| format!("invalid remote relay handshake: {error}"))?;
+        let RelayFrame::Hello { hello } = frame else {
+            return Err("remote relay did not send hello first".into());
+        };
+        if hello.fleet_protocol < FLEET_PROTOCOL_VERSION
+            || hello.min_fleet_protocol > FLEET_PROTOCOL_VERSION
+        {
+            return Err(format!(
+                "fleet protocol mismatch: local={FLEET_PROTOCOL_VERSION}, remote=[{},{}]",
+                hello.min_fleet_protocol, hello.fleet_protocol
+            ));
+        }
+        {
+            let mut registry = self.node_registry.write().await;
+            if let Some(other) = registry.get(&hello.node_id) {
+                if other != &self.alias {
+                    return Err(format!(
+                        "node id {} is already connected as host '{other}'",
+                        hello.node_id
+                    ));
+                }
+            }
+            registry.insert(hello.node_id.clone(), self.alias.clone());
+        }
+        let latency_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        self.apply_hello(&hello, latency_ms).await;
+        Ok(Connected {
+            child,
+            stdin,
+            reader,
+            stderr_task,
+            hello,
+            last_frame: Instant::now(),
+        })
+    }
+
+    async fn apply_hello(&self, hello: &RelayHello, latency_ms: u64) {
+        self.store
+            .mutate_host(&self.alias, |host| {
+                host.node_id = Some(hello.node_id.clone());
+                host.hostname = Some(hello.hostname.clone());
+                host.os = Some(hello.os.clone());
+                host.arch = Some(hello.arch.clone());
+                host.muxa_version = Some(hello.muxa_version.clone());
+                host.protocol = Some(hello.fleet_protocol);
+                host.capabilities.clone_from(&hello.capabilities);
+                host.daemon_generation = hello.daemon_generation;
+                host.boot_id = Some(hello.boot_id.clone());
+                host.latency_ms = Some(latency_ms);
+                host.last_seen_at = Some(hello.server_time);
+                host.received_at = Some(OffsetDateTime::now_utc());
+                host.error = None;
+                // Relay revisions are scoped to one SSH/relay stream and
+                // restart from zero after reconnect. Drop the stale revision
+                // here so a new revision 1 cannot be mistaken for an old
+                // duplicate. Offline state retained the snapshot until this
+                // authenticated hello completed.
+                host.remote = Some(muxa::fleet::RemoteSnapshot {
+                    revision: 0,
+                    observed_at: hello.server_time,
+                    agents: Vec::new(),
+                    panes: Vec::new(),
+                    sessions: Vec::new(),
+                    backends: hello.backends.clone(),
+                });
+            })
+            .await;
+    }
+
+    #[allow(clippy::too_many_lines)] // connection loop owns ordering, deadlines, and pending replies
+    async fn serve_connection(
+        &mut self,
+        mut connected: Connected,
+        desired: &mut bool,
+    ) -> Result<(), String> {
+        let mut pending = HashMap::<String, PendingRequest>::new();
+        if let Err(error) = send_request(
+            &mut connected.stdin,
+            &RelayRequest::Snapshot {
+                request_id: request_id(),
+            },
+        )
+        .await
+        {
+            let mut registry = self.node_registry.write().await;
+            if registry.get(&connected.hello.node_id) == Some(&self.alias) {
+                registry.remove(&connected.hello.node_id);
+            }
+            drop(registry);
+            let _ = connected.child.kill().await;
+            let _ = connected.child.wait().await;
+            let stderr = connected.stderr_task.await.unwrap_or_default();
+            return Err(if stderr.is_empty() {
+                error
+            } else {
+                format!("{error}: {stderr}")
+            });
+        }
+        let mut refresh = tokio::time::interval(Duration::from_secs(self.fleet.refresh_secs));
+        refresh.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        refresh.tick().await;
+        let mut keepalive = tokio::time::interval(Duration::from_secs(self.fleet.keepalive_secs));
+        keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        keepalive.tick().await;
+        let mut health = tokio::time::interval(Duration::from_secs(1));
+        health.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut line = String::new();
+
+        let outcome: Result<(), String> = loop {
+            line.clear();
+            tokio::select! {
+                _ = self.shutdown.recv() => {
+                    *desired = false;
+                    break Ok(());
+                }
+                command = self.commands.recv() => {
+                    let Some(command) = command else {
+                        *desired = false;
+                        break Ok(());
+                    };
+                    if let FleetOperation::Disconnect = command.operation {
+                        *desired = false;
+                        let _ = command.reply.send(Ok(FleetCommandResult::accepted("disconnected")));
+                        break Ok(());
+                    }
+                    if let FleetOperation::Connect = command.operation {
+                        let _ = command.reply.send(Ok(FleetCommandResult::accepted("already connected")));
+                        continue;
+                    }
+                    if matches!(command.operation, FleetOperation::SendPrompt { .. })
+                        && self.config.mode != HostAccessMode::Control
+                    {
+                        let _ = command.reply.send(Err(format!(
+                            "host '{}' is observe-only; set mode = 'control' to send prompts",
+                            self.alias
+                        )));
+                        continue;
+                    }
+                    if matches!(
+                        command.operation,
+                        FleetOperation::Capture { .. } | FleetOperation::CaptureWindow { .. }
+                    )
+                        && self.fleet.capture_policy == FleetCapturePolicy::Never
+                    {
+                        let _ = command.reply.send(Err("fleet capture_policy is 'never'".into()));
+                        continue;
+                    }
+                    if pending.len() >= MAX_PENDING_REQUESTS {
+                        let _ = command.reply.send(Err(format!(
+                            "host '{}' already has {MAX_PENDING_REQUESTS} commands awaiting acknowledgement",
+                            self.alias
+                        )));
+                        continue;
+                    }
+                    let id = request_id();
+                    let command_timeout = Duration::from_secs(self.fleet.command_timeout_secs);
+                    let request = match command.operation {
+                        FleetOperation::Refresh => {
+                            pending.insert(
+                                id.clone(),
+                                PendingRequest::new(PendingReply::Refresh(command.reply), command_timeout),
+                            );
+                            RelayRequest::Snapshot { request_id: id }
+                        }
+                        FleetOperation::Capture { pane } => {
+                            audit_operation(&self.alias, "capture", 0);
+                            pending.insert(
+                                id.clone(),
+                                PendingRequest::new(PendingReply::Command(command.reply), command_timeout),
+                            );
+                            RelayRequest::Capture { request_id: id, pane }
+                        }
+                        FleetOperation::CaptureWindow { window } => {
+                            audit_operation(&self.alias, "capture_window", 0);
+                            pending.insert(
+                                id.clone(),
+                                PendingRequest::new(PendingReply::Command(command.reply), command_timeout),
+                            );
+                            RelayRequest::CaptureWindow { request_id: id, window }
+                        }
+                        FleetOperation::SendPrompt { pane, text, submit } => {
+                            audit_operation(&self.alias, "send_prompt", text.len());
+                            pending.insert(
+                                id.clone(),
+                                PendingRequest::new(PendingReply::Command(command.reply), command_timeout),
+                            );
+                            RelayRequest::SendPrompt { request_id: id, pane, text, submit }
+                        }
+                        FleetOperation::Connect | FleetOperation::Disconnect => unreachable!(),
+                    };
+                    if let Err(error) = send_request(&mut connected.stdin, &request).await {
+                        if let Some(reply) = pending.remove(request.request_id()) {
+                            fail_pending(reply.reply, error.clone());
+                        }
+                        break Err(error);
+                    }
+                }
+                _ = refresh.tick() => {
+                    if let Err(error) = send_request(
+                        &mut connected.stdin,
+                        &RelayRequest::Snapshot { request_id: request_id() },
+                    ).await {
+                        break Err(error);
+                    }
+                }
+                _ = keepalive.tick() => {
+                    if let Err(error) = send_request(
+                        &mut connected.stdin,
+                        &RelayRequest::Ping { request_id: request_id() },
+                    ).await {
+                        break Err(error);
+                    }
+                }
+                _ = health.tick() => {
+                    expire_pending(
+                        &mut pending,
+                        Instant::now(),
+                        self.fleet.command_timeout_secs,
+                    );
+                    if connected.last_frame.elapsed() > Duration::from_secs(self.fleet.offline_after_secs) {
+                        break Err(format!(
+                            "no relay frame received for {} seconds",
+                            self.fleet.offline_after_secs
+                        ));
+                    }
+                    match connected.child.try_wait() {
+                        Ok(Some(status)) => break Err(format!("OpenSSH exited with {status}")),
+                        Ok(None) => {}
+                        Err(error) => break Err(error.to_string()),
+                    }
+                }
+                read = read_relay_line(&mut connected.reader, &mut line) => {
+                    let read = match read {
+                        Ok(read) => read,
+                        Err(error) => break Err(error.to_string()),
+                    };
+                    if read == 0 {
+                        break Err("SSH relay closed its output".into());
+                    }
+                    connected.last_frame = Instant::now();
+                    let frame: RelayFrame = match serde_json::from_str(line.trim()) {
+                        Ok(frame) => frame,
+                        Err(error) => break Err(format!("invalid relay frame: {error}")),
+                    };
+                    if let Err(error) = self.handle_frame(frame, &mut connected, &mut pending).await {
+                        break Err(error);
+                    }
+                }
+            }
+        };
+
+        for (_, request) in pending {
+            fail_pending(
+                request.reply,
+                "SSH connection closed before command acknowledgement".into(),
+            );
+        }
+        let mut registry = self.node_registry.write().await;
+        if registry.get(&connected.hello.node_id) == Some(&self.alias) {
+            registry.remove(&connected.hello.node_id);
+        }
+        drop(registry);
+        let _ = connected.child.kill().await;
+        let _ = connected.child.wait().await;
+        let stderr = connected.stderr_task.await.unwrap_or_default();
+        if !*desired {
+            self.store
+                .mutate_host(&self.alias, |host| {
+                    host.state = FleetHostState::Offline;
+                    host.error = Some("disconnected by operator".into());
+                })
+                .await;
+            return Ok(());
+        }
+        match outcome {
+            Ok(()) if stderr.is_empty() => Err("SSH relay disconnected".into()),
+            Ok(()) => Err(stderr),
+            Err(error) if stderr.is_empty() => Err(error),
+            Err(error) => Err(format!("{error}: {stderr}")),
+        }
+    }
+
+    #[allow(clippy::too_many_lines)] // exhaustive wire-frame state transition table
+    async fn handle_frame(
+        &self,
+        frame: RelayFrame,
+        connected: &mut Connected,
+        pending: &mut HashMap<String, PendingRequest>,
+    ) -> Result<(), String> {
+        match frame {
+            RelayFrame::Snapshot {
+                request_id,
+                snapshot,
+            } => {
+                let observed = snapshot.observed_at;
+                let revision = snapshot.revision;
+                self.store
+                    .mutate_host(&self.alias, |host| {
+                        // Never regress a newer transition that raced a slow
+                        // full scan. Pane/session inventories are still fresh,
+                        // but agent state and revision remain monotonic.
+                        let snapshot = merge_remote_snapshot(host.remote.take(), snapshot);
+                        host.remote = Some(snapshot);
+                        host.state = FleetHostState::Online;
+                        host.last_seen_at = Some(observed);
+                        host.received_at = Some(OffsetDateTime::now_utc());
+                        host.error = None;
+                    })
+                    .await;
+                if let Some(request) = pending.remove(&request_id) {
+                    match request.reply {
+                        PendingReply::Refresh(reply) | PendingReply::Command(reply) => {
+                            let _ = reply.send(Ok(FleetCommandResult::accepted(format!(
+                                "refreshed revision {revision}"
+                            ))));
+                        }
+                    }
+                }
+            }
+            RelayFrame::Transition {
+                revision,
+                transition,
+            } => {
+                self.store
+                    .apply_transition(&self.alias, revision, transition)
+                    .await;
+            }
+            RelayFrame::Keepalive {
+                revision,
+                observed_at,
+            } => {
+                let mut needs_resync = false;
+                self.store
+                    .mutate_host(&self.alias, |host| {
+                        host.last_seen_at = Some(observed_at);
+                        host.received_at = Some(OffsetDateTime::now_utc());
+                        if host
+                            .remote
+                            .as_ref()
+                            .is_some_and(|remote| remote.revision < revision)
+                        {
+                            host.state = FleetHostState::Degraded;
+                            host.error = Some("remote revision is ahead; resynchronizing".into());
+                            needs_resync = true;
+                        }
+                    })
+                    .await;
+                if needs_resync {
+                    send_request(
+                        &mut connected.stdin,
+                        &RelayRequest::Snapshot {
+                            request_id: request_id(),
+                        },
+                    )
+                    .await?;
+                }
+            }
+            RelayFrame::Result { request_id, result } => {
+                let result = sanitize_command_result(result);
+                if let Some(request) = pending.remove(&request_id) {
+                    match request.reply {
+                        PendingReply::Command(reply) | PendingReply::Refresh(reply) => {
+                            let _ = reply.send(Ok(result));
+                        }
+                    }
+                }
+            }
+            RelayFrame::Error {
+                request_id,
+                code,
+                message,
+            } => {
+                let code = sanitize_remote_error(&code);
+                let message = sanitize_remote_error(&message);
+                if let Some(request) = pending.remove(&request_id) {
+                    fail_pending(request.reply, format!("remote {code}: {message}"));
+                } else {
+                    tracing::warn!(host = %self.alias, %code, %message, "unmatched relay error");
+                }
+            }
+            RelayFrame::ResyncRequired { reason } => {
+                let reason = sanitize_remote_error(&reason);
+                let display_reason = reason.clone();
+                self.store
+                    .mutate_host(&self.alias, |host| {
+                        host.state = FleetHostState::Degraded;
+                        host.error = Some(reason);
+                    })
+                    .await;
+                // The relay's local transition subscription is gone. A full
+                // snapshot can repair current state but cannot restore future
+                // push events; reconnect the relay process instead.
+                return Err(format!("relay stream requires reconnect: {display_reason}"));
+            }
+            RelayFrame::Hello { .. } => return Err("relay sent a duplicate hello frame".into()),
+        }
+        Ok(())
+    }
+
+    async fn record_disconnect(&self, error: &str) {
+        let error = sanitize_remote_error(error);
+        let state = classify_error(&error);
+        self.store
+            .mutate_host(&self.alias, |host| {
+                host.state = state;
+                host.error = Some(error);
+                // Deliberately retain `remote`: callers see the last-known
+                // snapshot with stale/offline metadata instead of a false
+                // empty fleet.
+            })
+            .await;
+    }
+}
+
+struct Connected {
+    child: Child,
+    stdin: ChildStdin,
+    reader: BufReader<tokio::process::ChildStdout>,
+    stderr_task: tokio::task::JoinHandle<String>,
+    hello: RelayHello,
+    last_frame: Instant,
+}
+
+async fn read_relay_line(
+    reader: &mut BufReader<tokio::process::ChildStdout>,
+    line: &mut String,
+) -> std::io::Result<usize> {
+    read_bounded_line(reader, line, FLEET_MAX_FRAME_BYTES).await
+}
+
+async fn send_request(stdin: &mut ChildStdin, request: &RelayRequest) -> Result<(), String> {
+    let mut bytes = serde_json::to_vec(request).map_err(|error| error.to_string())?;
+    if bytes.len() > FLEET_MAX_FRAME_BYTES {
+        return Err(format!(
+            "relay request exceeds {FLEET_MAX_FRAME_BYTES} bytes"
+        ));
+    }
+    bytes.push(b'\n');
+    stdin
+        .write_all(&bytes)
+        .await
+        .map_err(|error| error.to_string())?;
+    stdin.flush().await.map_err(|error| error.to_string())
+}
+
+fn request_id() -> String {
+    Uuid::new_v4().to_string()
+}
+
+fn fail_pending(reply: PendingReply, error: String) {
+    match reply {
+        PendingReply::Command(reply) | PendingReply::Refresh(reply) => {
+            let _ = reply.send(Err(error));
+        }
+    }
+}
+
+fn expire_pending(pending: &mut HashMap<String, PendingRequest>, now: Instant, timeout_secs: u64) {
+    let expired = pending
+        .iter()
+        .filter_map(|(id, request)| (request.deadline <= now).then_some(id.clone()))
+        .collect::<Vec<_>>();
+    for id in expired {
+        if let Some(request) = pending.remove(&id) {
+            fail_pending(
+                request.reply,
+                format!("remote command timed out after {timeout_secs} seconds"),
+            );
+        }
+    }
+}
+
+fn classify_error(error: &str) -> FleetHostState {
+    let lower = error.to_ascii_lowercase();
+    if lower.contains("permission denied")
+        || lower.contains("host key verification failed")
+        || lower.contains("remote host identification has changed")
+    {
+        FleetHostState::AuthFailed
+    } else if lower.contains("protocol mismatch") {
+        FleetHostState::VersionSkew
+    } else {
+        FleetHostState::Offline
+    }
+}
+
+fn sanitize_remote_error(error: &str) -> String {
+    let mut clean = sanitize_terminal_text(error);
+    if clean.len() > FLEET_MAX_DIAGNOSTIC_BYTES {
+        let mut boundary = FLEET_MAX_DIAGNOSTIC_BYTES;
+        while !clean.is_char_boundary(boundary) {
+            boundary -= 1;
+        }
+        clean.truncate(boundary);
+        clean.push('…');
+    }
+    clean.trim().to_string()
+}
+
+fn sanitize_command_result(mut result: FleetCommandResult) -> FleetCommandResult {
+    result.message = result
+        .message
+        .map(|message| sanitize_remote_error(&message));
+    result.capture = result.capture.map(sanitize_capture_text);
+    if let Some(window) = &mut result.window_capture {
+        for pane in &mut window.panes {
+            pane.text = pane.text.take().map(sanitize_capture_text);
+        }
+    }
+    result
+}
+
+fn merge_remote_snapshot(
+    current: Option<muxa::fleet::RemoteSnapshot>,
+    mut snapshot: muxa::fleet::RemoteSnapshot,
+) -> muxa::fleet::RemoteSnapshot {
+    let Some(current) = current.filter(|current| current.revision > snapshot.revision) else {
+        return snapshot;
+    };
+    for current_agent in current.agents {
+        if let Some(agent) = snapshot.agents.iter_mut().find(|agent| {
+            agent.kind == current_agent.kind && agent.session_id == current_agent.session_id
+        }) {
+            *agent = current_agent;
+        } else {
+            snapshot.agents.push(current_agent);
+        }
+    }
+    snapshot.revision = current.revision;
+    snapshot.observed_at = snapshot.observed_at.max(current.observed_at);
+    snapshot
+}
+
+fn deterministic_jitter(alias: &str, base: Duration) -> Duration {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    alias.hash(&mut hasher);
+    let max_ms = u64::try_from(base.as_millis()).unwrap_or(u64::MAX) / 4 + 1;
+    Duration::from_millis(hasher.finish() % max_ms)
+}
+
+fn audit_operation(host: &str, operation: &str, body_bytes: usize) {
+    tracing::info!(
+        fleet_host = host,
+        fleet_operation = operation,
+        body_bytes,
+        "fleet control request"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use muxa::event::{AgentEvent, AgentId, AgentKind, AgentState};
+    use muxa::state::Store;
+
+    #[test]
+    fn ssh_errors_are_classified_without_ansi_controls() {
+        assert_eq!(
+            classify_error("Permission denied (publickey)"),
+            FleetHostState::AuthFailed
+        );
+        assert_eq!(
+            classify_error("fleet protocol mismatch"),
+            FleetHostState::VersionSkew
+        );
+        assert_eq!(classify_error("connection reset"), FleetHostState::Offline);
+        assert_eq!(sanitize_remote_error("\u{1b}[31mboom\u{1b}[0m"), "boom");
+        let unicode = sanitize_remote_error(&"가".repeat(400));
+        assert!(unicode.ends_with('…'));
+        assert!(unicode.len() <= FLEET_MAX_DIAGNOSTIC_BYTES + '…'.len_utf8());
+    }
+
+    #[test]
+    fn reconnect_jitter_is_stable_and_bounded() {
+        let base = Duration::from_secs(4);
+        let first = deterministic_jitter("dev", base);
+        assert_eq!(first, deterministic_jitter("dev", base));
+        assert!(first <= Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn newer_transition_state_overlays_a_slow_full_snapshot() {
+        let store = Store::shared();
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    kind: AgentKind::Codex,
+                    session_id: "agent-1".into(),
+                    surface: None,
+                    pane: Some("%1".into()),
+                    tmux_socket: Some("default".into()),
+                    cwd: Some("/tmp/project".into()),
+                },
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+        let original = store.snapshot().await.pop().unwrap();
+        let mut transitioned = original.clone();
+        transitioned.state = AgentState::Working;
+        let mut other = original.clone();
+        other.session_id = "agent-2".into();
+        let now = OffsetDateTime::now_utc();
+        let current = muxa::fleet::RemoteSnapshot {
+            revision: 2,
+            observed_at: now,
+            agents: vec![transitioned],
+            panes: Vec::new(),
+            sessions: Vec::new(),
+            backends: Vec::new(),
+        };
+        let stale_scan = muxa::fleet::RemoteSnapshot {
+            revision: 1,
+            observed_at: now - time::Duration::SECOND,
+            agents: vec![original, other],
+            panes: Vec::new(),
+            sessions: Vec::new(),
+            backends: Vec::new(),
+        };
+
+        let merged = merge_remote_snapshot(Some(current), stale_scan);
+        assert_eq!(merged.revision, 2);
+        assert_eq!(merged.agents.len(), 2);
+        assert_eq!(
+            merged
+                .agents
+                .iter()
+                .find(|agent| agent.session_id == "agent-1")
+                .unwrap()
+                .state,
+            AgentState::Working
+        );
+    }
+
+    #[test]
+    fn command_deadlines_release_pending_callers() {
+        let (reply, mut response) = oneshot::channel();
+        let now = Instant::now();
+        let mut pending = HashMap::from([(
+            "request".into(),
+            PendingRequest {
+                reply: PendingReply::Command(reply),
+                deadline: now,
+            },
+        )]);
+        expire_pending(&mut pending, now, 7);
+        assert!(pending.is_empty());
+        let error = response.try_recv().unwrap().unwrap_err();
+        assert_eq!(error, "remote command timed out after 7 seconds");
+    }
+}

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -162,8 +162,6 @@ async fn main() -> Result<()> {
     let collaboration = build_collaboration(&cfg).await;
     let collaboration_audit = build_collaboration_audit(&cfg);
     let ask = build_ask(&cfg).await;
-    let (fleet_runtime, fleet_handle) =
-        fleet_manager::start(&cfg.fleet, shutdown_tx.subscribe()).await;
 
     // The set of backends this daemon observes simultaneously — tmux + herdr
     // during a migration (see `docs/MULTI_HOST.md`). Resolution honors
@@ -208,6 +206,18 @@ async fn main() -> Result<()> {
     // operator sees rich rows for those panes immediately on restart
     // instead of `synthetic-%X` placeholders.
     enrich_from_history(&store, &history, &backends).await;
+
+    // The controller node is always a first-class Fleet host, even when
+    // outbound SSH connections are disabled. Start after hydration so its
+    // first published snapshot already contains restored local agents.
+    let (fleet_runtime, fleet_handle) = fleet_manager::start(
+        &cfg.fleet,
+        store.clone(),
+        backends.clone(),
+        restart.generation(),
+        shutdown_tx.subscribe(),
+    )
+    .await;
 
     let (activity_log, activity_writer_handle) =
         build_activity_log(&cfg, &writer_shutdown_tx).await;
@@ -311,7 +321,7 @@ async fn main() -> Result<()> {
             activity_path: dashboard_activity_path,
             session_activity_path: dashboard_session_activity_path,
             stats_config: dashboard_stats_config,
-            fleet: fleet_runtime.clone(),
+            fleet: Some(fleet_runtime.clone()),
         };
         tokio::spawn(async move {
             if let Err(e) = muxa::dashboard::serve(
@@ -346,7 +356,7 @@ async fn main() -> Result<()> {
         .find(|b| b.kind() == muxa::HostKind::Zellij)
         .cloned()
         .unwrap_or_else(|| primary.clone());
-    let mut server = Server::new(socket.clone(), store)
+    let server = Server::new(socket.clone(), store)
         .with_backend(ipc_backend)
         // The full observed set, so control methods (`send_prompt`,
         // `capture`) resolve the backend per pane-id namespace. `backends`
@@ -357,10 +367,8 @@ async fn main() -> Result<()> {
         .with_collaboration(collaboration)
         .with_collaboration_audit(collaboration_audit)
         .with_ask(ask)
+        .with_fleet(fleet_runtime)
         .with_restart_controller(Arc::clone(&restart));
-    if let Some(fleet) = fleet_runtime {
-        server = server.with_fleet(fleet);
-    }
     let handle = tokio::spawn(server.run(shutdown_tx.subscribe()));
 
     // Harden socket permissions once the listener exists. We poll briefly
@@ -412,7 +420,7 @@ async fn main() -> Result<()> {
     await_shutdown_task("history compaction", history_compaction_handle).await;
     await_shutdown_task("activity compaction", activity_compaction_handle).await;
     await_shutdown_task("collaboration waker", collaboration_waker_handle).await;
-    await_shutdown_task("fleet manager", fleet_handle).await;
+    await_shutdown_task("fleet manager", Some(fleet_handle)).await;
 
     let _ = activity_transition_shutdown_tx.send(());
     await_shutdown_task("activity transition", activity_transition_handle).await;

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -35,6 +35,7 @@ use std::sync::Arc;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::broadcast;
 
+mod fleet_manager;
 mod herdr_bridge;
 mod screen_detect;
 mod synthetic;
@@ -161,6 +162,8 @@ async fn main() -> Result<()> {
     let collaboration = build_collaboration(&cfg).await;
     let collaboration_audit = build_collaboration_audit(&cfg);
     let ask = build_ask(&cfg).await;
+    let (fleet_runtime, fleet_handle) =
+        fleet_manager::start(&cfg.fleet, shutdown_tx.subscribe()).await;
 
     // The set of backends this daemon observes simultaneously — tmux + herdr
     // during a migration (see `docs/MULTI_HOST.md`). Resolution honors
@@ -308,6 +311,7 @@ async fn main() -> Result<()> {
             activity_path: dashboard_activity_path,
             session_activity_path: dashboard_session_activity_path,
             stats_config: dashboard_stats_config,
+            fleet: fleet_runtime.clone(),
         };
         tokio::spawn(async move {
             if let Err(e) = muxa::dashboard::serve(
@@ -342,7 +346,7 @@ async fn main() -> Result<()> {
         .find(|b| b.kind() == muxa::HostKind::Zellij)
         .cloned()
         .unwrap_or_else(|| primary.clone());
-    let server = Server::new(socket.clone(), store)
+    let mut server = Server::new(socket.clone(), store)
         .with_backend(ipc_backend)
         // The full observed set, so control methods (`send_prompt`,
         // `capture`) resolve the backend per pane-id namespace. `backends`
@@ -354,6 +358,9 @@ async fn main() -> Result<()> {
         .with_collaboration_audit(collaboration_audit)
         .with_ask(ask)
         .with_restart_controller(Arc::clone(&restart));
+    if let Some(fleet) = fleet_runtime {
+        server = server.with_fleet(fleet);
+    }
     let handle = tokio::spawn(server.run(shutdown_tx.subscribe()));
 
     // Harden socket permissions once the listener exists. We poll briefly
@@ -405,6 +412,7 @@ async fn main() -> Result<()> {
     await_shutdown_task("history compaction", history_compaction_handle).await;
     await_shutdown_task("activity compaction", activity_compaction_handle).await;
     await_shutdown_task("collaboration waker", collaboration_waker_handle).await;
+    await_shutdown_task("fleet manager", fleet_handle).await;
 
     let _ = activity_transition_shutdown_tx.send(());
     await_shutdown_task("activity transition", activity_transition_handle).await;

--- a/docs/ARCHITECTURE.ko.md
+++ b/docs/ARCHITECTURE.ko.md
@@ -42,6 +42,9 @@ local muxad로 향하는 OpenSSH stdio relay 하나를 소유하고 자신의
 `FleetStore` entry만 갱신합니다. remote agent는 local `Store`에 넣지 않으므로 local
 reconcile, pane-id 재사용, GC가 다른 node의 truth를 손상시키지 않습니다.
 [FLEET.ko.md](FLEET.ko.md)를 참고하세요.
+local-only Fleet watch는 native watch runtime을 그대로 사용합니다. multi-node path는
+IPC로 `FleetStore` invalidation을 구독해 coalesce하고 revision이 바뀐 host topology만
+재구성하며, 느린 full-snapshot reconcile poll을 함께 유지합니다.
 
 ## Components
 

--- a/docs/ARCHITECTURE.ko.md
+++ b/docs/ARCHITECTURE.ko.md
@@ -36,6 +36,12 @@ agent hook/status event
 CLI는 live state를 socket으로 읽고, history/reporting view는 retained local
 file도 함께 사용합니다.
 
+`[fleet]`을 켜면 controller daemon에 별도의 physical-node plane이 추가됩니다. host별
+task가 remote user의 local muxad로 향하는 OpenSSH stdio relay 하나를 소유하고 자신의
+`FleetStore` entry만 갱신합니다. remote agent는 local `Store`에 넣지 않으므로 local
+reconcile, pane-id 재사용, GC가 다른 node의 truth를 손상시키지 않습니다.
+[FLEET.ko.md](FLEET.ko.md)를 참고하세요.
+
 ## Components
 
 | Component | 역할 |
@@ -45,6 +51,7 @@ file도 함께 사용합니다.
 | Agent adapters | Claude/Codex/Gemini hook event를 muxa state transition으로 변환. |
 | tmux backend | pane/session, pane capture, foreground session activity 조회. |
 | Activity ledger | state/tmux/human interval의 append-only duration source. |
+| FleetManager | 독립 SSH relay state machine, node identity/권한, revision reconcile, host별 cache. |
 
 ## Data Files
 
@@ -55,6 +62,7 @@ file도 함께 사용합니다.
 | `activity.ndjson` | append-only duration ledger. |
 | `session-activity.json` | legacy/compat tmux foreground total. |
 | `collaboration.json` | same-window mailbox와 exact-session alias/role snapshot. |
+| `host-id` | Fleet handshake에 쓰는 owner-only stable physical-node UUID. |
 
 경로는 설정 가능하며 기본값은 `$XDG_DATA_HOME/muxa` 아래입니다.
 
@@ -66,6 +74,8 @@ file도 함께 사용합니다.
   `public_read`는 익명 조회를 허용하되 변경에는 PAT를 요구하고, `none`은
   조회만 허용하며 변경 기능을 비활성화합니다.
 - External sink는 opt-in입니다.
+- Fleet은 fixed SSH command token을 사용하고 forwarding을 끄며 exact global pane identity를
+  검증합니다. host는 observe-only가 기본이고 remote network listener를 열지 않습니다.
 - Rust `unsafe`는 금지되어 있습니다.
 
 ## Shutdown

--- a/docs/ARCHITECTURE.ko.md
+++ b/docs/ARCHITECTURE.ko.md
@@ -36,8 +36,9 @@ agent hook/status event
 CLI는 live state를 socket으로 읽고, history/reporting view는 retained local
 file도 함께 사용합니다.
 
-`[fleet]`을 켜면 controller daemon에 별도의 physical-node plane이 추가됩니다. host별
-task가 remote user의 local muxad로 향하는 OpenSSH stdio relay 하나를 소유하고 자신의
+controller daemon은 항상 별도의 physical-node plane을 만들고 in-process Store/backend에서
+자신의 `local` node를 게시합니다. `[fleet]`을 켜면 remote host별 task가 remote user의
+local muxad로 향하는 OpenSSH stdio relay 하나를 소유하고 자신의
 `FleetStore` entry만 갱신합니다. remote agent는 local `Store`에 넣지 않으므로 local
 reconcile, pane-id 재사용, GC가 다른 node의 truth를 손상시키지 않습니다.
 [FLEET.ko.md](FLEET.ko.md)를 참고하세요.
@@ -51,7 +52,7 @@ reconcile, pane-id 재사용, GC가 다른 node의 truth를 손상시키지 않�
 | Agent adapters | Claude/Codex/Gemini hook event를 muxa state transition으로 변환. |
 | tmux backend | pane/session, pane capture, foreground session activity 조회. |
 | Activity ledger | state/tmux/human interval의 append-only duration source. |
-| FleetManager | 독립 SSH relay state machine, node identity/권한, revision reconcile, host별 cache. |
+| FleetManager | always-present local adapter, 독립 SSH relay state machine, node identity/권한, revision reconcile, host별 cache. |
 
 ## Data Files
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,6 +41,12 @@ The CLI reads live daemon state over the socket and local retained files
 for history/reporting views, and can drive agents back through the socket
 (`send_prompt`/`capture`, exposed to other agents via `muxa mcp`).
 
+With `[fleet]` enabled, the controller daemon adds a separate physical-node
+plane. Each host task owns one OpenSSH stdio relay to the remote user's local
+muxad and writes only to its own `FleetStore` entry. Remote agents are never
+inserted into the local `Store`, so local reconciliation, pane-id reuse, and GC
+cannot corrupt another node's truth. See [FLEET.md](FLEET.md).
+
 ## Components
 
 | Component | Role |
@@ -52,6 +58,7 @@ for history/reporting views, and can drive agents back through the socket
 | herdr bridge | Translates herdr's own `agent_status` stream into synthetic rows for agents muxa has no hooks for. |
 | Screen detection | Classifies hook-less agents (cursor, amp, …) from pane captures against TOML manifests; synthetic, hook-authoritative. |
 | Activity ledger | Append-only duration source for state/foreground/human intervals. |
+| FleetManager | Independent SSH relay state machines, node identity, authorization, revision reconciliation, and per-host caches. |
 
 Precedence when several producers describe one pane: **hooks > herdr
 bridge > screen detection** — synthetic rows are evicted the moment a real
@@ -66,6 +73,7 @@ hook claims the pane.
 | `activity.ndjson` | Append-only duration ledger. |
 | `session-activity.json` | Legacy/compat tmux foreground totals. |
 | `collaboration.json` | Durable same-window mailbox plus exact-session aliases and roles. |
+| `host-id` | Owner-only stable physical-node UUID used by Fleet handshakes. |
 
 Paths are configurable; defaults live under `$XDG_DATA_HOME/muxa`.
 
@@ -77,6 +85,9 @@ Paths are configurable; defaults live under `$XDG_DATA_HOME/muxa`.
   exposes anonymous reads while requiring a PAT for mutations; `none` exposes
   reads with mutations disabled.
 - External sinks are opt-in.
+- Fleet uses fixed SSH command tokens, disables forwarding, validates exact
+  global pane identities, defaults hosts to observe-only, and never opens a
+  remote network listener.
 - The codebase forbids unsafe Rust.
 
 ## Shutdown

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,6 +47,10 @@ its own `local` node directly from the in-process Store/backends. With
 remote user's local muxad and writes only to its own `FleetStore` entry. Remote agents are never
 inserted into the local `Store`, so local reconciliation, pane-id reuse, and GC
 cannot corrupt another node's truth. See [FLEET.md](FLEET.md).
+The local-only Fleet watch path reuses the native watch runtime directly. The
+multi-node path subscribes to `FleetStore` invalidations over IPC, coalesces
+them, and reconstructs only revision-changed host topologies while retaining a
+slow full-snapshot reconciliation poll.
 
 ## Components
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,9 +41,10 @@ The CLI reads live daemon state over the socket and local retained files
 for history/reporting views, and can drive agents back through the socket
 (`send_prompt`/`capture`, exposed to other agents via `muxa mcp`).
 
-With `[fleet]` enabled, the controller daemon adds a separate physical-node
-plane. Each host task owns one OpenSSH stdio relay to the remote user's local
-muxad and writes only to its own `FleetStore` entry. Remote agents are never
+The controller daemon always adds a separate physical-node plane and publishes
+its own `local` node directly from the in-process Store/backends. With
+`[fleet]` enabled, each remote host task owns one OpenSSH stdio relay to the
+remote user's local muxad and writes only to its own `FleetStore` entry. Remote agents are never
 inserted into the local `Store`, so local reconciliation, pane-id reuse, and GC
 cannot corrupt another node's truth. See [FLEET.md](FLEET.md).
 
@@ -58,7 +59,7 @@ cannot corrupt another node's truth. See [FLEET.md](FLEET.md).
 | herdr bridge | Translates herdr's own `agent_status` stream into synthetic rows for agents muxa has no hooks for. |
 | Screen detection | Classifies hook-less agents (cursor, amp, …) from pane captures against TOML manifests; synthetic, hook-authoritative. |
 | Activity ledger | Append-only duration source for state/foreground/human intervals. |
-| FleetManager | Independent SSH relay state machines, node identity, authorization, revision reconciliation, and per-host caches. |
+| FleetManager | Always-present local adapter plus independent SSH relay state machines, node identity, authorization, revision reconciliation, and per-host caches. |
 
 Precedence when several producers describe one pane: **hooks > herdr
 bridge > screen detection** — synthetic rows are evicted the moment a real

--- a/docs/COLLABORATION.ko.md
+++ b/docs/COLLABORATION.ko.md
@@ -196,6 +196,8 @@ watch composer는 `? QUESTION`, `◆ REVIEW`, `▶ TASK`, `! NOTICE`를 서로 �
 | --- | --- |
 | `muxa_collaboration_guide` | reviewer/question/subagent/AIR 전달의 권장 계약 조회 |
 | `muxa_room_context` | self, same-window peers, unread count 조회 |
+| `muxa_call_peer` | 등록 스킬 확장, peer 선택, durable 요청, 선택적 응답 대기, 확인 후 agent 생성 |
+| `muxa_peer_report` | 이전 peer 요청의 최신 완료 보고 또는 정확한 request id 조회 |
 | `muxa_set_identity` | 현재 agent session의 room-local alias/roles 교체 |
 | `muxa_send_message` | durable request 생성 |
 | `muxa_inbox` | 현재 agent session의 요청 claim/read |
@@ -203,6 +205,33 @@ watch composer는 `? QUESTION`, `◆ REVIEW`, `▶ TASK`, `! NOTICE`를 서로 �
 | `muxa_reply` | completed/blocked/declined/failed 구조화 응답 |
 | `muxa_wait_reply` | 요청의 terminal reply 대기 |
 | `muxa_cancel_message` | 아직 queued인 발신 요청 취소 |
+
+## Agent 대화에서 자연스럽게 호출하기
+
+`muxa mcp`에 연결된 Claude나 Codex agent는 `@peer`와 `@muxa-peer`를 Muxa 협업
+전용 표현으로 취급합니다. `@codex` 같은 provider, 고유한 `@alias`, `role:name`,
+또는 자연어로 동료에게 새 작업을 요청하는 표현은 `muxa_call_peer`로 변환합니다.
+`/name`으로 등록 스킬을 함께 지정할 수 있습니다.
+
+```text
+@peer 현재 변경사항을 리뷰해줘
+@codex /review-plan-feedback commit abc123을 context로 사용해줘
+```
+
+“`@peer`의 보고”, “peer 응답”, “peer 지적을 해결해”처럼 기존 결과를 가리키는
+표현은 먼저 `muxa_peer_report`로 실제 구조화된 mailbox 응답을 읽습니다. 사용자가
+제공했거나 이미 확인된 context에 명시적인 PR 번호나 GitHub PR URL이 없다면
+GitHub PR/review 도구를 호출하거나 PR을 추측해서는 안 됩니다. repository나 cwd만
+알고 있는 것은 충분한 근거가 아닙니다. Muxa 도구가 보이지 않을 때의 복구 방법은
+agent 재시작이며 GitHub를 대체 transport로 사용하지 않습니다.
+
+이 고수준 도구는 아래 mailbox 의미를 유지하면서 model이 여러 저수준 호출을 직접
+조립하지 않아도 되게 합니다. 기본값은 `kind=review`,
+`work_mode=read_only`이며 정상 peer를 결정적으로 선택하고 구조화된 응답을
+기다립니다. execute mode에는 명시적인 task 승인이 필요합니다. 적합한 peer가 없을
+때 Muxa는 자동으로 만들지 않고 확인을 요청하며, 사용자가 승인한 뒤에만
+`spawn_if_missing=true`로 다시 호출할 수 있습니다. MCP process는 시작할 때 도구와
+스킬을 읽으므로 스킬 변경이나 Muxa 업그레이드 뒤에는 기존 agent를 재시작하세요.
 
 일반적인 흐름:
 

--- a/docs/COLLABORATION.md
+++ b/docs/COLLABORATION.md
@@ -171,6 +171,8 @@ worktrees remain the safest choice for concurrent edits.
 | --- | --- |
 | `muxa_collaboration_guide` | Retrieve reviewer, question, delegated-subagent, and AIR handoff contracts. |
 | `muxa_room_context` | Identify self, list same-window peers, and show unread count. |
+| `muxa_call_peer` | Expand a registered skill, select a peer, send a durable request, optionally wait, and explicitly spawn when confirmed. |
+| `muxa_peer_report` | Read the newest completed report from a prior peer request, or retrieve an exact request id. |
 | `muxa_set_identity` | Replace this exact session's room-local alias and roles. |
 | `muxa_send_message` | Create a durable peer request. |
 | `muxa_inbox` | Claim/read requests for this exact agent session. |
@@ -178,6 +180,37 @@ worktrees remain the safest choice for concurrent edits.
 | `muxa_reply` | Return a completed/blocked/declined/failed response. |
 | `muxa_wait_reply` | Wait for the structured terminal response. |
 | `muxa_cancel_message` | Cancel a sent request while it is still queued. |
+
+## Natural calls from an agent conversation
+
+A Claude or Codex agent connected to `muxa mcp` treats `@peer` and
+`@muxa-peer` as reserved Muxa collaboration expressions. Provider mentions such
+as `@codex`, a unique `@alias`, `role:name`, or a natural “call a colleague”
+request for new work map to `muxa_call_peer`. A registered skill can be included
+as `/name`:
+
+```text
+@peer review the current changes
+@codex /review-plan-feedback using commit abc123 as context
+```
+
+Possessive references such as “`@peer`'s report”, “the peer reply”, or “resolve
+the peer findings” map to `muxa_peer_report` first, so the agent evaluates the
+actual structured mailbox response rather than fabricating external review
+state. Without an explicit PR number or GitHub PR URL in user-provided or
+grounded context, peer review language must not invoke GitHub PR/review tools or
+invent a PR; repository/cwd context alone is insufficient. If Muxa tools are
+unavailable, the correct recovery is to restart the agent, never to substitute
+GitHub.
+
+The high-level tool keeps the mailbox semantics below while removing the need
+for the model to compose several low-level calls. It defaults to
+`kind=review`, `work_mode=read_only`, selects a healthy peer deterministically,
+and waits for the structured reply. Execute mode requires an explicit task
+authorization. If no eligible peer exists, Muxa asks for confirmation instead
+of silently creating one; `spawn_if_missing=true` is valid only after that
+confirmation. Restart existing agents after changing skills or upgrading Muxa
+because their MCP process loads tools and templates at startup.
 
 ## Reviewers and delegated subagents
 

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -217,6 +217,47 @@ stale state가 오래 남는 것을 줄입니다. timeout 값 `0`은 해당 time
 같은 루프가 pid-liveness 스윕도 돌려, 등록된 백그라운드 task(`muxa register` 참고)는
 프로세스가 종료되면 `stopped`로 전환됩니다.
 
+## Fleet
+
+```toml
+[fleet]
+enabled = true
+refresh_secs = 15
+keepalive_secs = 10
+offline_after_secs = 30
+connect_timeout_secs = 10
+command_timeout_secs = 10
+max_parallel_connects = 6
+capture_policy = "selected" # selected | never
+
+[fleet.hosts.dev]
+ssh = "muxa-devbox"
+muxa_path = "muxa"
+enabled = true
+connect = "auto"            # auto | on_demand
+mode = "observe"            # observe | control
+# remote_socket = "/run/user/1000/muxa.sock"
+
+[fleet.hosts.dev.labels]
+environment = "development"
+region = "icn"
+
+[fleet.hosts.dev.annotations]
+"muxa.dev/owner" = "platform"
+```
+
+Fleet은 활성 physical host마다 persistent OpenSSH stdio relay 하나를 유지합니다.
+`offline_after_secs`는 `keepalive_secs`의 두 배 이상이어야 하며 timeout/concurrency 값은
+0일 수 없습니다. `capture_policy = "never"`는 control host에서도 pane/window capture를
+manager 단계에서 차단합니다.
+
+`ssh`에는 flag가 아닌 OpenSSH destination/Host alias를 씁니다. port, identity,
+ProxyJump, host-key 정책은 `~/.ssh/config`에 둡니다. `muxa_path`와 `remote_socket`은
+fixed remote command token으로 검증됩니다. label은 Kubernetes-style selector에 쓰고,
+annotation은 설명형 value를 허용하지만 같은 namespaced key 문법을 사용합니다.
+inventory는 `muxa host add/label/annotate`로 atomic하게 편집하는 것을 권장합니다.
+[FLEET.ko.md](FLEET.ko.md)를 참고하세요.
+
 ## Dashboard
 
 ```toml

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -104,7 +104,7 @@ agent를 정확한 pane id로 지정할 수 있습니다.
 ## 메시지 스킬
 
 반복해서 쓰는 prompt 템플릿은 일반 TOML table에 저장하며 watch와 dashboard의
-`m` composer, watch의 `a` composer가 함께 사용합니다.
+`m` composer, watch의 `a` composer, MCP의 `muxa_call_peer`가 함께 사용합니다.
 
 ```toml
 [message.skills]
@@ -128,6 +128,11 @@ muxa skill remove agent-review
 확인 후 삭제할 수 있습니다. 기존 `Ctrl-A`, `Ctrl-D`도 호환 alias로 유지합니다.
 multi-line 템플릿은 CLI add 명령의 prompt
 자리에 `-`를 넘겨 stdin으로 등록할 수 있습니다.
+
+MCP가 연결된 agent 대화에서는 `/name`으로 같은 템플릿을 `muxa_call_peer`에
+선택할 수 있고, 선택적인 body와 context가 템플릿을 바꾸지 않은 채 뒤에
+추가됩니다. MCP process는 시작할 때 스킬 table을 읽으므로 스킬을 추가·수정·삭제한
+뒤에는 실행 중인 agent를 재시작하세요.
 
 스킬은 prompt 본문만 저장합니다. request kind, collaboration mode, agent, cwd,
 timeout, permission scope를 포함하지 않습니다. `m`에서는 현재 선택한 kind/mode가

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -221,7 +221,7 @@ stale state가 오래 남는 것을 줄입니다. timeout 값 `0`은 해당 time
 
 ```toml
 [fleet]
-enabled = true
+enabled = true              # outbound SSH host; local은 항상 표시
 refresh_secs = 15
 keepalive_secs = 10
 offline_after_secs = 30
@@ -229,6 +229,12 @@ connect_timeout_secs = 10
 command_timeout_secs = 10
 max_parallel_connects = 6
 capture_policy = "selected" # selected | never
+
+[fleet.local.labels]
+environment = "development"
+
+[fleet.local.annotations]
+"muxa.dev/owner" = "platform"
 
 [fleet.hosts.dev]
 ssh = "muxa-devbox"
@@ -246,7 +252,9 @@ region = "icn"
 "muxa.dev/owner" = "platform"
 ```
 
-Fleet은 활성 physical host마다 persistent OpenSSH stdio relay 하나를 유지합니다.
+Fleet은 controller를 첫 번째 `local` host로 항상 in-process 게시하며 `enabled = false`여도
+사용할 수 있습니다. 이 flag는 outbound SSH host만 제어합니다. 활성 remote physical
+host마다 persistent OpenSSH stdio relay 하나를 유지합니다.
 `offline_after_secs`는 `keepalive_secs`의 두 배 이상이어야 하며 timeout/concurrency 값은
 0일 수 없습니다. `capture_policy = "never"`는 control host에서도 pane/window capture를
 manager 단계에서 차단합니다.
@@ -256,6 +264,8 @@ ProxyJump, host-key 정책은 `~/.ssh/config`에 둡니다. `muxa_path`와 `remo
 fixed remote command token으로 검증됩니다. label은 Kubernetes-style selector에 쓰고,
 annotation은 설명형 value를 허용하지만 같은 namespaced key 문법을 사용합니다.
 inventory는 `muxa host add/label/annotate`로 atomic하게 편집하는 것을 권장합니다.
+controller metadata는 `muxa host label local`, `muxa host annotate local`로 관리하며
+muxad가 제공하는 identity label은 덮어쓸 수 없습니다.
 [FLEET.ko.md](FLEET.ko.md)를 참고하세요.
 
 ## Dashboard

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -107,7 +107,8 @@ See [COLLABORATION.md](COLLABORATION.md).
 ## Message skills
 
 Reusable prompt templates live in a regular TOML table. They are shared by the
-watch and dashboard `m` composers and the watch `a` composer:
+watch and dashboard `m` composers, the watch `a` composer, and MCP
+`muxa_call_peer` requests:
 
 ```toml
 [message.skills]
@@ -130,6 +131,11 @@ send. Multiple skills can be combined in one draft. In `muxa watch`, `F2` opens
 an add/update form inside the palette and `Delete` removes the selected skill
 after confirmation. `Ctrl-A` and `Ctrl-D` remain compatibility aliases.
 Pass `-` as the CLI add prompt to read a multi-line template from stdin.
+
+In an MCP-connected agent conversation, `/name` selects the same template for
+`muxa_call_peer`; its optional body and context are appended without changing
+the template. The MCP process loads the skill table at startup, so restart an
+already-running agent after adding, updating, or removing a skill.
 
 A skill stores prompt text only. It has no request kind, collaboration mode,
 agent, cwd, timeout, or permission scope of its own. The `m` composer keeps its

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -223,6 +223,47 @@ values of `0` disable that timeout. The same loop also runs the pid-liveness
 sweep that flips registered background tasks (see `muxa register`) to
 `stopped` once their process exits.
 
+## Fleet
+
+```toml
+[fleet]
+enabled = true
+refresh_secs = 15
+keepalive_secs = 10
+offline_after_secs = 30
+connect_timeout_secs = 10
+command_timeout_secs = 10
+max_parallel_connects = 6
+capture_policy = "selected" # selected | never
+
+[fleet.hosts.dev]
+ssh = "muxa-devbox"
+muxa_path = "muxa"
+enabled = true
+connect = "auto"            # auto | on_demand
+mode = "observe"            # observe | control
+# remote_socket = "/run/user/1000/muxa.sock"
+
+[fleet.hosts.dev.labels]
+environment = "development"
+region = "icn"
+
+[fleet.hosts.dev.annotations]
+"muxa.dev/owner" = "platform"
+```
+
+Fleet maintains one persistent OpenSSH stdio relay per enabled physical host.
+`offline_after_secs` must be at least twice `keepalive_secs`, and all timeout
+and concurrency values must be non-zero. `capture_policy = "never"` disables
+both pane and window capture at the manager even on control hosts.
+
+`ssh` is an OpenSSH destination/Host alias, not a place for flags. Put port,
+identity, ProxyJump, and host-key policy in `~/.ssh/config`. `muxa_path` and
+`remote_socket` are validated as fixed remote command tokens. Labels implement
+Kubernetes-style selectors; annotations allow descriptive values but use the
+same namespaced key syntax. Prefer `muxa host add/label/annotate` to edit the
+inventory atomically. See [FLEET.md](FLEET.md).
+
 ## Dashboard
 
 ```toml

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -227,7 +227,7 @@ sweep that flips registered background tasks (see `muxa register`) to
 
 ```toml
 [fleet]
-enabled = true
+enabled = true              # outbound SSH hosts; local is always visible
 refresh_secs = 15
 keepalive_secs = 10
 offline_after_secs = 30
@@ -235,6 +235,12 @@ connect_timeout_secs = 10
 command_timeout_secs = 10
 max_parallel_connects = 6
 capture_policy = "selected" # selected | never
+
+[fleet.local.labels]
+environment = "development"
+
+[fleet.local.annotations]
+"muxa.dev/owner" = "platform"
 
 [fleet.hosts.dev]
 ssh = "muxa-devbox"
@@ -252,7 +258,10 @@ region = "icn"
 "muxa.dev/owner" = "platform"
 ```
 
-Fleet maintains one persistent OpenSSH stdio relay per enabled physical host.
+Fleet always publishes the controller as the first `local` host using an
+in-process snapshot; this remains available with `enabled = false`. The flag
+controls outbound SSH hosts. Fleet maintains one persistent OpenSSH stdio
+relay per enabled remote physical host.
 `offline_after_secs` must be at least twice `keepalive_secs`, and all timeout
 and concurrency values must be non-zero. `capture_policy = "never"` disables
 both pane and window capture at the manager even on control hosts.
@@ -262,7 +271,9 @@ identity, ProxyJump, and host-key policy in `~/.ssh/config`. `muxa_path` and
 `remote_socket` are validated as fixed remote command tokens. Labels implement
 Kubernetes-style selectors; annotations allow descriptive values but use the
 same namespaced key syntax. Prefer `muxa host add/label/annotate` to edit the
-inventory atomically. See [FLEET.md](FLEET.md).
+inventory atomically. Use `muxa host label local` and `muxa host annotate
+local` for controller metadata; muxad-managed identity labels cannot be
+overridden. See [FLEET.md](FLEET.md).
 
 ## Dashboard
 

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -20,7 +20,7 @@ machine without explicit public-bind acknowledgement.
 | `GET /api/health`   | `{ ok, version, protocol }`                                                    |
 | `GET /api/access`   | Current read/control access mode and whether the supplied PAT can edit.        |
 | `GET /api/agents`   | Current `Store` snapshot.                                                      |
-| `GET /api/fleet?selector=...` | Cached physical-host hierarchy, optionally label-filtered.          |
+| `GET /api/fleet?selector=...` | Cached hierarchy, including the always-present local node.          |
 | `GET /api/panes`    | Global tmux pane list (every readable socket), with per-socket scan errors.   |
 | `GET /api/terminal-sessions` | Muxa-owned PTY sessions.                                           |
 | `GET /api/timeline` | Timeline document from `activity.ndjson` plus currently-open agent/tmux spans. |
@@ -35,8 +35,9 @@ machine without explicit public-bind acknowledgement.
 GET/SSE endpoints public but always requires the bearer token for POST control
 actions. `auth = "none"` leaves reads public and disables POST control entirely.
 Static routes are public in every mode — see "Why the HTML is public" below.
-Fleet routes exist only when `[fleet] enabled = true`; reads reuse the daemon's
-per-host cache and never create request-scoped SSH connections. See
+Fleet routes always expose the in-process `local` node. `[fleet] enabled =
+true` adds outbound SSH hosts; reads reuse the daemon's per-host cache and
+never create request-scoped SSH connections. See
 [FLEET.md](FLEET.md).
 
 ## Quick start

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -20,12 +20,14 @@ machine without explicit public-bind acknowledgement.
 | `GET /api/health`   | `{ ok, version, protocol }`                                                    |
 | `GET /api/access`   | Current read/control access mode and whether the supplied PAT can edit.        |
 | `GET /api/agents`   | Current `Store` snapshot.                                                      |
+| `GET /api/fleet?selector=...` | Cached physical-host hierarchy, optionally label-filtered.          |
 | `GET /api/panes`    | Global tmux pane list (every readable socket), with per-socket scan errors.   |
 | `GET /api/terminal-sessions` | Muxa-owned PTY sessions.                                           |
 | `GET /api/timeline` | Timeline document from `activity.ndjson` plus currently-open agent/tmux spans. |
 | `GET /api/events`   | SSE stream: `snapshot` (initial), `transition` (live), `lagged` (backpressure)|
 | `POST /api/panes/{pane}/prompt` | Send and optionally submit text to a pane.                       |
 | `POST /api/panes/{pane}/abort` | Send Ctrl-C to a pane.                                             |
+| `POST /api/fleet/{host}/command` | Execute a serialized Fleet operation; host mode is rechecked.   |
 | `POST /api/terminal-sessions/{id}/input` | Send input to a Muxa-owned PTY.                         |
 | `POST /api/terminal-sessions/{id}/terminate` | Terminate a Muxa-owned PTY.                          |
 
@@ -33,6 +35,9 @@ machine without explicit public-bind acknowledgement.
 GET/SSE endpoints public but always requires the bearer token for POST control
 actions. `auth = "none"` leaves reads public and disables POST control entirely.
 Static routes are public in every mode — see "Why the HTML is public" below.
+Fleet routes exist only when `[fleet] enabled = true`; reads reuse the daemon's
+per-host cache and never create request-scoped SSH connections. See
+[FLEET.md](FLEET.md).
 
 ## Quick start
 

--- a/docs/FLEET.ko.md
+++ b/docs/FLEET.ko.md
@@ -1,0 +1,193 @@
+# Muxa Fleet
+
+Muxa Fleet은 기존 session/window/pane 구조 위에 physical host 계층을 더하는
+중앙 control plane입니다.
+
+```text
+local muxad
+  FleetManager
+    ├─ SSH stdio relay ─ host dev ─ session ─ window ─ pane(agent)
+    ├─ SSH stdio relay ─ host gpu ─ session ─ window ─ pane(agent)
+    └─ host별 cache    ─ host prod ─ offline 중 last known snapshot
+```
+
+설정된 host마다 독립적인 OpenSSH process 하나를 유지합니다. 원격에서는
+`muxa relay --stdio`가 실행되어 같은 사용자의 owner-only muxad Unix socket과만
+통신합니다. 원격 TCP port를 열거나 agent socket을 forwarding하지 않으며 terminal
+내용도 상시 복제하지 않습니다.
+
+여기서 Fleet host는 물리 node입니다. 기존 문서에서 사용하던 tmux/rmux/herdr/
+zellij “pane host”는 각 node 내부의 backend kind로 그대로 유지됩니다.
+
+## 준비
+
+- controller와 모든 remote host에 같은 Muxa version을 설치합니다.
+- 각 remote host에서 같은 Unix user로 muxad를 실행합니다.
+- non-interactive OpenSSH 인증과 host-key trust를 먼저 확인합니다.
+- user, port, key, ProxyJump 등 SSH 정책은 `~/.ssh/config`에 둡니다.
+
+```sshconfig
+Host muxa-devbox
+  HostName devbox.example.com
+  User june
+  IdentityFile ~/.ssh/id_ed25519
+  IdentitiesOnly yes
+```
+
+등록 전 transport를 확인할 수 있습니다.
+
+```bash
+ssh -T -o BatchMode=yes muxa-devbox muxa relay --stdio
+```
+
+JSON hello 한 줄이 출력된 뒤 요청을 기다리면 정상입니다. 수동 확인에서는
+`Ctrl-C`로 종료합니다.
+
+## Inventory와 Kubernetes-style metadata
+
+CLI를 사용하면 TOML을 검증하고 atomic하게 변경합니다.
+
+```bash
+muxa host add dev muxa-devbox \
+  --label environment=development \
+  --label region=icn \
+  --annotation muxa.dev/owner=platform \
+  --mode observe
+
+muxa host doctor dev
+muxa host list
+muxa host show dev
+```
+
+첫 host 명령은 `[fleet]`을 활성화합니다. 변경 후에는 연결 목록과 권한 정책이
+함께 다시 로드되도록 muxad self-restart를 요청합니다. daemon에 연결할 수 없으면
+config 변경은 보존하고 수동 restart 안내를 출력합니다.
+
+label은 Kubernetes key/value 규칙을 따르는 selection metadata입니다.
+
+```bash
+muxa host label dev tier=worker accelerator=gpu
+muxa host label dev tier=worker --overwrite
+muxa host label dev accelerator-              # 제거
+muxa host tag dev region=icn                   # label의 visible alias
+```
+
+annotation key도 namespaced key 규칙을 따르지만 value에는 설명이나 URL을 넣을 수
+있습니다.
+
+```bash
+muxa host annotate dev muxa.dev/runbook=https://example.invalid/dev
+```
+
+controller alias는 사람이 읽는 config identity입니다. relay는 별도로
+`$XDG_DATA_HOME/muxa/host-id`에 owner-only stable UUID를 만듭니다. SSH alias,
+hostname, inventory alias를 바꿔도 node identity는 유지됩니다. 동일 UUID를 보고하는
+두 alias가 동시에 연결되면 한 물리 장비를 중복 제어하지 않도록 거부합니다.
+
+지원 selector는 다음과 같습니다.
+
+- `environment=production`, `environment==production`
+- `environment!=production`
+- `region in (icn,nrt)`, `region notin (iad,sfo)`
+- `accelerator`(key 존재), `!accelerator`(key 없음)
+- comma는 AND: `environment=production,region in (icn,nrt)`
+
+## 권한과 연결 정책
+
+각 host는 두 정책을 독립적으로 가집니다.
+
+- `mode = "observe"`: snapshot과 on-demand capture는 허용하지만 prompt 전송은
+  거부합니다. 기본값입니다.
+- `mode = "control"`: exact-pane prompt 전송까지 허용합니다.
+- `connect = "auto"`: bounded exponential backoff로 persistent relay를 유지합니다.
+- `connect = "on_demand"`: `muxa fleet connect` 전까지 연결하지 않습니다.
+
+`muxa host disable`은 metadata를 남기고 연결만 막으며, `muxa host enable`로 다시
+활성화합니다.
+
+## 사용
+
+```bash
+muxa fleet status
+muxa fleet status -l 'environment=production,region in (icn,nrt)'
+muxa fleet status --json
+muxa fleet watch
+muxa watch --fleet --selector 'accelerator=gpu'
+
+muxa fleet connect dev
+muxa fleet disconnect dev
+muxa fleet refresh dev
+muxa fleet panes dev
+muxa fleet capture dev '%12'
+muxa fleet send dev '%12' '현재 결과를 요약해주세요.'
+muxa fleet attach dev '%12'
+```
+
+bare pane id나 `session/window/pane` path는 해당 물리 host의 모든 backend endpoint에서
+유일할 때만 허용합니다. display path도 모호하면 `muxa fleet panes HOST --json`이
+capture/send/attach와 MCP 도구에 그대로 전달할 수 있는 complete `PaneKey` JSON을
+출력합니다. 내부 명령은 완전한 node/backend/session/window/pane identity를 전달하고,
+relay가 control 직전에 fresh pane list로 다시 확인합니다.
+
+Fleet TUI 동작:
+
+- Up/Down은 보이는 모든 structural node를 순회합니다.
+- `j`/`k`는 singleton session/window chain에서도 actionable pane 사이를 바로
+  이동합니다.
+- `h`/`l` 또는 Left/Right는 접기/내리기, Space는 parent toggle입니다.
+- `/` 검색, `a` attention-only, `r` refresh, `c` host 연결/해제입니다.
+- `p` pane capture, `m` exact-pane prompt composer, Enter remote attach, `?` help입니다.
+
+session inspector는 window와 하위 pane을 함께 roll-up합니다. window를 선택하면
+필요할 때만 pane을 capture하고 실제 tmux split geometry로 mosaic를 렌더링합니다.
+접힌 window나 선택하지 않은 window에는 capture를 수행하지 않습니다.
+
+## 상태, 일관성, 성능
+
+host 상태는 `disabled`, `connecting`, `online`, `degraded`, `offline`,
+`auth_failed`, `version_skew`입니다. offline에서도 last good snapshot을 유지합니다.
+새 handshake가 성공하면 예전 remote identity를 먼저 지우고 새 full snapshot을
+받습니다.
+
+snapshot/transition에는 monotonic revision이 있습니다. gap은 degraded로 표시하고
+reconcile하며, subscription을 잃으면 relay를 재연결합니다. keepalive는 조용히 끊긴
+transport를 감지합니다. host마다 task/state/backoff가 독립적이므로 느린 host 하나가
+전체를 막지 않고 `max_parallel_connects`가 동시 SSH handshake를 제한합니다.
+
+central cache에는 agent/topology metadata만 저장합니다. terminal capture는 선택 시에만
+요청하고 크기를 제한하며 control sequence를 제거합니다. window capture의 병렬성과
+payload도 제한됩니다. prompt는 remote shell command에 삽입하지 않고 stdin frame으로만
+보내며 manager audit log에 body를 남기지 않습니다.
+
+mutation은 자동 retry하지 않습니다. 결과는 text delivery와 Enter submit 여부를 따로
+알려 partial acknowledgement 뒤 prompt를 중복 전송하지 않게 합니다.
+
+## 다른 interface
+
+`muxa mcp`는 `muxa_fleet_status`, `muxa_fleet_capture`,
+`muxa_fleet_send_prompt`를 제공합니다. remote 도구는 host와 pane을 명시해야 하며 같은
+observe/control 검사를 거칩니다.
+
+web dashboard를 켜면 read API에 `GET /api/fleet?selector=...`가 추가됩니다.
+`POST /api/fleet/{host}/command`는 serialized `FleetOperation`을 받아 PAT를 요구합니다.
+dashboard `auth = "none"`에서는 기존 정책대로 모든 write가 비활성화됩니다.
+
+durable Muxa collaboration mailbox는 이번 버전에서 physical node local입니다. Fleet
+prompt로 remote agent에게 작업을 요청할 수는 있지만 cross-host `@peer`가 durable reply를
+보장한다고 가장하지 않습니다. 향후 hub transport는 현재 node/pane identity를 바꾸지
+않고 추가할 수 있습니다.
+
+## 보안 checklist
+
+- controller dashboard는 의도적으로 PAT/public bind를 구성한 경우가 아니면
+  loopback-only로 유지합니다.
+- OpenSSH `Host` alias와 `known_hosts`를 검토합니다. Fleet은 `BatchMode=yes`를 쓰며
+  host-key 검사를 끄지 않습니다.
+- Fleet은 `ClearAllForwardings=yes`를 강제하고 agent forwarding을 요청하지 않습니다.
+- 새 host는 observe로 시작하고 필요한 node만 control로 승격합니다.
+- controller의 muxad socket, config, SSH key 접근은 shell-equivalent 권한으로
+  취급합니다.
+- label/annotation에 secret을 넣지 않습니다. inspector에 표시됩니다.
+
+전체 설정은 [CONFIGURATION.ko.md](CONFIGURATION.ko.md), 같은 물리 node 안에서 여러
+backend를 관측하는 기능은 [MULTI_HOST.md](MULTI_HOST.md)를 참고하세요.

--- a/docs/FLEET.ko.md
+++ b/docs/FLEET.ko.md
@@ -179,11 +179,14 @@ multi-node Fleet TUI 동작:
 - `h`/`l` 또는 Left/Right는 접기/내리기, Space는 parent toggle입니다.
 - `/` 검색, `a` attention-only, `r` refresh, `c` remote host 연결/해제입니다.
   `local`에서는 항상 연결됐다는 안내만 표시합니다.
-- `o`/`p` pane capture, `m` exact-pane prompt composer이며 composer의 `/`는 공용
-  message-skill palette를 엽니다. Enter는 `local`이면 직접 이동하고
+- `o`/`p`는 선택 pane을 capture합니다. `m`은 session/window/pane에서 사용할 수
+  있고 parent에서는 live agent가 있는 가장 낮은 index의 pane을 안정적으로
+  선택합니다. composer의 `/`는 공용 message-skill palette를 엽니다. Enter는
+  `local`이면 직접 이동하고
   remote이면 SSH attach하며, `?`는 help입니다.
 - `--view`, `--layout tree|swarm`, `--sort`, `--theme`은 native watch와 같은 값을
-  사용합니다.
+  사용합니다. `focus` 확장은 선택한 view 깊이를 지키고, `manual`은 구조 키로만
+  바뀌며, `j`/`k` 직접 이동은 대상의 ancestor만 엽니다.
 - 기본 설정이 숨기는 pane 없는 agent는 `--include-paneless`로 표시할 수 있습니다.
   별도 행과 Inspector로 상태를 볼 수 있지만 pane 대상 attach/capture/message는
   의도적으로 비활성화됩니다.
@@ -204,11 +207,13 @@ reconcile하며, subscription을 잃으면 relay를 재연결합니다. keepaliv
 transport를 감지합니다. host마다 task/state/backoff가 독립적이므로 느린 host 하나가
 전체를 막지 않고 `max_parallel_connects`가 동시 SSH handshake를 제한합니다.
 
-central TUI는 작은 Fleet cache invalidation을 구독하고 burst를 coalesce한 다음
-selector가 적용된 coherent snapshot을 한 번만 가져옵니다. 최신 daemon에서는 15초의
-느린 reconcile poll만 유지하고 `fleet_subscribe`가 없는 예전 daemon에서는 1초 polling으로
-fallback합니다. idle 화면은 초당 최대 한 번만 그리고 입력이나 상태 변경은 즉시
-반영합니다.
+central TUI는 selector 범위의 작은 Fleet cache invalidation만 구독하고 burst를
+coalesce한 다음 coherent filtered snapshot을 한 번만 가져옵니다. server는 ACK보다
+먼저 stream을 설치하고 client는 직후 fresh snapshot을 가져와 시작 시점의 event 유실을
+막습니다. refresh는 75ms 동안 합치고 초당 최대 4번으로 제한합니다. 최신 daemon에서는
+15초의 느린 reconcile poll만 유지하고 `fleet_subscribe`가 없는 예전 daemon에서는 1초
+polling으로 fallback합니다. idle 화면은 초당 최대 한 번만 그리고 입력이나 상태 변경은
+즉시 반영합니다.
 
 local adapter는 Store transition을 직접 구독하고 `refresh_secs`마다 backend topology를
 갱신합니다. backend scan은 async IPC executor가 아닌 blocking worker에서 실행되며,

--- a/docs/FLEET.ko.md
+++ b/docs/FLEET.ko.md
@@ -131,7 +131,10 @@ local node는 항상 connected/control이며, 아래 설정은 remote inventory�
 ```bash
 muxa fleet status
 muxa fleet status -l 'environment=production,region in (icn,nrt)'
-muxa fleet status --json
+muxa fleet status -o wide
+muxa fleet status -L environment,region
+muxa fleet status --show-labels
+muxa fleet status -o json                 # `--json`도 계속 지원
 muxa fleet watch
 muxa watch --fleet --selector 'accelerator=gpu'
 
@@ -157,7 +160,18 @@ relay가 control 직전에 fresh pane list로 다시 확인합니다.
 local adapter도 같은 exact key 검증을 in-process로 수행하며 attach 시 SSH를 열지 않고
 직접 이동합니다.
 
-Fleet TUI 동작:
+기본 status table은 `HOST/STATE/MODE/AGENTS/PANES/ATTN/AGE`만 표시하며 managed
+label 전체를 보통 터미널 행에 넣지 않습니다. 필요한 label은 `-L`, 전체 label map은
+`--show-labels`, 공간에 맞춘 hostname/version/latency는 `-o wide`, 손실 없는 machine
+interface는 `-o json`으로 봅니다.
+
+selector 결과가 controller의 `local` 하나뿐이면 Fleet watch는 완전한 native
+`muxa watch`로 진입합니다. 불필요한 host row를 추가하지 않으며 기존 Inspector,
+tree/swarm, collaboration/mailbox, ask, preview, command palette, message skill 편집과
+설정 저장을 모두 그대로 사용합니다. 두 번째 physical node가 보일 때만 host 계층을
+표시합니다.
+
+multi-node Fleet TUI 동작:
 
 - Up/Down은 보이는 모든 structural node를 순회합니다.
 - `j`/`k`는 singleton session/window chain에서도 actionable pane 사이를 바로
@@ -165,8 +179,14 @@ Fleet TUI 동작:
 - `h`/`l` 또는 Left/Right는 접기/내리기, Space는 parent toggle입니다.
 - `/` 검색, `a` attention-only, `r` refresh, `c` remote host 연결/해제입니다.
   `local`에서는 항상 연결됐다는 안내만 표시합니다.
-- `p` pane capture, `m` exact-pane prompt composer, Enter는 `local`이면 직접 이동하고
+- `o`/`p` pane capture, `m` exact-pane prompt composer이며 composer의 `/`는 공용
+  message-skill palette를 엽니다. Enter는 `local`이면 직접 이동하고
   remote이면 SSH attach하며, `?`는 help입니다.
+- `--view`, `--layout tree|swarm`, `--sort`, `--theme`은 native watch와 같은 값을
+  사용합니다.
+- 기본 설정이 숨기는 pane 없는 agent는 `--include-paneless`로 표시할 수 있습니다.
+  별도 행과 Inspector로 상태를 볼 수 있지만 pane 대상 attach/capture/message는
+  의도적으로 비활성화됩니다.
 
 session inspector는 window와 하위 pane을 함께 roll-up합니다. window를 선택하면
 필요할 때만 pane을 capture하고 실제 tmux split geometry로 mosaic를 렌더링합니다.
@@ -183,6 +203,12 @@ snapshot/transition에는 monotonic revision이 있습니다. gap은 degraded로
 reconcile하며, subscription을 잃으면 relay를 재연결합니다. keepalive는 조용히 끊긴
 transport를 감지합니다. host마다 task/state/backoff가 독립적이므로 느린 host 하나가
 전체를 막지 않고 `max_parallel_connects`가 동시 SSH handshake를 제한합니다.
+
+central TUI는 작은 Fleet cache invalidation을 구독하고 burst를 coalesce한 다음
+selector가 적용된 coherent snapshot을 한 번만 가져옵니다. 최신 daemon에서는 15초의
+느린 reconcile poll만 유지하고 `fleet_subscribe`가 없는 예전 daemon에서는 1초 polling으로
+fallback합니다. idle 화면은 초당 최대 한 번만 그리고 입력이나 상태 변경은 즉시
+반영합니다.
 
 local adapter는 Store transition을 직접 구독하고 `refresh_secs`마다 backend topology를
 갱신합니다. backend scan은 async IPC executor가 아닌 blocking worker에서 실행되며,

--- a/docs/FLEET.ko.md
+++ b/docs/FLEET.ko.md
@@ -6,12 +6,14 @@ Muxa Fleet은 기존 session/window/pane 구조 위에 physical host 계층을 �
 ```text
 local muxad
   FleetManager
+    ├─ in-process      ─ host local ─ session ─ window ─ pane(agent)
     ├─ SSH stdio relay ─ host dev ─ session ─ window ─ pane(agent)
     ├─ SSH stdio relay ─ host gpu ─ session ─ window ─ pane(agent)
     └─ host별 cache    ─ host prod ─ offline 중 last known snapshot
 ```
 
-설정된 host마다 독립적인 OpenSSH process 하나를 유지합니다. 원격에서는
+controller는 항상 첫 번째 `local` host로 in-process 게시됩니다. 설정된 remote
+host마다 독립적인 OpenSSH process 하나를 유지합니다. 원격에서는
 `muxa relay --stdio`가 실행되어 같은 사용자의 owner-only muxad Unix socket과만
 통신합니다. 원격 TCP port를 열거나 agent socket을 forwarding하지 않으며 terminal
 내용도 상시 복제하지 않습니다.
@@ -45,6 +47,22 @@ JSON hello 한 줄이 출력된 뒤 요청을 기다리면 정상입니다. 수�
 
 ## Inventory와 Kubernetes-style metadata
 
+controller node는 별도 설정 없이 바로 사용할 수 있습니다.
+
+```bash
+muxa fleet status
+muxa host show local
+muxa host doctor local
+muxa host label local environment=development
+muxa host annotate local muxa.dev/owner=platform
+```
+
+`local`도 remote node와 같은 stable NodeId와 topology를 가지지만 SSH를 사용하지 않고
+항상 connected/control 상태입니다. add/remove/disable/disconnect할 수 없으며 사용자
+metadata는 `[fleet.local]`에 저장됩니다. `muxa.io/local`, `muxa.io/transport`,
+`kubernetes.io/{hostname,os,arch}`는 muxad가 관리하는 사실 label이므로 selector에는
+쓸 수 있지만 사용자가 덮어쓸 수 없습니다.
+
 CLI를 사용하면 TOML을 검증하고 atomic하게 변경합니다.
 
 ```bash
@@ -59,7 +77,8 @@ muxa host list
 muxa host show dev
 ```
 
-첫 host 명령은 `[fleet]`을 활성화합니다. 변경 후에는 연결 목록과 권한 정책이
+첫 remote host 명령은 outbound SSH Fleet 연결을 활성화합니다. `[fleet] enabled = false`여도
+local node는 계속 보입니다. 변경 후에는 연결 목록과 권한 정책이
 함께 다시 로드되도록 muxad self-restart를 요청합니다. daemon에 연결할 수 없으면
 config 변경은 보존하고 수동 restart 안내를 출력합니다.
 
@@ -96,6 +115,8 @@ hostname, inventory alias를 바꿔도 node identity는 유지됩니다. 동일 
 
 각 host는 두 정책을 독립적으로 가집니다.
 
+local node는 항상 connected/control이며, 아래 설정은 remote inventory에 적용됩니다.
+
 - `mode = "observe"`: snapshot과 on-demand capture는 허용하지만 prompt 전송은
   거부합니다. 기본값입니다.
 - `mode = "control"`: exact-pane prompt 전송까지 허용합니다.
@@ -114,6 +135,11 @@ muxa fleet status --json
 muxa fleet watch
 muxa watch --fleet --selector 'accelerator=gpu'
 
+muxa fleet panes local
+muxa fleet capture local '%12'
+muxa fleet send local '%12' '현재 결과를 요약해주세요.'
+muxa fleet attach local '%12'
+
 muxa fleet connect dev
 muxa fleet disconnect dev
 muxa fleet refresh dev
@@ -128,6 +154,8 @@ bare pane id나 `session/window/pane` path는 해당 물리 host의 모든 backe
 capture/send/attach와 MCP 도구에 그대로 전달할 수 있는 complete `PaneKey` JSON을
 출력합니다. 내부 명령은 완전한 node/backend/session/window/pane identity를 전달하고,
 relay가 control 직전에 fresh pane list로 다시 확인합니다.
+local adapter도 같은 exact key 검증을 in-process로 수행하며 attach 시 SSH를 열지 않고
+직접 이동합니다.
 
 Fleet TUI 동작:
 
@@ -135,8 +163,10 @@ Fleet TUI 동작:
 - `j`/`k`는 singleton session/window chain에서도 actionable pane 사이를 바로
   이동합니다.
 - `h`/`l` 또는 Left/Right는 접기/내리기, Space는 parent toggle입니다.
-- `/` 검색, `a` attention-only, `r` refresh, `c` host 연결/해제입니다.
-- `p` pane capture, `m` exact-pane prompt composer, Enter remote attach, `?` help입니다.
+- `/` 검색, `a` attention-only, `r` refresh, `c` remote host 연결/해제입니다.
+  `local`에서는 항상 연결됐다는 안내만 표시합니다.
+- `p` pane capture, `m` exact-pane prompt composer, Enter는 `local`이면 직접 이동하고
+  remote이면 SSH attach하며, `?`는 help입니다.
 
 session inspector는 window와 하위 pane을 함께 roll-up합니다. window를 선택하면
 필요할 때만 pane을 capture하고 실제 tmux split geometry로 mosaic를 렌더링합니다.
@@ -154,6 +184,11 @@ reconcile하며, subscription을 잃으면 relay를 재연결합니다. keepaliv
 transport를 감지합니다. host마다 task/state/backoff가 독립적이므로 느린 host 하나가
 전체를 막지 않고 `max_parallel_connects`가 동시 SSH handshake를 제한합니다.
 
+local adapter는 Store transition을 직접 구독하고 `refresh_secs`마다 backend topology를
+갱신합니다. backend scan은 async IPC executor가 아닌 blocking worker에서 실행되며,
+별도의 revisioned Fleet snapshot을 유지하므로 selector/UI가 authoritative local Store를
+복제하거나 변경하지 않습니다.
+
 central cache에는 agent/topology metadata만 저장합니다. terminal capture는 선택 시에만
 요청하고 크기를 제한하며 control sequence를 제거합니다. window capture의 병렬성과
 payload도 제한됩니다. prompt는 remote shell command에 삽입하지 않고 stdin frame으로만
@@ -165,8 +200,8 @@ mutation은 자동 retry하지 않습니다. 결과는 text delivery와 Enter su
 ## 다른 interface
 
 `muxa mcp`는 `muxa_fleet_status`, `muxa_fleet_capture`,
-`muxa_fleet_send_prompt`를 제공합니다. remote 도구는 host와 pane을 명시해야 하며 같은
-observe/control 검사를 거칩니다.
+`muxa_fleet_send_prompt`를 제공합니다. control 도구는 host와 pane을 명시해야 합니다.
+remote는 observe/control 검사를 적용하고 `local`은 owner-only socket control입니다.
 
 web dashboard를 켜면 read API에 `GET /api/fleet?selector=...`가 추가됩니다.
 `POST /api/fleet/{host}/command`는 serialized `FleetOperation`을 받아 PAT를 요구합니다.

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -1,0 +1,209 @@
+# Muxa Fleet
+
+Muxa Fleet is the physical-host control plane above the existing
+session/window/pane model:
+
+```text
+local muxad
+  FleetManager
+    ├─ SSH stdio relay ─ host dev ─ session ─ window ─ pane (agent)
+    ├─ SSH stdio relay ─ host gpu ─ session ─ window ─ pane (agent)
+    └─ per-host cache  ─ host prod ─ last known snapshot while offline
+```
+
+Each configured host gets one independent, persistent OpenSSH process. The
+remote command is `muxa relay --stdio`, which talks only to that user's local
+owner-only muxad Unix socket. Fleet does not expose a remote TCP port, forward
+an agent socket, or copy terminal contents continuously.
+
+This is distinct from Muxa's historical “pane host” terminology. A Fleet host
+is a physical node. tmux, rmux, herdr, and zellij remain backend kinds inside
+that node.
+
+## Prerequisites
+
+- Install the same Muxa version on the controller and every remote host.
+- Run muxad for the same Unix user on every remote host.
+- Configure and test non-interactive OpenSSH authentication and host-key trust.
+- Put users, ports, keys, ProxyJump, and other SSH policy in `~/.ssh/config`.
+
+For example:
+
+```sshconfig
+Host muxa-devbox
+  HostName devbox.example.com
+  User june
+  IdentityFile ~/.ssh/id_ed25519
+  IdentitiesOnly yes
+```
+
+Then verify the transport before adding it:
+
+```bash
+ssh -T -o BatchMode=yes muxa-devbox muxa relay --stdio
+```
+
+The command emits one JSON hello frame and waits for requests; `Ctrl-C` is
+expected for this manual probe.
+
+## Inventory and metadata
+
+Register hosts through the CLI so Muxa validates and atomically updates the
+TOML inventory:
+
+```bash
+muxa host add dev muxa-devbox \
+  --label environment=development \
+  --label region=icn \
+  --annotation muxa.dev/owner=platform \
+  --mode observe
+
+muxa host doctor dev
+muxa host list
+muxa host show dev
+```
+
+The first host command enables `[fleet]`. Host mutations ask muxad to restart
+itself so the connection set and authorization policy are reloaded together.
+If the daemon cannot be reached, the config edit remains valid and the CLI
+prints a reminder to restart it manually.
+
+Labels follow Kubernetes key/value rules and are meant for selection:
+
+```bash
+muxa host label dev tier=worker accelerator=gpu
+muxa host label dev tier=worker --overwrite
+muxa host label dev accelerator-              # remove
+muxa host tag dev region=icn                   # visible alias of label
+```
+
+Annotation keys use the same namespaced key rules but their values may hold
+descriptive text or URLs:
+
+```bash
+muxa host annotate dev muxa.dev/runbook=https://example.invalid/dev
+```
+
+The controller alias is human-friendly configuration identity. The relay also
+creates `$XDG_DATA_HOME/muxa/host-id` as an owner-only stable UUID. Rename an
+SSH alias, hostname, or inventory alias without changing node identity. Muxa
+refuses two live aliases that report the same node UUID, preventing accidental
+double control of one machine.
+
+Supported selector requirements are:
+
+- `environment=production` and `environment==production`
+- `environment!=production`
+- `region in (icn,nrt)` and `region notin (iad,sfo)`
+- `accelerator` (key exists) and `!accelerator` (key does not exist)
+- comma-separated AND, such as `environment=production,region in (icn,nrt)`
+
+## Access policy and connection policy
+
+Every host has two independent policies:
+
+- `mode = "observe"` allows snapshots and on-demand captures but rejects
+  prompt delivery. This is the default.
+- `mode = "control"` additionally permits exact-pane prompt delivery.
+- `connect = "auto"` keeps a relay connected with bounded exponential
+  reconnect backoff.
+- `connect = "on_demand"` remains disconnected until `muxa fleet connect`.
+
+Use `muxa host disable` to keep metadata but suppress all connections, and
+`muxa host enable` to restore it.
+
+## Operating the fleet
+
+```bash
+muxa fleet status
+muxa fleet status -l 'environment=production,region in (icn,nrt)'
+muxa fleet status --json
+muxa fleet watch
+muxa watch --fleet --selector 'accelerator=gpu'
+
+muxa fleet connect dev
+muxa fleet disconnect dev
+muxa fleet refresh dev
+muxa fleet panes dev
+muxa fleet capture dev '%12'
+muxa fleet send dev '%12' 'Please summarize the current result.'
+muxa fleet attach dev '%12'
+```
+
+A bare pane id or `session/window/pane` path is accepted only when unique
+across all backend endpoints on that physical host. If even the display path
+is ambiguous, `muxa fleet panes HOST --json` prints the complete `PaneKey` JSON
+accepted by capture/send/attach and MCP tools. Internally, every command carries
+the complete node/backend/session/window/pane identity, and the relay verifies
+that identity again against a fresh pane list before a control action.
+
+The Fleet TUI uses the same focused hierarchy developed for local watch:
+
+- Arrow Up/Down visits every visible structural node.
+- `j`/`k` jumps directly between actionable panes, including a singleton
+  session/window chain.
+- `h`/`l` or Left/Right collapses/descends; Space toggles a parent.
+- `/` filters, `a` toggles attention-only, `r` refreshes, and `c` connects or
+  disconnects the selected host.
+- `p` captures the selected pane, `m` composes an exact-pane prompt, Enter
+  attaches through a separate SSH TTY, and `?` shows help.
+
+Session inspectors roll up their windows and panes. A selected window fetches
+its panes on demand and renders their actual tmux split geometry. Captures are
+rate-limited and never performed for collapsed or unselected windows.
+
+## Health and consistency
+
+Host state is one of `disabled`, `connecting`, `online`, `degraded`, `offline`,
+`auth_failed`, or `version_skew`. The last good snapshot remains visible while
+a host is offline. A successful new handshake clears stale remote identity
+before accepting the new snapshot.
+
+Relay snapshots and transitions carry monotonic revisions. A gap marks the
+host degraded and triggers reconciliation; a lost subscription reconnects the
+relay. Keepalives detect a silent transport, while each host's state machine,
+backoff, and task remain independent so one slow host cannot stall the fleet.
+`max_parallel_connects` caps simultaneous SSH handshakes.
+
+The central cache stores agent/topology metadata only. Pane captures are
+bounded, sanitized for terminal control sequences, and requested only when a
+consumer selects them. Window capture parallelism and payload sizes are also
+bounded. Prompt text is sent over stdin, never interpolated into a remote shell
+command, and is not included in manager audit logs.
+
+Mutating requests are never retried automatically. A result distinguishes text
+delivery from Enter submission so callers do not duplicate a prompt after a
+partial acknowledgement.
+
+## Other interfaces
+
+`muxa mcp` exposes `muxa_fleet_status`, `muxa_fleet_capture`, and
+`muxa_fleet_send_prompt`. Remote control tools require an explicit host and
+pane; the same observe/control check applies.
+
+When the web dashboard is enabled, its authenticated read surface includes
+`GET /api/fleet?selector=...`. PAT-gated control is available at
+`POST /api/fleet/{host}/command` with a serialized `FleetOperation`; dashboard
+`auth = "none"` still disables all writes.
+
+Durable Muxa collaboration mailboxes remain local to a physical node in this
+release. Fleet prompt delivery can ask a remote agent to work, but it does not
+pretend that a cross-host `@peer` request has durable reply semantics. A future
+hub transport can add that capability without changing node or pane identity.
+
+## Security checklist
+
+- Keep the controller dashboard loopback-only unless its documented PAT and
+  public-bind controls are intentional.
+- Prefer OpenSSH `Host` aliases and review `known_hosts`; Fleet uses
+  `BatchMode=yes` and never disables host-key checking.
+- Fleet forces `ClearAllForwardings=yes` and does not request agent forwarding.
+- Start new hosts in observe mode, then promote only the hosts that need
+  control with `muxa host add ... --mode control --overwrite`.
+- Treat access to the controller's muxad socket, config file, and SSH keys as
+  shell-equivalent authority.
+- Use labels for selection, not secrets. Annotations are displayed in the
+  inspector and must not contain credentials either.
+
+See [CONFIGURATION.md](CONFIGURATION.md) for every setting and
+[MULTI_HOST.md](MULTI_HOST.md) for local multi-backend observation.

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -191,12 +191,15 @@ The multi-node Fleet TUI uses the same focused navigation conventions:
 - `h`/`l` or Left/Right collapses/descends; Space toggles a parent.
 - `/` filters, `a` toggles attention-only, `r` refreshes, and `c` connects or
   disconnects a remote host (`local` reports that it is always connected).
-- `o`/`p` captures the selected pane, `m` composes an exact-pane prompt (`/`
-  opens the shared message-skill palette), Enter
+- `o`/`p` captures the selected pane. `m` works on a session, window, or pane:
+  parent nodes resolve to the lowest-index pane that owns a live agent, while
+  an exact pane stays exact (`/` opens the shared message-skill palette). Enter
   attaches directly on `local` or through a separate remote SSH TTY, and `?`
   shows help.
 - `--view`, `--layout tree|swarm`, `--sort`, and `--theme` use the same values
-  as native watch.
+  as native watch. `focus` expansion follows the selected view depth,
+  `manual` changes only through structural keys, and direct `j`/`k` jumps
+  reveal only the target's ancestors.
 - `--include-paneless` exposes agents hidden by the default setting as explicit
   rows with inspectors; pane-only attach/capture/message actions stay disabled.
 
@@ -217,8 +220,11 @@ relay. Keepalives detect a silent transport, while each host's state machine,
 backoff, and task remain independent so one slow host cannot stall the fleet.
 `max_parallel_connects` caps simultaneous SSH handshakes.
 
-The central TUI subscribes to compact Fleet cache invalidations and coalesces
-bursts before fetching one coherent selector-filtered snapshot. With a current
+The central TUI subscribes to compact, selector-scoped Fleet cache
+invalidations and coalesces bursts before fetching one coherent filtered
+snapshot. The server installs the stream before acknowledging it and the
+client then performs a fresh snapshot, closing the startup race. Refreshes are
+coalesced for 75 ms and capped at four snapshots per second. With a current
 daemon it performs a slow 15-second reconciliation poll; an older daemon that
 does not advertise `fleet_subscribe` falls back to one-second polling. Idle
 frames redraw at most once per second, while input and state changes repaint

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -140,7 +140,10 @@ Use `muxa host disable` to keep metadata but suppress all connections, and
 ```bash
 muxa fleet status
 muxa fleet status -l 'environment=production,region in (icn,nrt)'
-muxa fleet status --json
+muxa fleet status -o wide
+muxa fleet status -L environment,region
+muxa fleet status --show-labels
+muxa fleet status -o json                 # `--json` remains compatible
 muxa fleet watch
 muxa watch --fleet --selector 'accelerator=gpu'
 
@@ -167,7 +170,20 @@ that identity again against a fresh pane list before a control action.
 The local adapter performs the same exact-key verification in process; local
 attach jumps directly without opening an SSH TTY.
 
-The Fleet TUI uses the same focused hierarchy developed for local watch:
+The default status table is deliberately compact (`HOST/STATE/MODE/AGENTS/
+PANES/ATTN/AGE`) and never prints the full managed-label set into a normal
+terminal row. Use `-L` for selected Kubernetes-style label columns,
+`--show-labels` for the complete label map, `-o wide` for host/version/latency
+details as space permits, or `-o json` for the lossless machine interface.
+
+When the selector contains only the controller's `local` node, Fleet watch
+delegates to the full native `muxa watch` surface. There is no redundant host
+row, and all existing inspectors, tree/swarm modes, collaboration/mailbox,
+ask, previews, command palette, message-skill editing, and configuration
+persistence remain available. Once a second physical node is visible, the
+host level becomes meaningful and the central Fleet hierarchy is shown.
+
+The multi-node Fleet TUI uses the same focused navigation conventions:
 
 - Arrow Up/Down visits every visible structural node.
 - `j`/`k` jumps directly between actionable panes, including a singleton
@@ -175,9 +191,14 @@ The Fleet TUI uses the same focused hierarchy developed for local watch:
 - `h`/`l` or Left/Right collapses/descends; Space toggles a parent.
 - `/` filters, `a` toggles attention-only, `r` refreshes, and `c` connects or
   disconnects a remote host (`local` reports that it is always connected).
-- `p` captures the selected pane, `m` composes an exact-pane prompt, Enter
+- `o`/`p` captures the selected pane, `m` composes an exact-pane prompt (`/`
+  opens the shared message-skill palette), Enter
   attaches directly on `local` or through a separate remote SSH TTY, and `?`
   shows help.
+- `--view`, `--layout tree|swarm`, `--sort`, and `--theme` use the same values
+  as native watch.
+- `--include-paneless` exposes agents hidden by the default setting as explicit
+  rows with inspectors; pane-only attach/capture/message actions stay disabled.
 
 Session inspectors roll up their windows and panes. A selected window fetches
 its panes on demand and renders their actual tmux split geometry. Captures are
@@ -195,6 +216,13 @@ host degraded and triggers reconciliation; a lost subscription reconnects the
 relay. Keepalives detect a silent transport, while each host's state machine,
 backoff, and task remain independent so one slow host cannot stall the fleet.
 `max_parallel_connects` caps simultaneous SSH handshakes.
+
+The central TUI subscribes to compact Fleet cache invalidations and coalesces
+bursts before fetching one coherent selector-filtered snapshot. With a current
+daemon it performs a slow 15-second reconciliation poll; an older daemon that
+does not advertise `fleet_subscribe` falls back to one-second polling. Idle
+frames redraw at most once per second, while input and state changes repaint
+immediately.
 
 The local adapter consumes Store transitions directly and refreshes backend
 topology at `refresh_secs`; backend scans run on blocking workers rather than

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -6,12 +6,14 @@ session/window/pane model:
 ```text
 local muxad
   FleetManager
+    ├─ in-process      ─ host local ─ session ─ window ─ pane (agent)
     ├─ SSH stdio relay ─ host dev ─ session ─ window ─ pane (agent)
     ├─ SSH stdio relay ─ host gpu ─ session ─ window ─ pane (agent)
     └─ per-host cache  ─ host prod ─ last known snapshot while offline
 ```
 
-Each configured host gets one independent, persistent OpenSSH process. The
+The controller is always published as the first, in-process `local` host.
+Each configured remote host gets one independent, persistent OpenSSH process. The
 remote command is `muxa relay --stdio`, which talks only to that user's local
 owner-only muxad Unix socket. Fleet does not expose a remote TCP port, forward
 an agent socket, or copy terminal contents continuously.
@@ -48,6 +50,23 @@ expected for this manual probe.
 
 ## Inventory and metadata
 
+No setup is required for the controller node:
+
+```bash
+muxa fleet status
+muxa host show local
+muxa host doctor local
+muxa host label local environment=development
+muxa host annotate local muxa.dev/owner=platform
+```
+
+`local` has the same stable NodeId and topology shape as a remote node, but it
+does not use SSH and is always connected in control mode. It cannot be added,
+removed, disabled, or disconnected. User metadata is stored under
+`[fleet.local]`. muxad owns the truthful `muxa.io/local`,
+`muxa.io/transport`, and `kubernetes.io/{hostname,os,arch}` labels; selectors
+may use them, but user configuration cannot override them.
+
 Register hosts through the CLI so Muxa validates and atomically updates the
 TOML inventory:
 
@@ -63,8 +82,9 @@ muxa host list
 muxa host show dev
 ```
 
-The first host command enables `[fleet]`. Host mutations ask muxad to restart
-itself so the connection set and authorization policy are reloaded together.
+The first remote-host command enables outbound SSH Fleet connections. The
+local node remains available when `[fleet] enabled = false`. Host mutations
+ask muxad to restart itself so the connection set and authorization policy are reloaded together.
 If the daemon cannot be reached, the config edit remains valid and the CLI
 prints a reminder to restart it manually.
 
@@ -102,6 +122,9 @@ Supported selector requirements are:
 
 Every host has two independent policies:
 
+The local node is always connected and always uses `control`; these settings
+apply to remote inventory entries:
+
 - `mode = "observe"` allows snapshots and on-demand captures but rejects
   prompt delivery. This is the default.
 - `mode = "control"` additionally permits exact-pane prompt delivery.
@@ -121,6 +144,11 @@ muxa fleet status --json
 muxa fleet watch
 muxa watch --fleet --selector 'accelerator=gpu'
 
+muxa fleet panes local
+muxa fleet capture local '%12'
+muxa fleet send local '%12' 'Please summarize the current result.'
+muxa fleet attach local '%12'
+
 muxa fleet connect dev
 muxa fleet disconnect dev
 muxa fleet refresh dev
@@ -136,6 +164,8 @@ is ambiguous, `muxa fleet panes HOST --json` prints the complete `PaneKey` JSON
 accepted by capture/send/attach and MCP tools. Internally, every command carries
 the complete node/backend/session/window/pane identity, and the relay verifies
 that identity again against a fresh pane list before a control action.
+The local adapter performs the same exact-key verification in process; local
+attach jumps directly without opening an SSH TTY.
 
 The Fleet TUI uses the same focused hierarchy developed for local watch:
 
@@ -144,9 +174,10 @@ The Fleet TUI uses the same focused hierarchy developed for local watch:
   session/window chain.
 - `h`/`l` or Left/Right collapses/descends; Space toggles a parent.
 - `/` filters, `a` toggles attention-only, `r` refreshes, and `c` connects or
-  disconnects the selected host.
+  disconnects a remote host (`local` reports that it is always connected).
 - `p` captures the selected pane, `m` composes an exact-pane prompt, Enter
-  attaches through a separate SSH TTY, and `?` shows help.
+  attaches directly on `local` or through a separate remote SSH TTY, and `?`
+  shows help.
 
 Session inspectors roll up their windows and panes. A selected window fetches
 its panes on demand and renders their actual tmux split geometry. Captures are
@@ -165,6 +196,12 @@ relay. Keepalives detect a silent transport, while each host's state machine,
 backoff, and task remain independent so one slow host cannot stall the fleet.
 `max_parallel_connects` caps simultaneous SSH handshakes.
 
+The local adapter consumes Store transitions directly and refreshes backend
+topology at `refresh_secs`; backend scans run on blocking workers rather than
+the async IPC executor. It maintains its own revisioned Fleet snapshot, so
+selectors and UI rendering never clone or rewrite the authoritative local
+Store.
+
 The central cache stores agent/topology metadata only. Pane captures are
 bounded, sanitized for terminal control sequences, and requested only when a
 consumer selects them. Window capture parallelism and payload sizes are also
@@ -178,8 +215,9 @@ partial acknowledgement.
 ## Other interfaces
 
 `muxa mcp` exposes `muxa_fleet_status`, `muxa_fleet_capture`, and
-`muxa_fleet_send_prompt`. Remote control tools require an explicit host and
-pane; the same observe/control check applies.
+`muxa_fleet_send_prompt`. Control tools require an explicit host and pane;
+remote hosts apply the observe/control check, while `local` is owner-socket
+control.
 
 When the web dashboard is enabled, its authenticated read surface includes
 `GET /api/fleet?selector=...`. PAT-gated control is available at

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -50,7 +50,7 @@ claude mcp add --scope user muxa -e MUXA_SOCKET=/run/user/1000/muxa.sock -- muxa
 ```
 
 Restart agents that were already running, then verify with `claude mcp list`
-or `codex mcp list` (the `muxa` server should list eighteen tools). Other MCP
+or `codex mcp list` (the `muxa` server should list twenty-one tools). Other MCP
 hosts can run `muxa mcp` as a stdio server command in their config.
 
 At initialization muxa tells the agent how to use same-window peers as a
@@ -58,6 +58,23 @@ reviewer, focused question target, or delegated subagent. The agent can call
 `muxa_collaboration_guide` to retrieve that contract again at any time.
 The same instructions map conversational `@peer`, provider mentions, aliases,
 roles, and registered `/skills` to `muxa_call_peer`.
+
+### Physical-host Fleet tools
+
+When `[fleet] enabled = true`, the same MCP server can operate the cached
+host/session/window/pane hierarchy:
+
+```text
+muxa_fleet_status      { "selector": "environment=production" }
+muxa_fleet_capture     { "host": "dev", "pane": "%12" }
+muxa_fleet_send_prompt { "host": "dev", "pane": "%12",
+                         "text": "Summarize the result", "submit": true }
+```
+
+The host and pane are always explicit. Ambiguous pane ids are rejected, the
+relay verifies the complete identity again, and an observe-mode host rejects
+prompt delivery. Fleet calls use muxad's persistent SSH/cache control plane;
+the MCP subprocess never opens SSH itself. See [FLEET.md](FLEET.md).
 
 ## Implementation
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -61,20 +61,23 @@ roles, and registered `/skills` to `muxa_call_peer`.
 
 ### Physical-host Fleet tools
 
-When `[fleet] enabled = true`, the same MCP server can operate the cached
+The same MCP server can always operate the controller through host `local`.
+When `[fleet] enabled = true`, it additionally operates the cached remote
 host/session/window/pane hierarchy:
 
 ```text
 muxa_fleet_status      { "selector": "environment=production" }
+muxa_fleet_capture     { "host": "local", "pane": "%12" }
 muxa_fleet_capture     { "host": "dev", "pane": "%12" }
 muxa_fleet_send_prompt { "host": "dev", "pane": "%12",
                          "text": "Summarize the result", "submit": true }
 ```
 
-The host and pane are always explicit. Ambiguous pane ids are rejected, the
-relay verifies the complete identity again, and an observe-mode host rejects
-prompt delivery. Fleet calls use muxad's persistent SSH/cache control plane;
-the MCP subprocess never opens SSH itself. See [FLEET.md](FLEET.md).
+The host and pane are always explicit. Ambiguous pane ids are rejected. The
+local in-process adapter and remote relay both verify the complete identity
+again, and an observe-mode remote host rejects prompt delivery. Fleet calls
+use muxad's cache/control plane; the MCP subprocess never opens SSH itself.
+See [FLEET.md](FLEET.md).
 
 ## Implementation
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -50,12 +50,14 @@ claude mcp add --scope user muxa -e MUXA_SOCKET=/run/user/1000/muxa.sock -- muxa
 ```
 
 Restart agents that were already running, then verify with `claude mcp list`
-or `codex mcp list` (the `muxa` server should list sixteen tools). Other MCP
+or `codex mcp list` (the `muxa` server should list eighteen tools). Other MCP
 hosts can run `muxa mcp` as a stdio server command in their config.
 
 At initialization muxa tells the agent how to use same-window peers as a
 reviewer, focused question target, or delegated subagent. The agent can call
 `muxa_collaboration_guide` to retrieve that contract again at any time.
+The same instructions map conversational `@peer`, provider mentions, aliases,
+roles, and registered `/skills` to `muxa_call_peer`.
 
 ## Implementation
 
@@ -103,6 +105,8 @@ it:
 | `muxa_wait_for_change` | `timeout_secs?`, `pane?`, `until?`, `include_capture?` | Wait for any change or a focused settled/idle/blocked/stopped state, optionally returning the screen. |
 | `muxa_collaboration_guide` | — | Show the recommended reviewer, question, delegated-subagent, incoming-work, and AIR handoff contracts. |
 | `muxa_room_context` | — | Identify self, list same-window peers, and report unread request/reply counts. |
+| `muxa_call_peer` | `target?`, `intent?`, `body?`, `skill?`, `context?`, `execute?`, `paths?`, `wait?`, `timeout_secs?`, `spawn_if_missing?`, `spawn_agent?`, `spawn_timeout_secs?`, `air_artifacts?` | Expand a registered skill, select a peer, send a durable request, optionally wait for its reply, and explicitly spawn an agent when no peer exists. |
+| `muxa_peer_report` | `target?`, `request_id?` | Read the newest completed peer report, optionally filtered by provider/pane/alias/role, or retrieve an exact prior request. |
 | `muxa_set_identity` | `alias?`, `roles?` | Replace this exact session's room-local alias and role set; empty input clears it. |
 | `muxa_send_message` | `target`, `body`, `kind?`, `work_mode?`, `paths?`, `air_artifacts?` | Create a durable same-window peer request. |
 | `muxa_inbox` | — | Claim and read requests addressed to this exact agent session. |
@@ -117,6 +121,59 @@ only reaches the focused pane. tmux, rmux, and herdr support it.
 
 Pane ids carry their host namespace: tmux `%12`, rmux `rmux:%12`, herdr
 `herdr:p1`. Use the `pane` field from `muxa_status` verbatim.
+
+### Natural peer calls
+
+Once the MCP server is connected, type requests naturally in the agent
+conversation:
+
+```text
+@peer review the current changes
+@codex /review-plan-feedback using commit abc123 as context
+@reviewer check the auth path for races
+@peer's report: summarize the findings and apply only the valid ones
+```
+
+`@peer` and the more explicit `@muxa-peer` are reserved Muxa collaboration
+expressions. New work maps to `muxa_call_peer`; possessive references to an
+existing report, reply, findings, or conversation map to `muxa_peer_report`
+first. Muxa does not intercept terminal keystrokes. `target="auto"` prefers a
+healthy peer from a
+different provider, then applies stable state/provider/numeric-pane ordering.
+Use a provider, pane id, unique alias, or `role:name` when the recipient
+matters. Ambiguous roles are refused instead of guessed.
+
+Muxa report language never implies a GitHub PR. The agent must not invoke a
+GitHub PR/review workflow unless the user or grounded conversation context
+provides an explicit PR number or GitHub PR URL; knowing the repository or cwd
+alone is insufficient. It must never invent a PR, issue, or review thread.
+“Resolve the peer feedback” means evaluate each Muxa finding, apply valid
+advice, record why rejected advice was not used, and optionally send that
+decision back to the peer. If the Muxa tools are missing, restart the agent;
+GitHub is not a fallback transport.
+
+The safe default is `intent="review"` with a read-only contract. `execute=true`
+is accepted only with `intent="task"`, so a conversational review cannot
+silently acquire edit authority. When there is no eligible peer, the tool
+returns `action_required="confirm_spawn"`; only repeat the call with
+`spawn_if_missing=true` after the user explicitly confirms creating a pane.
+Automatic spawning defaults to the other provider when possible.
+
+Registered message skills can be selected with or without a leading slash:
+
+```text
+muxa_call_peer(target="auto", intent="review",
+               skill="review-plan-feedback",
+               context="Review commit abc123", wait=true)
+
+muxa_call_peer(target="@codex", intent="task", execute=true,
+               body="Add regression tests only",
+               paths=["crates/auth/tests/**"])
+```
+
+The MCP process reads `[message.skills]` at startup. Restart an already-running
+agent after `muxa skill add/remove`, after editing the table, or after upgrading
+Muxa so it loads the current skills and tool definitions.
 
 ### Deterministic agent launch
 

--- a/docs/MULTI_HOST.md
+++ b/docs/MULTI_HOST.md
@@ -1,5 +1,10 @@
 # Multi-host observation
 
+> This document uses the original “host” name for local pane backends
+> (tmux/rmux/herdr/zellij) inside one physical machine. For central management
+> of several SSH-reachable physical nodes, see [FLEET.md](FLEET.md). Fleet
+> preserves this backend set independently inside every node.
+
 Status: **daemon + CLI implemented.** `muxad` observes every backend in
 `muxa::active_backends()` simultaneously (for example tmux + rmux + herdr during a
 migration) — the reconciler, discovery, session-activity sampling,


### PR DESCRIPTION
## Summary

Add a production-oriented physical-host Fleet layer to Muxa:

- model host -> session -> window -> pane(agent) with persistent UUID NodeIds
- always publish the controller itself as the first-class `local` host
- manage Kubernetes-style labels, annotations, selectors, and compact/wide/JSON host views
- connect remote nodes through persistent OpenSSH stdio relays with observe/control policy
- expose Fleet operations through CLI, TUI, local IPC, dashboard API, and MCP
- preserve per-host last-known state and explicit lifecycle/error states
- delegate the single-local-host path to the mature native `muxa watch`
- document deployment, security, performance, protocol, and operations in English and Korean

This branch contains six logical commits because the local main branch was already one commit ahead of `origin/main`:

1. `5ea744e` adds natural `@peer` MCP collaboration routing
2. `9c24f8e` adds the physical-host Fleet implementation
3. `38f1fba` updates h2 for RUSTSEC-2026-0258
4. `7bd8c1b` exposes the controller as the always-present local Fleet host
5. `b85d426` integrates native watch, compact tables, rich multi-host UI, and push invalidation
6. `964a348` hardens selector subscriptions, navigation, parent messaging, and rendering safety

## Local controller node

- available without Fleet configuration and with `fleet.enabled = false`
- always sorted first as alias `local` through an in-process adapter
- carries stable NodeId plus immutable local/transport and Kubernetes platform labels
- accepts user labels and annotations through `muxa host label local` and `muxa host annotate local`
- supports the same selectors, topology, captures, prompts, attach, dashboard, and MCP surfaces
- cannot be added, removed, disabled, or disconnected
- verifies exact pane keys and rejects a duplicate local NodeId through SSH

## Status and watch UX

- terminal-width-aware `HOST/STATE/MODE/AGENTS/PANES/ATTN/AGE` default status table
- `-L`, `--show-labels`, `-o wide`, and `-o json` progressively expose richer inventory
- local-only selection delegates to native watch with its complete feature set
- multi-host tree/swarm layouts with host/session/window/pane inspectors and window geometry mosaics
- Arrow Up/Down visits structural rows; `j`/`k` jumps directly between actionable panes
- focus/manual/always expansion follows configured view depth without forcing singleton traversal
- Swarm always keeps its visible agent and actual action target synchronized
- `m` works from a session, window, or pane; parents choose the lowest-index live agent pane
- the shared `/` message-skill palette works in the multi-host composer
- `--include-paneless` exposes detached agents, including search and attention filtering, while pane-only actions remain disabled

## Architecture, performance, and safety

- no inbound Fleet listener and no SSH port forwarding
- OpenSSH BatchMode stdio transport with protocol/capability negotiation
- observe is the remote default; prompts require explicit control permission
- exact host/backend/session/window/pane identities prevent cross-host collisions
- bounded frames, lines, stderr, pending commands, prompts, and capture payloads
- controller-side terminal sanitization, including remote identifiers and mosaic titles
- no automatic retry for mutating prompt sends
- isolated per-host tasks/caches, bounded connection concurrency, backoff, jitter, keepalive, and command deadlines
- revision-aware snapshots preserve newer state transitions during slow refreshes
- selected-window captures are lazy, rate-limited, and serialized to avoid stale pending races
- selector-scoped `fleet_subscribe` installs its receiver before ACK; the client fetches a fresh snapshot after ACK
- invalidations coalesce for 75 ms, refresh at most four times per second, and explicitly resync after stream lag
- modern daemons retain a 15-second reconciliation poll; older daemons fall back to one-second polling

## User surfaces

- `muxa host add|list|show|remove|label|tag|annotate|enable|disable|doctor`
- `muxa fleet status|watch|connect|disconnect|refresh|panes|capture|send|attach`
- `muxa watch --fleet --selector ...`
- Fleet dashboard read and PAT-protected command endpoints
- `muxa_fleet_status`, `muxa_fleet_capture`, and `muxa_fleet_send_prompt` MCP tools
- `docs/FLEET.md` and `docs/FLEET.ko.md`

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- muxa core: 643 passed, 1 environment-dependent rmux smoke test ignored
- sink integration: 7 passed
- muxa CLI: 675 passed, plus 12 e2e tests
- muxad: 58 passed
- selector stream filtering plus enter/leave membership round trip
- focus/manual/view navigation, Swarm selection, parent message routing, paneless search, and sanitization regressions
- `git diff --check`

## Relationship to #65

PR #65 manages agent work inside a local Muxa environment. This PR manages physical nodes and their multiplexer hierarchy. They are complementary; ordinary README/CLI conflict resolution may be needed if #65 lands first.

## Rollout

The controller works immediately as `local`. Controller and remotes should run the same Fleet-capable Muxa version. Start remotes in observe mode, verify `muxa host doctor`, then grant control only where remote prompt dispatch is needed. Cut a release after review and merge.
