### PR TITLE
fix(ci): support Rust 1.98 clippy

### DIFF
--- a/crates/muxa-cli/src/relay.rs
+++ b/crates/muxa-cli/src/relay.rs
@@ -471,7 +471,9 @@ fn decode_attach_token(token: &str) -> Result<GlobalPaneRef> {
     }
     let bytes = token
         .as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             let pair = std::str::from_utf8(pair)?;
             u8::from_str_radix(pair, 16).map_err(anyhow::Error::from)

--- a/crates/muxa/src/ask.rs
+++ b/crates/muxa/src/ask.rs
@@ -160,7 +160,10 @@ impl AskStore {
     /// failures: their child process died with the previous daemon.
     // `async` for symmetry with `CollaborationStore::load` and so the
     // daemon's startup path reads the same for both stores.
-    #[allow(clippy::unused_async)]
+    // Rust 1.98 renamed/expanded this lint. Keep the async API stable for
+    // startup symmetry while supporting both the MSRV and current stable.
+    #[allow(unknown_lints)]
+    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
     pub async fn load(opts: AskOptions) -> Arc<Self> {
         let mut snapshot = opts
             .path

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -605,7 +605,6 @@ struct HerdrProcess {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write as _;
     use std::os::unix::net::UnixListener;
     use std::path::Path;
     use std::thread;


### PR DESCRIPTION
## Summary

- allow the Rust 1.98 name for the intentionally async `AskStore::load` API while retaining compatibility with older toolchains
- remove a test-only import that became redundant under Rust 1.98
- use fixed-size byte chunks when decoding relay attach tokens

## Why

The post-merge `main` CI run for #77 picked up Rust 1.98 and failed on newly enabled Clippy lints, although the PR run had passed on Rust 1.96. This keeps `main` green across the project MSRV and current stable.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings` (Rust 1.96)
- `cargo +1.98.0 fmt --all -- --check`
- `cargo +1.98.0 clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.88.0 check --workspace --locked`
- `cargo build --workspace --bins --locked && cargo test --workspace --locked`