### PR TITLE
feat(dashboard): add ticket workflow control plane

### DIFF
--- a/crates/muxa/src/dashboard/assets.rs
+++ b/crates/muxa/src/dashboard/assets.rs
@@ -89,6 +89,7 @@ mod tests {
         // test instead of a nebulous binary bloat.
         assert!(WebAssets::get("index.html").is_some());
         assert!(WebAssets::get("main.js").is_some());
+        assert!(WebAssets::get("work-model.mjs").is_some());
         assert!(WebAssets::get("style.css").is_some());
     }
 
@@ -96,6 +97,7 @@ mod tests {
     fn mime_table_covers_served_extensions() {
         assert_eq!(mime_for("foo.html"), "text/html; charset=utf-8");
         assert_eq!(mime_for("foo.js"), "application/javascript; charset=utf-8");
+        assert_eq!(mime_for("foo.mjs"), "application/javascript; charset=utf-8");
         assert_eq!(mime_for("foo.css"), "text/css; charset=utf-8");
         assert_eq!(mime_for("foo.unknown"), "application/octet-stream");
     }

--- a/crates/muxa/src/dashboard/mod.rs
+++ b/crates/muxa/src/dashboard/mod.rs
@@ -24,6 +24,7 @@ pub mod assets;
 pub mod auth;
 pub mod config;
 pub mod server;
+mod work_store;
 
 pub use config::{DashboardConfig, DashboardConfigError, DashboardOverrides};
 pub use server::{router, serve, AppState, DashboardRuntimeConfig};

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -20,7 +20,7 @@ use axum::{
         sse::{Event as SseEvent, KeepAlive, Sse},
         IntoResponse, Json, Response,
     },
-    routing::{get, post},
+    routing::{get, post, put},
     Router,
 };
 use futures::stream::{self, Stream, StreamExt};
@@ -40,6 +40,7 @@ use tower_http::trace::TraceLayer;
 
 use crate::backend::{HostKind, SharedBackend};
 use crate::config::{DashboardAuthMode, StatsConfig};
+use crate::dashboard::work_store::{WorkKey, WorkMetadataPatch, WorkRecord, WorkStore};
 use crate::dashboard::{assets, auth, DashboardConfig};
 use crate::event::{AgentKind, AgentState, PROTOCOL_VERSION};
 use crate::fleet::{FleetOperation, FleetRuntime, LabelSelector};
@@ -51,7 +52,7 @@ use crate::timeline::{
     self, TimelineBuildInput, TimelineDocument, TimelineFilters, TimelineLane, TimelineLaneKind,
     TimelineRange, TimelineTotals,
 };
-use crate::tmux::scanner::{self, PaneCache, PaneSummary, ScanError};
+use crate::tmux::scanner::{self, MuxaPaneMetadata, PaneCache, PaneSummary, ScanError};
 
 /// SSE keep-alive ping interval. Picked long enough to be invisible
 /// (15s is well under any sane proxy idle-timeout) but short enough
@@ -122,6 +123,9 @@ pub struct AppState {
     /// Optional SSH fleet runtime. Fleet reads reuse muxad's per-host cache;
     /// dashboard requests never launch their own SSH processes.
     pub fleet: Option<FleetRuntime>,
+    /// Durable operator-authored work metadata. Execution topology remains in
+    /// the backend; only workflow annotations are stored here.
+    work_store: Arc<tokio::sync::Mutex<WorkStore>>,
     /// 1-second cache for the `agents_by_state` histogram. See the
     /// [`AGENTS_BY_STATE_CACHE_TTL`] doc-comment for the perf rationale
     /// and the eventual plan to replace this with per-state atomics.
@@ -139,6 +143,7 @@ pub struct AppState {
 pub struct DashboardRuntimeConfig {
     pub activity_path: Option<PathBuf>,
     pub session_activity_path: Option<PathBuf>,
+    pub work_store_path: Option<PathBuf>,
     pub stats_config: StatsConfig,
     pub fleet: Option<FleetRuntime>,
 }
@@ -164,6 +169,7 @@ impl AppState {
             session_activity_path: None,
             stats_config: StatsConfig::default(),
             fleet: None,
+            work_store: Arc::new(tokio::sync::Mutex::new(WorkStore::memory())),
             agents_by_state_cache: Arc::new(tokio::sync::Mutex::new(AgentsByStateCache::default())),
             activity_ledger_cache: Arc::new(tokio::sync::Mutex::new(
                 crate::activity::ActivityCache::default(),
@@ -194,6 +200,12 @@ impl AppState {
     #[must_use]
     pub fn with_fleet(mut self, fleet: Option<FleetRuntime>) -> Self {
         self.fleet = fleet;
+        self
+    }
+
+    #[must_use]
+    pub fn with_work_store_path(mut self, path: Option<PathBuf>) -> Self {
+        self.work_store = Arc::new(tokio::sync::Mutex::new(WorkStore::load(path)));
         self
     }
 
@@ -272,6 +284,7 @@ fn backend_scan_result(kind: HostKind, panes: Vec<crate::tmux::PaneInfo>) -> sca
                     .map_or_else(|| PathBuf::from("tmux"), PathBuf::from),
             };
             PaneSummary {
+                host: kind,
                 pane_id: pane.pane_id,
                 session_id: pane.session_id,
                 session: pane.session,
@@ -282,7 +295,9 @@ fn backend_scan_result(kind: HostKind, panes: Vec<crate::tmux::PaneInfo>) -> sca
                 tty: pane.tty,
                 current_command: pane.current_command,
                 title: pane.title,
+                current_path: pane.current_path,
                 socket,
+                muxa: MuxaPaneMetadata::default(),
                 attach_command: String::new(),
             }
         })
@@ -319,6 +334,7 @@ pub fn router(state: AppState) -> Router {
         .route("/api/agents", get(agents_handler))
         .route("/api/fleet", get(fleet_handler))
         .route("/api/panes", get(panes_handler))
+        .route("/api/work-metadata", get(work_metadata_handler))
         .route("/api/terminal-sessions", get(terminal_sessions_handler))
         .route(
             "/api/terminal-sessions/{id}/capture",
@@ -336,6 +352,9 @@ pub fn router(state: AppState) -> Router {
         .route("/api/panes/{pane}/prompt", post(pane_prompt_handler))
         .route("/api/fleet/{host}/command", post(fleet_command_handler))
         .route("/api/panes/{pane}/abort", post(pane_abort_handler))
+        .route("/api/work-metadata", put(work_metadata_put_handler))
+        .route("/api/work-control/prompt", post(work_prompt_handler))
+        .route("/api/work-control/abort", post(work_abort_handler))
         .route(
             "/api/terminal-sessions/{id}/input",
             post(terminal_input_handler),
@@ -405,6 +424,7 @@ pub async fn serve(
     let state = AppState::new(store, config.clone(), pane_cache, sessions)
         .with_backends(backends)
         .with_activity_paths(runtime.activity_path, runtime.session_activity_path)
+        .with_work_store_path(runtime.work_store_path)
         .with_stats_config(runtime.stats_config)
         .with_fleet(runtime.fleet);
     let app = router(state);
@@ -676,6 +696,211 @@ async fn panes_handler(State(state): State<AppState>) -> impl IntoResponse {
         panes: result.panes,
         errors: result.errors,
         fetched_at: result.fetched_at,
+    })
+}
+
+#[derive(Debug, Serialize)]
+struct WorkMetadataResponse {
+    works: Vec<WorkRecord>,
+}
+
+async fn work_metadata_handler(State(state): State<AppState>) -> impl IntoResponse {
+    Json(WorkMetadataResponse {
+        works: state.work_store.lock().await.records(),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkMetadataPutRequest {
+    key: WorkKey,
+    metadata: WorkMetadataPatch,
+}
+
+async fn work_metadata_put_handler(
+    State(state): State<AppState>,
+    Json(input): Json<WorkMetadataPutRequest>,
+) -> Response {
+    let metadata = match input.metadata.validate() {
+        Ok(metadata) => metadata,
+        Err(error) => return control_error(StatusCode::BAD_REQUEST, error),
+    };
+    let scan = state.refresh_pane_scan().await;
+    if !scan
+        .panes
+        .iter()
+        .any(|pane| pane_matches_work_key(pane, &input.key))
+    {
+        return control_error(StatusCode::NOT_FOUND, "work item is no longer present");
+    }
+    match state
+        .work_store
+        .lock()
+        .await
+        .upsert(input.key, metadata)
+        .await
+    {
+        Ok(record) => Json(json!({ "ok": true, "work": record })).into_response(),
+        Err(error) => control_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("persist work metadata: {error}"),
+        ),
+    }
+}
+
+fn pane_socket_identity(pane: &PaneSummary) -> String {
+    if pane.host == HostKind::Tmux {
+        pane.socket
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("default")
+            .to_string()
+    } else {
+        pane.socket.to_string_lossy().to_string()
+    }
+}
+
+fn pane_matches_work_key(pane: &PaneSummary, key: &WorkKey) -> bool {
+    pane.host == key.host
+        && pane_socket_identity(pane) == key.socket
+        && pane.session_id == key.session_id
+        && pane.window_id == key.window_id
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkPromptRequest {
+    key: WorkKey,
+    text: String,
+    #[serde(default = "default_true")]
+    submit: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkAbortRequest {
+    key: WorkKey,
+}
+
+#[derive(Debug, Serialize)]
+struct WorkControlResult {
+    pane: String,
+    sent: bool,
+    submitted: bool,
+}
+
+async fn work_prompt_handler(
+    State(state): State<AppState>,
+    Json(input): Json<WorkPromptRequest>,
+) -> Response {
+    if input.text.trim().is_empty() {
+        return control_error(StatusCode::BAD_REQUEST, "prompt text is empty");
+    }
+    run_work_control(&state, input.key, input.text, input.submit, "prompt").await
+}
+
+async fn work_abort_handler(
+    State(state): State<AppState>,
+    Json(input): Json<WorkAbortRequest>,
+) -> Response {
+    run_work_control(&state, input.key, "\u{3}".to_string(), false, "abort").await
+}
+
+async fn run_work_control(
+    state: &AppState,
+    key: WorkKey,
+    text: String,
+    submit: bool,
+    action: &'static str,
+) -> Response {
+    let backend = match state
+        .backends
+        .iter()
+        .find(|backend| backend.kind() == key.host)
+        .cloned()
+    {
+        Some(backend) if backend.caps().send_text => backend,
+        Some(backend) => {
+            return control_error(
+                StatusCode::NOT_IMPLEMENTED,
+                format!("{} backend does not support pane input", backend.kind()),
+            );
+        }
+        None => {
+            return control_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!("no active {} backend", key.host),
+            );
+        }
+    };
+    let scan = state.refresh_pane_scan().await;
+    let agents = state.store.snapshot().await;
+    let candidates = scan
+        .panes
+        .iter()
+        .filter(|pane| pane_matches_work_key(pane, &key))
+        .filter(|pane| pane.muxa.managed_agent || pane_has_live_agent(pane, &scan.panes, &agents))
+        .map(|pane| pane.pane_id.clone())
+        .collect::<Vec<_>>();
+    if candidates.is_empty() {
+        return control_error(
+            StatusCode::NOT_FOUND,
+            "work item has no live or managed agent panes",
+        );
+    }
+
+    let socket = key.socket;
+    let results = tokio::task::spawn_blocking(move || {
+        candidates
+            .into_iter()
+            .map(|pane| {
+                let sent = backend.send_text_on(Some(&socket), &pane, &text);
+                let submitted = if sent && submit {
+                    std::thread::sleep(crate::backend::PROMPT_SUBMIT_GRACE);
+                    backend.send_text_on(Some(&socket), &pane, "\r")
+                } else {
+                    false
+                };
+                WorkControlResult {
+                    pane,
+                    sent,
+                    submitted,
+                }
+            })
+            .collect::<Vec<_>>()
+    })
+    .await
+    .unwrap_or_default();
+    let succeeded = results.iter().filter(|result| result.sent).count();
+    if succeeded == 0 {
+        return control_error(
+            StatusCode::BAD_GATEWAY,
+            format!("{action} failed for every agent pane"),
+        );
+    }
+    Json(json!({
+        "ok": succeeded == results.len(),
+        "action": action,
+        "attempted": results.len(),
+        "succeeded": succeeded,
+        "results": results,
+    }))
+    .into_response()
+}
+
+fn pane_has_live_agent(pane: &PaneSummary, panes: &[PaneSummary], agents: &[Agent]) -> bool {
+    let duplicates = panes
+        .iter()
+        .filter(|candidate| candidate.host == pane.host && candidate.pane_id == pane.pane_id)
+        .count();
+    agents.iter().any(|agent| {
+        agent.state != AgentState::Stopped
+            && agent.pane.as_deref() == Some(&pane.pane_id)
+            && crate::backend::pane_id_host_kind(&pane.pane_id).is_none_or(|host| host == pane.host)
+            && match agent.tmux_socket.as_deref() {
+                Some(socket) => {
+                    crate::backend::pane_endpoint_identity(Some(&pane.pane_id), socket)
+                        == pane_socket_identity(pane)
+                }
+                None => duplicates == 1,
+            }
     })
 }
 
@@ -1674,6 +1899,7 @@ mod tests {
 
     struct RecordingControlBackend {
         sent: Arc<Mutex<Vec<(String, String)>>>,
+        panes: Vec<PaneInfo>,
     }
 
     struct InventoryBackend {
@@ -1724,11 +1950,14 @@ mod tests {
         }
 
         fn list_panes(&self) -> Vec<PaneInfo> {
-            Vec::new()
+            self.panes.clone()
         }
 
-        fn resolve_pane(&self, _pane_id: &str) -> Option<PaneInfo> {
-            None
+        fn resolve_pane(&self, pane_id: &str) -> Option<PaneInfo> {
+            self.panes
+                .iter()
+                .find(|pane| pane.pane_id == pane_id)
+                .cloned()
         }
 
         fn capture_pane(&self, _pane_id: &str) -> Option<String> {
@@ -1785,6 +2014,47 @@ mod tests {
         cfg.auth = DashboardAuthMode::PublicRead;
         cfg.token = Some(token.to_string());
         state_from(cfg)
+    }
+
+    fn test_pane(
+        pane_id: &str,
+        session_id: &str,
+        session: &str,
+        window_id: &str,
+        window_name: &str,
+    ) -> PaneInfo {
+        PaneInfo {
+            socket: None,
+            pane_id: pane_id.into(),
+            session_id: session_id.into(),
+            session: session.into(),
+            window_id: window_id.into(),
+            window_name: window_name.into(),
+            window_index: "0".into(),
+            pane_index: "0".into(),
+            tty: String::new(),
+            current_command: "codex".into(),
+            title: String::new(),
+            pane_pid: 0,
+            current_path: "/work/muxa".into(),
+        }
+    }
+
+    async fn seed_agent(state: &AppState, session_id: &str, pane: &str) {
+        state
+            .store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    tmux_socket: None,
+                    kind: AgentKind::Codex,
+                    session_id: session_id.into(),
+                    surface: None,
+                    pane: Some(pane.into()),
+                    cwd: None,
+                },
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
     }
 
     fn state_from(cfg: DashboardConfig) -> AppState {
@@ -2096,6 +2366,7 @@ mod tests {
         use std::path::PathBuf;
 
         let tmux_pane = PaneSummary {
+            host: HostKind::Tmux,
             pane_id: "%1".into(),
             session_id: "$1".into(),
             session: "main".into(),
@@ -2106,7 +2377,9 @@ mod tests {
             tty: String::new(),
             current_command: "zsh".into(),
             title: String::new(),
+            current_path: "/tmp/project".into(),
             socket: PathBuf::from("default"),
+            muxa: MuxaPaneMetadata::default(),
             attach_command: "tmux attach".into(),
         };
         let tmux = ScanResult {
@@ -2440,7 +2713,10 @@ mod tests {
     #[tokio::test]
     async fn public_read_pat_can_send_and_submit_a_pane_prompt() {
         let sent = Arc::new(Mutex::new(Vec::new()));
-        let backend: SharedBackend = Arc::new(RecordingControlBackend { sent: sent.clone() });
+        let backend: SharedBackend = Arc::new(RecordingControlBackend {
+            sent: sent.clone(),
+            panes: Vec::new(),
+        });
         let app = router(public_read_state("edit-pat").with_backend(backend));
         let response = app
             .oneshot(
@@ -2460,6 +2736,124 @@ mod tests {
             vec![
                 ("herdr:p1".to_string(), "review this".to_string()),
                 ("herdr:p1".to_string(), "\r".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn work_metadata_requires_pat_and_persists_for_the_exact_ticket() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("dashboard-work.json");
+        let backend: SharedBackend = Arc::new(InventoryBackend {
+            kind: HostKind::Herdr,
+            panes: vec![test_pane(
+                "herdr:p1",
+                "session-1",
+                "muxa",
+                "window-1",
+                "CAL-101",
+            )],
+        });
+        let state = public_read_state("edit-pat")
+            .with_backend(backend)
+            .with_work_store_path(Some(path.clone()));
+        let app = router(state);
+        let body = r#"{
+            "key":{"host":"herdr","socket":"herdr","session_id":"session-1","window_id":"window-1"},
+            "metadata":{"title":"Repair auth","goal":"No stale tokens","next_action":"Run tests","stage":"review"}
+        }"#;
+
+        let locked = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/work-metadata")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(locked.status(), StatusCode::UNAUTHORIZED);
+
+        let saved = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/work-metadata")
+                    .header(header::AUTHORIZATION, "Bearer edit-pat")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(saved.status(), StatusCode::OK);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/work-metadata")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let response = body_json(response).await;
+        assert_eq!(response["works"][0]["metadata"]["title"], "Repair auth");
+        assert_eq!(response["works"][0]["metadata"]["stage"], "review");
+
+        let reloaded = WorkStore::load(Some(path));
+        assert_eq!(reloaded.records().len(), 1);
+        assert_eq!(
+            reloaded.records()[0].metadata.title.as_deref(),
+            Some("Repair auth")
+        );
+    }
+
+    #[tokio::test]
+    async fn work_prompt_targets_only_live_agents_in_the_selected_ticket() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let panes = vec![
+            test_pane("herdr:p1", "session-1", "muxa", "window-1", "CAL-101"),
+            test_pane("herdr:p2", "session-1", "muxa", "window-1", "CAL-101"),
+            test_pane("herdr:p3", "session-1", "muxa", "window-2", "CAL-102"),
+            test_pane("herdr:shell", "session-1", "muxa", "window-1", "CAL-101"),
+        ];
+        let backend: SharedBackend = Arc::new(RecordingControlBackend {
+            sent: sent.clone(),
+            panes,
+        });
+        let state = public_read_state("edit-pat").with_backend(backend);
+        seed_agent(&state, "agent-1", "herdr:p1").await;
+        seed_agent(&state, "agent-2", "herdr:p2").await;
+        seed_agent(&state, "agent-3", "herdr:p3").await;
+
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/work-control/prompt")
+                    .header(header::AUTHORIZATION, "Bearer edit-pat")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{"key":{"host":"herdr","socket":"herdr","session_id":"session-1","window_id":"window-1"},"text":"report status","submit":false}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let response = body_json(response).await;
+        assert_eq!(response["attempted"], 2);
+        assert_eq!(response["succeeded"], 2);
+        assert_eq!(
+            *sent.lock().unwrap(),
+            vec![
+                ("herdr:p1".to_string(), "report status".to_string()),
+                ("herdr:p2".to_string(), "report status".to_string()),
             ]
         );
     }

--- a/crates/muxa/src/dashboard/web/index.html
+++ b/crates/muxa/src/dashboard/web/index.html
@@ -28,11 +28,11 @@
     <aside class="panel session-panel">
       <div class="panel-header compact">
         <div class="panel-title">
-          <h2>Sessions</h2>
+          <h2>Workspaces</h2>
           <span class="panel-meta" id="sessions-meta"></span>
         </div>
         <div class="session-actions">
-          <select id="session-sort" class="select compact-select" title="Sort sessions">
+          <select id="session-sort" class="select compact-select" title="Sort workspaces">
             <option value="priority">priority</option>
             <option value="latest">latest</option>
             <option value="name">A-Z</option>
@@ -40,7 +40,7 @@
             <option value="human">human</option>
             <option value="tmux">tmux</option>
           </select>
-          <button class="icon-btn" type="button" id="show-all-sessions" title="Show all sessions">∅</button>
+          <button class="icon-btn" type="button" id="show-all-sessions" title="Show all workspaces">∅</button>
         </div>
       </div>
       <div class="session-list" id="session-list">
@@ -51,11 +51,11 @@
     <section class="workbench">
       <section class="overview-strip" id="overview-strip">
         <div class="metric-card">
-          <span>working</span>
+          <span>active tickets</span>
           <strong id="metric-working">—</strong>
         </div>
         <div class="metric-card attention">
-          <span>waiting</span>
+          <span>attention</span>
           <strong id="metric-waiting">—</strong>
         </div>
         <div class="metric-card danger">
@@ -76,6 +76,19 @@
         </div>
       </section>
 
+      <section class="panel work-items-panel" id="work-items-panel">
+        <div class="panel-header">
+          <div class="panel-title">
+            <h2>Work items</h2>
+            <span class="panel-meta" id="work-items-meta"></span>
+          </div>
+          <button class="control-btn" type="button" id="toggle-work-execution">expand execution</button>
+        </div>
+        <div class="work-items-content" id="work-items-content">
+          <div class="empty-block">loading…</div>
+        </div>
+      </section>
+
       <section class="panel timeline-panel" id="timeline-panel" data-panel="timeline">
         <div class="panel-header">
           <div class="panel-title">
@@ -88,9 +101,9 @@
           <div class="filters">
             <span class="filter-label">range:</span>
             <span class="chips" id="timeline-range-chips"></span>
-            <span class="filter-label">session:</span>
+            <span class="filter-label">workspace:</span>
             <select id="timeline-session" class="select">
-              <option value="">all sessions</option>
+              <option value="">all workspaces</option>
             </select>
           </div>
         </div>
@@ -114,7 +127,10 @@
       <section class="panel data-panel" id="data-panel">
         <div class="panel-header">
           <div class="panel-title">
-            <h2>Data</h2>
+            <button class="collapse-btn" type="button" data-collapse-target="data-panel" aria-expanded="true" aria-controls="data-panel-content" title="Collapse execution inventory">
+              <span aria-hidden="true">⌄</span>
+            </button>
+            <h2>Execution inventory</h2>
             <span class="panel-meta" id="data-meta"></span>
           </div>
           <div class="tabs" id="data-tabs">
@@ -124,6 +140,7 @@
           </div>
         </div>
 
+        <div class="panel-content" id="data-panel-content">
         <div class="tab-pane active" id="agents-tab">
           <div class="panel-toolbar">
             <div class="filters">
@@ -207,6 +224,7 @@
               </tbody>
             </table>
           </div>
+        </div>
         </div>
       </section>
     </section>

--- a/crates/muxa/src/dashboard/web/index.html
+++ b/crates/muxa/src/dashboard/web/index.html
@@ -36,9 +36,6 @@
             <option value="priority">priority</option>
             <option value="latest">latest</option>
             <option value="name">A-Z</option>
-            <option value="active">active</option>
-            <option value="human">human</option>
-            <option value="tmux">tmux</option>
           </select>
           <button class="icon-btn" type="button" id="show-all-sessions" title="Show all workspaces">∅</button>
         </div>
@@ -50,45 +47,50 @@
 
     <section class="workbench">
       <section class="overview-strip" id="overview-strip">
-        <div class="metric-card">
-          <span>active tickets</span>
-          <strong id="metric-working">—</strong>
-        </div>
         <div class="metric-card attention">
           <span>attention</span>
-          <strong id="metric-waiting">—</strong>
-        </div>
-        <div class="metric-card danger">
-          <span>errors</span>
-          <strong id="metric-errors">—</strong>
+          <strong id="metric-attention">—</strong>
         </div>
         <div class="metric-card active">
-          <span title="engaged human time estimated from prompts, tmux input, and thinking">act</span>
-          <strong id="metric-active">—</strong>
+          <span>in progress</span>
+          <strong id="metric-progress">—</strong>
+        </div>
+        <div class="metric-card review">
+          <span>review</span>
+          <strong id="metric-review">—</strong>
         </div>
         <div class="metric-card">
-          <span title="tmux foreground plus muxa-recorded human interactions">human</span>
-          <strong id="metric-human">—</strong>
+          <span>queued</span>
+          <strong id="metric-queued">—</strong>
         </div>
         <div class="metric-card">
-          <span>tmux</span>
-          <strong id="metric-tmux">—</strong>
+          <span>done</span>
+          <strong id="metric-done">—</strong>
+        </div>
+        <div class="metric-card">
+          <span>participants</span>
+          <strong id="metric-participants">—</strong>
         </div>
       </section>
 
       <section class="panel work-items-panel" id="work-items-panel">
         <div class="panel-header">
           <div class="panel-title">
-            <h2>Work items</h2>
+            <h2>Work board</h2>
             <span class="panel-meta" id="work-items-meta"></span>
           </div>
           <button class="control-btn" type="button" id="toggle-work-execution">expand execution</button>
         </div>
-        <div class="work-items-content" id="work-items-content">
+        <div class="work-items-content work-board" id="work-items-content">
           <div class="empty-block">loading…</div>
         </div>
       </section>
 
+      <section class="diagnostics-section">
+        <div class="diagnostics-heading">
+          <span>Execution diagnostics</span>
+          <small>secondary topology and retained activity</small>
+        </div>
       <section class="panel timeline-panel" id="timeline-panel" data-panel="timeline">
         <div class="panel-header">
           <div class="panel-title">
@@ -227,20 +229,24 @@
         </div>
         </div>
       </section>
+      </section>
     </section>
 
-    <aside class="panel inspector-panel">
+    <aside class="panel inspector-panel work-drawer" id="work-drawer" role="dialog" aria-modal="true" aria-labelledby="work-drawer-title" hidden>
       <div class="panel-header compact">
         <div class="panel-title">
-          <h2>Inspector</h2>
+          <h2 id="work-drawer-title">Work details</h2>
           <span class="panel-meta" id="inspector-meta"></span>
         </div>
+        <button class="icon-btn" type="button" id="close-work-drawer" title="Close work details">×</button>
       </div>
       <div class="inspector-body" id="inspector-body">
         <div class="empty-block">loading…</div>
       </div>
     </aside>
   </main>
+
+  <button class="drawer-backdrop" type="button" id="drawer-backdrop" aria-label="Close work details" hidden></button>
 
   <div id="toast" class="toast" hidden></div>
 

--- a/crates/muxa/src/dashboard/web/main.js
+++ b/crates/muxa/src/dashboard/web/main.js
@@ -1,3 +1,5 @@
+import { buildWorkProjection, normalizeAgent } from "./work-model.mjs";
+
 // muxa dashboard frontend.
 //
 // Vanilla ES2022 modules — no build step. Loaded as
@@ -27,6 +29,7 @@
 const TOKEN_KEY = "muxa.token";
 const COLLAPSED_PANELS_KEY = "muxa.dashboard.collapsedPanels";
 const COLLAPSED_TIMELINE_GROUPS_KEY = "muxa.dashboard.collapsedTimelineGroups";
+const EXPANDED_WORKS_KEY = "muxa.dashboard.expandedWorks";
 const DATA_TAB_KEY = "muxa.dashboard.dataTab";
 const SESSION_SORT_KEY = "muxa.dashboard.sessionSort";
 const PANES_REFETCH_INTERVAL_MS = 5000;
@@ -206,6 +209,9 @@ const dom = {
   sessionsMeta: document.getElementById("sessions-meta"),
   sessionSort: document.getElementById("session-sort"),
   showAllSessions: document.getElementById("show-all-sessions"),
+  workItemsMeta: document.getElementById("work-items-meta"),
+  workItemsContent: document.getElementById("work-items-content"),
+  toggleWorkExecution: document.getElementById("toggle-work-execution"),
   metricWorking: document.getElementById("metric-working"),
   metricWaiting: document.getElementById("metric-waiting"),
   metricErrors: document.getElementById("metric-errors"),
@@ -271,6 +277,7 @@ function renderAccess() {
   if (store.agents.size > 0) renderAgents();
   if (store.panes.length > 0) renderPanes();
   if (store.terminalSessions.length > 0) renderTerminals();
+  renderWorkItems();
 }
 
 async function fetchAccess() {
@@ -314,13 +321,13 @@ function initAccessControl() {
   });
 }
 
-function loadSet(key) {
+function loadSet(key, fallback = []) {
   try {
     const raw = localStorage.getItem(key);
-    const vals = raw ? JSON.parse(raw) : [];
-    return new Set(Array.isArray(vals) ? vals : []);
+    const vals = raw ? JSON.parse(raw) : fallback;
+    return new Set(Array.isArray(vals) ? vals : fallback);
   } catch (_) {
-    return new Set();
+    return new Set(fallback);
   }
 }
 
@@ -375,16 +382,21 @@ const store = {
     terminalFingerprint: "",
     sessionSummariesKey: "",
     sessionSummaries: [],
+    workProjectionKey: "",
+    workspaces: [],
   },
   ui: {
-    collapsedPanels: loadSet(COLLAPSED_PANELS_KEY),
+    collapsedPanels: loadSet(COLLAPSED_PANELS_KEY, ["timeline-panel", "data-panel"]),
     collapsedTimelineGroups: loadSet(COLLAPSED_TIMELINE_GROUPS_KEY),
+    expandedWorks: loadSet(EXPANDED_WORKS_KEY),
     activeTab: loadValue(DATA_TAB_KEY, "agents"),
     sessionSort: normalizeSessionSort(loadValue(SESSION_SORT_KEY, "priority")),
     sessionLimit: SESSION_PAGE_SIZE,
     selectedSegment: null,
     terminalCapture: null,
     selectedTimelineDay: "",
+    selectedWorkKey: "",
+    selectedWorkspaceKey: "",
   },
   filters: {
     agentStates: new Set(AGENT_STATES),
@@ -427,6 +439,35 @@ function rebuildTimelineIndexes() {
       store.indexes.timelineSessionByAgent.set(lane.session_id, lane.session_name || lane.session_id);
     }
   }
+}
+
+function workspaces() {
+  const cacheKey = `${store.revisions.agents}:${store.revisions.panes}`;
+  if (store.cache.workProjectionKey === cacheKey) return store.cache.workspaces;
+  store.cache.workProjectionKey = cacheKey;
+  store.cache.workspaces = buildWorkProjection(store.panes, [...store.agents.values()]);
+  return store.cache.workspaces;
+}
+
+function selectedWorkspace() {
+  if (!store.ui.selectedWorkspaceKey) return null;
+  return workspaces().find((workspace) => workspace.key === store.ui.selectedWorkspaceKey) || null;
+}
+
+function visibleWorks() {
+  const selected = selectedWorkspace();
+  if (selected) return selected.works;
+  const session = selectedSession();
+  return workspaces()
+    .filter((workspace) => !session || workspace.name === session)
+    .flatMap((workspace) => workspace.works);
+}
+
+function selectedWork() {
+  if (!store.ui.selectedWorkKey) return null;
+  return workspaces()
+    .flatMap((workspace) => workspace.works)
+    .find((work) => work.key === store.ui.selectedWorkKey) || null;
 }
 
 function paneForAgent(agent) {
@@ -483,6 +524,9 @@ function setSelectedSession(session) {
   const next = session || "";
   if (store.filters.timelineSession === next && store.timeline) return;
   store.filters.timelineSession = next;
+  const matchingWorkspaces = workspaces().filter((workspace) => workspace.name === next);
+  store.ui.selectedWorkspaceKey = matchingWorkspaces.length === 1 ? matchingWorkspaces[0].key : "";
+  store.ui.selectedWorkKey = "";
   store.ui.selectedSegment = null;
   store.ui.terminalCapture = null;
   store.indexes.timelineSessionByAgent.clear();
@@ -491,8 +535,21 @@ function setSelectedSession(session) {
   renderTimeline();
   renderAgents();
   renderPanes();
+  renderWorkItems();
   renderInspector();
   fetchTimeline({ force: true }).catch(() => {});
+}
+
+function setSelectedWorkspace(workspaceKey, session) {
+  store.ui.selectedWorkspaceKey = workspaceKey || "";
+  store.ui.selectedWorkKey = "";
+  setSelectedSession(session || "");
+  // setSelectedSession resolves name-only selections for timeline consumers;
+  // restore the exact endpoint-aware key supplied by the workspace rail.
+  store.ui.selectedWorkspaceKey = workspaceKey || "";
+  renderSessionSidebar();
+  renderWorkItems();
+  renderInspector();
 }
 
 // Copy text to clipboard. Uses the async Clipboard API when available
@@ -539,18 +596,19 @@ function renderCounts() {
   dom.counts.textContent = s;
   renderOverview();
   renderSessionSidebar();
+  renderWorkItems();
   renderInspector();
 }
 
 function renderOverview() {
-  const agents = [...store.agents.values()].filter(agentMatchesSelectedSession);
-  const working = agents.filter((a) => a.state === "working").length;
-  const waiting = agents.filter((a) => a.state === "waiting_input" || a.state === "waiting_choice").length;
-  const errors = agents.filter((a) => a.state === "error").length;
+  const works = visibleWorks();
+  const active = works.filter((work) => work.working > 0).length;
+  const attention = works.filter((work) => work.attention > 0).length;
+  const errors = works.filter((work) => work.errors > 0).length;
   const lanes = store.timeline?.lanes || [];
   const totals = store.timeline?.totals || {};
-  dom.metricWorking.textContent = String(working);
-  dom.metricWaiting.textContent = String(waiting);
+  dom.metricWorking.textContent = String(active);
+  dom.metricWaiting.textContent = String(attention);
   dom.metricErrors.textContent = String(errors);
   dom.metricActive.textContent = formatDuration(totals.active_secs || 0);
   dom.metricHuman.textContent = formatDuration(
@@ -569,22 +627,20 @@ function renderSessionSidebar() {
   }
   dom.sessionsMeta.textContent = `${Math.min(store.ui.sessionLimit, summaries.length)}/${summaries.length}`;
   if (dom.sessionSort) dom.sessionSort.value = store.ui.sessionSort;
-  const allAgents = store.agents.size;
-  const allWaiting = [...store.agents.values()].filter((a) =>
-    a.state === "waiting_input" || a.state === "waiting_choice" || a.state === "error"
-  ).length;
+  const allWorks = workspaces().flatMap((workspace) => workspace.works);
+  const allWaiting = allWorks.filter((work) => work.attention > 0).length;
   const allActive = active === "";
-  const allRow = `<button class="session-row${allActive ? " active" : ""}" type="button" data-session="">
+  const allRow = `<button class="session-row${allActive ? " active" : ""}" type="button" data-workspace="" data-session="">
     <span class="session-dot ${allWaiting > 0 ? "waiting" : "working"}"></span>
     <span class="session-main">
-      <span class="session-name">all sessions</span>
-      <span class="session-detail">${allAgents} agents · ${store.panes.length} panes</span>
+      <span class="session-name">all workspaces</span>
+      <span class="session-detail">${allWorks.length} tickets · ${store.agents.size} agents</span>
     </span>
     <span class="session-score">${allWaiting}</span>
   </button>`;
   const rows = visible.map((s) => {
-    const stateClass = s.errors > 0 ? "error" : s.waiting > 0 ? "waiting" : s.working > 0 ? "working" : "idle";
-    return `<button class="session-row${s.label === active ? " active" : ""}" type="button" data-session="${esc(s.label)}">
+    const stateClass = s.errorTickets > 0 ? "error" : s.attentionTickets > 0 ? "waiting" : s.activeTickets > 0 ? "working" : "idle";
+    return `<button class="session-row${s.label === active ? " active" : ""}" type="button" data-workspace="${esc(s.workspaceKey || "")}" data-session="${esc(s.label)}">
       <span class="session-dot ${stateClass}"></span>
       <span class="session-main">
         <span class="session-name">${esc(s.label)}</span>
@@ -615,6 +671,12 @@ function buildSessionSummaries() {
         working: 0,
         waiting: 0,
         errors: 0,
+        tickets: 0,
+        activeTickets: 0,
+        attentionTickets: 0,
+        errorTickets: 0,
+        workspaceKey: "",
+        workspaceKeyConflict: false,
         latest: "",
         totals: emptyTimelineTotals(),
         human_presence_secs: 0,
@@ -655,6 +717,19 @@ function buildSessionSummaries() {
   for (const pane of store.panes) {
     ensure(pane.session).panes += 1;
   }
+  for (const workspace of workspaces()) {
+    const s = ensure(workspace.name);
+    s.tickets += workspace.works.length;
+    s.activeTickets += workspace.active;
+    s.attentionTickets += workspace.attention;
+    s.errorTickets += workspace.errors;
+    if (!s.workspaceKeyConflict && !s.workspaceKey) {
+      s.workspaceKey = workspace.key;
+    } else if (s.workspaceKey !== workspace.key) {
+      s.workspaceKey = "";
+      s.workspaceKeyConflict = true;
+    }
+  }
   for (const active of store.timelineSummary?.active_sessions || store.timeline?.active_sessions || []) {
     ensure(active.label).totals.active_secs = active.active_secs || 0;
   }
@@ -676,13 +751,13 @@ function buildSessionSummaries() {
 
 function sessionSummaryLine(s) {
   const parts = [];
-  if (s.working) parts.push(`${s.working} work`);
-  if (s.waiting) parts.push(`${s.waiting} wait`);
-  if (s.errors) parts.push(`${s.errors} err`);
-  if (s.totals?.active_secs) parts.push(`act ${formatDuration(s.totals.active_secs)}`);
+  if (s.tickets) parts.push(`${s.tickets} tickets`);
+  if (s.attentionTickets) parts.push(`${s.attentionTickets} attention`);
+  if (s.errorTickets) parts.push(`${s.errorTickets} errors`);
+  if (s.activeTickets) parts.push(`${s.activeTickets} active`);
   if (s.agents) parts.push(`${s.agents} agents`);
-  if (s.panes) parts.push(`${s.panes} panes`);
-  return parts.slice(0, 3).join(" · ") || `${s.lanes} lanes`;
+  if (s.totals?.active_secs) parts.push(`act ${formatDuration(s.totals.active_secs)}`);
+  return parts.slice(0, 3).join(" · ") || `${s.panes} panes`;
 }
 
 function compareSessionSummaries(a, b) {
@@ -710,8 +785,8 @@ function compareSessionSummaries(a, b) {
 }
 
 function comparePriority(a, b) {
-  const scoreA = a.errors * 1000 + a.waiting * 100 + a.working * 10;
-  const scoreB = b.errors * 1000 + b.waiting * 100 + b.working * 10;
+  const scoreA = a.errorTickets * 1000 + a.attentionTickets * 100 + a.activeTickets * 10;
+  const scoreB = b.errorTickets * 1000 + b.attentionTickets * 100 + b.activeTickets * 10;
   return compareNumeric(scoreB, scoreA);
 }
 
@@ -732,10 +807,133 @@ function sessionScoreLabel(s, sort) {
   if (sort === "active") return formatDuration(s.totals.active_secs || 0);
   if (sort === "human") return formatDuration(s.human_presence_secs || 0);
   if (sort === "tmux") return formatDuration(s.totals.foreground_secs || 0);
-  if (s.errors > 0) return String(s.errors);
-  if (s.waiting > 0) return String(s.waiting);
-  if (s.working > 0) return String(s.working);
+  if (s.errorTickets > 0) return String(s.errorTickets);
+  if (s.attentionTickets > 0) return String(s.attentionTickets);
+  if (s.activeTickets > 0) return String(s.activeTickets);
   return "·";
+}
+
+function workStateLabel(work) {
+  switch (work.state) {
+    case "error": return "error";
+    case "needs_attention": return "needs attention";
+    case "active": return "active";
+    case "available": return "available";
+    default: return "untracked";
+  }
+}
+
+function workSummary(work) {
+  return String(work.summary || "No recent work summary").split("\n")[0].slice(0, 180);
+}
+
+function renderWorkParticipant(agent) {
+  return `<span class="participant-pill ${esc(agent.state)}" title="${esc(agent.model || agent.kind)}">
+    <span class="state-dot ${esc(agent.state)}"></span>
+    <span>${esc(agent.kind)}</span>
+    <small>${esc(agent.state.replaceAll("_", " "))}</small>
+  </span>`;
+}
+
+function renderWorkExecution(work) {
+  const panes = work.panes.map((pane) => {
+    const agent = pane.agent;
+    const state = agent?.state || "untracked";
+    const identity = `${work.workspaceName}:${work.index}.${pane.pane_index}`;
+    const attach = pane.attach_command
+      ? `<button class="attach-btn" type="button" data-cmd="${esc(pane.attach_command)}">copy attach</button>`
+      : "";
+    return `<div class="execution-pane-row">
+      <span class="state-dot ${esc(state)}"></span>
+      <span class="execution-pane-id" title="${esc(pane.pane_id)}">${esc(identity)}</span>
+      <span class="execution-pane-command">${esc(agent?.kind || pane.current_command || "shell")}</span>
+      <span class="execution-pane-title">${esc(agent?.ai_title || agent?.last_prompt || pane.title || "")}</span>
+      <span class="control-actions">${attach}${paneControlButtons(pane.pane_id, pane.socket)}</span>
+    </div>`;
+  }).join("");
+
+  return `<div class="work-execution">
+    <div class="execution-breadcrumb">
+      <span>session</span> ${esc(work.workspaceName)}
+      <b>›</b><span>window</span> ${esc(work.index)} · ${esc(work.name)}
+      <small>${esc(work.host)} · ${esc(work.endpoint)}</small>
+    </div>
+    <div class="execution-pane-list">${panes}</div>
+  </div>`;
+}
+
+function renderWorkItems() {
+  if (!dom.workItemsContent) return;
+  const works = visibleWorks();
+  const selected = store.ui.selectedWorkKey;
+  const attention = works.filter((work) => work.attention > 0).length;
+  const scope = selectedWorkspace()?.name || selectedSession() || "all workspaces";
+  dom.workItemsMeta.textContent = `${scope} · ${works.length} tickets${attention ? ` · ${attention} attention` : ""}`;
+
+  if (works.length === 0) {
+    dom.workItemsContent.innerHTML = `<div class="empty-block work-empty">
+      No window-backed work items in this scope.<br>
+      <small>Start a work window or choose another workspace.</small>
+    </div>`;
+    dom.toggleWorkExecution.textContent = "expand execution";
+    return;
+  }
+
+  dom.workItemsContent.innerHTML = works.map((work) => {
+    const expanded = store.ui.expandedWorks.has(work.key);
+    const participants = work.participants.length
+      ? work.participants.map(renderWorkParticipant).join("")
+      : `<span class="participant-empty">no tracked agent</span>`;
+    const stateClass = work.state === "needs_attention" ? "waiting" : work.state;
+    return `<article class="work-card state-${esc(stateClass)}${selected === work.key ? " selected" : ""}">
+      <div class="work-card-head">
+        <button class="work-card-select" type="button" data-select-work="${esc(work.key)}">
+          <span class="work-identity">
+            <strong>${esc(work.name)}</strong>
+            <small>${esc(work.workspaceName)} · window ${esc(work.index)}</small>
+          </span>
+          <span class="work-state ${esc(stateClass)}">${esc(workStateLabel(work))}</span>
+        </button>
+        <button class="work-expand" type="button" data-toggle-work="${esc(work.key)}" aria-expanded="${expanded ? "true" : "false"}">
+          <span aria-hidden="true">${expanded ? "⌄" : "›"}</span>
+          ${work.panes.length} pane${work.panes.length === 1 ? "" : "s"}
+        </button>
+      </div>
+      <button class="work-card-body" type="button" data-select-work="${esc(work.key)}">
+        <span class="work-summary">${esc(workSummary(work))}</span>
+        <span class="work-facts">
+          <span>${work.participants.length} agents</span>
+          ${work.working ? `<span>${work.working} working</span>` : ""}
+          ${work.waiting ? `<span class="attention-text">${work.waiting} waiting</span>` : ""}
+          ${work.errors ? `<span class="error-text">${work.errors} error</span>` : ""}
+          <span>${esc(relTime(work.latest))}</span>
+        </span>
+        <span class="participant-list">${participants}</span>
+      </button>
+      ${expanded ? renderWorkExecution(work) : ""}
+    </article>`;
+  }).join("");
+
+  const allExpanded = works.every((work) => store.ui.expandedWorks.has(work.key));
+  dom.toggleWorkExecution.textContent = allExpanded ? "collapse execution" : "expand execution";
+}
+
+function setSelectedWork(workKey) {
+  store.ui.selectedWorkKey = workKey || "";
+  store.ui.selectedSegment = null;
+  store.ui.terminalCapture = null;
+  renderWorkItems();
+  renderInspector();
+}
+
+function toggleWorkExecution(workKey) {
+  if (store.ui.expandedWorks.has(workKey)) {
+    store.ui.expandedWorks.delete(workKey);
+  } else {
+    store.ui.expandedWorks.add(workKey);
+  }
+  saveSet(EXPANDED_WORKS_KEY, store.ui.expandedWorks);
+  renderWorkItems();
 }
 
 function renderTimeline() {
@@ -1332,7 +1530,7 @@ function renderTimelineSessionOptions(doc) {
     if (session.label) store.timelineSessions.add(session.label);
   }
   const current = store.filters.timelineSession;
-  const options = [`<option value="">all sessions</option>`]
+  const options = [`<option value="">all workspaces</option>`]
     .concat([...store.timelineSessions.values()].sort().map((s) =>
       `<option value="${esc(s)}"${s === current ? " selected" : ""}>${esc(s)}</option>`
     ));
@@ -1613,7 +1811,7 @@ function renderTerminalCapture(capture) {
 }
 
 function renderDataMeta() {
-  const scope = selectedSession() || "all sessions";
+  const scope = selectedSession() || "all workspaces";
   dom.dataMeta.textContent = `${store.ui.activeTab} · ${scope}`;
 }
 
@@ -1734,6 +1932,16 @@ function initSessionControls() {
     saveValue(SESSION_SORT_KEY, store.ui.sessionSort);
     renderSessionSidebar();
   });
+  dom.toggleWorkExecution?.addEventListener("click", () => {
+    const works = visibleWorks();
+    const allExpanded = works.length > 0 && works.every((work) => store.ui.expandedWorks.has(work.key));
+    for (const work of works) {
+      if (allExpanded) store.ui.expandedWorks.delete(work.key);
+      else store.ui.expandedWorks.add(work.key);
+    }
+    saveSet(EXPANDED_WORKS_KEY, store.ui.expandedWorks);
+    renderWorkItems();
+  });
 }
 
 function initDynamicEventDelegation() {
@@ -1745,7 +1953,33 @@ function initDynamicEventDelegation() {
       return;
     }
     const row = event.target.closest("[data-session]");
-    if (row) setSelectedSession(row.getAttribute("data-session") || "");
+    if (row) {
+      setSelectedWorkspace(
+        row.getAttribute("data-workspace") || "",
+        row.getAttribute("data-session") || ""
+      );
+    }
+  });
+
+  dom.workItemsContent.addEventListener("click", async (event) => {
+    const control = event.target.closest("[data-pane-action]");
+    if (control) {
+      await runPaneControl(control).catch((error) => showToast(error.message));
+      return;
+    }
+    const copy = event.target.closest("[data-cmd]");
+    if (copy) {
+      const ok = await copyToClipboard(copy.getAttribute("data-cmd") || "");
+      showToast(ok ? "copied attach command" : "clipboard blocked — copy manually");
+      return;
+    }
+    const toggle = event.target.closest("[data-toggle-work]");
+    if (toggle) {
+      toggleWorkExecution(toggle.getAttribute("data-toggle-work") || "");
+      return;
+    }
+    const select = event.target.closest("[data-select-work]");
+    if (select) setSelectedWork(select.getAttribute("data-select-work") || "");
   });
 
   dom.timelineHeatmap.addEventListener("click", (event) => {
@@ -1817,6 +2051,18 @@ function initDynamicEventDelegation() {
     renderPanes();
     renderInspector();
   });
+
+  dom.inspectorBody.addEventListener("click", async (event) => {
+    const control = event.target.closest("[data-pane-action]");
+    if (control) {
+      await runPaneControl(control).catch((error) => showToast(error.message));
+      return;
+    }
+    const copy = event.target.closest("[data-cmd]");
+    if (!copy) return;
+    const ok = await copyToClipboard(copy.getAttribute("data-cmd") || "");
+    showToast(ok ? "copied attach command" : "clipboard blocked — copy manually");
+  });
 }
 
 function initCollapseControls() {
@@ -1860,6 +2106,11 @@ function renderInspector() {
     renderSegmentInspector(store.ui.selectedSegment);
     return;
   }
+  const work = selectedWork();
+  if (work) {
+    renderWorkInspector(work);
+    return;
+  }
 
   const session = selectedSession();
   const summaries = buildSessionSummaries();
@@ -1870,7 +2121,7 @@ function renderInspector() {
   const panes = store.panes.filter(paneMatchesSelectedSession);
 
   dom.inspectorMeta.textContent = session || "overview";
-  const title = session || "all sessions";
+  const title = session || "all workspaces";
   const activeSummary = summary || {
     working: agents.filter((a) => a.state === "working").length,
     waiting: agents.filter((a) => a.state === "waiting_input" || a.state === "waiting_choice").length,
@@ -1905,6 +2156,42 @@ function renderInspector() {
     <div class="inspector-section">
       <h3>Panes</h3>
       ${renderInspectorPanes(panes.slice(0, 8))}
+    </div>`;
+}
+
+function renderWorkInspector(work) {
+  dom.inspectorMeta.textContent = "ticket";
+  const participants = work.participants.length
+    ? work.participants.map((agent) => `<div class="mini-row participant-row">
+        <span class="state-dot ${esc(agent.state)}"></span>
+        <span>${esc(agent.kind)} · ${esc(agent.model || "default model")}</span>
+        <small>${esc(agent.state.replaceAll("_", " "))}</small>
+      </div>`).join("")
+    : `<div class="empty-block compact">no tracked agents</div>`;
+  dom.inspectorBody.innerHTML = `
+    <div class="inspector-title">
+      <span>${esc(work.name)}</span>
+      <small>${esc(work.workspaceName)} · ${esc(workStateLabel(work))}</small>
+    </div>
+    <div class="inspector-grid">
+      ${inspectorMetric("agents", work.participants.length)}
+      ${inspectorMetric("panes", work.panes.length)}
+      ${inspectorMetric("working", work.working)}
+      ${inspectorMetric("attention", work.attention)}
+      ${inspectorMetric("errors", work.errors)}
+      ${inspectorMetric("activity", relTime(work.latest))}
+    </div>
+    <div class="inspector-section">
+      <h3>Latest work signal</h3>
+      <p class="inspector-summary">${esc(workSummary(work))}</p>
+    </div>
+    <div class="inspector-section">
+      <h3>Participants</h3>
+      ${participants}
+    </div>
+    <div class="inspector-section inspector-execution">
+      <h3>Execution hierarchy</h3>
+      ${renderWorkExecution(work)}
     </div>`;
 }
 
@@ -2018,7 +2305,10 @@ function scheduleLiveRender({ panes = false, terminals = false } = {}) {
 async function fetchAgentsSnapshot() {
   const data = await jsonFetch("/api/agents");
   store.agents.clear();
-  for (const a of data.agents || []) store.agents.set(a.session_id, a);
+  for (const raw of data.agents || []) {
+    const agent = normalizeAgent(raw);
+    store.agents.set(agent.session_id, agent);
+  }
   store.revisions.agents += 1;
   scheduleLiveRender();
 }
@@ -2142,7 +2432,10 @@ async function fetchHealth() {
 
 function applySnapshot(payload) {
   store.agents.clear();
-  for (const a of payload.agents || []) store.agents.set(a.session_id, a);
+  for (const raw of payload.agents || []) {
+    const agent = normalizeAgent(raw);
+    store.agents.set(agent.session_id, agent);
+  }
   store.revisions.agents += 1;
   scheduleLiveRender();
   scheduleTimelineRefresh();
@@ -2150,7 +2443,7 @@ function applySnapshot(payload) {
 
 function applyTransition(t) {
   if (!t || !t.agent) return;
-  const a = t.agent;
+  const a = normalizeAgent(t.agent);
   if (t.to === "stopped" && t.from === "stopped") {
     store.agents.delete(a.session_id);
   } else {

--- a/crates/muxa/src/dashboard/web/main.js
+++ b/crates/muxa/src/dashboard/web/main.js
@@ -1,4 +1,4 @@
-import { buildWorkProjection, normalizeAgent } from "./work-model.mjs";
+import { buildWorkProjection, normalizeAgent, WORK_STAGES } from "./work-model.mjs";
 
 // muxa dashboard frontend.
 //
@@ -33,6 +33,7 @@ const EXPANDED_WORKS_KEY = "muxa.dashboard.expandedWorks";
 const DATA_TAB_KEY = "muxa.dashboard.dataTab";
 const SESSION_SORT_KEY = "muxa.dashboard.sessionSort";
 const PANES_REFETCH_INTERVAL_MS = 5000;
+const WORK_METADATA_REFETCH_INTERVAL_MS = 15000;
 const TERMINALS_REFETCH_INTERVAL_MS = 2000;
 const TIMELINE_REFETCH_INTERVAL_MS = 30000;
 const TIMELINE_MIN_REFRESH_INTERVAL_MS = 10000;
@@ -42,7 +43,7 @@ const SESSION_PAGE_SIZE = 40;
 const AGENT_STATES = ["working", "waiting_input", "waiting_choice", "idle", "starting", "error", "stopped"];
 const AGENT_KINDS = ["claude_code", "codex", "gemini_cli", "opencode", "unknown"];
 const TIMELINE_RANGES = ["24h", "today", "last week", "month", "last month", "7d", "30d", "12w"];
-const SESSION_SORTS = new Set(["priority", "latest", "name", "active", "human", "tmux"]);
+const SESSION_SORTS = new Set(["priority", "latest", "name"]);
 
 // ── Token bootstrap ────────────────────────────────────────────────
 
@@ -212,12 +213,12 @@ const dom = {
   workItemsMeta: document.getElementById("work-items-meta"),
   workItemsContent: document.getElementById("work-items-content"),
   toggleWorkExecution: document.getElementById("toggle-work-execution"),
-  metricWorking: document.getElementById("metric-working"),
-  metricWaiting: document.getElementById("metric-waiting"),
-  metricErrors: document.getElementById("metric-errors"),
-  metricActive: document.getElementById("metric-active"),
-  metricHuman: document.getElementById("metric-human"),
-  metricTmux: document.getElementById("metric-tmux"),
+  metricAttention: document.getElementById("metric-attention"),
+  metricProgress: document.getElementById("metric-progress"),
+  metricReview: document.getElementById("metric-review"),
+  metricQueued: document.getElementById("metric-queued"),
+  metricDone: document.getElementById("metric-done"),
+  metricParticipants: document.getElementById("metric-participants"),
   agentsBody: document.getElementById("agents-tbody"),
   panesBody: document.getElementById("panes-tbody"),
   terminalsBody: document.getElementById("terminals-tbody"),
@@ -240,6 +241,9 @@ const dom = {
   terminalsTab: document.getElementById("terminals-tab"),
   inspectorBody: document.getElementById("inspector-body"),
   inspectorMeta: document.getElementById("inspector-meta"),
+  workDrawer: document.getElementById("work-drawer"),
+  closeWorkDrawer: document.getElementById("close-work-drawer"),
+  drawerBackdrop: document.getElementById("drawer-backdrop"),
   toast: document.getElementById("toast"),
 };
 
@@ -278,6 +282,7 @@ function renderAccess() {
   if (store.panes.length > 0) renderPanes();
   if (store.terminalSessions.length > 0) renderTerminals();
   renderWorkItems();
+  renderInspector();
 }
 
 async function fetchAccess() {
@@ -366,6 +371,7 @@ const store = {
   },
   agents: new Map(), // session_id -> Agent
   panes: [], // PaneSummary[]
+  workMetadata: [], // WorkRecord[]
   terminalSessions: [], // SessionRef[]
   paneErrors: [], // ScanError[]
   timeline: null, // TimelineDocument
@@ -376,9 +382,10 @@ const store = {
     panesById: new Map(),
     timelineSessionByAgent: new Map(),
   },
-  revisions: { agents: 0, panes: 0, timeline: 0 },
+  revisions: { agents: 0, panes: 0, timeline: 0, workMetadata: 0 },
   cache: {
     paneFingerprint: "",
+    workMetadataFingerprint: "",
     terminalFingerprint: "",
     sessionSummariesKey: "",
     sessionSummaries: [],
@@ -442,10 +449,14 @@ function rebuildTimelineIndexes() {
 }
 
 function workspaces() {
-  const cacheKey = `${store.revisions.agents}:${store.revisions.panes}`;
+  const cacheKey = `${store.revisions.agents}:${store.revisions.panes}:${store.revisions.workMetadata}`;
   if (store.cache.workProjectionKey === cacheKey) return store.cache.workspaces;
   store.cache.workProjectionKey = cacheKey;
-  store.cache.workspaces = buildWorkProjection(store.panes, [...store.agents.values()]);
+  store.cache.workspaces = buildWorkProjection(
+    store.panes,
+    [...store.agents.values()],
+    store.workMetadata
+  );
   return store.cache.workspaces;
 }
 
@@ -457,10 +468,7 @@ function selectedWorkspace() {
 function visibleWorks() {
   const selected = selectedWorkspace();
   if (selected) return selected.works;
-  const session = selectedSession();
-  return workspaces()
-    .filter((workspace) => !session || workspace.name === session)
-    .flatMap((workspace) => workspace.works);
+  return workspaces().flatMap((workspace) => workspace.works);
 }
 
 function selectedWork() {
@@ -524,9 +532,6 @@ function setSelectedSession(session) {
   const next = session || "";
   if (store.filters.timelineSession === next && store.timeline) return;
   store.filters.timelineSession = next;
-  const matchingWorkspaces = workspaces().filter((workspace) => workspace.name === next);
-  store.ui.selectedWorkspaceKey = matchingWorkspaces.length === 1 ? matchingWorkspaces[0].key : "";
-  store.ui.selectedWorkKey = "";
   store.ui.selectedSegment = null;
   store.ui.terminalCapture = null;
   store.indexes.timelineSessionByAgent.clear();
@@ -540,16 +545,13 @@ function setSelectedSession(session) {
   fetchTimeline({ force: true }).catch(() => {});
 }
 
-function setSelectedWorkspace(workspaceKey, session) {
+function setSelectedWorkspace(workspaceKey) {
   store.ui.selectedWorkspaceKey = workspaceKey || "";
   store.ui.selectedWorkKey = "";
-  setSelectedSession(session || "");
-  // setSelectedSession resolves name-only selections for timeline consumers;
-  // restore the exact endpoint-aware key supplied by the workspace rail.
-  store.ui.selectedWorkspaceKey = workspaceKey || "";
+  closeWorkDrawer();
   renderSessionSidebar();
+  renderOverview();
   renderWorkItems();
-  renderInspector();
 }
 
 // Copy text to clipboard. Uses the async Clipboard API when available
@@ -602,58 +604,75 @@ function renderCounts() {
 
 function renderOverview() {
   const works = visibleWorks();
-  const active = works.filter((work) => work.working > 0).length;
-  const attention = works.filter((work) => work.attention > 0).length;
-  const errors = works.filter((work) => work.errors > 0).length;
-  const lanes = store.timeline?.lanes || [];
-  const totals = store.timeline?.totals || {};
-  dom.metricWorking.textContent = String(active);
-  dom.metricWaiting.textContent = String(attention);
-  dom.metricErrors.textContent = String(errors);
-  dom.metricActive.textContent = formatDuration(totals.active_secs || 0);
-  dom.metricHuman.textContent = formatDuration(
-    store.timeline?.summary?.human_presence_secs ?? humanPresenceSecs(lanes)
+  dom.metricAttention.textContent = String(works.filter((work) => work.stage === "attention").length);
+  dom.metricProgress.textContent = String(works.filter((work) => work.stage === "in_progress").length);
+  dom.metricReview.textContent = String(works.filter((work) => work.stage === "review").length);
+  dom.metricQueued.textContent = String(works.filter((work) => work.stage === "queued").length);
+  dom.metricDone.textContent = String(works.filter((work) => work.stage === "done").length);
+  dom.metricParticipants.textContent = String(
+    works.reduce((total, work) => total + work.participants.length, 0)
   );
-  dom.metricTmux.textContent = formatDuration(totals.foreground_secs || 0);
 }
 
 function renderSessionSidebar() {
-  const summaries = buildSessionSummaries();
-  const visible = summaries.slice(0, store.ui.sessionLimit);
-  const active = selectedSession();
-  if (active && !visible.some((summary) => summary.label === active)) {
-    const selected = summaries.find((summary) => summary.label === active);
+  const sorted = [...workspaces()].sort(compareWorkspaceRows);
+  const visible = sorted.slice(0, store.ui.sessionLimit);
+  const active = store.ui.selectedWorkspaceKey;
+  if (active && !visible.some((workspace) => workspace.key === active)) {
+    const selected = sorted.find((workspace) => workspace.key === active);
     if (selected) visible.push(selected);
   }
-  dom.sessionsMeta.textContent = `${Math.min(store.ui.sessionLimit, summaries.length)}/${summaries.length}`;
+  dom.sessionsMeta.textContent = `${Math.min(store.ui.sessionLimit, sorted.length)}/${sorted.length}`;
   if (dom.sessionSort) dom.sessionSort.value = store.ui.sessionSort;
-  const allWorks = workspaces().flatMap((workspace) => workspace.works);
-  const allWaiting = allWorks.filter((work) => work.attention > 0).length;
-  const allActive = active === "";
-  const allRow = `<button class="session-row${allActive ? " active" : ""}" type="button" data-workspace="" data-session="">
-    <span class="session-dot ${allWaiting > 0 ? "waiting" : "working"}"></span>
+  const allWorks = sorted.flatMap((workspace) => workspace.works);
+  const allAttention = allWorks.filter((work) => work.stage === "attention").length;
+  const allRow = `<button class="session-row${active ? "" : " active"}" type="button" data-workspace="">
+    <span class="session-dot ${allAttention > 0 ? "waiting" : "working"}"></span>
     <span class="session-main">
       <span class="session-name">all workspaces</span>
       <span class="session-detail">${allWorks.length} tickets · ${store.agents.size} agents</span>
     </span>
-    <span class="session-score">${allWaiting}</span>
+    <span class="session-score">${allAttention || "·"}</span>
   </button>`;
-  const rows = visible.map((s) => {
-    const stateClass = s.errorTickets > 0 ? "error" : s.attentionTickets > 0 ? "waiting" : s.activeTickets > 0 ? "working" : "idle";
-    return `<button class="session-row${s.label === active ? " active" : ""}" type="button" data-workspace="${esc(s.workspaceKey || "")}" data-session="${esc(s.label)}">
+  const rows = visible.map((workspace) => {
+    const stateClass = workspace.errors > 0 ? "error" : workspace.attention > 0 ? "waiting" : workspace.active > 0 ? "working" : "idle";
+    const source = workspace.source === "managed" ? "managed" : workspace.source === "inferred" ? "repo" : "session";
+    return `<button class="session-row${workspace.key === active ? " active" : ""}" type="button" data-workspace="${esc(workspace.key)}">
       <span class="session-dot ${stateClass}"></span>
       <span class="session-main">
-        <span class="session-name">${esc(s.label)}</span>
-        <span class="session-detail">${esc(sessionSummaryLine(s))}</span>
+        <span class="session-name">${esc(workspace.name)}</span>
+        <span class="session-detail">${workspace.works.length} tickets · ${workspace.agents} agents · ${source}</span>
       </span>
-      <span class="session-score">${esc(sessionScoreLabel(s, store.ui.sessionSort))}</span>
+      <span class="session-score">${esc(workspaceScoreLabel(workspace))}</span>
     </button>`;
   }).join("");
-  const remaining = Math.max(0, summaries.length - store.ui.sessionLimit);
+  const remaining = Math.max(0, sorted.length - store.ui.sessionLimit);
   const loadMore = remaining > 0
     ? `<button class="session-load-more" type="button" data-load-more-sessions>show ${Math.min(SESSION_PAGE_SIZE, remaining)} more · ${remaining} hidden</button>`
     : "";
   dom.sessionList.innerHTML = allRow + rows + loadMore;
+}
+
+function compareWorkspaceRows(left, right) {
+  if (store.ui.sessionSort === "name") return left.name.localeCompare(right.name);
+  if (store.ui.sessionSort === "latest") {
+    return (right.latest || "").localeCompare(left.latest || "") || left.name.localeCompare(right.name);
+  }
+  return right.errors - left.errors ||
+    right.attention - left.attention ||
+    right.active - left.active ||
+    right.review - left.review ||
+    (right.latest || "").localeCompare(left.latest || "") ||
+    left.name.localeCompare(right.name);
+}
+
+function workspaceScoreLabel(workspace) {
+  if (store.ui.sessionSort === "latest") return relTime(workspace.latest);
+  if (workspace.errors > 0) return String(workspace.errors);
+  if (workspace.attention > 0) return String(workspace.attention);
+  if (workspace.active > 0) return String(workspace.active);
+  if (workspace.review > 0) return String(workspace.review);
+  return "·";
 }
 
 function buildSessionSummaries() {
@@ -823,14 +842,26 @@ function workStateLabel(work) {
   }
 }
 
+function workStageLabel(stage) {
+  switch (stage) {
+    case "attention": return "Attention";
+    case "in_progress": return "In progress";
+    case "review": return "Review";
+    case "done": return "Recently done";
+    default: return "Queued";
+  }
+}
+
 function workSummary(work) {
   return String(work.summary || "No recent work summary").split("\n")[0].slice(0, 180);
 }
 
-function renderWorkParticipant(agent) {
-  return `<span class="participant-pill ${esc(agent.state)}" title="${esc(agent.model || agent.kind)}">
+function renderWorkParticipant(agent, metadata = {}) {
+  const label = metadata.role || metadata.agent || agent.kind;
+  const title = [agent.kind, agent.model, metadata.task].filter(Boolean).join(" · ");
+  return `<span class="participant-pill ${esc(agent.state)}" title="${esc(title)}">
     <span class="state-dot ${esc(agent.state)}"></span>
-    <span>${esc(agent.kind)}</span>
+    <span>${esc(label)}</span>
     <small>${esc(agent.state.replaceAll("_", " "))}</small>
   </span>`;
 }
@@ -839,7 +870,7 @@ function renderWorkExecution(work) {
   const panes = work.panes.map((pane) => {
     const agent = pane.agent;
     const state = agent?.state || "untracked";
-    const identity = `${work.workspaceName}:${work.index}.${pane.pane_index}`;
+    const identity = `${work.sessionName}:${work.index}.${pane.pane_index}`;
     const attach = pane.attach_command
       ? `<button class="attach-btn" type="button" data-cmd="${esc(pane.attach_command)}">copy attach</button>`
       : "";
@@ -854,7 +885,8 @@ function renderWorkExecution(work) {
 
   return `<div class="work-execution">
     <div class="execution-breadcrumb">
-      <span>session</span> ${esc(work.workspaceName)}
+      <span>workspace</span> ${esc(work.workspaceName)}
+      <b>›</b><span>session</span> ${esc(work.sessionName)}
       <b>›</b><span>window</span> ${esc(work.index)} · ${esc(work.name)}
       <small>${esc(work.host)} · ${esc(work.endpoint)}</small>
     </div>
@@ -866,8 +898,8 @@ function renderWorkItems() {
   if (!dom.workItemsContent) return;
   const works = visibleWorks();
   const selected = store.ui.selectedWorkKey;
-  const attention = works.filter((work) => work.attention > 0).length;
-  const scope = selectedWorkspace()?.name || selectedSession() || "all workspaces";
+  const attention = works.filter((work) => work.stage === "attention").length;
+  const scope = selectedWorkspace()?.name || "all workspaces";
   dom.workItemsMeta.textContent = `${scope} · ${works.length} tickets${attention ? ` · ${attention} attention` : ""}`;
 
   if (works.length === 0) {
@@ -879,39 +911,48 @@ function renderWorkItems() {
     return;
   }
 
-  dom.workItemsContent.innerHTML = works.map((work) => {
-    const expanded = store.ui.expandedWorks.has(work.key);
-    const participants = work.participants.length
-      ? work.participants.map(renderWorkParticipant).join("")
-      : `<span class="participant-empty">no tracked agent</span>`;
-    const stateClass = work.state === "needs_attention" ? "waiting" : work.state;
-    return `<article class="work-card state-${esc(stateClass)}${selected === work.key ? " selected" : ""}">
-      <div class="work-card-head">
-        <button class="work-card-select" type="button" data-select-work="${esc(work.key)}">
-          <span class="work-identity">
-            <strong>${esc(work.name)}</strong>
-            <small>${esc(work.workspaceName)} · window ${esc(work.index)}</small>
-          </span>
-          <span class="work-state ${esc(stateClass)}">${esc(workStateLabel(work))}</span>
-        </button>
-        <button class="work-expand" type="button" data-toggle-work="${esc(work.key)}" aria-expanded="${expanded ? "true" : "false"}">
-          <span aria-hidden="true">${expanded ? "⌄" : "›"}</span>
-          ${work.panes.length} pane${work.panes.length === 1 ? "" : "s"}
-        </button>
-      </div>
-      <button class="work-card-body" type="button" data-select-work="${esc(work.key)}">
-        <span class="work-summary">${esc(workSummary(work))}</span>
-        <span class="work-facts">
-          <span>${work.participants.length} agents</span>
-          ${work.working ? `<span>${work.working} working</span>` : ""}
-          ${work.waiting ? `<span class="attention-text">${work.waiting} waiting</span>` : ""}
-          ${work.errors ? `<span class="error-text">${work.errors} error</span>` : ""}
-          <span>${esc(relTime(work.latest))}</span>
+  const columns = ["attention", "in_progress", "review", "queued", "done"];
+  dom.workItemsContent.innerHTML = columns.map((stage) => {
+    const staged = works.filter((work) => work.stage === stage);
+    const cards = staged.map((work) => {
+      const expanded = store.ui.expandedWorks.has(work.key);
+      const participants = work.participants.length
+        ? work.panes.filter((pane) => pane.agent)
+          .map((pane) => renderWorkParticipant(pane.agent, pane.muxa || {})).join("")
+        : `<span class="participant-empty">no tracked agent</span>`;
+      const stateClass = work.state === "needs_attention" ? "waiting" : work.state;
+      const managed = work.managed ? `<span class="managed-badge">managed</span>` : "";
+      const next = work.nextAction
+        ? `<span class="ticket-next"><b>next</b>${esc(work.nextAction)}</span>`
+        : "";
+      return `<article class="work-card board-ticket state-${esc(stateClass)}${selected === work.key ? " selected" : ""}">
+      <button class="work-card-select" type="button" data-select-work="${esc(work.key)}">
+        <span class="ticket-kicker">
+          <span>${esc(work.ticketId)}</span>${managed}
+          <small>${esc(work.workspaceName)}</small>
         </span>
+        <strong class="ticket-title">${esc(work.title)}</strong>
+        <span class="work-summary">${esc(work.goal || workSummary(work))}</span>
+        ${next}
         <span class="participant-list">${participants}</span>
       </button>
+      <div class="ticket-footer">
+        <span>${work.participants.length} agents · ${esc(relTime(work.latest))}</span>
+        <button class="work-expand" type="button" data-toggle-work="${esc(work.key)}" aria-expanded="${expanded ? "true" : "false"}">
+          <span aria-hidden="true">${expanded ? "⌄" : "›"}</span>
+          execution
+        </button>
+      </div>
       ${expanded ? renderWorkExecution(work) : ""}
     </article>`;
+    }).join("");
+    return `<section class="work-lane stage-${stage}">
+      <div class="work-lane-header">
+        <span>${workStageLabel(stage)}</span>
+        <strong>${staged.length}</strong>
+      </div>
+      <div class="work-lane-list">${cards || `<div class="lane-empty">No work</div>`}</div>
+    </section>`;
   }).join("");
 
   const allExpanded = works.every((work) => store.ui.expandedWorks.has(work.key));
@@ -924,6 +965,7 @@ function setSelectedWork(workKey) {
   store.ui.terminalCapture = null;
   renderWorkItems();
   renderInspector();
+  openWorkDrawer();
 }
 
 function toggleWorkExecution(workKey) {
@@ -1768,6 +1810,72 @@ async function runPaneControl(button) {
   }
 }
 
+function sameWorkIdentity(left, right) {
+  return left?.host === right?.host &&
+    left?.socket === right?.socket &&
+    left?.session_id === right?.session_id &&
+    left?.window_id === right?.window_id;
+}
+
+function acceptWorkRecord(record) {
+  const index = store.workMetadata.findIndex((candidate) =>
+    sameWorkIdentity(candidate.key, record.key)
+  );
+  if (index === -1) store.workMetadata.push(record);
+  else store.workMetadata[index] = record;
+  store.revisions.workMetadata += 1;
+  renderOverview();
+  renderSessionSidebar();
+  renderWorkItems();
+  renderInspector();
+}
+
+async function saveWorkMetadata(form) {
+  const work = selectedWork();
+  if (!work) throw new Error("selected work item is no longer present");
+  const data = new FormData(form);
+  const payload = await controlFetch("/api/work-metadata", {
+    method: "PUT",
+    body: JSON.stringify({
+      key: work.identity,
+      metadata: {
+        title: data.get("title") || null,
+        stage: data.get("stage") || "auto",
+        goal: data.get("goal") || null,
+        next_action: data.get("next_action") || null,
+      },
+    }),
+  });
+  acceptWorkRecord(payload.work);
+  showToast(`saved ${work.ticketId}`);
+}
+
+async function runWorkAction(action) {
+  const work = selectedWork();
+  if (!work) throw new Error("selected work item is no longer present");
+  if (action === "abort") {
+    if (!window.confirm(`Abort every live agent in ${work.ticketId}?`)) return;
+    const result = await controlFetch("/api/work-control/abort", {
+      method: "POST",
+      body: JSON.stringify({ key: work.identity }),
+    });
+    showToast(`aborted ${result.succeeded}/${result.attempted} agents`);
+    return;
+  }
+
+  const textarea = document.getElementById("work-batch-prompt");
+  const text = action === "status"
+    ? "Report current progress, blockers, evidence, and the next concrete action in one concise update."
+    : textarea?.value.trim();
+  if (!text) throw new Error("enter a ticket instruction first");
+  const result = await controlFetch("/api/work-control/prompt", {
+    method: "POST",
+    body: JSON.stringify({ key: work.identity, text, submit: true }),
+  });
+  if (textarea && action === "prompt") textarea.value = "";
+  showToast(`prompted ${result.succeeded}/${result.attempted} agents`);
+}
+
 async function runTerminalControl(button) {
   const action = button.getAttribute("data-terminal-action");
   const id = button.getAttribute("data-session");
@@ -1925,7 +2033,12 @@ function initDataTabs() {
 }
 
 function initSessionControls() {
-  dom.showAllSessions.addEventListener("click", () => setSelectedSession(""));
+  dom.showAllSessions.addEventListener("click", () => setSelectedWorkspace(""));
+  dom.closeWorkDrawer.addEventListener("click", closeWorkDrawer);
+  dom.drawerBackdrop.addEventListener("click", closeWorkDrawer);
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && !dom.workDrawer.hidden) closeWorkDrawer();
+  });
   dom.sessionSort?.addEventListener("change", () => {
     store.ui.sessionSort = normalizeSessionSort(dom.sessionSort.value);
     store.ui.sessionLimit = SESSION_PAGE_SIZE;
@@ -1952,13 +2065,8 @@ function initDynamicEventDelegation() {
       renderSessionSidebar();
       return;
     }
-    const row = event.target.closest("[data-session]");
-    if (row) {
-      setSelectedWorkspace(
-        row.getAttribute("data-workspace") || "",
-        row.getAttribute("data-session") || ""
-      );
-    }
+    const row = event.target.closest("[data-workspace]");
+    if (row) setSelectedWorkspace(row.getAttribute("data-workspace") || "");
   });
 
   dom.workItemsContent.addEventListener("click", async (event) => {
@@ -2053,6 +2161,12 @@ function initDynamicEventDelegation() {
   });
 
   dom.inspectorBody.addEventListener("click", async (event) => {
+    const workAction = event.target.closest("[data-work-action]");
+    if (workAction) {
+      await runWorkAction(workAction.getAttribute("data-work-action") || "")
+        .catch((error) => showToast(error.message));
+      return;
+    }
     const control = event.target.closest("[data-pane-action]");
     if (control) {
       await runPaneControl(control).catch((error) => showToast(error.message));
@@ -2062,6 +2176,13 @@ function initDynamicEventDelegation() {
     if (!copy) return;
     const ok = await copyToClipboard(copy.getAttribute("data-cmd") || "");
     showToast(ok ? "copied attach command" : "clipboard blocked — copy manually");
+  });
+
+  dom.inspectorBody.addEventListener("submit", async (event) => {
+    const form = event.target.closest("[data-work-metadata-form]");
+    if (!form) return;
+    event.preventDefault();
+    await saveWorkMetadata(form).catch((error) => showToast(error.message));
   });
 }
 
@@ -2097,95 +2218,93 @@ function setPanelCollapsed(panel, btn, collapsed) {
   if (icon) icon.textContent = collapsed ? "›" : "⌄";
 }
 
+function openWorkDrawer() {
+  dom.workDrawer.hidden = false;
+  dom.drawerBackdrop.hidden = false;
+  document.body.classList.add("drawer-open");
+}
+
+function closeWorkDrawer() {
+  store.ui.selectedWorkKey = "";
+  store.ui.selectedSegment = null;
+  store.ui.terminalCapture = null;
+  dom.workDrawer.hidden = true;
+  dom.drawerBackdrop.hidden = true;
+  document.body.classList.remove("drawer-open");
+  renderWorkItems();
+}
+
 function renderInspector() {
   if (store.ui.terminalCapture) {
     renderTerminalCapture(store.ui.terminalCapture);
+    openWorkDrawer();
     return;
   }
   if (store.ui.selectedSegment) {
     renderSegmentInspector(store.ui.selectedSegment);
+    openWorkDrawer();
     return;
   }
   const work = selectedWork();
   if (work) {
     renderWorkInspector(work);
+    openWorkDrawer();
     return;
   }
-
-  const session = selectedSession();
-  const summaries = buildSessionSummaries();
-  const summary = session ? summaries.find((s) => s.label === session) : null;
-  const agents = [...store.agents.values()]
-    .filter(agentMatchesSelectedSession)
-    .sort((a, b) => (b.last_activity_at || "").localeCompare(a.last_activity_at || ""));
-  const panes = store.panes.filter(paneMatchesSelectedSession);
-
-  dom.inspectorMeta.textContent = session || "overview";
-  const title = session || "all workspaces";
-  const activeSummary = summary || {
-    working: agents.filter((a) => a.state === "working").length,
-    waiting: agents.filter((a) => a.state === "waiting_input" || a.state === "waiting_choice").length,
-    errors: agents.filter((a) => a.state === "error").length,
-    agents: agents.length,
-    panes: panes.length,
-    totals: store.timeline?.totals || emptyTimelineTotals(),
-    human_presence_secs: store.timeline?.summary?.human_presence_secs ?? humanPresenceSecs(store.timeline?.lanes || []),
-  };
-  const humanSecs = activeSummary.human_presence_secs ??
-    store.timeline?.summary?.human_presence_secs ??
-    humanPresenceSecs(store.timeline?.lanes || []);
-
-  dom.inspectorBody.innerHTML = `
-    <div class="inspector-title">
-      <span>${esc(title)}</span>
-      <small>${esc(sessionSummaryLine(activeSummary))}</small>
-    </div>
-    <div class="inspector-grid">
-      ${inspectorMetric("work", activeSummary.working)}
-      ${inspectorMetric("wait", activeSummary.waiting)}
-      ${inspectorMetric("err", activeSummary.errors)}
-      ${inspectorMetric("act", formatDuration(activeSummary.totals.active_secs || 0))}
-      ${inspectorMetric("human", formatDuration(humanSecs))}
-      ${inspectorMetric("tmux", formatDuration(activeSummary.totals.foreground_secs || 0))}
-      ${inspectorMetric("panes", panes.length)}
-    </div>
-    <div class="inspector-section">
-      <h3>Agents</h3>
-      ${renderInspectorAgents(agents.slice(0, 8))}
-    </div>
-    <div class="inspector-section">
-      <h3>Panes</h3>
-      ${renderInspectorPanes(panes.slice(0, 8))}
-    </div>`;
+  dom.workDrawer.hidden = true;
+  dom.drawerBackdrop.hidden = true;
+  document.body.classList.remove("drawer-open");
 }
 
 function renderWorkInspector(work) {
-  dom.inspectorMeta.textContent = "ticket";
+  dom.inspectorMeta.textContent = `${workStageLabel(work.stage)} · ${work.participants.length} agents`;
   const participants = work.participants.length
-    ? work.participants.map((agent) => `<div class="mini-row participant-row">
-        <span class="state-dot ${esc(agent.state)}"></span>
-        <span>${esc(agent.kind)} · ${esc(agent.model || "default model")}</span>
-        <small>${esc(agent.state.replaceAll("_", " "))}</small>
-      </div>`).join("")
+    ? work.panes.filter((pane) => pane.agent).map((pane) => {
+      const metadata = pane.muxa || {};
+      const identity = metadata.role || metadata.agent || pane.agent.kind;
+      const task = metadata.task || pane.agent.ai_title || pane.agent.last_prompt || "No assigned task";
+      return `<div class="drawer-participant">
+        <span class="state-dot ${esc(pane.agent.state)}"></span>
+        <span><b>${esc(identity)}</b><small>${esc(task)}</small></span>
+        <em>${esc(pane.agent.state.replaceAll("_", " "))}</em>
+      </div>`;
+    }).join("")
     : `<div class="empty-block compact">no tracked agents</div>`;
+  const manualStage = work.metadata?.stage || "auto";
+  const stageOptions = WORK_STAGES.map((stage) =>
+    `<option value="${stage}"${stage === manualStage ? " selected" : ""}>${stage.replaceAll("_", " ")}</option>`
+  ).join("");
+  const disabled = store.access.writeAuthorized ? "" : " disabled";
   dom.inspectorBody.innerHTML = `
-    <div class="inspector-title">
-      <span>${esc(work.name)}</span>
-      <small>${esc(work.workspaceName)} · ${esc(workStateLabel(work))}</small>
+    <div class="drawer-work-heading">
+      <span class="drawer-ticket-id">${esc(work.ticketId)}</span>
+      <h2>${esc(work.title)}</h2>
+      <p>${esc(work.workspaceName)} · ${esc(workStateLabel(work))} · ${esc(work.source)}</p>
     </div>
-    <div class="inspector-grid">
-      ${inspectorMetric("agents", work.participants.length)}
-      ${inspectorMetric("panes", work.panes.length)}
-      ${inspectorMetric("working", work.working)}
-      ${inspectorMetric("attention", work.attention)}
-      ${inspectorMetric("errors", work.errors)}
-      ${inspectorMetric("activity", relTime(work.latest))}
+    <div class="drawer-signal">
+      <span>Latest work signal</span>
+      <p>${esc(workSummary(work))}</p>
+      <small>${esc(relTime(work.latest))}</small>
     </div>
-    <div class="inspector-section">
-      <h3>Latest work signal</h3>
-      <p class="inspector-summary">${esc(workSummary(work))}</p>
+    <form class="work-metadata-form" data-work-metadata-form>
+      <h3>Work definition</h3>
+      <label>Title<input name="title" maxlength="160" value="${esc(work.metadata?.title || "")}" placeholder="Human-readable work title"${disabled}></label>
+      <label>Stage<select name="stage"${disabled}>${stageOptions}</select></label>
+      <label>Goal<textarea name="goal" maxlength="4000" rows="3" placeholder="What outcome defines success?"${disabled}>${esc(work.goal)}</textarea></label>
+      <label>Next action<textarea name="next_action" maxlength="1000" rows="2" placeholder="The next concrete step"${disabled}>${esc(work.nextAction)}</textarea></label>
+      <button class="control-btn primary" type="submit"${disabled}>save work</button>
+      ${store.access.writeAuthorized ? "" : `<small class="locked-note">Unlock edit to change workflow metadata.</small>`}
+    </form>
+    <div class="inspector-section drawer-controls">
+      <h3>Ticket command</h3>
+      <textarea id="work-batch-prompt" rows="3" placeholder="Send one instruction to every live agent in this ticket"${disabled}></textarea>
+      <div class="drawer-action-row">
+        <button class="control-btn primary" type="button" data-work-action="prompt"${disabled}>prompt all</button>
+        <button class="control-btn" type="button" data-work-action="status"${disabled}>request status</button>
+        <button class="control-btn danger" type="button" data-work-action="abort"${disabled}>abort all</button>
+      </div>
     </div>
-    <div class="inspector-section">
+    <div class="inspector-section drawer-participants">
       <h3>Participants</h3>
       ${participants}
     </div>
@@ -2339,6 +2458,26 @@ async function fetchPanes() {
   return panesRequest;
 }
 
+let workMetadataRequest = null;
+async function fetchWorkMetadata() {
+  if (workMetadataRequest) return workMetadataRequest;
+  workMetadataRequest = (async () => {
+    try {
+      const data = await jsonFetch("/api/work-metadata");
+      const works = data.works || [];
+      const fingerprint = JSON.stringify(works);
+      if (fingerprint === store.cache.workMetadataFingerprint) return;
+      store.cache.workMetadataFingerprint = fingerprint;
+      store.workMetadata = works;
+      store.revisions.workMetadata += 1;
+      scheduleLiveRender();
+    } finally {
+      workMetadataRequest = null;
+    }
+  })();
+  return workMetadataRequest;
+}
+
 let terminalsRequest = null;
 async function fetchTerminalSessions() {
   if (terminalsRequest) return terminalsRequest;
@@ -2486,11 +2625,13 @@ async function main() {
   await Promise.all([
     fetchAgentsSnapshot(),
     fetchPanes(),
+    fetchWorkMetadata(),
     store.ui.activeTab === "terminals" ? fetchTerminalSessions() : Promise.resolve(),
     fetchTimeline({ force: true }),
   ]);
 
   setTimeout(pollPanes, PANES_REFETCH_INTERVAL_MS);
+  setTimeout(pollWorkMetadata, WORK_METADATA_REFETCH_INTERVAL_MS);
   setTimeout(pollTerminals, TERMINALS_REFETCH_INTERVAL_MS);
   setTimeout(pollTimeline, TIMELINE_REFETCH_INTERVAL_MS);
 
@@ -2498,6 +2639,7 @@ async function main() {
     if (document.hidden) return;
     scheduleLiveRender({ panes: true, terminals: true });
     fetchPanes().catch(() => {});
+    fetchWorkMetadata().catch(() => {});
     if (store.ui.activeTab === "terminals") fetchTerminalSessions().catch(() => {});
     if (Date.now() - lastTimelineFetchAt >= TIMELINE_MIN_REFRESH_INTERVAL_MS) {
       fetchTimeline().catch(() => {});
@@ -2520,6 +2662,11 @@ async function main() {
 async function pollPanes() {
   if (!document.hidden) await fetchPanes().catch(() => {});
   setTimeout(pollPanes, PANES_REFETCH_INTERVAL_MS);
+}
+
+async function pollWorkMetadata() {
+  if (!document.hidden) await fetchWorkMetadata().catch(() => {});
+  setTimeout(pollWorkMetadata, WORK_METADATA_REFETCH_INTERVAL_MS);
 }
 
 async function pollTerminals() {

--- a/crates/muxa/src/dashboard/web/style.css
+++ b/crates/muxa/src/dashboard/web/style.css
@@ -142,7 +142,7 @@ button, select {
 
 .dashboard-shell {
   display: grid;
-  grid-template-columns: minmax(230px, 280px) minmax(0, 1fr) minmax(270px, 330px);
+  grid-template-columns: minmax(230px, 280px) minmax(0, 1fr);
   gap: 14px;
   height: calc(100vh - 52px);
   padding: 14px;
@@ -1418,6 +1418,374 @@ table.data tr.lagged td { background: color-mix(in srgb, var(--red) 12%, transpa
   white-space: nowrap;
 }
 
+/* Work control plane ----------------------------------------------------- */
+
+.work-items-panel {
+  min-height: 430px;
+}
+
+.work-board {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(235px, 1fr));
+  align-items: start;
+  gap: 10px;
+  padding: 10px;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+}
+
+.work-lane {
+  min-width: 235px;
+  min-height: 348px;
+  padding: 8px;
+  border: 1px solid var(--border-soft);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--surface-2) 76%, transparent);
+}
+
+.work-lane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 28px;
+  padding: 0 3px 8px;
+  color: var(--fg-muted);
+  font: 10px/1.2 var(--mono);
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.work-lane-header strong {
+  min-width: 22px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--surface-3);
+  color: var(--fg);
+  text-align: center;
+  font-size: 10px;
+}
+
+.work-lane.stage-attention .work-lane-header { color: var(--yellow); }
+.work-lane.stage-in_progress .work-lane-header { color: var(--green); }
+.work-lane.stage-review .work-lane-header { color: var(--magenta); }
+.work-lane.stage-done .work-lane-header { color: var(--fg-dim); }
+
+.work-lane-list {
+  display: grid;
+  gap: 8px;
+}
+
+.lane-empty {
+  display: grid;
+  min-height: 72px;
+  place-items: center;
+  border: 1px dashed var(--border-soft);
+  border-radius: 5px;
+  color: var(--fg-dim);
+  font: 10px/1.2 var(--mono);
+}
+
+.board-ticket {
+  border-left-width: 2px;
+  background: var(--surface);
+}
+
+.board-ticket .work-card-select {
+  width: 100%;
+  display: block;
+  padding: 10px;
+}
+
+.ticket-kicker {
+  display: grid;
+  grid-template-columns: minmax(0, auto) auto 1fr;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  color: var(--accent);
+  font: 10px/1.2 var(--mono);
+}
+
+.ticket-kicker > span,
+.ticket-kicker small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ticket-kicker small {
+  color: var(--fg-dim);
+  text-align: right;
+}
+
+.managed-badge {
+  padding: 2px 4px;
+  border: 1px solid color-mix(in srgb, var(--accent) 42%, var(--border));
+  border-radius: 3px;
+  color: var(--accent);
+  font-size: 8px;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.ticket-title {
+  display: -webkit-box;
+  margin-top: 8px;
+  overflow: hidden;
+  font-size: 13px;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.board-ticket .work-summary {
+  min-height: 0;
+  margin-top: 7px;
+  color: var(--fg-muted);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.ticket-next {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 6px 7px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--accent) 8%, var(--surface-2));
+  color: var(--fg-muted);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.ticket-next b {
+  flex: 0 0 auto;
+  color: var(--accent);
+  font: 9px/1.5 var(--mono);
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.board-ticket .participant-list {
+  margin-top: 9px;
+}
+
+.ticket-footer {
+  min-height: 31px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-left: 10px;
+  border-top: 1px solid var(--border-soft);
+  color: var(--fg-dim);
+  font: 9px/1.2 var(--mono);
+}
+
+.ticket-footer .work-expand {
+  align-self: stretch;
+  min-width: 76px;
+}
+
+.diagnostics-section {
+  display: grid;
+  gap: 10px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.diagnostics-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  color: var(--fg-dim);
+  font: 10px/1.2 var(--mono);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.diagnostics-heading small {
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+[hidden] { display: none !important; }
+
+.drawer-backdrop {
+  position: fixed;
+  inset: 52px 0 0;
+  z-index: 40;
+  border: 0;
+  background: rgba(0, 0, 0, .42);
+  cursor: default;
+}
+
+.work-drawer {
+  position: fixed;
+  z-index: 50;
+  top: 66px;
+  right: 14px;
+  bottom: 14px;
+  width: min(460px, calc(100vw - 28px));
+  display: flex;
+  box-shadow: -10px 0 36px rgba(0, 0, 0, .32);
+}
+
+.work-drawer .inspector-body {
+  flex: 1 1 auto;
+}
+
+.drawer-work-heading {
+  padding-bottom: 13px;
+  border-bottom: 1px solid var(--border);
+}
+
+.drawer-ticket-id {
+  color: var(--accent);
+  font: 10px/1.2 var(--mono);
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.drawer-work-heading h2 {
+  margin: 5px 0 4px;
+  font-size: 17px;
+  line-height: 1.3;
+}
+
+.drawer-work-heading p,
+.drawer-signal p {
+  margin: 0;
+}
+
+.drawer-work-heading p,
+.drawer-signal span,
+.drawer-signal small {
+  color: var(--fg-muted);
+  font: 10px/1.35 var(--mono);
+}
+
+.drawer-signal {
+  margin-top: 12px;
+  padding: 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: 5px;
+  background: var(--surface-2);
+}
+
+.drawer-signal p {
+  margin: 5px 0;
+  line-height: 1.5;
+}
+
+.work-metadata-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 130px;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.work-metadata-form h3,
+.work-metadata-form label:nth-of-type(3),
+.work-metadata-form label:nth-of-type(4),
+.work-metadata-form .locked-note {
+  grid-column: 1 / -1;
+}
+
+.work-metadata-form h3 {
+  margin: 0;
+  color: var(--fg-muted);
+  font: 10px/1.2 var(--mono);
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.work-metadata-form label {
+  display: grid;
+  gap: 4px;
+  color: var(--fg-muted);
+  font: 10px/1.2 var(--mono);
+}
+
+.work-metadata-form input,
+.work-metadata-form textarea,
+.work-metadata-form select,
+.drawer-controls textarea {
+  width: 100%;
+  min-width: 0;
+  padding: 7px 8px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  outline: none;
+  background: var(--surface-2);
+  color: var(--fg);
+  font: 12px/1.4 var(--sans);
+  resize: vertical;
+}
+
+.work-metadata-form input:focus,
+.work-metadata-form textarea:focus,
+.work-metadata-form select:focus,
+.drawer-controls textarea:focus {
+  border-color: var(--accent);
+}
+
+.work-metadata-form :disabled,
+.drawer-controls :disabled {
+  cursor: not-allowed;
+  opacity: .58;
+}
+
+.control-btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 60%, var(--border));
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+}
+
+.locked-note {
+  color: var(--fg-dim);
+  font: 10px/1.3 var(--mono);
+}
+
+.drawer-controls textarea {
+  display: block;
+  margin-bottom: 8px;
+}
+
+.drawer-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.drawer-participant {
+  min-height: 40px;
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--border-soft);
+  font: 10px/1.3 var(--mono);
+}
+
+.drawer-participant span:nth-child(2) {
+  min-width: 0;
+}
+
+.drawer-participant b,
+.drawer-participant small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.drawer-participant small,
+.drawer-participant em {
+  color: var(--fg-muted);
+  font-style: normal;
+}
+
 .toast {
   position: fixed;
   left: 50%;
@@ -1435,20 +1803,12 @@ table.data tr.lagged td { background: color-mix(in srgb, var(--red) 12%, transpa
 }
 
 @media (max-width: 1180px) {
-  .dashboard-shell {
-    grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
-    height: auto;
-    min-height: calc(100vh - 52px);
-    overflow: visible;
+  .overview-strip {
+    grid-template-columns: repeat(3, minmax(104px, 1fr));
   }
 
-  .inspector-panel {
-    grid-column: 1 / -1;
-    min-height: 280px;
-  }
-
-  .workbench {
-    overflow: visible;
+  .work-board {
+    grid-template-columns: repeat(5, minmax(225px, 1fr));
   }
 }
 
@@ -1465,15 +1825,26 @@ table.data tr.lagged td { background: color-mix(in srgb, var(--red) 12%, transpa
 
   .dashboard-shell {
     grid-template-columns: minmax(0, 1fr);
+    height: auto;
+    min-height: calc(100vh - 52px);
     padding: 10px;
+    overflow: visible;
   }
 
   .overview-strip {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .work-items-content {
-    grid-template-columns: minmax(0, 1fr);
+  .workbench {
+    overflow: visible;
+  }
+
+  .session-panel {
+    max-height: 260px;
+  }
+
+  .work-board {
+    grid-template-columns: repeat(5, minmax(220px, 78vw));
   }
 
   .execution-pane-row {
@@ -1484,9 +1855,21 @@ table.data tr.lagged td { background: color-mix(in srgb, var(--red) 12%, transpa
     display: none;
   }
 
-  .session-panel,
-  .inspector-panel {
-    max-height: none;
+  .work-drawer {
+    top: 58px;
+    right: 6px;
+    bottom: 6px;
+    width: calc(100vw - 12px);
+  }
+
+  .work-metadata-form {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .work-metadata-form label,
+  .work-metadata-form h3,
+  .work-metadata-form .locked-note {
+    grid-column: 1;
   }
 
   .timeline-wrap {

--- a/crates/muxa/src/dashboard/web/style.css
+++ b/crates/muxa/src/dashboard/web/style.css
@@ -293,6 +293,275 @@ button, select {
 .metric-card.danger strong { color: var(--red); }
 .metric-card.active strong { color: var(--cyan); }
 
+.work-items-panel {
+  flex: 0 0 auto;
+  overflow: visible;
+}
+
+.work-items-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 10px;
+  padding: 10px;
+}
+
+.work-empty {
+  grid-column: 1 / -1;
+  padding: 28px 16px;
+  text-align: center;
+}
+
+.work-empty small {
+  color: var(--fg-dim);
+  font-family: var(--mono);
+}
+
+.work-card {
+  min-width: 0;
+  align-self: start;
+  border: 1px solid var(--border-soft);
+  border-left: 3px solid var(--fg-dim);
+  border-radius: 6px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+
+.work-card.state-active { border-left-color: var(--green); }
+.work-card.state-waiting { border-left-color: var(--yellow); }
+.work-card.state-error { border-left-color: var(--red); }
+
+.work-card.selected {
+  border-color: color-mix(in srgb, var(--accent) 58%, var(--border));
+  border-left-color: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.work-card-head {
+  min-height: 54px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.work-card-select,
+.work-card-body,
+.work-expand {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.work-card-select {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 11px;
+}
+
+.work-card-select:hover,
+.work-card-select:focus-visible,
+.work-card-body:hover,
+.work-card-body:focus-visible {
+  background: var(--row-hover);
+  outline: none;
+}
+
+.work-identity {
+  min-width: 0;
+}
+
+.work-identity strong,
+.work-identity small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.work-identity strong {
+  font-family: var(--mono);
+  font-size: 13px;
+}
+
+.work-identity small {
+  margin-top: 3px;
+  color: var(--fg-muted);
+  font-family: var(--mono);
+  font-size: 10px;
+}
+
+.work-state {
+  flex: 0 0 auto;
+  padding: 3px 7px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  color: var(--fg-muted);
+  font: 9px/1.2 var(--mono);
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.work-state.active { color: var(--green); border-color: color-mix(in srgb, var(--green) 48%, var(--border)); }
+.work-state.waiting { color: var(--yellow); border-color: color-mix(in srgb, var(--yellow) 48%, var(--border)); }
+.work-state.error { color: var(--red); border-color: color-mix(in srgb, var(--red) 48%, var(--border)); }
+
+.work-expand {
+  min-width: 78px;
+  padding: 0 10px;
+  border-left: 1px solid var(--border-soft);
+  color: var(--fg-muted);
+  font: 10px/1.2 var(--mono);
+  white-space: nowrap;
+}
+
+.work-expand:hover,
+.work-expand:focus-visible {
+  color: var(--accent);
+  background: var(--row-hover);
+  outline: none;
+}
+
+.work-card-body {
+  width: 100%;
+  display: block;
+  padding: 10px 11px 11px;
+}
+
+.work-summary {
+  display: -webkit-box;
+  min-height: 20px;
+  overflow: hidden;
+  color: var(--fg);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.work-facts,
+.participant-list {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 9px;
+}
+
+.work-facts {
+  color: var(--fg-muted);
+  font: 10px/1.2 var(--mono);
+}
+
+.work-facts span + span::before {
+  content: "·";
+  margin-right: 6px;
+  color: var(--fg-dim);
+}
+
+.attention-text { color: var(--yellow); }
+.error-text { color: var(--red); }
+
+.participant-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 100%;
+  padding: 3px 6px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: var(--surface);
+  font: 10px/1.2 var(--mono);
+}
+
+.participant-pill small {
+  color: var(--fg-muted);
+}
+
+.participant-empty {
+  color: var(--fg-dim);
+  font: 10px/1.2 var(--mono);
+}
+
+.work-execution {
+  padding: 9px 10px 10px;
+  border-top: 1px solid var(--border-soft);
+  background: var(--surface);
+}
+
+.execution-breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-bottom: 7px;
+  color: var(--fg-muted);
+  font: 10px/1.3 var(--mono);
+}
+
+.execution-breadcrumb span {
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.execution-breadcrumb small {
+  margin-left: auto;
+  color: var(--fg-dim);
+}
+
+.execution-pane-row {
+  min-height: 32px;
+  display: grid;
+  grid-template-columns: 8px minmax(82px, auto) minmax(62px, auto) minmax(80px, 1fr) auto;
+  align-items: center;
+  gap: 7px;
+  border-top: 1px solid var(--border-soft);
+  font: 10px/1.2 var(--mono);
+}
+
+.execution-pane-id,
+.execution-pane-command,
+.execution-pane-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.execution-pane-command { color: var(--cyan); }
+.execution-pane-title { color: var(--fg-muted); }
+
+.inspector-summary {
+  margin: 0;
+  color: var(--fg);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.inspector-execution .work-execution {
+  margin: 0 -4px;
+  padding: 0;
+  border: 0;
+}
+
+.inspector-execution .execution-pane-row {
+  grid-template-columns: 8px minmax(68px, auto) minmax(0, 1fr);
+  padding: 5px 0;
+}
+
+.inspector-execution .execution-pane-title,
+.inspector-execution .control-actions {
+  grid-column: 2 / -1;
+}
+
+.panel.collapsed > .panel-header .filters,
+.data-panel.collapsed > .panel-header .tabs {
+  display: none;
+}
+
 .session-panel,
 .inspector-panel {
   min-height: 0;
@@ -375,6 +644,7 @@ button, select {
 .state-dot.starting { background: var(--cyan); }
 .state-dot.idle,
 .state-dot.stopped,
+.state-dot.untracked,
 .session-dot.idle { background: var(--fg-dim); }
 
 .session-main {
@@ -1200,6 +1470,18 @@ table.data tr.lagged td { background: color-mix(in srgb, var(--red) 12%, transpa
 
   .overview-strip {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .work-items-content {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .execution-pane-row {
+    grid-template-columns: 8px minmax(72px, auto) minmax(0, 1fr) auto;
+  }
+
+  .execution-pane-title {
+    display: none;
   }
 
   .session-panel,

--- a/crates/muxa/src/dashboard/web/work-model.mjs
+++ b/crates/muxa/src/dashboard/web/work-model.mjs
@@ -1,0 +1,181 @@
+// Logical dashboard projection.
+//
+// The multiplexer topology remains the execution substrate, but the dashboard
+// presents it as workspace -> work item -> participant.  Stable backend ids
+// stay attached to every projection node so an expanded work item can still
+// target the exact session/window/pane that produced it.
+
+const ATTENTION_STATES = new Set(["waiting_input", "waiting_choice", "error"]);
+
+// `agent_session_id` is the current public wire name. Keep the older local
+// alias because older daemons and cached fixtures can still send `session_id`.
+export function normalizeAgent(agent) {
+  if (!agent || agent.session_id || !agent.agent_session_id) return agent;
+  return { ...agent, session_id: agent.agent_session_id };
+}
+
+function hostForPane(pane) {
+  const id = pane?.pane_id || "";
+  if (id.startsWith("rmux:")) return "rmux";
+  if (id.startsWith("zellij:")) return "zellij";
+  if (id.startsWith("herdr:")) return "herdr";
+  return "tmux";
+}
+
+function endpointFor(host, socket) {
+  const raw = String(socket || host || "default");
+  if (host === "rmux") return raw;
+  return raw.split("/").pop() || raw;
+}
+
+function key(parts) {
+  return parts.map((part) => encodeURIComponent(String(part || ""))).join("/");
+}
+
+function agentPaneKey(agent) {
+  if (!agent?.pane) return null;
+  const host = hostForPane({ pane_id: agent.pane });
+  return key([host, endpointFor(host, agent.tmux_socket), agent.pane]);
+}
+
+function paneAgentKey(pane) {
+  const host = hostForPane(pane);
+  return key([host, endpointFor(host, pane.socket), pane.pane_id]);
+}
+
+function latestAgentSummary(agent) {
+  return agent?.recap || agent?.ai_title || agent?.last_prompt || agent?.last_notification || "";
+}
+
+function summarizeWork(work) {
+  const participants = work.panes.flatMap((pane) => pane.agent ? [pane.agent] : []);
+  const working = participants.filter((agent) => agent.state === "working").length;
+  const waiting = participants.filter((agent) =>
+    agent.state === "waiting_input" || agent.state === "waiting_choice"
+  ).length;
+  const errors = participants.filter((agent) => agent.state === "error").length;
+  const latestAgent = [...participants].sort((left, right) =>
+    (right.last_activity_at || "").localeCompare(left.last_activity_at || "")
+  )[0];
+
+  work.participants = participants;
+  work.working = working;
+  work.waiting = waiting;
+  work.errors = errors;
+  work.attention = waiting + errors;
+  work.latest = latestAgent?.last_activity_at || "";
+  work.summary = latestAgentSummary(latestAgent) ||
+    work.panes.find((pane) => pane.title)?.title ||
+    "No recent work summary";
+  work.state = errors > 0
+    ? "error"
+    : waiting > 0
+      ? "needs_attention"
+      : working > 0
+        ? "active"
+        : participants.length > 0
+          ? "available"
+          : "untracked";
+  return work;
+}
+
+function summarizeWorkspace(workspace) {
+  workspace.works.sort(compareWorks);
+  workspace.active = workspace.works.filter((work) => work.working > 0).length;
+  workspace.attention = workspace.works.filter((work) => work.attention > 0).length;
+  workspace.errors = workspace.works.filter((work) => work.errors > 0).length;
+  workspace.agents = workspace.works.reduce((total, work) => total + work.participants.length, 0);
+  workspace.panes = workspace.works.reduce((total, work) => total + work.panes.length, 0);
+  workspace.latest = workspace.works.reduce(
+    (latest, work) => work.latest > latest ? work.latest : latest,
+    ""
+  );
+  return workspace;
+}
+
+export function compareWorks(left, right) {
+  const priority = (work) => work.errors * 1000 + work.waiting * 100 + work.working * 10;
+  return priority(right) - priority(left) ||
+    (right.latest || "").localeCompare(left.latest || "") ||
+    left.name.localeCompare(right.name);
+}
+
+export function buildWorkProjection(panes, agents) {
+  const exactAgents = new Map();
+  const agentsByPane = new Map();
+  for (const agent of agents || []) {
+    if (!agent?.pane) continue;
+    const exactKey = agentPaneKey(agent);
+    if (exactKey) exactAgents.set(exactKey, agent);
+    if (!agentsByPane.has(agent.pane)) agentsByPane.set(agent.pane, []);
+    agentsByPane.get(agent.pane).push(agent);
+  }
+
+  const workspaces = new Map();
+  for (const pane of panes || []) {
+    const host = hostForPane(pane);
+    const endpoint = endpointFor(host, pane.socket);
+    const sessionId = pane.session_id || pane.session || "unknown";
+    const workspaceKey = key(["workspace", host, endpoint, sessionId]);
+    let workspace = workspaces.get(workspaceKey);
+    if (!workspace) {
+      workspace = {
+        key: workspaceKey,
+        host,
+        endpoint,
+        sessionId,
+        name: pane.session || sessionId,
+        worksByKey: new Map(),
+      };
+      workspaces.set(workspaceKey, workspace);
+    }
+
+    const windowId = pane.window_id || pane.window_index || "unknown";
+    const workKey = key([workspaceKey, "work", windowId]);
+    let work = workspace.worksByKey.get(workKey);
+    if (!work) {
+      work = {
+        key: workKey,
+        workspaceKey,
+        workspaceName: workspace.name,
+        host,
+        endpoint,
+        sessionId,
+        windowId,
+        index: pane.window_index || "",
+        name: pane.window_name || `window ${pane.window_index || windowId}`,
+        panes: [],
+      };
+      workspace.worksByKey.set(workKey, work);
+    }
+
+    const exact = exactAgents.get(paneAgentKey(pane));
+    const candidates = agentsByPane.get(pane.pane_id) || [];
+    const agent = exact || (candidates.length === 1 ? candidates[0] : null);
+    work.panes.push({ ...pane, agent });
+  }
+
+  const result = [...workspaces.values()].map((workspace) => {
+    workspace.works = [...workspace.worksByKey.values()].map((work) => {
+      work.panes.sort((left, right) =>
+        String(left.pane_index || "").localeCompare(String(right.pane_index || ""), undefined, { numeric: true })
+      );
+      return summarizeWork(work);
+    });
+    delete workspace.worksByKey;
+    return summarizeWorkspace(workspace);
+  });
+
+  result.sort((left, right) =>
+    right.errors - left.errors ||
+    right.attention - left.attention ||
+    right.active - left.active ||
+    (right.latest || "").localeCompare(left.latest || "") ||
+    left.name.localeCompare(right.name)
+  );
+  return result;
+}
+
+export function workNeedsAttention(work) {
+  return work?.participants?.some((agent) => ATTENTION_STATES.has(agent.state)) || false;
+}

--- a/crates/muxa/src/dashboard/web/work-model.mjs
+++ b/crates/muxa/src/dashboard/web/work-model.mjs
@@ -1,11 +1,16 @@
-// Logical dashboard projection.
+// Work-centric projection for the dashboard control plane.
 //
-// The multiplexer topology remains the execution substrate, but the dashboard
-// presents it as workspace -> work item -> participant.  Stable backend ids
-// stay attached to every projection node so an expanded work item can still
-// target the exact session/window/pane that produced it.
+// Backend topology is execution detail. Managed muxa metadata is preferred;
+// unmanaged legacy panes are grouped by repository cwd so a dozen ticket-like
+// tmux sessions do not masquerade as a dozen unrelated workspaces.
 
 const ATTENTION_STATES = new Set(["waiting_input", "waiting_choice", "error"]);
+const GENERIC_WINDOW_NAMES = new Set([
+  "bash", "claude", "codex", "fish", "node", "nu", "pwsh", "python", "sh", "shell", "zsh",
+]);
+const TICKET_PATTERN = /^(?:[a-z][a-z0-9]+-\d+|#\d+)$/i;
+
+export const WORK_STAGES = ["auto", "queued", "in_progress", "review", "blocked", "done"];
 
 // `agent_session_id` is the current public wire name. Keep the older local
 // alias because older daemons and cached fixtures can still send `session_id`.
@@ -15,6 +20,7 @@ export function normalizeAgent(agent) {
 }
 
 function hostForPane(pane) {
+  if (pane?.host) return pane.host;
   const id = pane?.pane_id || "";
   if (id.startsWith("rmux:")) return "rmux";
   if (id.startsWith("zellij:")) return "zellij";
@@ -32,6 +38,15 @@ function key(parts) {
   return parts.map((part) => encodeURIComponent(String(part || ""))).join("/");
 }
 
+function identityKey(identity) {
+  return key([
+    identity?.host,
+    identity?.socket,
+    identity?.session_id,
+    identity?.window_id,
+  ]);
+}
+
 function agentPaneKey(agent) {
   if (!agent?.pane) return null;
   const host = hostForPane({ pane_id: agent.pane });
@@ -44,12 +59,78 @@ function paneAgentKey(pane) {
 }
 
 function latestAgentSummary(agent) {
-  return agent?.recap || agent?.ai_title || agent?.last_prompt || agent?.last_notification || "";
+  return agent?.recap || agent?.ai_title || agent?.last_response ||
+    agent?.last_prompt || agent?.last_notification || "";
 }
 
-function summarizeWork(work) {
+function pathWorkspace(path) {
+  const parts = String(path || "").split("/").filter(Boolean);
+  return parts.at(-1) || "";
+}
+
+function logicalWorkspace(pane, host, endpoint) {
+  const managed = pane.muxa?.managed_workspace && pane.muxa?.workspace_id;
+  if (managed) {
+    return {
+      key: key(["workspace", host, endpoint, "managed", pane.muxa.workspace_id]),
+      name: pane.muxa.workspace_id,
+      source: "managed",
+      cwd: pane.muxa.workspace_cwd || pane.current_path || "",
+    };
+  }
+  const cwd = pane.muxa?.workspace_cwd || pane.muxa?.work_cwd || pane.current_path || "";
+  const name = pathWorkspace(cwd);
+  if (name) {
+    return {
+      key: key(["workspace", host, endpoint, "cwd", cwd]),
+      name,
+      source: "inferred",
+      cwd,
+    };
+  }
+  const sessionId = pane.session_id || pane.session || "unknown";
+  return {
+    key: key(["workspace", host, endpoint, "session", sessionId]),
+    name: pane.session || sessionId,
+    source: "session",
+    cwd: "",
+  };
+}
+
+function logicalTicket(pane) {
+  if (pane.muxa?.managed_work && pane.muxa?.work_id) {
+    return { id: pane.muxa.work_id, name: pane.muxa.work_id, source: "managed" };
+  }
+  const windowName = String(pane.window_name || "").trim();
+  const sessionName = String(pane.session || "").trim();
+  if (TICKET_PATTERN.test(sessionName) && GENERIC_WINDOW_NAMES.has(windowName.toLowerCase())) {
+    return { id: sessionName.toUpperCase(), name: sessionName.toUpperCase(), source: "inferred" };
+  }
+  const fallback = windowName || `window ${pane.window_index || pane.window_id || "?"}`;
+  return { id: fallback, name: fallback, source: "window" };
+}
+
+function metadataByIdentity(records) {
+  const metadata = new Map();
+  for (const record of records || []) {
+    if (record?.key && record?.metadata) metadata.set(identityKey(record.key), record.metadata);
+  }
+  return metadata;
+}
+
+function effectiveStage(work) {
+  const manual = work.metadata?.stage || "auto";
+  if (manual === "done") return "done";
+  if (manual === "review") return "review";
+  if (manual === "blocked") return "attention";
+  if (work.errors > 0 || work.waiting > 0) return "attention";
+  if (manual === "in_progress" || work.working > 0) return "in_progress";
+  return "queued";
+}
+
+function summarizeWork(work, metadata) {
   const participants = work.panes.flatMap((pane) => pane.agent ? [pane.agent] : []);
-  const working = participants.filter((agent) => agent.state === "working").length;
+  const working = participants.filter((agent) => agent.state === "working" || agent.state === "starting").length;
   const waiting = participants.filter((agent) =>
     agent.state === "waiting_input" || agent.state === "waiting_choice"
   ).length;
@@ -64,9 +145,14 @@ function summarizeWork(work) {
   work.errors = errors;
   work.attention = waiting + errors;
   work.latest = latestAgent?.last_activity_at || "";
+  work.metadata = metadata || null;
+  work.title = metadata?.title || work.name;
+  work.goal = metadata?.goal || "";
+  work.nextAction = metadata?.next_action || "";
   work.summary = latestAgentSummary(latestAgent) ||
+    work.panes.find((pane) => pane.muxa?.task)?.muxa.task ||
     work.panes.find((pane) => pane.title)?.title ||
-    "No recent work summary";
+    "No recent work signal";
   work.state = errors > 0
     ? "error"
     : waiting > 0
@@ -76,13 +162,16 @@ function summarizeWork(work) {
         : participants.length > 0
           ? "available"
           : "untracked";
+  work.stage = effectiveStage(work);
   return work;
 }
 
 function summarizeWorkspace(workspace) {
   workspace.works.sort(compareWorks);
-  workspace.active = workspace.works.filter((work) => work.working > 0).length;
-  workspace.attention = workspace.works.filter((work) => work.attention > 0).length;
+  workspace.active = workspace.works.filter((work) => work.stage === "in_progress").length;
+  workspace.attention = workspace.works.filter((work) => work.stage === "attention").length;
+  workspace.review = workspace.works.filter((work) => work.stage === "review").length;
+  workspace.done = workspace.works.filter((work) => work.stage === "done").length;
   workspace.errors = workspace.works.filter((work) => work.errors > 0).length;
   workspace.agents = workspace.works.reduce((total, work) => total + work.participants.length, 0);
   workspace.panes = workspace.works.reduce((total, work) => total + work.panes.length, 0);
@@ -90,19 +179,21 @@ function summarizeWorkspace(workspace) {
     (latest, work) => work.latest > latest ? work.latest : latest,
     ""
   );
+  workspace.sessionNames = [...workspace.sessionNames].sort();
   return workspace;
 }
 
 export function compareWorks(left, right) {
-  const priority = (work) => work.errors * 1000 + work.waiting * 100 + work.working * 10;
-  return priority(right) - priority(left) ||
+  const stagePriority = { attention: 5, in_progress: 4, review: 3, queued: 2, done: 1 };
+  return (stagePriority[right.stage] || 0) - (stagePriority[left.stage] || 0) ||
     (right.latest || "").localeCompare(left.latest || "") ||
-    left.name.localeCompare(right.name);
+    left.title.localeCompare(right.title);
 }
 
-export function buildWorkProjection(panes, agents) {
+export function buildWorkProjection(panes, agents, metadataRecords = []) {
   const exactAgents = new Map();
   const agentsByPane = new Map();
+  const annotations = metadataByIdentity(metadataRecords);
   for (const agent of agents || []) {
     if (!agent?.pane) continue;
     const exactKey = agentPaneKey(agent);
@@ -115,35 +206,45 @@ export function buildWorkProjection(panes, agents) {
   for (const pane of panes || []) {
     const host = hostForPane(pane);
     const endpoint = endpointFor(host, pane.socket);
-    const sessionId = pane.session_id || pane.session || "unknown";
-    const workspaceKey = key(["workspace", host, endpoint, sessionId]);
-    let workspace = workspaces.get(workspaceKey);
+    const logical = logicalWorkspace(pane, host, endpoint);
+    let workspace = workspaces.get(logical.key);
     if (!workspace) {
       workspace = {
-        key: workspaceKey,
+        key: logical.key,
         host,
         endpoint,
-        sessionId,
-        name: pane.session || sessionId,
+        name: logical.name,
+        source: logical.source,
+        cwd: logical.cwd,
+        sessionNames: new Set(),
         worksByKey: new Map(),
       };
-      workspaces.set(workspaceKey, workspace);
+      workspaces.set(logical.key, workspace);
     }
+    workspace.sessionNames.add(pane.session || pane.session_id || "unknown");
 
+    const sessionId = pane.session_id || pane.session || "unknown";
     const windowId = pane.window_id || pane.window_index || "unknown";
-    const workKey = key([workspaceKey, "work", windowId]);
+    const identity = { host, socket: endpoint, session_id: sessionId, window_id: windowId };
+    const workKey = key(["work", host, endpoint, sessionId, windowId]);
     let work = workspace.worksByKey.get(workKey);
     if (!work) {
+      const ticket = logicalTicket(pane);
       work = {
         key: workKey,
-        workspaceKey,
+        identity,
+        workspaceKey: workspace.key,
         workspaceName: workspace.name,
         host,
         endpoint,
         sessionId,
+        sessionName: pane.session || sessionId,
         windowId,
         index: pane.window_index || "",
-        name: pane.window_name || `window ${pane.window_index || windowId}`,
+        ticketId: ticket.id,
+        name: ticket.name,
+        source: ticket.source,
+        managed: Boolean(pane.muxa?.managed_work),
         panes: [],
       };
       workspace.worksByKey.set(workKey, work);
@@ -160,16 +261,16 @@ export function buildWorkProjection(panes, agents) {
       work.panes.sort((left, right) =>
         String(left.pane_index || "").localeCompare(String(right.pane_index || ""), undefined, { numeric: true })
       );
-      return summarizeWork(work);
+      return summarizeWork(work, annotations.get(identityKey(work.identity)));
     });
     delete workspace.worksByKey;
     return summarizeWorkspace(workspace);
   });
 
   result.sort((left, right) =>
-    right.errors - left.errors ||
     right.attention - left.attention ||
     right.active - left.active ||
+    right.review - left.review ||
     (right.latest || "").localeCompare(left.latest || "") ||
     left.name.localeCompare(right.name)
   );
@@ -177,5 +278,10 @@ export function buildWorkProjection(panes, agents) {
 }
 
 export function workNeedsAttention(work) {
-  return work?.participants?.some((agent) => ATTENTION_STATES.has(agent.state)) || false;
+  return work?.stage === "attention" ||
+    work?.participants?.some((agent) => ATTENTION_STATES.has(agent.state)) || false;
+}
+
+export function workIdentityKey(identity) {
+  return identityKey(identity);
 }

--- a/crates/muxa/src/dashboard/work_store.rs
+++ b/crates/muxa/src/dashboard/work_store.rs
@@ -1,0 +1,282 @@
+//! Durable operator annotations for dashboard work items.
+//!
+//! Session/window/pane identity remains authoritative in the active backend.
+//! This store deliberately persists only information tmux cannot express well:
+//! a human title, goal, next action, and explicit workflow stage.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
+
+use crate::backend::HostKind;
+
+const WORK_STORE_SCHEMA_VERSION: u8 = 1;
+#[cfg(unix)]
+const WORK_STORE_FILE_MODE: u32 = 0o600;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct WorkKey {
+    pub host: HostKind,
+    pub socket: String,
+    pub session_id: String,
+    pub window_id: String,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkStage {
+    #[default]
+    Auto,
+    Queued,
+    InProgress,
+    Review,
+    Blocked,
+    Done,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_action: Option<String>,
+    #[serde(default)]
+    pub stage: WorkStage,
+    #[serde(with = "time::serde::rfc3339")]
+    pub updated_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct WorkMetadataPatch {
+    pub title: Option<String>,
+    pub goal: Option<String>,
+    pub next_action: Option<String>,
+    #[serde(default)]
+    pub stage: WorkStage,
+}
+
+impl WorkMetadataPatch {
+    pub fn validate(self) -> Result<Self, String> {
+        Ok(Self {
+            title: clean(self.title, 160, "title")?,
+            goal: clean(self.goal, 4_000, "goal")?,
+            next_action: clean(self.next_action, 1_000, "next action")?,
+            stage: self.stage,
+        })
+    }
+
+    fn into_metadata(self, updated_at: OffsetDateTime) -> WorkMetadata {
+        WorkMetadata {
+            title: self.title,
+            goal: self.goal,
+            next_action: self.next_action,
+            stage: self.stage,
+            updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkRecord {
+    pub key: WorkKey,
+    pub metadata: WorkMetadata,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WorkStoreFile {
+    version: u8,
+    works: Vec<WorkRecord>,
+}
+
+#[derive(Debug)]
+pub struct WorkStore {
+    path: Option<PathBuf>,
+    works: HashMap<WorkKey, WorkMetadata>,
+}
+
+impl WorkStore {
+    pub fn memory() -> Self {
+        Self {
+            path: None,
+            works: HashMap::new(),
+        }
+    }
+
+    pub fn load(path: Option<PathBuf>) -> Self {
+        let Some(path) = path else {
+            return Self::memory();
+        };
+        let works = std::fs::read(&path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<WorkStoreFile>(&bytes).ok())
+            .filter(|file| file.version == WORK_STORE_SCHEMA_VERSION)
+            .map(|file| {
+                file.works
+                    .into_iter()
+                    .map(|record| (record.key, record.metadata))
+                    .collect()
+            })
+            .unwrap_or_default();
+        Self {
+            path: Some(path),
+            works,
+        }
+    }
+
+    pub fn records(&self) -> Vec<WorkRecord> {
+        let mut records = self
+            .works
+            .iter()
+            .map(|(key, metadata)| WorkRecord {
+                key: key.clone(),
+                metadata: metadata.clone(),
+            })
+            .collect::<Vec<_>>();
+        records.sort_by(|left, right| {
+            left.key
+                .socket
+                .cmp(&right.key.socket)
+                .then_with(|| left.key.session_id.cmp(&right.key.session_id))
+                .then_with(|| left.key.window_id.cmp(&right.key.window_id))
+        });
+        records
+    }
+
+    pub async fn upsert(
+        &mut self,
+        key: WorkKey,
+        patch: WorkMetadataPatch,
+    ) -> std::io::Result<WorkRecord> {
+        let metadata = patch.into_metadata(OffsetDateTime::now_utc());
+        let previous = self.works.insert(key.clone(), metadata.clone());
+        if let Some(path) = &self.path {
+            if let Err(error) = save(path, self.records()).await {
+                if let Some(previous) = previous {
+                    self.works.insert(key, previous);
+                } else {
+                    self.works.remove(&key);
+                }
+                return Err(error);
+            }
+        }
+        Ok(WorkRecord { key, metadata })
+    }
+}
+
+fn clean(value: Option<String>, max: usize, label: &str) -> Result<Option<String>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(None);
+    }
+    if value.len() > max {
+        return Err(format!("{label} is too long (max {max} bytes)"));
+    }
+    if value.chars().any(|ch| ch == '\0') {
+        return Err(format!("{label} cannot contain NUL"));
+    }
+    Ok(Some(value.to_string()))
+}
+
+async fn save(path: &Path, works: Vec<WorkRecord>) -> std::io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "work store path has no parent",
+        )
+    })?;
+    tokio::fs::create_dir_all(parent).await?;
+    let basename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("dashboard-work.json");
+    let temporary = parent.join(format!(".{basename}.{}.tmp", std::process::id()));
+    let bytes = serde_json::to_vec_pretty(&WorkStoreFile {
+        version: WORK_STORE_SCHEMA_VERSION,
+        works,
+    })
+    .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    {
+        let mut options = OpenOptions::new();
+        options.create(true).truncate(true).write(true);
+        #[cfg(unix)]
+        options.mode(WORK_STORE_FILE_MODE);
+        let mut file = options.open(&temporary).await?;
+        file.write_all(&bytes).await?;
+        file.flush().await?;
+        file.sync_all().await?;
+    }
+    tokio::fs::rename(&temporary, path).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key() -> WorkKey {
+        WorkKey {
+            host: HostKind::Tmux,
+            socket: "default".into(),
+            session_id: "$1".into(),
+            window_id: "@2".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn work_metadata_survives_a_store_reload() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("dashboard-work.json");
+        let mut store = WorkStore::load(Some(path.clone()));
+        store
+            .upsert(
+                key(),
+                WorkMetadataPatch {
+                    title: Some("Authentication cleanup".into()),
+                    goal: Some("Remove the legacy token flow".into()),
+                    next_action: Some("Run integration tests".into()),
+                    stage: WorkStage::Review,
+                },
+            )
+            .await
+            .unwrap();
+
+        let loaded = WorkStore::load(Some(path));
+        let records = loaded.records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].metadata.stage, WorkStage::Review);
+        assert_eq!(
+            records[0].metadata.title.as_deref(),
+            Some("Authentication cleanup")
+        );
+    }
+
+    #[test]
+    fn metadata_validation_trims_blanks_and_rejects_oversized_values() {
+        let clean = WorkMetadataPatch {
+            title: Some("  ".into()),
+            goal: Some(" ship it ".into()),
+            ..Default::default()
+        }
+        .validate()
+        .unwrap();
+        assert_eq!(clean.title, None);
+        assert_eq!(clean.goal.as_deref(), Some("ship it"));
+
+        let error = WorkMetadataPatch {
+            title: Some("x".repeat(161)),
+            ..Default::default()
+        }
+        .validate()
+        .unwrap_err();
+        assert!(error.contains("title is too long"));
+    }
+}

--- a/crates/muxa/src/paths.rs
+++ b/crates/muxa/src/paths.rs
@@ -13,6 +13,7 @@ pub const COLLABORATION_FILENAME: &str = "collaboration.json";
 pub const COLLABORATION_AUDIT_FILENAME: &str = "collaboration-audit.ndjson";
 pub const ASK_FILENAME: &str = "ask.json";
 pub const NODE_ID_FILENAME: &str = "host-id";
+pub const DASHBOARD_WORK_FILENAME: &str = "dashboard-work.json";
 
 /// Default daemon socket path. Prefers `$XDG_RUNTIME_DIR/muxa.sock`; falls
 /// back to `/tmp/muxa-<uid>.sock` when the runtime dir is unset.
@@ -79,6 +80,13 @@ pub fn default_collaboration_file() -> Option<PathBuf> {
 /// Default append-only collaboration caller audit ledger.
 pub fn default_collaboration_audit_file() -> Option<PathBuf> {
     dirs::data_dir().map(|d| d.join(CONFIG_DIRNAME).join(COLLABORATION_AUDIT_FILENAME))
+}
+
+/// Durable dashboard-only work metadata. Execution identity remains owned by
+/// the pane backend; this file stores operator annotations such as title,
+/// workflow stage, goal, and next action.
+pub fn default_dashboard_work_file() -> Option<PathBuf> {
+    dirs::data_dir().map(|d| d.join(CONFIG_DIRNAME).join(DASHBOARD_WORK_FILENAME))
 }
 
 fn posix_uid() -> u32 {

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -557,7 +557,7 @@ pub struct ClientInfo {
 /// `tmux -F` format string for `list-panes`. Tab-separated columns parsed
 /// in `parse_pane_lines`. Kept `pub(crate)` so [`scanner`] can reuse it.
 pub(crate) const PANE_FMT: &str =
-    "#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_tty}\t#{pane_current_command}\t#{pane_title}\t#{pane_pid}\t#{pane_current_path}\t#{session_id}\t#{window_id}\t#{window_name}";
+    "#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_tty}\t#{pane_current_command}\t#{pane_title}\t#{pane_pid}\t#{pane_current_path}\t#{session_id}\t#{window_id}\t#{window_name}\t#{@muxa_workspace_id}\t#{@muxa_workspace_cwd}\t#{@muxa_managed_workspace}\t#{@muxa_work_id}\t#{@muxa_work_cwd}\t#{@muxa_managed_work}\t#{@muxa_agent}\t#{@muxa_agent_role}\t#{@muxa_agent_task}\t#{@muxa_managed_agent}\t#{@muxa_agent_workspace_id}\t#{@muxa_agent_work_id}";
 
 pub(crate) const SESSION_FMT: &str = "#{session_id}\t#{session_name}\t#{session_attached}";
 pub(crate) const CLIENT_FMT: &str =

--- a/crates/muxa/src/tmux/scanner.rs
+++ b/crates/muxa/src/tmux/scanner.rs
@@ -22,6 +22,7 @@
 //!
 //! [`HerdrBackend`]: crate::backend::herdr::HerdrBackend
 
+use crate::backend::HostKind;
 use crate::tmux::{PaneInfo, PANE_FMT};
 use serde::Serialize;
 use std::collections::HashSet;
@@ -44,6 +45,7 @@ const TMUX_LIST_TIMEOUT: Duration = Duration::from_secs(1);
 /// server.
 #[derive(Debug, Clone, Serialize)]
 pub struct PaneSummary {
+    pub host: HostKind,
     pub pane_id: String,
     pub session_id: String,
     pub session: String,
@@ -54,11 +56,53 @@ pub struct PaneSummary {
     pub tty: String,
     pub current_command: String,
     pub title: String,
+    pub current_path: String,
     pub socket: PathBuf,
+    pub muxa: MuxaPaneMetadata,
     /// Shell-quoted command that, when run, attaches to this pane. Uses
     /// `tmux -S <socket> attach-session -t <session>` plus
     /// `select-window` / `select-pane` to land on the exact pane.
     pub attach_command: String,
+}
+
+/// Muxa-managed logical identity stored in tmux user options. These values
+/// survive muxad restarts and are intentionally separate from mutable tmux
+/// names. Non-tmux and unmanaged panes serialize a well-formed empty object.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct MuxaPaneMetadata {
+    pub managed_workspace: bool,
+    pub managed_work: bool,
+    pub managed_agent: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub work_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub work_cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
+}
+
+#[derive(Debug)]
+struct ScannedPane {
+    pane: PaneInfo,
+    muxa: MuxaPaneMetadata,
+}
+
+#[cfg(test)]
+impl ScannedPane {
+    fn unmanaged(pane: PaneInfo) -> Self {
+        Self {
+            pane,
+            muxa: MuxaPaneMetadata::default(),
+        }
+    }
 }
 
 /// A single per-socket failure during a scan. We collect these instead of
@@ -262,18 +306,18 @@ pub async fn scan() -> ScanResult {
 /// Generic scan entry point — runs `fetcher` against each socket and
 /// aggregates the results. Public-in-crate so the unit tests can swap in
 /// a deterministic fetcher.
-pub(crate) async fn scan_with<F, Fut>(sockets: Vec<PathBuf>, mut fetcher: F) -> ScanResult
+async fn scan_with<F, Fut>(sockets: Vec<PathBuf>, mut fetcher: F) -> ScanResult
 where
     F: FnMut(PathBuf) -> Fut,
-    Fut: std::future::Future<Output = Result<Vec<PaneInfo>, String>>,
+    Fut: std::future::Future<Output = Result<Vec<ScannedPane>, String>>,
 {
     let mut panes: Vec<PaneSummary> = Vec::new();
     let mut errors: Vec<ScanError> = Vec::new();
     for sock in sockets {
         match fetcher(sock.clone()).await {
             Ok(items) => {
-                for p in items {
-                    panes.push(to_summary(p, sock.clone()));
+                for pane in items {
+                    panes.push(to_summary(pane, sock.clone()));
                 }
             }
             Err(message) => errors.push(ScanError {
@@ -289,7 +333,7 @@ where
     }
 }
 
-async fn list_panes_for_socket(sock: PathBuf) -> Result<Vec<PaneInfo>, String> {
+async fn list_panes_for_socket(sock: PathBuf) -> Result<Vec<ScannedPane>, String> {
     let sock_str = sock
         .to_str()
         .ok_or_else(|| "non-utf8 socket path".to_string())?;
@@ -316,17 +360,49 @@ async fn list_panes_for_socket(sock: PathBuf) -> Result<Vec<PaneInfo>, String> {
     }
     let stdout = String::from_utf8_lossy(&out.stdout);
     let socket = crate::tmux::socket_short_name(sock_str);
-    Ok(crate::tmux::parse_pane_lines_for_socket(
-        &stdout,
-        Some(&socket),
-    ))
+    Ok(parse_scanned_panes(&stdout, &socket))
+}
+
+fn parse_scanned_panes(stdout: &str, socket: &str) -> Vec<ScannedPane> {
+    crate::tmux::parse_pane_lines_for_socket(stdout, Some(socket))
+        .into_iter()
+        .zip(stdout.lines().filter(|line| line.split('\t').count() >= 7))
+        .map(|(pane, line)| {
+            let columns = line.split('\t').collect::<Vec<_>>();
+            let value = |index: usize| {
+                columns
+                    .get(index)
+                    .map(|value| value.trim())
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+            };
+            let workspace_id = value(22).or_else(|| value(12));
+            let work_id = value(23).or_else(|| value(15));
+            ScannedPane {
+                pane,
+                muxa: MuxaPaneMetadata {
+                    managed_workspace: columns.get(14).is_some_and(|value| *value == "1"),
+                    managed_work: columns.get(17).is_some_and(|value| *value == "1"),
+                    managed_agent: columns.get(21).is_some_and(|value| *value == "1"),
+                    workspace_id,
+                    workspace_cwd: value(13),
+                    work_id,
+                    work_cwd: value(16),
+                    agent: value(18),
+                    role: value(19),
+                    task: value(20),
+                },
+            }
+        })
+        .collect()
 }
 
 fn is_no_server_running(stderr: &str) -> bool {
     stderr.starts_with("no server running on")
 }
 
-fn to_summary(p: PaneInfo, socket: PathBuf) -> PaneSummary {
+fn to_summary(scanned: ScannedPane, socket: PathBuf) -> PaneSummary {
+    let p = scanned.pane;
     let attach_command = format!(
         "tmux -S {sock} attach-session -t {sess} \\; select-window -t {sess}:{win} \\; select-pane -t {pane}",
         sock = shell_quote(&socket),
@@ -335,6 +411,7 @@ fn to_summary(p: PaneInfo, socket: PathBuf) -> PaneSummary {
         pane = p.pane_id,
     );
     PaneSummary {
+        host: HostKind::Tmux,
         pane_id: p.pane_id,
         session_id: p.session_id,
         session: p.session,
@@ -345,7 +422,9 @@ fn to_summary(p: PaneInfo, socket: PathBuf) -> PaneSummary {
         tty: p.tty,
         current_command: p.current_command,
         title: p.title,
+        current_path: p.current_path,
         socket,
+        muxa: scanned.muxa,
         attach_command,
     }
 }
@@ -386,6 +465,7 @@ pub(crate) fn herdr_scan_result(panes: Vec<PaneInfo>) -> ScanResult {
 
 fn to_herdr_summary(p: PaneInfo) -> PaneSummary {
     PaneSummary {
+        host: HostKind::Herdr,
         pane_id: p.pane_id,
         session_id: p.session_id,
         session: p.session,
@@ -396,7 +476,9 @@ fn to_herdr_summary(p: PaneInfo) -> PaneSummary {
         tty: p.tty,
         current_command: p.current_command,
         title: p.title,
+        current_path: p.current_path,
         socket: PathBuf::from(HERDR_SOCKET_LABEL),
+        muxa: MuxaPaneMetadata::default(),
         // herdr has no `tmux attach`-style command a user copies; the CLI
         // (`muxa` jump / `jump_to_pane`) focuses over the socket instead.
         attach_command: String::new(),
@@ -646,13 +728,56 @@ mod tests {
         assert!(!is_no_server_running("server exiting"));
     }
 
+    #[test]
+    fn parse_scanned_panes_reads_managed_workspace_work_and_agent_metadata() {
+        let line = [
+            "%7",
+            "physical-session",
+            "2",
+            "0",
+            "/dev/pts/7",
+            "codex",
+            "agent",
+            "4242",
+            "/work/payments",
+            "$7",
+            "@7",
+            "shell",
+            "workspace-from-session",
+            "/work/payments",
+            "1",
+            "work-from-window",
+            "/work/payments/ticket",
+            "1",
+            "codex-primary",
+            "implementer",
+            "repair settlement retries",
+            "1",
+            "payments",
+            "PAY-42",
+        ]
+        .join("\t");
+
+        let panes = parse_scanned_panes(&line, "default");
+        assert_eq!(panes.len(), 1);
+        let pane = &panes[0];
+        assert_eq!(pane.pane.socket.as_deref(), Some("default"));
+        assert!(pane.muxa.managed_workspace);
+        assert!(pane.muxa.managed_work);
+        assert!(pane.muxa.managed_agent);
+        assert_eq!(pane.muxa.workspace_id.as_deref(), Some("payments"));
+        assert_eq!(pane.muxa.work_id.as_deref(), Some("PAY-42"));
+        assert_eq!(pane.muxa.role.as_deref(), Some("implementer"));
+        assert_eq!(pane.muxa.task.as_deref(), Some("repair settlement retries"));
+    }
+
     #[tokio::test]
     async fn scan_with_one_bad_socket_does_not_fail_the_whole_scan() {
         let s_good = PathBuf::from("/run/fake/good");
         let s_bad = PathBuf::from("/run/fake/bad");
         let result = scan_with(vec![s_good.clone(), s_bad.clone()], |sock| async move {
             if sock.file_name().and_then(|s| s.to_str()) == Some("good") {
-                Ok(vec![fake_pane("%1", "main")])
+                Ok(vec![ScannedPane::unmanaged(fake_pane("%1", "main"))])
             } else {
                 Err("simulated tmux failure".to_string())
             }
@@ -670,7 +795,7 @@ mod tests {
     async fn scan_with_attaches_socket_and_attach_command_per_pane() {
         let s = PathBuf::from("/tmp/tmux-1000/default");
         let result = scan_with(vec![s.clone()], |_| async {
-            Ok(vec![fake_pane("%7", "work")])
+            Ok(vec![ScannedPane::unmanaged(fake_pane("%7", "work"))])
         })
         .await;
         assert_eq!(result.panes.len(), 1);

--- a/crates/muxa/tests-js/dashboard-work-model.test.mjs
+++ b/crates/muxa/tests-js/dashboard-work-model.test.mjs
@@ -87,7 +87,7 @@ test("projects panes as workspace work items with agents as participants", () =>
   assert.equal(workspace.works[0].state, "needs_attention");
   assert.equal(workspace.works[0].summary, "review the authentication change");
   assert.equal(workspace.attention, 1);
-  assert.equal(workspace.active, 1);
+  assert.equal(workspace.active, 0);
   assert.equal(workNeedsAttention(workspace.works[0]), true);
 });
 
@@ -101,13 +101,93 @@ test("does not collide identical pane ids across tmux sockets", () => {
 
 test("orders attention work ahead of active and available work", () => {
   const works = [
-    { name: "idle", errors: 0, waiting: 0, working: 0, latest: "" },
-    { name: "active", errors: 0, waiting: 0, working: 1, latest: "" },
-    { name: "attention", errors: 0, waiting: 1, working: 0, latest: "" },
+    { title: "idle", stage: "queued", latest: "" },
+    { title: "active", stage: "in_progress", latest: "" },
+    { title: "attention", stage: "attention", latest: "" },
   ];
 
   works.sort(compareWorks);
-  assert.deepEqual(works.map((work) => work.name), ["attention", "active", "idle"]);
+  assert.deepEqual(works.map((work) => work.title), ["attention", "active", "idle"]);
+});
+
+test("groups ticket-shaped sessions under one repository workspace", () => {
+  const repoPanes = [
+    {
+      pane_id: "%10",
+      session_id: "$10",
+      session: "CAL-101",
+      window_id: "@10",
+      window_name: "codex",
+      socket: "default",
+      current_path: "/work/muxa",
+    },
+    {
+      pane_id: "%11",
+      session_id: "$11",
+      session: "CAL-102",
+      window_id: "@11",
+      window_name: "claude",
+      socket: "default",
+      current_path: "/work/muxa",
+    },
+  ];
+
+  const workspaces = buildWorkProjection(repoPanes, []);
+  assert.equal(workspaces.length, 1);
+  assert.equal(workspaces[0].name, "muxa");
+  assert.equal(workspaces[0].source, "inferred");
+  assert.deepEqual(workspaces[0].works.map((work) => work.ticketId), ["CAL-101", "CAL-102"]);
+});
+
+test("prefers managed identities and overlays durable workflow metadata", () => {
+  const managedPane = {
+    pane_id: "%20",
+    session_id: "$20",
+    session: "physical-session",
+    window_id: "@20",
+    window_name: "shell",
+    socket: "/tmp/tmux-1000/default",
+    current_path: "/work/physical",
+    muxa: {
+      managed_workspace: true,
+      managed_work: true,
+      workspace_id: "payments",
+      workspace_cwd: "/work/payments",
+      work_id: "PAY-42",
+    },
+  };
+  const metadata = [{
+    key: { host: "tmux", socket: "default", session_id: "$20", window_id: "@20" },
+    metadata: {
+      title: "Repair settlement retries",
+      goal: "No duplicate settlements",
+      next_action: "Run the recovery suite",
+      stage: "review",
+    },
+  }];
+
+  const [workspace] = buildWorkProjection([managedPane], [], metadata);
+  const [work] = workspace.works;
+  assert.equal(workspace.name, "payments");
+  assert.equal(workspace.source, "managed");
+  assert.equal(work.ticketId, "PAY-42");
+  assert.equal(work.title, "Repair settlement retries");
+  assert.equal(work.goal, "No duplicate settlements");
+  assert.equal(work.nextAction, "Run the recovery suite");
+  assert.equal(work.stage, "review");
+});
+
+test("live attention overrides in-progress metadata while done remains explicit", () => {
+  const metadata = [{
+    key: { host: "tmux", socket: "default", session_id: "$1", window_id: "@1" },
+    metadata: { title: "Auth", goal: "", next_action: "", stage: "in_progress" },
+  }];
+  const workspace = buildWorkProjection(panes.slice(0, 2), agents.slice(0, 2), metadata)[0];
+  assert.equal(workspace.works[0].stage, "attention");
+
+  metadata[0].metadata.stage = "done";
+  const done = buildWorkProjection(panes.slice(0, 2), agents.slice(0, 2), metadata)[0];
+  assert.equal(done.works[0].stage, "done");
 });
 
 test("normalizes the current agent_session_id wire field without overwriting legacy ids", () => {

--- a/crates/muxa/tests-js/dashboard-work-model.test.mjs
+++ b/crates/muxa/tests-js/dashboard-work-model.test.mjs
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildWorkProjection,
+  compareWorks,
+  normalizeAgent,
+  workNeedsAttention,
+} from "../src/dashboard/web/work-model.mjs";
+
+const panes = [
+  {
+    pane_id: "%1",
+    session_id: "$1",
+    session: "muxa",
+    window_id: "@1",
+    window_name: "TEST-123",
+    window_index: "1",
+    pane_index: "0",
+    socket: "/tmp/tmux-1000/default",
+    current_command: "codex",
+    title: "implement auth",
+  },
+  {
+    pane_id: "%2",
+    session_id: "$1",
+    session: "muxa",
+    window_id: "@1",
+    window_name: "TEST-123",
+    window_index: "1",
+    pane_index: "1",
+    socket: "/tmp/tmux-1000/default",
+    current_command: "claude",
+    title: "review auth",
+  },
+  {
+    pane_id: "%1",
+    session_id: "$2",
+    session: "another",
+    window_id: "@2",
+    window_name: "DOCS-9",
+    window_index: "0",
+    pane_index: "0",
+    socket: "/tmp/tmux-1000/agents",
+    current_command: "codex",
+    title: "write docs",
+  },
+];
+
+const agents = [
+  {
+    agent_session_id: "agent-1",
+    pane: "%1",
+    tmux_socket: "default",
+    kind: "codex",
+    state: "working",
+    ai_title: "implement refresh lock",
+    last_activity_at: "2026-08-20T01:03:00Z",
+  },
+  {
+    agent_session_id: "agent-2",
+    pane: "%2",
+    tmux_socket: "default",
+    kind: "claude_code",
+    state: "waiting_input",
+    last_prompt: "review the authentication change",
+    last_activity_at: "2026-08-20T01:04:00Z",
+  },
+  {
+    agent_session_id: "agent-3",
+    pane: "%1",
+    tmux_socket: "agents",
+    kind: "codex",
+    state: "idle",
+    last_activity_at: "2026-08-20T00:30:00Z",
+  },
+];
+
+test("projects panes as workspace work items with agents as participants", () => {
+  const workspaces = buildWorkProjection(panes, agents);
+
+  assert.equal(workspaces.length, 2);
+  const workspace = workspaces.find((item) => item.name === "muxa");
+  assert.equal(workspace.works.length, 1);
+  assert.equal(workspace.works[0].name, "TEST-123");
+  assert.equal(workspace.works[0].participants.length, 2);
+  assert.equal(workspace.works[0].state, "needs_attention");
+  assert.equal(workspace.works[0].summary, "review the authentication change");
+  assert.equal(workspace.attention, 1);
+  assert.equal(workspace.active, 1);
+  assert.equal(workNeedsAttention(workspace.works[0]), true);
+});
+
+test("does not collide identical pane ids across tmux sockets", () => {
+  const workspaces = buildWorkProjection(panes, agents);
+  const docs = workspaces.find((item) => item.name === "another").works[0];
+
+  assert.equal(docs.participants.length, 1);
+  assert.equal(docs.participants[0].agent_session_id, "agent-3");
+});
+
+test("orders attention work ahead of active and available work", () => {
+  const works = [
+    { name: "idle", errors: 0, waiting: 0, working: 0, latest: "" },
+    { name: "active", errors: 0, waiting: 0, working: 1, latest: "" },
+    { name: "attention", errors: 0, waiting: 1, working: 0, latest: "" },
+  ];
+
+  works.sort(compareWorks);
+  assert.deepEqual(works.map((work) => work.name), ["attention", "active", "idle"]);
+});
+
+test("normalizes the current agent_session_id wire field without overwriting legacy ids", () => {
+  assert.equal(normalizeAgent({ agent_session_id: "current" }).session_id, "current");
+  assert.equal(
+    normalizeAgent({ agent_session_id: "current", session_id: "legacy" }).session_id,
+    "legacy"
+  );
+});

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -320,6 +320,7 @@ async fn main() -> Result<()> {
         let dashboard_runtime = muxa::dashboard::DashboardRuntimeConfig {
             activity_path: dashboard_activity_path,
             session_activity_path: dashboard_session_activity_path,
+            work_store_path: paths::default_dashboard_work_file(),
             stats_config: dashboard_stats_config,
             fleet: Some(fleet_runtime.clone()),
         };

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -29,18 +29,22 @@ machine without explicit public-bind acknowledgement.
 | `GET /api/agents`   | Current `Store` snapshot.                                                      |
 | `GET /api/fleet?selector=...` | Cached hierarchy, including the always-present local node.          |
 | `GET /api/panes`    | Global tmux pane list (every readable socket), with per-socket scan errors.   |
+| `GET /api/work-metadata` | Durable titles, goals, next actions, and manual workflow stages.        |
 | `GET /api/terminal-sessions` | Muxa-owned PTY sessions.                                           |
 | `GET /api/timeline` | Timeline document from `activity.ndjson` plus currently-open agent/tmux spans. |
 | `GET /api/events`   | SSE stream: `snapshot` (initial), `transition` (live), `lagged` (backpressure)|
 | `POST /api/panes/{pane}/prompt` | Send and optionally submit text to a pane.                       |
 | `POST /api/panes/{pane}/abort` | Send Ctrl-C to a pane.                                             |
 | `POST /api/fleet/{host}/command` | Execute a serialized Fleet operation; host mode is rechecked.   |
+| `PUT /api/work-metadata` | Save the work definition for one exact host/socket/session/window.     |
+| `POST /api/work-control/prompt` | Prompt every live or managed agent pane in one ticket.           |
+| `POST /api/work-control/abort` | Send Ctrl-C to every live or managed agent pane in one ticket.     |
 | `POST /api/terminal-sessions/{id}/input` | Send input to a Muxa-owned PTY.                         |
 | `POST /api/terminal-sessions/{id}/terminate` | Terminate a Muxa-owned PTY.                          |
 
 `auth = "token"` protects all API endpoints. `auth = "public_read"` leaves
-GET/SSE endpoints public but always requires the bearer token for POST control
-actions. `auth = "none"` leaves reads public and disables POST control entirely.
+GET/SSE endpoints public but always requires the bearer token for write/control
+actions. `auth = "none"` leaves reads public and disables writes entirely.
 Static routes are public in every mode — see "Why the HTML is public" below.
 Fleet routes always expose the in-process `local` node. `[fleet] enabled =
 true` adds outbound SSH hosts; reads reuse the daemon's per-host cache and
@@ -209,27 +213,42 @@ hammering refresh loop doesn't fork tmux 60 times a minute.
 
 ## Work-oriented projection
 
-The browser derives its work view from the existing `/api/panes` and
-`/api/agents` snapshots; this version does not introduce another database or
-duplicate tmux state on the server.
+The browser derives execution identity from `/api/panes` and `/api/agents`, then
+overlays the small `/api/work-metadata` annotation store. It does not copy live
+tmux state into another database: host, socket, session, window, pane, and agent
+liveness remain owned by the execution backend.
 
 | Dashboard concept | Execution source | Primary information |
 | ----------------- | ---------------- | ------------------- |
-| Workspace | tmux session, scoped by host/socket | ticket counts, activity, and attention |
-| Work item / ticket | tmux window | state, latest work signal, participants, last activity |
+| Workspace | managed workspace ID, otherwise repository cwd or session fallback | ticket counts, workflow stage, and attention |
+| Work item / ticket | exact host/socket/session/window, labeled by managed work ID or inferred name | title, goal, next action, state, participants |
 | Participant / agent | tracked agent attached to a pane | runtime, model, and agent state |
 | Execution detail | pane plus its session/window coordinates | attach, prompt, and abort controls |
 
 The workspace rail deliberately does not render nested windows and panes.
-Selecting a workspace filters the ticket board. Expanding one ticket—or using
-the board-wide **expand execution** control—reveals only that work item's
-session/window/pane hierarchy. Endpoint-aware keys keep identical pane IDs on
-different tmux sockets from being merged.
+Selecting a workspace filters a five-lane ticket board: **Attention**, **In
+progress**, **Review**, **Queued**, and **Done**. Selecting a ticket opens a
+fixed detail drawer for its work definition, participant status, ticket-level
+commands, and execution hierarchy. Expanding one ticket—or using the
+board-wide **expand execution** control—reveals the session/window/pane
+hierarchy only when it is needed.
 
-Names currently come from the underlying tmux session and window names, so
-unmanaged or legacy sessions may still look process-oriented. A team can get
-useful work labels immediately by naming sessions after workspaces and windows
-after tickets; explicit persisted ticket metadata is a future extension.
+Muxa-managed tmux options (`@muxa_workspace_id`, `@muxa_work_id`, agent role,
+and task) are the preferred logical identities. For legacy/unmanaged sessions,
+panes sharing a repository cwd are grouped into one workspace; ticket-shaped
+session names such as `CAL-101` are used when the tmux window is only named
+`codex`, `claude`, or another generic process name. A session fallback keeps
+older rows visible when no cwd exists. Endpoint-aware keys keep identical pane
+IDs on different tmux sockets from being merged.
+
+The operator can persist a human title, goal, next action, and manual stage in
+`$XDG_DATA_HOME/muxa/dashboard-work.json` (normally
+`~/.local/share/muxa/dashboard-work.json`). Writes use a temporary file and
+rename, and are serialized by the daemon. Live errors or agents waiting for
+input still lift a ticket into **Attention**; `done` and `review` remain explicit
+operator decisions. Ticket commands target only live registered agents or
+panes marked `@muxa_managed_agent` inside that exact work identity, never every
+shell pane in the window.
 
 ## Timeline
 
@@ -255,10 +274,10 @@ attach; not a plain open `muxa watch` interval). The `human` metric follows
 interaction intervals. Timeline lanes still show raw human-interaction spans
 separately as `interaction`.
 
-The workspace sidebar can sort by `active`, `human`, or `tmux`. `active` uses
-the same last-touch attribution as `muxa stats`, so overlapping work across
-multiple sessions is counted once and assigned to the most recently touched
-session.
+The workspace sidebar sorts by workflow priority, latest agent activity, or
+name. Timeline session filtering remains independent from logical workspace
+selection because one repository workspace may contain several physical tmux
+sessions.
 
 Closed intervals come from `activity.ndjson`. Currently-open agent states
 come from the live `Store` snapshot, and currently-open tmux foreground spans
@@ -298,12 +317,12 @@ that strips the carve-out (or use mTLS).
 
 ## What it doesn't do (yet)
 
-- No dashboard-specific database. The daemon rehydrates live state from
-  `state.json`, while prompt and activity history use the configured local
-  NDJSON files.
-- Control is intentionally narrow: pane prompt/abort and Muxa-owned PTY
-  input/terminate. Configuration, files, and arbitrary commands are not
-  writable through the dashboard.
+- The dashboard stores only work annotations in one local JSON file. It does
+  not yet keep ticket history, dependencies, estimates, or external issue
+  tracker synchronization.
+- Control is intentionally narrow: ticket/pane prompt and abort plus
+  Muxa-owned PTY input/terminate. Configuration, files, and arbitrary shell
+  commands are not writable through the dashboard.
 - No mobile UI. The CSS scales OK to ~600 px but isn't designed for phones.
 - No multi-user auth. One token = one bearer.
 

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -1,10 +1,17 @@
 # muxa dashboard
 
-A small HTTP UI bolted onto the daemon. It shows the same agents you see on the
-tmux status line, a timeline graph of work/wait/error intervals, plus
-**every tmux pane on the box** (across all running servers), updated live
-over Server-Sent Events. Optional control actions are protected by a bearer
-token that can be pasted into the browser like a PAT.
+A work-oriented HTTP UI bolted onto the daemon. Its primary view projects the
+tmux execution topology into larger logical units: **session → workspace**,
+**window → work item (ticket)**, and **pane → participant (agent)**. This is a
+dashboard for scanning progress and attention across work, rather than another
+always-expanded tmux tree. Each ticket can still reveal its exact
+session/window/pane hierarchy and pane controls when execution detail is
+needed.
+
+The timeline and raw agent/pane/terminal inventories remain available as
+collapsed secondary panels. Data is updated live over Server-Sent Events, and
+optional control actions are protected by a bearer token that can be pasted
+into the browser like a PAT.
 
 The dashboard is **off by default** and **loopback-only when on by default**.
 Token authentication is the default auth mode, and an enabled dashboard must
@@ -200,6 +207,30 @@ ones. Every per-socket invocation has a 1 s timeout.
 Results are cached for `pane_cache_ttl_ms` (default 2 s, lazy pull) so a
 hammering refresh loop doesn't fork tmux 60 times a minute.
 
+## Work-oriented projection
+
+The browser derives its work view from the existing `/api/panes` and
+`/api/agents` snapshots; this version does not introduce another database or
+duplicate tmux state on the server.
+
+| Dashboard concept | Execution source | Primary information |
+| ----------------- | ---------------- | ------------------- |
+| Workspace | tmux session, scoped by host/socket | ticket counts, activity, and attention |
+| Work item / ticket | tmux window | state, latest work signal, participants, last activity |
+| Participant / agent | tracked agent attached to a pane | runtime, model, and agent state |
+| Execution detail | pane plus its session/window coordinates | attach, prompt, and abort controls |
+
+The workspace rail deliberately does not render nested windows and panes.
+Selecting a workspace filters the ticket board. Expanding one ticket—or using
+the board-wide **expand execution** control—reveals only that work item's
+session/window/pane hierarchy. Endpoint-aware keys keep identical pane IDs on
+different tmux sockets from being merged.
+
+Names currently come from the underlying tmux session and window names, so
+unmanaged or legacy sessions may still look process-oriented. A team can get
+useful work labels immediately by naming sessions after workspaces and windows
+after tickets; explicit persisted ticket metadata is a future extension.
+
 ## Timeline
 
 The timeline panel calls `/api/timeline?since=7d` by default and can switch
@@ -224,7 +255,7 @@ attach; not a plain open `muxa watch` interval). The `human` metric follows
 interaction intervals. Timeline lanes still show raw human-interaction spans
 separately as `interaction`.
 
-The session sidebar can sort by `active`, `human`, or `tmux`. `active` uses
+The workspace sidebar can sort by `active`, `human`, or `tmux`. `active` uses
 the same last-touch attribution as `muxa stats`, so overlapping work across
 multiple sessions is counted once and assigned to the most recently touched
 session.


### PR DESCRIPTION
## Summary

- replace the always-expanded tmux hierarchy with a workspace rail and five-stage ticket board
- prefer Muxa-managed workspace/work/agent identities and infer legacy workspaces from repository cwd
- add a PAT-gated work drawer with durable title, goal, next-action, and workflow metadata
- add exact-ticket batch prompt/status/abort controls while preserving Fleet dashboard routes
- keep session/window/pane topology available as secondary execution diagnostics

## Validation

- `cargo fmt --all -- --check`
- `node --check crates/muxa/src/dashboard/web/main.js`
- `node --test crates/muxa/tests-js/dashboard-work-model.test.mjs`
- `cargo build -p muxad`
- `cargo test --workspace --no-fail-fast`
- `cargo clippy --workspace --all-targets -- -D warnings`