### PR TITLE
feat(agy): support Google Antigravity CLI as a first-class agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Google Antigravity CLI (`agy`) is a first-class agent.** agy replaced the
+  Gemini CLI upstream but shares none of its hook contract, so muxa's existing
+  Gemini support was silently inert against it: agy reads
+  `~/.gemini/config/hooks.json` (or `<workspace>/.agents/hooks.json`), not the
+  `hooks` key of `~/.gemini/settings.json`; its lifecycle is
+  `SessionStart`/`PreInvocation`/`PostInvocation`/`PreToolUse`/`PostToolUse`/`Stop`;
+  and its payloads are camelCase protojson keyed on `conversationId`. A new
+  `AgentKind::Antigravity`, adapter, and `muxa hook agy` handler cover all six
+  events. Neither prompts nor responses appear in any agy payload, so
+  `PreInvocation` and `Stop` read them out of the transcript agy points at —
+  `PreInvocation` only on `invocationNum == 0`, the turn boundary, so a
+  multi-invocation turn doesn't restate its prompt. `muxa init` gains an
+  `agy-hooks` component that owns one named key in agy's `hooks.json` (leaving
+  plugin and `/hooks`-authored entries alone), `muxa doctor` grew a matching
+  check, and `agy` panes are discovered, launchable (`muxa agent start --agent
+  agy`), filterable in `muxa timeline`, and reported to the omp sink under their
+  own `antigravity` slug rather than as `gemini`.
+
+  `muxa hook agy` is deliberately fail-open and byte-silent on stdout: agy reads
+  a hook's stdout as a verdict and treats a non-zero exit or a `decision`-less
+  reply as `tool call denied by pre-tool hook`, so a muxa parse error or a down
+  daemon must never be able to block the user's tool call.
+
+  A bundled `agy` screen manifest covers panes with no hooks wired — and is the
+  only way an agy row reaches `WaitingInput`, since agy exposes no
+  permission/notification hook. Unlike the other bundled manifests it was
+  derived from a real agy 1.1.17 session rather than written blind.
+  See [docs/ANTIGRAVITY.md](docs/ANTIGRAVITY.md).
+
 - **Central SSH fleet management adds a physical host → session → window →
   pane(agent) control plane.** `muxad` now maintains one isolated persistent
   OpenSSH stdio relay and last-known cache per configured node, with stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reply as `tool call denied by pre-tool hook`, so a muxa parse error or a down
   daemon must never be able to block the user's tool call.
 
-  A bundled `agy` screen manifest covers panes with no hooks wired — and is the
-  only way an agy row reaches `WaitingInput`, since agy exposes no
-  permission/notification hook. Unlike the other bundled manifests it was
-  derived from a real agy 1.1.17 session rather than written blind.
-  See [docs/ANTIGRAVITY.md](docs/ANTIGRAVITY.md).
+  A bundled `agy` screen manifest supplies the one state agy's hooks cannot:
+  `WaitingInput`. agy fires no hook when it raises an approval prompt, so
+  hook-authoritative precedence gains its first carve-out — a row whose kind
+  reports `hooks_report_attention() == false` stays screen-inferred, and the
+  detector applies the attention signal (and only that) to the **real** row
+  rather than minting a synthetic one. Claude Code, Codex, the Gemini CLI and
+  opencode are unaffected. Unlike the other bundled manifests, agy's patterns
+  were derived from a real agy 1.1.17 session rather than written blind.
+  See [docs/ANTIGRAVITY.md](docs/ANTIGRAVITY.md) and
+  [docs/SCREEN_DETECTION.md](docs/SCREEN_DETECTION.md).
 
 - **Central SSH fleet management adds a physical host → session → window →
   pane(agent) control plane.** `muxad` now maintains one isolated persistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A hook subcommand no longer aborts on an unreadable `config.toml`.**
+  `muxa hook …` now falls back to compiled defaults and puts the parse error
+  on stderr instead of exiting non-zero. Every other subcommand still fails
+  loudly. This matters because agy reads a non-zero hook exit as its verdict
+  (`tool call denied by pre-tool hook`), so one TOML typo would otherwise have
+  blocked every tool call in every agy session with nothing naming the cause.
+
 - **Session and window rows can send contracted messages without hierarchy
   descent.** Pressing `m` on a parent deterministically targets the first live
   tracked agent in numeric window/pane order, with the exact resolved pane

--- a/README.ko.md
+++ b/README.ko.md
@@ -279,7 +279,9 @@ case-sensitive이고 `*`, `?` wildcard를 지원합니다. 예:
 
 **화면 감지(fallback).** 훅이 없는 에이전트는 pane 내용을 TOML 매니페스트로
 분류합니다 — `agy`, `cursor-agent`, `amp`, `copilot`, `aider`, `goose`용
-매니페스트가 기본 번들로 제공되며 사용자가 확장 가능. 훅이 있으면 항상 훅이 우선합니다.
+매니페스트가 기본 번들로 제공되며 사용자가 확장 가능. 훅이 있으면 훅이 우선하되
+예외가 하나 있습니다: `agy`는 승인 프롬프트에 대한 훅이 없어서 그 신호만은
+화면 감지가 계속 담당합니다.
 [docs/SCREEN_DETECTION.md](docs/SCREEN_DETECTION.md) 참고.
 
 ## Fleet host

--- a/README.ko.md
+++ b/README.ko.md
@@ -31,7 +31,8 @@ curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/onboard.s
 </div>
 
 `muxa`는 terminal multiplexer pane 안에서 실행되는 AI coding agent를 관측하는
-작은 daemon + CLI입니다. Claude Code, OpenAI Codex, Google Gemini CLI의 기존
+작은 daemon + CLI입니다. Claude Code, OpenAI Codex, Google Gemini CLI와 그
+후속인 Antigravity CLI(`agy`)의 기존
 hook/event 시스템을 사용하고, 이를 tmux pane/session과 연결합니다.
 
 tmux나 agent binary를 fork하지 않습니다. tmux는 기본 full backend이고,
@@ -273,11 +274,12 @@ case-sensitive이고 `*`, `?` wildcard를 지원합니다. 예:
 | Claude Code | 지원 | `~/.claude/settings.json` |
 | OpenAI Codex | 지원 | `~/.codex/config.toml` |
 | Google Gemini CLI | 지원 | `~/.gemini/settings.json` |
+| Google Antigravity CLI (`agy`) | 지원 | `~/.gemini/config/hooks.json` — [문서](docs/ANTIGRAVITY.md) |
 | opencode | 예정 | [tracking issue](https://github.com/Open330/muxa/issues/14) |
 
 **화면 감지(fallback).** 훅이 없는 에이전트는 pane 내용을 TOML 매니페스트로
-분류합니다 — `cursor-agent`, `amp`, `copilot`, `aider`, `goose`용 매니페스트가
-기본 번들로 제공되며 사용자가 확장 가능. 훅이 있으면 항상 훅이 우선합니다.
+분류합니다 — `agy`, `cursor-agent`, `amp`, `copilot`, `aider`, `goose`용
+매니페스트가 기본 번들로 제공되며 사용자가 확장 가능. 훅이 있으면 항상 훅이 우선합니다.
 [docs/SCREEN_DETECTION.md](docs/SCREEN_DETECTION.md) 참고.
 
 ## Fleet host

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/onboard.s
 `muxa` is a small daemon and CLI for observing — and now driving — AI
 coding agents running inside terminal multiplexer panes. It reads agent
 state from existing hook/event systems (Claude Code, OpenAI Codex, Google
-Gemini CLI), falls back to screen-manifest detection for hook-less agents,
+Gemini CLI and its Antigravity successor), falls back to screen-manifest
+detection for hook-less agents,
 and correlates it all with multiplexer panes and sessions. Through `muxa
 mcp` a coding agent can also orchestrate the others — inspect state, send
 prompts, wait for changes.
@@ -312,12 +313,12 @@ systems, so muxa gets exact state transitions:
 | Claude Code | Supported | `~/.claude/settings.json` |
 | OpenAI Codex | Supported | `~/.codex/config.toml` |
 | Google Gemini CLI | Supported | `~/.gemini/settings.json` |
+| Google Antigravity CLI (`agy`) | Supported | `~/.gemini/config/hooks.json` — [details](docs/ANTIGRAVITY.md) |
 | opencode | Planned | [tracking issue](https://github.com/Open330/muxa/issues/14) |
 
 **Screen-detected (fallback).** Agents with no hooks are classified from
-their pane contents via TOML manifests — bundled best-effort for
-`cursor-agent`, `amp`, `copilot`, `aider`, and `goose`, extensible per
-user. Hooks always win when present. See
+their pane contents via TOML manifests — bundled for `agy`, `cursor-agent`,
+`amp`, `copilot`, `aider`, and `goose`, extensible per user. Hooks always win when present. See
 [docs/SCREEN_DETECTION.md](docs/SCREEN_DETECTION.md).
 
 On [herdr](https://herdr.dev) hosts, muxa additionally surfaces every
@@ -374,6 +375,7 @@ simultaneously.
 | rmux host support | [docs/RMUX.md](docs/RMUX.md) |
 | Multi-host observation | [docs/MULTI_HOST.md](docs/MULTI_HOST.md) |
 | Physical SSH fleet | [docs/FLEET.md](docs/FLEET.md) |
+| Antigravity CLI (`agy`) support | [docs/ANTIGRAVITY.md](docs/ANTIGRAVITY.md) |
 | Screen-manifest detection | [docs/SCREEN_DETECTION.md](docs/SCREEN_DETECTION.md) |
 | Live TUI and prompt composer | [docs/WATCH.md](docs/WATCH.md) |
 | CLI dashboard | [docs/DASHBOARD_CLI.md](docs/DASHBOARD_CLI.md) |

--- a/README.md
+++ b/README.md
@@ -318,7 +318,9 @@ systems, so muxa gets exact state transitions:
 
 **Screen-detected (fallback).** Agents with no hooks are classified from
 their pane contents via TOML manifests — bundled for `agy`, `cursor-agent`,
-`amp`, `copilot`, `aider`, and `goose`, extensible per user. Hooks always win when present. See
+`amp`, `copilot`, `aider`, and `goose`, extensible per user. Hooks win when
+present, with one carve-out: `agy` fires no hook for an approval prompt, so its
+panes stay screen-inferred for that one signal. See
 [docs/SCREEN_DETECTION.md](docs/SCREEN_DETECTION.md).
 
 On [herdr](https://herdr.dev) hosts, muxa additionally surfaces every

--- a/config.example.toml
+++ b/config.example.toml
@@ -479,7 +479,7 @@
 
 # [[pipeline.triad.agent]]
 # alias   = 'plan'
-# program = 'codex'               # claude | codex | gemini | opencode
+# program = 'codex'               # claude | codex | gemini | agy | opencode
 # role    = 'planner'             # peers can address it as role:planner
 # prompt  = 'You own the approach. Write the plan first; do not edit code.'
 

--- a/crates/muxa-cli/src/agent_launch.rs
+++ b/crates/muxa-cli/src/agent_launch.rs
@@ -16,6 +16,12 @@ pub enum AgentProgram {
     Claude,
     Codex,
     Gemini,
+    /// The Antigravity CLI. Named for its binary (`agy`) rather than the
+    /// product, mirroring `Gemini` → `gemini`; `antigravity` stays accepted
+    /// as an alias on both the CLI flag and [`AgentProgram::parse`].
+    #[value(name = "agy", alias = "antigravity")]
+    #[serde(rename = "agy")]
+    Antigravity,
     Opencode,
 }
 
@@ -25,9 +31,10 @@ impl AgentProgram {
             "claude" | "claude_code" | "claude-code" => Ok(Self::Claude),
             "codex" | "cx" => Ok(Self::Codex),
             "gemini" | "gemini_cli" | "gemini-cli" => Ok(Self::Gemini),
+            "agy" | "antigravity" => Ok(Self::Antigravity),
             "opencode" => Ok(Self::Opencode),
             _ => Err(format!(
-                "unknown agent {value:?}; expected claude, codex, gemini, or opencode"
+                "unknown agent {value:?}; expected claude, codex, gemini, agy, or opencode"
             )),
         }
     }
@@ -37,6 +44,7 @@ impl AgentProgram {
             Self::Claude => "claude",
             Self::Codex => "codex",
             Self::Gemini => "gemini",
+            Self::Antigravity => "agy",
             Self::Opencode => "opencode",
         }
     }
@@ -57,6 +65,13 @@ impl AgentProgram {
                 format!("gemini --approval-mode yolo --skip-trust -i {prompt}")
             }
             (Self::Gemini, None) => "gemini --approval-mode yolo --skip-trust".into(),
+            // agy's own flag spelling: it has no `--approval-mode`/`--skip-trust`,
+            // and `-i` is its `--prompt-interactive` alias (so the pane stays
+            // interactive after the first prompt, matching gemini's behaviour).
+            (Self::Antigravity, Some(prompt)) => {
+                format!("agy --dangerously-skip-permissions -i {prompt}")
+            }
+            (Self::Antigravity, None) => "agy --dangerously-skip-permissions".into(),
             (Self::Opencode, Some(prompt)) => format!("opencode --prompt {prompt}"),
             (Self::Opencode, None) => "opencode".into(),
         }

--- a/crates/muxa-cli/src/doctor.rs
+++ b/crates/muxa-cli/src/doctor.rs
@@ -370,7 +370,7 @@ fn check_systemd_unit_file() -> CheckResult {
 /// returns `(label, result)` so `run()` can log them with a consistent
 /// `Hooks · <agent>` prefix.
 fn check_agent_hooks() -> Vec<(String, CheckResult)> {
-    vec![
+    let mut checks = vec![
         (
             "Hooks · Claude".to_string(),
             check_one_agent_hook("claude", claude::default_path(), claude_hook_configured),
@@ -383,15 +383,23 @@ fn check_agent_hooks() -> Vec<(String, CheckResult)> {
             "Hooks · Gemini".to_string(),
             check_one_agent_hook("gemini", gemini::default_path(), gemini_hook_configured),
         ),
-        (
+    ];
+    // agy only: reported when agy is actually installed. Unlike the other
+    // three, a missing `hooks.json` is the *normal* state for a fresh agy
+    // (it writes the file only once `/hooks` is used), so an unconditional
+    // check would turn a red line — and a "run `muxa init`" remedy that
+    // wires an agent they don't have — on for every existing user.
+    if crate::init::detect::antigravity_installed() {
+        checks.push((
             "Hooks · Antigravity".to_string(),
             check_one_agent_hook(
                 "agy",
                 antigravity::default_path(),
                 antigravity_hook_configured,
             ),
-        ),
-    ]
+        ));
+    }
+    checks
 }
 
 fn check_one_agent_hook(
@@ -450,20 +458,37 @@ pub fn gemini_hook_configured(settings_text: &str) -> bool {
 /// take a matcher.
 pub fn antigravity_hook_configured(hooks_text: &str) -> bool {
     const PREFIX: &str = "muxa hook agy";
+    /// Every event muxa needs wired. Checking the whole set — rather than
+    /// "any muxa command anywhere" — is what makes a block left over from an
+    /// older muxa report as broken. A partial block is the worst state to
+    /// call healthy: the row exists but never shows prompts or tools, and
+    /// nothing tells the user to re-run `muxa init`.
+    const REQUIRED: &[&str] = &[
+        "SessionStart",
+        "PreInvocation",
+        "PostInvocation",
+        "PreToolUse",
+        "PostToolUse",
+        "Stop",
+    ];
+
     let Ok(root) = serde_json::from_str::<serde_json::Value>(hooks_text) else {
         return false;
     };
     let Some(named) = root.as_object() else {
         return false;
     };
-    named.values().any(|spec| {
-        spec.as_object().is_some_and(|events| {
-            events.values().any(|entries| {
-                entries.as_array().is_some_and(|arr| {
+    // Union across named hooks rather than requiring one key to hold them
+    // all: muxa writes a single `muxa` key, but a hand-split config that
+    // still covers every event is genuinely configured.
+    REQUIRED.iter().all(|event| {
+        named.values().any(|spec| {
+            spec.get(event)
+                .and_then(serde_json::Value::as_array)
+                .is_some_and(|arr| {
                     arr.iter()
                         .any(|entry| has_command(entry, PREFIX) || entry_has_command(entry, PREFIX))
                 })
-            })
         })
     })
 }
@@ -909,23 +934,47 @@ mod tests {
         assert!(!claude_hook_configured(""));
     }
 
+    /// The block `files::antigravity::upsert` writes is what "configured"
+    /// means, and both event shapes in it have to be recognized.
     #[test]
-    fn antigravity_hook_configured_accepts_both_event_shapes() {
-        // Exactly what `files::antigravity::upsert` writes.
+    fn antigravity_hook_configured_accepts_the_written_block() {
         let written = crate::init::files::antigravity::upsert("").unwrap().0;
         assert!(antigravity_hook_configured(&written));
 
-        // The grouped (matcher) form on its own...
-        let grouped = r#"{"muxa":{"PreToolUse":[
-            { "matcher": "*", "hooks": [{ "type": "command", "command": "muxa hook agy --event pre_tool_use" }] }
-        ]}}"#;
-        assert!(antigravity_hook_configured(grouped));
+        // Split across two named keys by hand, still complete.
+        let split = r#"{
+            "muxa-lifecycle": {
+                "SessionStart":   [{ "type": "command", "command": "muxa hook agy --event session_start" }],
+                "PreInvocation":  [{ "type": "command", "command": "muxa hook agy --event pre_invocation" }],
+                "PostInvocation": [{ "type": "command", "command": "muxa hook agy --event post_invocation" }],
+                "Stop":           [{ "type": "command", "command": "muxa hook agy --event stop" }]
+            },
+            "muxa-tools": {
+                "PreToolUse":  [{ "matcher": "*", "hooks": [{ "type": "command", "command": "muxa hook agy --event pre_tool_use" }] }],
+                "PostToolUse": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "muxa hook agy --event post_tool_use" }] }]
+            }
+        }"#;
+        assert!(
+            antigravity_hook_configured(split),
+            "coverage is what matters, not which key holds it",
+        );
+    }
 
-        // ...and the flat form on its own.
-        let flat = r#"{"muxa":{"Stop":[
+    /// A block left over from an older muxa covers only some events. Calling
+    /// that healthy is the worst outcome: the row exists but never shows a
+    /// prompt or a tool, and nothing points at the fix.
+    #[test]
+    fn antigravity_hook_configured_rejects_a_partial_block() {
+        let stale = r#"{"muxa":{"Stop":[
             { "type": "command", "command": "muxa hook agy --event stop" }
         ]}}"#;
-        assert!(antigravity_hook_configured(flat));
+        assert!(!antigravity_hook_configured(stale));
+
+        // Everything but `PreToolUse` — one missing event is still broken.
+        let mut v: serde_json::Value =
+            serde_json::from_str(&crate::init::files::antigravity::upsert("").unwrap().0).unwrap();
+        v["muxa"].as_object_mut().unwrap().remove("PreToolUse");
+        assert!(!antigravity_hook_configured(&v.to_string()));
     }
 
     /// Someone else's hooks in the same file must not read as ours — that is

--- a/crates/muxa-cli/src/doctor.rs
+++ b/crates/muxa-cli/src/doctor.rs
@@ -23,7 +23,7 @@ use muxa::state::SYNTHETIC_SESSION_PREFIX;
 use muxa::Agent;
 use tokio::time::timeout;
 
-use crate::init::files::{claude, codex, gemini, launchd, systemd as systemd_files};
+use crate::init::files::{antigravity, claude, codex, gemini, launchd, systemd as systemd_files};
 
 /// Marker block ids the `muxa init` tmux installer writes — must match
 /// the constants in `init::components::Component::id`. Duplicated as
@@ -366,7 +366,7 @@ fn check_systemd_unit_file() -> CheckResult {
     }
 }
 
-/// Run the per-agent hook check for Claude, Codex, and Gemini. Each
+/// Run the per-agent hook check for Claude, Codex, Gemini, and agy. Each
 /// returns `(label, result)` so `run()` can log them with a consistent
 /// `Hooks · <agent>` prefix.
 fn check_agent_hooks() -> Vec<(String, CheckResult)> {
@@ -382,6 +382,14 @@ fn check_agent_hooks() -> Vec<(String, CheckResult)> {
         (
             "Hooks · Gemini".to_string(),
             check_one_agent_hook("gemini", gemini::default_path(), gemini_hook_configured),
+        ),
+        (
+            "Hooks · Antigravity".to_string(),
+            check_one_agent_hook(
+                "agy",
+                antigravity::default_path(),
+                antigravity_hook_configured,
+            ),
         ),
     ]
 }
@@ -429,6 +437,43 @@ pub fn claude_hook_configured(settings_text: &str) -> bool {
 /// Claude.
 pub fn gemini_hook_configured(settings_text: &str) -> bool {
     json_hooks_dict_has_command(settings_text, "muxa hook gemini")
+}
+
+/// True iff agy's `hooks.json` contains at least one handler whose command
+/// starts with `muxa hook agy`.
+///
+/// A different shape from the Claude/Gemini walker, not a variant of it: agy
+/// keys the file by hook NAME first (`{"<name>": {"<Event>": [...]}}`), and an
+/// event's entries are either bare handlers (`Stop`, `PreInvocation`, …) or
+/// `{matcher, hooks[]}` groups (`PreToolUse`, `PostToolUse`). Both forms are
+/// accepted here so the check keeps passing if agy ever relaxes which events
+/// take a matcher.
+pub fn antigravity_hook_configured(hooks_text: &str) -> bool {
+    const PREFIX: &str = "muxa hook agy";
+    let Ok(root) = serde_json::from_str::<serde_json::Value>(hooks_text) else {
+        return false;
+    };
+    let Some(named) = root.as_object() else {
+        return false;
+    };
+    named.values().any(|spec| {
+        spec.as_object().is_some_and(|events| {
+            events.values().any(|entries| {
+                entries.as_array().is_some_and(|arr| {
+                    arr.iter()
+                        .any(|entry| has_command(entry, PREFIX) || entry_has_command(entry, PREFIX))
+                })
+            })
+        })
+    })
+}
+
+/// A bare handler object — the flat (matcher-less) event form.
+fn has_command(entry: &serde_json::Value, prefix: &str) -> bool {
+    entry
+        .get("command")
+        .and_then(|v| v.as_str())
+        .is_some_and(|c| c.trim_start().starts_with(prefix))
 }
 
 /// True iff Codex's `config.toml` contains at least one hook entry
@@ -862,6 +907,43 @@ mod tests {
         // Garbage in must not panic — bare `false` is the right signal.
         assert!(!claude_hook_configured("not even json {"));
         assert!(!claude_hook_configured(""));
+    }
+
+    #[test]
+    fn antigravity_hook_configured_accepts_both_event_shapes() {
+        // Exactly what `files::antigravity::upsert` writes.
+        let written = crate::init::files::antigravity::upsert("").unwrap().0;
+        assert!(antigravity_hook_configured(&written));
+
+        // The grouped (matcher) form on its own...
+        let grouped = r#"{"muxa":{"PreToolUse":[
+            { "matcher": "*", "hooks": [{ "type": "command", "command": "muxa hook agy --event pre_tool_use" }] }
+        ]}}"#;
+        assert!(antigravity_hook_configured(grouped));
+
+        // ...and the flat form on its own.
+        let flat = r#"{"muxa":{"Stop":[
+            { "type": "command", "command": "muxa hook agy --event stop" }
+        ]}}"#;
+        assert!(antigravity_hook_configured(flat));
+    }
+
+    /// Someone else's hooks in the same file must not read as ours — that is
+    /// the whole point of walking the structure instead of substring-matching.
+    #[test]
+    fn antigravity_hook_configured_rejects_foreign_hooks() {
+        let other = r#"{"lint-checker":{"PostToolUse":[
+            { "matcher": "run_command", "hooks": [{ "type": "command", "command": "./lint.sh" }] }
+        ]}}"#;
+        assert!(!antigravity_hook_configured(other));
+        // The Gemini CLI's file shape must not satisfy the agy check either:
+        // that is the exact mix-up this whole adapter exists to prevent.
+        let gemini_shaped = r#"{"hooks":{"BeforeAgent":[
+            { "hooks": [{ "type": "command", "command": "muxa hook gemini --event before_agent" }] }
+        ]}}"#;
+        assert!(!antigravity_hook_configured(gemini_shaped));
+        assert!(!antigravity_hook_configured("{ not json"));
+        assert!(!antigravity_hook_configured("[]"));
     }
 
     #[test]

--- a/crates/muxa-cli/src/init/components.rs
+++ b/crates/muxa-cli/src/init/components.rs
@@ -21,6 +21,8 @@ pub enum Component {
     CodexHooks,
     /// Gemini CLI shell hooks
     GeminiHooks,
+    /// Antigravity CLI (`agy`) lifecycle hooks
+    AntigravityHooks,
     /// opencode plugin event bridge
     OpencodeHooks,
     /// `muxad` user-level systemd service (Linux only)
@@ -47,6 +49,7 @@ impl Component {
         Component::ClaudeHooks,
         Component::CodexHooks,
         Component::GeminiHooks,
+        Component::AntigravityHooks,
         Component::OpencodeHooks,
         Component::MuxadSystemd,
         Component::MuxadLaunchd,
@@ -65,6 +68,7 @@ impl Component {
             Component::ClaudeHooks => "claude-hooks",
             Component::CodexHooks => "codex-hooks",
             Component::GeminiHooks => "gemini-hooks",
+            Component::AntigravityHooks => "agy-hooks",
             Component::OpencodeHooks => "opencode-hooks",
             Component::MuxadSystemd => "muxad-systemd",
             Component::MuxadLaunchd => "muxad-launchd",
@@ -88,6 +92,7 @@ impl Component {
             Component::ClaudeHooks => "Claude Code: shell hooks + statusLine",
             Component::CodexHooks => "OpenAI Codex: shell hooks",
             Component::GeminiHooks => "Gemini CLI: shell hooks",
+            Component::AntigravityHooks => "Antigravity CLI (agy): lifecycle hooks",
             Component::OpencodeHooks => "opencode: plugin event bridge",
             Component::MuxadSystemd => "muxad: systemd user service (auto-start on login)",
             Component::MuxadLaunchd => "muxad: launchd LaunchAgent (auto-start on login)",
@@ -107,6 +112,7 @@ impl Component {
             Component::ClaudeHooks => "auto-detect when ~/.claude/settings.json exists",
             Component::CodexHooks => "auto-detect when ~/.codex/config.toml exists",
             Component::GeminiHooks => "auto-detect when ~/.gemini/settings.json exists",
+            Component::AntigravityHooks => "writes ~/.gemini/config/hooks.json; agy's own format",
             Component::OpencodeHooks => "installs ~/.config/opencode/plugins/muxa.ts",
             Component::MuxadSystemd => "Linux only; skipped on macOS / launchd hosts",
             Component::MuxadLaunchd => "macOS only; skipped on Linux / systemd hosts",
@@ -158,6 +164,7 @@ impl Component {
                 Component::ClaudeHooks,
                 Component::CodexHooks,
                 Component::GeminiHooks,
+                Component::AntigravityHooks,
                 Component::OpencodeHooks,
                 Component::Collaboration,
                 Component::Ask,

--- a/crates/muxa-cli/src/init/detect.rs
+++ b/crates/muxa-cli/src/init/detect.rs
@@ -179,17 +179,13 @@ fn existing_dir(p: Option<PathBuf>) -> Option<PathBuf> {
     p.filter(|p| p.is_dir())
 }
 
-/// opencode has no single well-known settings file the way the other
-/// agents do — it keeps state under `~/.config/opencode/` (that's also
-/// where its `plugins/` dir lives). Presence of that directory is our
-/// "opencode is installed" signal.
-/// Is the Antigravity CLI installed?
+/// Is the Antigravity CLI installed, and where does it keep state?
 ///
 /// Prefers its state directory — `agy` creates `~/.gemini/antigravity-cli/`
-/// on first run, and unlike a PATH probe that survives a shell whose PATH the
-/// wizard didn't inherit. Falls back to `agy` on PATH so a fresh install that
-/// has never been run still pre-checks.
-fn detect_antigravity() -> Option<PathBuf> {
+/// on first run, and that survives a shell whose PATH the wizard didn't
+/// inherit. Falls back to `agy` on PATH so a fresh install that has never
+/// been run still pre-checks.
+pub fn detect_antigravity() -> Option<PathBuf> {
     let home = home_join(".gemini/antigravity-cli");
     if home.is_dir() {
         return Some(home);
@@ -197,6 +193,16 @@ fn detect_antigravity() -> Option<PathBuf> {
     which::which("agy").ok()
 }
 
+/// Presence-only form of [`detect_antigravity`], for callers (like `doctor`)
+/// that have no `Detection` in hand.
+pub fn antigravity_installed() -> bool {
+    detect_antigravity().is_some()
+}
+
+/// opencode has no single well-known settings file the way the other
+/// agents do — it keeps state under `~/.config/opencode/` (that's also
+/// where its `plugins/` dir lives). Presence of that directory is our
+/// "opencode is installed" signal.
 fn opencode_config_dir() -> Option<PathBuf> {
     dirs::config_dir().map(|d| d.join("opencode"))
 }

--- a/crates/muxa-cli/src/init/detect.rs
+++ b/crates/muxa-cli/src/init/detect.rs
@@ -22,6 +22,11 @@ pub struct Detection {
     pub claude_settings: Option<PathBuf>,
     pub codex_config: Option<PathBuf>,
     pub gemini_settings: Option<PathBuf>,
+    /// Marker that the Antigravity CLI has run here. Separate from
+    /// `gemini_settings`: agy shares the `~/.gemini` tree with the CLI it
+    /// replaced, so the presence of `settings.json` says nothing about
+    /// whether `agy` is installed (and vice versa).
+    pub antigravity_home: Option<PathBuf>,
     pub opencode_config: Option<PathBuf>,
     pub muxad_running: bool,
     pub systemd_user_available: bool,
@@ -37,6 +42,7 @@ impl Detection {
             claude_settings: existing_file(home_join(".claude/settings.json")),
             codex_config: existing_file(home_join(".codex/config.toml")),
             gemini_settings: existing_file(home_join(".gemini/settings.json")),
+            antigravity_home: detect_antigravity(),
             opencode_config: existing_dir(opencode_config_dir()),
             muxad_running: muxad_is_running(),
             systemd_user_available: super::files::systemd::systemd_available(),
@@ -74,6 +80,9 @@ impl Detection {
         if self.gemini_settings.is_some() {
             out.push(Component::GeminiHooks);
         }
+        if self.antigravity_home.is_some() {
+            out.push(Component::AntigravityHooks);
+        }
         // Pre-check the daemon-manager that fits this host so the
         // wizard's default produces a working install. The picker
         // hides the others (filtered via `Component::applicable_here`).
@@ -84,8 +93,8 @@ impl Detection {
 
     /// Whether an agent-hook component's config is present on disk.
     ///
-    /// Returns `Some(true)`/`Some(false)` for the four agent hooks
-    /// (Claude/Codex/Gemini/opencode) and `None` for every other
+    /// Returns `Some(true)`/`Some(false)` for the five agent hooks
+    /// (Claude/Codex/Gemini/agy/opencode) and `None` for every other
     /// component — the caller reads `None` as "not an agent hook, always
     /// keep". This is what lets the non-interactive/preset path skip
     /// wiring up an agent the user doesn't actually have installed,
@@ -95,6 +104,7 @@ impl Detection {
             Component::ClaudeHooks => Some(self.claude_settings.is_some()),
             Component::CodexHooks => Some(self.codex_config.is_some()),
             Component::GeminiHooks => Some(self.gemini_settings.is_some()),
+            Component::AntigravityHooks => Some(self.antigravity_home.is_some()),
             Component::OpencodeHooks => Some(self.opencode_config.is_some()),
             _ => None,
         }
@@ -173,6 +183,20 @@ fn existing_dir(p: Option<PathBuf>) -> Option<PathBuf> {
 /// agents do — it keeps state under `~/.config/opencode/` (that's also
 /// where its `plugins/` dir lives). Presence of that directory is our
 /// "opencode is installed" signal.
+/// Is the Antigravity CLI installed?
+///
+/// Prefers its state directory — `agy` creates `~/.gemini/antigravity-cli/`
+/// on first run, and unlike a PATH probe that survives a shell whose PATH the
+/// wizard didn't inherit. Falls back to `agy` on PATH so a fresh install that
+/// has never been run still pre-checks.
+fn detect_antigravity() -> Option<PathBuf> {
+    let home = home_join(".gemini/antigravity-cli");
+    if home.is_dir() {
+        return Some(home);
+    }
+    which::which("agy").ok()
+}
+
 fn opencode_config_dir() -> Option<PathBuf> {
     dirs::config_dir().map(|d| d.join("opencode"))
 }

--- a/crates/muxa-cli/src/init/files/antigravity.rs
+++ b/crates/muxa-cli/src/init/files/antigravity.rs
@@ -59,7 +59,7 @@ pub fn default_path() -> Option<std::path::PathBuf> {
 
 pub fn upsert(original: &str) -> Result<(String, Outcome)> {
     let mut root = parse_or_empty(original)?;
-    let obj = ensure_object(&mut root);
+    let obj = as_object_mut(&mut root)?;
 
     let want = muxa_hook_spec();
     let changed = obj.get(HOOK_NAME) != Some(&want);
@@ -81,7 +81,12 @@ pub fn remove(original: &str) -> Result<(String, Outcome)> {
         return Ok((original.to_string(), Outcome::AlreadyAbsent));
     }
     let mut root = parse_or_empty(original)?;
-    let obj = ensure_object(&mut root);
+    // Uninstall is lenient where install is strict: a root we don't
+    // recognize cannot be holding our key, so report absence and leave the
+    // file byte-identical rather than erroring on the way out.
+    let Ok(obj) = as_object_mut(&mut root) else {
+        return Ok((original.to_string(), Outcome::AlreadyAbsent));
+    };
     if obj.remove(HOOK_NAME).is_none() {
         return Ok((original.to_string(), Outcome::AlreadyAbsent));
     }
@@ -119,11 +124,16 @@ fn parse_or_empty(text: &str) -> Result<Value> {
     }
 }
 
-fn ensure_object(v: &mut Value) -> &mut Map<String, Value> {
-    if !v.is_object() {
-        *v = Value::Object(Map::new());
-    }
-    v.as_object_mut().expect("just ensured object")
+/// Borrow the root as an object, or fail.
+///
+/// Deliberately NOT "replace whatever is there with `{}`": a root that parses
+/// but isn't an object (`[]`, `"x"`, `5`) is a file we don't understand, and
+/// silently overwriting it is the same class of data loss as overwriting
+/// unparseable JSON. agy itself refuses to save over a `hooks.json` it can't
+/// read; muxa matches that.
+fn as_object_mut(v: &mut Value) -> Result<&mut Map<String, Value>> {
+    v.as_object_mut()
+        .context("agy hooks.json must contain a JSON object at its root")
 }
 
 fn pretty_print(v: &Value) -> Result<String> {
@@ -278,5 +288,25 @@ mod tests {
     fn malformed_json_is_an_error_not_a_silent_overwrite() {
         assert!(upsert("{ not json").is_err());
         assert!(remove("{ not json").is_err());
+    }
+
+    /// Valid JSON of the wrong shape is data loss just the same, so `upsert`
+    /// refuses it instead of replacing the root with `{}`.
+    #[test]
+    fn a_non_object_root_is_refused_by_upsert() {
+        for text in ["[]", r#""a string""#, "5", "null"] {
+            assert!(upsert(text).is_err(), "upsert should refuse {text}");
+        }
+    }
+
+    /// Uninstall stays lenient: nothing of ours can live in a root we don't
+    /// recognize, so it reports absence and leaves the bytes alone.
+    #[test]
+    fn a_non_object_root_is_left_alone_by_remove() {
+        for text in ["[]", r#""a string""#, "5"] {
+            let (out, outcome) = remove(text).unwrap();
+            assert_eq!(outcome, Outcome::AlreadyAbsent, "{text}");
+            assert_eq!(out, text, "{text}");
+        }
     }
 }

--- a/crates/muxa-cli/src/init/files/antigravity.rs
+++ b/crates/muxa-cli/src/init/files/antigravity.rs
@@ -1,0 +1,282 @@
+//! `~/.gemini/config/hooks.json` content layer — Antigravity CLI (`agy`).
+//!
+//! agy shares the `~/.gemini` tree with the CLI it replaced but reads none of
+//! the same files: hooks live in their own `hooks.json` under a *customization
+//! root*, not in the `hooks` key of `settings.json`. muxa writes the global
+//! root (`~/.gemini/config/hooks.json`) — the same file agy's own `/hooks`
+//! command manages, and the one shared with the Antigravity backend.
+//!
+//! ## Why this is simpler than [`super::gemini`]
+//!
+//! agy's `hooks.json` is keyed by **hook name**, so muxa owns exactly one
+//! top-level key (`muxa`) instead of merging entries into per-event arrays.
+//! Install is "set our key", uninstall is "drop our key", and a user's own
+//! hooks — hand-written, plugin-installed, or added through `/hooks` — are
+//! untouched by construction.
+//!
+//! ## Shape
+//!
+//! `PreToolUse`/`PostToolUse` take the grouped `{matcher, hooks[]}` form;
+//! `SessionStart`, `PreInvocation`, `PostInvocation` and `Stop` take a flat
+//! list of handlers. Getting this wrong is silent — agy logs
+//! `loaded 0 named hooks` and carries on — so [`tests`] pins both shapes.
+
+use crate::init::marker::Outcome;
+use anyhow::{Context, Result};
+use serde_json::{json, Map, Value};
+
+/// Our top-level key in `hooks.json`. Uninstall keys off this exact string,
+/// so renaming it would orphan every previously written block.
+const HOOK_NAME: &str = "muxa";
+
+/// Events taking the flat handler-list form, paired with the `--event` flag
+/// [`muxa::adapters::antigravity`] parses.
+const FLAT_EVENTS: &[(&str, &str)] = &[
+    ("SessionStart", "session_start"),
+    ("PreInvocation", "pre_invocation"),
+    ("PostInvocation", "post_invocation"),
+    ("Stop", "stop"),
+];
+
+/// Events taking the grouped `{matcher, hooks[]}` form. `*` matches every
+/// tool — muxa observes them all and gates none.
+const TOOL_EVENTS: &[(&str, &str)] = &[
+    ("PreToolUse", "pre_tool_use"),
+    ("PostToolUse", "post_tool_use"),
+];
+
+/// Per-handler timeout, in seconds.
+///
+/// Well above the 750 ms bound `Client::ingest` already applies, so it can
+/// only fire if something is pathologically wrong — at which point a bounded
+/// stall beats agy's 30 s default, because these hooks run synchronously
+/// inside the agent's loop.
+const TIMEOUT_SECS: u64 = 10;
+
+pub fn default_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(".gemini").join("config").join("hooks.json"))
+}
+
+pub fn upsert(original: &str) -> Result<(String, Outcome)> {
+    let mut root = parse_or_empty(original)?;
+    let obj = ensure_object(&mut root);
+
+    let want = muxa_hook_spec();
+    let changed = obj.get(HOOK_NAME) != Some(&want);
+    obj.insert(HOOK_NAME.to_string(), want);
+
+    let new_text = pretty_print(&root)?;
+    let outcome = if original.trim().is_empty() {
+        Outcome::Inserted
+    } else if changed || new_text.trim() != original.trim() {
+        Outcome::Replaced
+    } else {
+        Outcome::Unchanged
+    };
+    Ok((new_text, outcome))
+}
+
+pub fn remove(original: &str) -> Result<(String, Outcome)> {
+    if original.trim().is_empty() {
+        return Ok((original.to_string(), Outcome::AlreadyAbsent));
+    }
+    let mut root = parse_or_empty(original)?;
+    let obj = ensure_object(&mut root);
+    if obj.remove(HOOK_NAME).is_none() {
+        return Ok((original.to_string(), Outcome::AlreadyAbsent));
+    }
+    Ok((pretty_print(&root)?, Outcome::Removed))
+}
+
+/// The full `muxa` hook spec, exactly as agy expects to read it back.
+fn muxa_hook_spec() -> Value {
+    let mut spec = Map::new();
+    for (event, flag) in FLAT_EVENTS {
+        spec.insert((*event).to_string(), json!([handler(flag)]));
+    }
+    for (event, flag) in TOOL_EVENTS {
+        spec.insert(
+            (*event).to_string(),
+            json!([{ "matcher": "*", "hooks": [handler(flag)] }]),
+        );
+    }
+    Value::Object(spec)
+}
+
+fn handler(flag: &str) -> Value {
+    json!({
+        "type": "command",
+        "command": format!("muxa hook agy --event {flag}"),
+        "timeout": TIMEOUT_SECS,
+    })
+}
+
+fn parse_or_empty(text: &str) -> Result<Value> {
+    if text.trim().is_empty() {
+        Ok(Value::Object(Map::new()))
+    } else {
+        serde_json::from_str(text).context("parsing agy hooks.json")
+    }
+}
+
+fn ensure_object(v: &mut Value) -> &mut Map<String, Value> {
+    if !v.is_object() {
+        *v = Value::Object(Map::new());
+    }
+    v.as_object_mut().expect("just ensured object")
+}
+
+fn pretty_print(v: &Value) -> Result<String> {
+    let mut s = serde_json::to_string_pretty(v)?;
+    s.push('\n');
+    Ok(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use muxa::adapters::{antigravity::AntigravityAdapter, HookAdapter};
+
+    fn parse(text: &str) -> Value {
+        serde_json::from_str(text).unwrap()
+    }
+
+    #[test]
+    fn upsert_into_empty_writes_every_event() {
+        let (out, o) = upsert("").unwrap();
+        assert_eq!(o, Outcome::Inserted);
+        let v = parse(&out);
+        for (event, _) in FLAT_EVENTS.iter().chain(TOOL_EVENTS) {
+            assert!(
+                v[HOOK_NAME][event]
+                    .as_array()
+                    .is_some_and(|a| !a.is_empty()),
+                "missing {event}",
+            );
+        }
+    }
+
+    /// agy parses the two families differently: a `PreToolUse` written flat
+    /// (or a `Stop` written grouped) is dropped without an error message.
+    #[test]
+    fn tool_events_are_grouped_and_lifecycle_events_are_flat() {
+        let v = parse(&upsert("").unwrap().0);
+
+        let stop = &v[HOOK_NAME]["Stop"][0];
+        assert_eq!(stop["type"], "command");
+        assert!(stop.get("matcher").is_none(), "Stop must not be grouped");
+
+        let pre_tool = &v[HOOK_NAME]["PreToolUse"][0];
+        assert_eq!(pre_tool["matcher"], "*");
+        assert_eq!(pre_tool["hooks"][0]["type"], "command");
+    }
+
+    /// Every `--event` flag written here must be one the adapter parses; a
+    /// mismatch surfaces only as a silently ignored hook inside agy.
+    #[test]
+    fn every_written_flag_is_understood_by_the_adapter() {
+        let v = parse(&upsert("").unwrap().0);
+        let mut checked = 0;
+
+        for (event, _) in FLAT_EVENTS {
+            let cmd = v[HOOK_NAME][event][0]["command"].as_str().unwrap();
+            assert!(
+                AntigravityAdapter::parse_event(flag_of(cmd)).is_ok(),
+                "{cmd}"
+            );
+            checked += 1;
+        }
+        for (event, _) in TOOL_EVENTS {
+            let cmd = v[HOOK_NAME][event][0]["hooks"][0]["command"]
+                .as_str()
+                .unwrap();
+            assert!(
+                AntigravityAdapter::parse_event(flag_of(cmd)).is_ok(),
+                "{cmd}"
+            );
+            checked += 1;
+        }
+        assert_eq!(checked, FLAT_EVENTS.len() + TOOL_EVENTS.len());
+    }
+
+    fn flag_of(command: &str) -> &str {
+        command.rsplit("--event ").next().unwrap().trim()
+    }
+
+    #[test]
+    fn upsert_is_idempotent() {
+        let (first, _) = upsert("").unwrap();
+        let (second, o) = upsert(&first).unwrap();
+        assert_eq!(o, Outcome::Unchanged);
+        assert_eq!(first, second);
+    }
+
+    /// The file is shared with agy's own `/hooks` command, plugins, and
+    /// anything the user wrote by hand. Owning one named key means none of
+    /// that can be clobbered.
+    #[test]
+    fn upsert_preserves_other_named_hooks() {
+        let user = r#"{
+  "lint-checker": {
+    "PostToolUse": [
+      { "matcher": "run_command", "hooks": [{ "type": "command", "command": "./lint.sh" }] }
+    ]
+  }
+}"#;
+        let v = parse(&upsert(user).unwrap().0);
+        assert_eq!(
+            v["lint-checker"]["PostToolUse"][0]["hooks"][0]["command"],
+            "./lint.sh",
+        );
+        assert!(v[HOOK_NAME].is_object());
+    }
+
+    /// A stale block from an older muxa is rewritten to the current spec
+    /// rather than left half-configured.
+    #[test]
+    fn upsert_replaces_an_outdated_block() {
+        let stale =
+            r#"{"muxa":{"Stop":[{"type":"command","command":"muxa hook agy --event stop"}]}}"#;
+        let (out, o) = upsert(stale).unwrap();
+        assert_eq!(o, Outcome::Replaced);
+        let v = parse(&out);
+        assert!(v[HOOK_NAME]["PreToolUse"].is_array());
+        assert_eq!(v[HOOK_NAME]["Stop"][0]["timeout"], TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn remove_strips_only_our_key() {
+        let user = r#"{"lint-checker":{"PostToolUse":[]}}"#;
+        let (with, _) = upsert(user).unwrap();
+        let (after, o) = remove(&with).unwrap();
+        assert_eq!(o, Outcome::Removed);
+        let v = parse(&after);
+        assert!(v.get(HOOK_NAME).is_none());
+        assert!(v.get("lint-checker").is_some());
+    }
+
+    /// With nothing but our key, removal leaves an inert `{}` rather than
+    /// deleting the file. `push_edit_or_delete`'s delete demotion keys on a
+    /// *blank* remainder, and `{}` is not blank — deliberately, because agy's
+    /// own `/hooks` command owns this path too and may have created it. An
+    /// empty object is a valid hooks.json that loads zero hooks.
+    #[test]
+    fn remove_from_a_muxa_only_file_leaves_an_empty_object() {
+        let (with, _) = upsert("").unwrap();
+        let (after, o) = remove(&with).unwrap();
+        assert_eq!(o, Outcome::Removed);
+        assert_eq!(parse(&after), json!({}));
+    }
+
+    #[test]
+    fn remove_is_idempotent_and_reports_absence() {
+        assert_eq!(remove("").unwrap().1, Outcome::AlreadyAbsent);
+        assert_eq!(remove(r#"{"other":{}}"#).unwrap().1, Outcome::AlreadyAbsent,);
+    }
+
+    #[test]
+    fn malformed_json_is_an_error_not_a_silent_overwrite() {
+        assert!(upsert("{ not json").is_err());
+        assert!(remove("{ not json").is_err());
+    }
+}

--- a/crates/muxa-cli/src/init/files/mod.rs
+++ b/crates/muxa-cli/src/init/files/mod.rs
@@ -5,6 +5,7 @@
 //! the disk — `apply.rs` owns I/O so the same edits can be unit-tested
 //! and dry-run-rendered.
 
+pub mod antigravity;
 pub mod ask;
 pub mod claude;
 pub mod codex;

--- a/crates/muxa-cli/src/init/mod.rs
+++ b/crates/muxa-cli/src/init/mod.rs
@@ -343,6 +343,7 @@ mod tests {
             Component::ClaudeHooks
                 | Component::CodexHooks
                 | Component::GeminiHooks
+                | Component::AntigravityHooks
                 | Component::OpencodeHooks
         )
     }

--- a/crates/muxa-cli/src/init/plan.rs
+++ b/crates/muxa-cli/src/init/plan.rs
@@ -102,6 +102,7 @@ pub fn build(
             Component::ClaudeHooks => plan_claude(direction, *c, &mut actions, &mut warnings)?,
             Component::CodexHooks => plan_codex(direction, *c, &mut actions)?,
             Component::GeminiHooks => plan_gemini(direction, *c, &mut actions)?,
+            Component::AntigravityHooks => plan_antigravity(direction, *c, &mut actions)?,
             Component::OpencodeHooks => plan_opencode(direction, *c, &mut actions)?,
             Component::MuxadSystemd => plan_systemd(direction, *c, detect, &mut actions)?,
             Component::MuxadLaunchd => plan_launchd(direction, *c, detect, &mut actions)?,
@@ -427,6 +428,27 @@ fn plan_gemini(direction: Direction, c: Component, actions: &mut Vec<Action>) ->
         }
         Direction::Uninstall => {
             files::gemini::remove(&original).context("scrubbing gemini settings.json")?
+        }
+    };
+    push_edit_or_delete(direction, c, path, before, after, outcome, actions);
+    Ok(())
+}
+
+/// agy's hooks live in their own file, so unlike `plan_gemini` this creates
+/// `~/.gemini/config/hooks.json` when absent — that is the normal case, since
+/// agy only writes it once its own `/hooks` command is used.
+fn plan_antigravity(direction: Direction, c: Component, actions: &mut Vec<Action>) -> Result<()> {
+    let Some(path) = files::antigravity::default_path() else {
+        return Ok(());
+    };
+    let before = read_to_string_opt(&path)?;
+    let original = before.clone().unwrap_or_default();
+    let (after, outcome) = match direction {
+        Direction::Install => {
+            files::antigravity::upsert(&original).context("merging agy hooks.json")?
+        }
+        Direction::Uninstall => {
+            files::antigravity::remove(&original).context("scrubbing agy hooks.json")?
         }
     };
     push_edit_or_delete(direction, c, path, before, after, outcome, actions);

--- a/crates/muxa-cli/src/init/ui.rs
+++ b/crates/muxa-cli/src/init/ui.rs
@@ -107,6 +107,10 @@ pub fn render_detection(mode: Mode, d: &Detection) {
     lines.push(check_path("Claude Code config", d.claude_settings.as_ref()));
     lines.push(check_path("Codex config", d.codex_config.as_ref()));
     lines.push(check_path("Gemini CLI config", d.gemini_settings.as_ref()));
+    lines.push(check_path(
+        "Antigravity CLI (agy)",
+        d.antigravity_home.as_ref(),
+    ));
     lines.push(format!(
         "{} systemctl --user",
         if d.systemd_user_available {

--- a/crates/muxa-cli/src/init/verify.rs
+++ b/crates/muxa-cli/src/init/verify.rs
@@ -47,6 +47,7 @@ fn agent_component(c: Component) -> bool {
         Component::ClaudeHooks
             | Component::CodexHooks
             | Component::GeminiHooks
+            | Component::AntigravityHooks
             | Component::OpencodeHooks
     )
 }

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -599,7 +599,21 @@ async fn main() -> Result<()> {
     }
     let config_path = args.config.clone().or_else(paths::default_config_file);
     let skill_path = config_path.clone();
-    let cfg = Config::load_or_default(config_path.as_deref()).context("loading config")?;
+    let cfg = match Config::load_or_default(config_path.as_deref()) {
+        Ok(cfg) => cfg,
+        // A hook handler must not hard-fail on an unreadable config. agy
+        // reads a non-zero hook exit as its verdict
+        // (`tool call denied by pre-tool hook`), so one TOML typo in
+        // config.toml would otherwise block every tool call in every agy
+        // session — with nothing on screen naming the cause. Degrade to
+        // defaults and put the reason on stderr, never stdout (stdout is
+        // the verdict channel).
+        Err(e) if matches!(args.cmd, Cmd::Hook { .. }) => {
+            eprintln!("muxa: config unreadable ({e:#}); this hook is using defaults");
+            Config::default()
+        }
+        Err(e) => return Err(e).context("loading config"),
+    };
     set_icon_set(cfg.ui.icons);
     let socket = args
         .socket

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -28,7 +28,8 @@ use clap::{Parser, Subcommand, ValueEnum};
 use comfy_table::presets::UTF8_BORDERS_ONLY;
 use comfy_table::{Cell, ColumnConstraint, ContentArrangement, Table, Width};
 use muxa::adapters::{
-    claude, run_hook, ClaudeAdapter, CodexAdapter, GeminiAdapter, OpencodeAdapter,
+    claude, run_hook, AntigravityAdapter, ClaudeAdapter, CodexAdapter, GeminiAdapter,
+    OpencodeAdapter,
 };
 use muxa::collaboration::{
     AirArtifactReference, CollaborationClientKind, CollaborationOrigin, NewRequest, RequestKind,
@@ -461,6 +462,15 @@ enum HookCmd {
     },
     /// Gemini CLI hook handler.
     Gemini {
+        #[arg(long)]
+        event: String,
+    },
+    /// Antigravity CLI (`agy`) hook handler. Reads hook JSON on stdin.
+    ///
+    /// Writes NOTHING to stdout on any event: agy reads a hook's stdout as a
+    /// verdict, and a `PreToolUse` reply without a valid `decision` blocks the
+    /// tool call outright.
+    Agy {
         #[arg(long)]
         event: String,
     },
@@ -1309,6 +1319,9 @@ async fn cmd_sync(client: &Client) -> Result<()> {
     if report.gemini_cli > 0 {
         parts.push(format!("{} gemini_cli", report.gemini_cli));
     }
+    if report.antigravity > 0 {
+        parts.push(format!("{} antigravity", report.antigravity));
+    }
 
     let total = report.total_ingested();
     if total == 0 && report.skipped_known == 0 && report.failed == 0 {
@@ -1946,6 +1959,20 @@ async fn handle_hook(client: &Client, cmd: HookCmd) -> Result<()> {
         HookCmd::Gemini { event } => {
             let ev = run_hook::<GeminiAdapter, _>(&event, &mut std::io::stdin())?;
             best_effort_ingest(client, &ev).await;
+        }
+        HookCmd::Agy { event } => {
+            // FAIL-OPEN, and deliberately unlike the other hook arms.
+            //
+            // agy treats a non-zero hook exit as a verdict: a `PreToolUse`
+            // handler that dies takes the tool call down with it
+            // ("tool call denied by pre-tool hook"). Observability must never
+            // be able to block the agent, so an unparseable payload — a shape
+            // change in a future agy, a truncated stdin — is logged and
+            // swallowed rather than propagated to a non-zero exit.
+            match run_hook::<AntigravityAdapter, _>(&event, &mut std::io::stdin()) {
+                Ok(ev) => best_effort_ingest(client, &ev).await,
+                Err(e) => tracing::debug!(error = %e, event, "agy hook payload ignored"),
+            }
         }
         HookCmd::Opencode { event } => {
             let ev = run_hook::<OpencodeAdapter, _>(&event, &mut std::io::stdin())?;

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -601,7 +601,7 @@ fn tool_definitions() -> Vec<Value> {
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "target": { "type": "string", "description": "Default auto. Accepts auto/peer, codex/claude/gemini/opencode (with or without @), pane:%N/%N, @alias, or role:<name>." },
+                    "target": { "type": "string", "description": "Default auto. Accepts auto/peer, codex/claude/gemini/agy/opencode (with or without @), pane:%N/%N, @alias, or role:<name>." },
                     "intent": { "type": "string", "enum": ["review", "question", "task"], "description": "Default review." },
                     "body": { "type": "string", "description": "Request-specific instruction. Optional when skill is supplied." },
                     "skill": { "type": "string", "description": "Registered Muxa message skill name, with or without leading /. Its prompt is expanded before sending." },
@@ -611,7 +611,7 @@ fn tool_definitions() -> Vec<Value> {
                     "wait": { "type": "boolean", "description": "Wait for the structured reply in this call. Default true." },
                     "timeout_secs": { "type": "integer", "minimum": 1, "maximum": 600, "description": "Reply wait timeout. Default 300." },
                     "spawn_if_missing": { "type": "boolean", "description": "Default false. Create a same-window bypass-permission peer only after explicit user confirmation." },
-                    "spawn_agent": { "type": "string", "enum": ["claude", "codex", "gemini", "opencode"], "description": "Provider to create when spawn_if_missing=true. Defaults to the current agent's opposite provider." },
+                    "spawn_agent": { "type": "string", "enum": ["claude", "codex", "gemini", "agy", "opencode"], "description": "Provider to create when spawn_if_missing=true. Defaults to the current agent's opposite provider." },
                     "spawn_timeout_secs": { "type": "integer", "minimum": 1, "maximum": 60, "description": "How long to wait for the new pane to register as a collaboration peer. Default 30." },
                     "air_artifacts": {
                         "type": "array",

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -429,7 +429,7 @@ fn tool_definitions() -> Vec<Value> {
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "agent": { "type": "string", "enum": ["claude", "codex", "gemini", "opencode"] },
+                    "agent": { "type": "string", "enum": ["claude", "codex", "gemini", "agy", "opencode"] },
                     "placement": { "type": "string", "enum": ["pane", "window", "session"], "description": "Default pane." },
                     "target": { "type": "string", "description": "tmux target for pane/window placement. Defaults to TMUX_PANE." },
                     "cwd": { "type": "string", "description": "Existing working directory. Defaults to the MCP process cwd." },
@@ -1710,9 +1710,10 @@ fn provider_rank(kind: AgentKind) -> u8 {
         AgentKind::Codex => 0,
         AgentKind::ClaudeCode => 1,
         AgentKind::GeminiCli => 2,
-        AgentKind::Opencode => 3,
-        AgentKind::Task => 4,
-        AgentKind::Unknown => 5,
+        AgentKind::Antigravity => 3,
+        AgentKind::Opencode => 4,
+        AgentKind::Task => 5,
+        AgentKind::Unknown => 6,
     }
 }
 
@@ -1730,6 +1731,7 @@ fn provider_kind(target: &str) -> Option<AgentKind> {
         "claude" | "claude_code" | "claude-code" => Some(AgentKind::ClaudeCode),
         "codex" | "cx" => Some(AgentKind::Codex),
         "gemini" | "gemini_cli" | "gemini-cli" => Some(AgentKind::GeminiCli),
+        "agy" | "antigravity" => Some(AgentKind::Antigravity),
         "opencode" => Some(AgentKind::Opencode),
         _ => None,
     }
@@ -1754,13 +1756,20 @@ fn peer_spawn_program(
             ));
         }
     }
-    Ok(requested.or(targeted).unwrap_or(match current.agent_kind {
+    // Enumerated rather than collapsed to a `_` arm, and the duplicate
+    // `Codex` bodies are deliberate: spelling out every kind is what makes a
+    // new `AgentKind` a compile error here instead of a silent default.
+    #[allow(clippy::match_same_arms)]
+    let fallback = match current.agent_kind {
         AgentKind::ClaudeCode => crate::agent_launch::AgentProgram::Codex,
         AgentKind::Codex => crate::agent_launch::AgentProgram::Claude,
-        AgentKind::GeminiCli | AgentKind::Opencode | AgentKind::Task | AgentKind::Unknown => {
-            crate::agent_launch::AgentProgram::Codex
-        }
-    }))
+        AgentKind::GeminiCli
+        | AgentKind::Antigravity
+        | AgentKind::Opencode
+        | AgentKind::Task
+        | AgentKind::Unknown => crate::agent_launch::AgentProgram::Codex,
+    };
+    Ok(requested.or(targeted).unwrap_or(fallback))
 }
 
 fn agent_program_for_kind(kind: AgentKind) -> crate::agent_launch::AgentProgram {
@@ -1770,6 +1779,7 @@ fn agent_program_for_kind(kind: AgentKind) -> crate::agent_launch::AgentProgram 
             crate::agent_launch::AgentProgram::Codex
         }
         AgentKind::GeminiCli => crate::agent_launch::AgentProgram::Gemini,
+        AgentKind::Antigravity => crate::agent_launch::AgentProgram::Antigravity,
         AgentKind::Opencode => crate::agent_launch::AgentProgram::Opencode,
     }
 }
@@ -1779,6 +1789,7 @@ fn agent_program_label(program: crate::agent_launch::AgentProgram) -> &'static s
         crate::agent_launch::AgentProgram::Claude => "claude",
         crate::agent_launch::AgentProgram::Codex => "codex",
         crate::agent_launch::AgentProgram::Gemini => "gemini",
+        crate::agent_launch::AgentProgram::Antigravity => "agy",
         crate::agent_launch::AgentProgram::Opencode => "opencode",
     }
 }
@@ -2632,7 +2643,7 @@ mod tests {
         assert_eq!(start_agent["inputSchema"]["required"], json!(["agent"]));
         assert_eq!(
             start_agent["inputSchema"]["properties"]["agent"]["enum"],
-            json!(["claude", "codex", "gemini", "opencode"])
+            json!(["claude", "codex", "gemini", "agy", "opencode"])
         );
         assert!(start_agent["inputSchema"]["properties"]["work"].is_object());
         assert!(start_agent["inputSchema"]["properties"]["workspace"].is_object());

--- a/crates/muxa-cli/src/timeline.rs
+++ b/crates/muxa-cli/src/timeline.rs
@@ -179,6 +179,8 @@ enum AgentKindArg {
     Codex,
     #[value(alias = "gemini_cli")]
     GeminiCli,
+    #[value(alias = "agy")]
+    Antigravity,
     Opencode,
     Unknown,
 }
@@ -189,6 +191,7 @@ impl From<AgentKindArg> for AgentKind {
             AgentKindArg::ClaudeCode => Self::ClaudeCode,
             AgentKindArg::Codex => Self::Codex,
             AgentKindArg::GeminiCli => Self::GeminiCli,
+            AgentKindArg::Antigravity => Self::Antigravity,
             AgentKindArg::Opencode => Self::Opencode,
             AgentKindArg::Unknown => Self::Unknown,
         }

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -1846,6 +1846,7 @@ enum SpawnAgent {
     Claude,
     Codex,
     Gemini,
+    Antigravity,
     Opencode,
 }
 
@@ -1855,6 +1856,7 @@ impl SpawnAgent {
             Self::Claude => "claude",
             Self::Codex => "codex",
             Self::Gemini => "gemini",
+            Self::Antigravity => "agy",
             Self::Opencode => "opencode",
         }
     }
@@ -1863,7 +1865,8 @@ impl SpawnAgent {
         match self {
             Self::Claude => Self::Codex,
             Self::Codex => Self::Gemini,
-            Self::Gemini => Self::Opencode,
+            Self::Gemini => Self::Antigravity,
+            Self::Antigravity => Self::Opencode,
             Self::Opencode => Self::Claude,
         }
     }
@@ -1873,7 +1876,8 @@ impl SpawnAgent {
             Self::Claude => Self::Opencode,
             Self::Codex => Self::Claude,
             Self::Gemini => Self::Codex,
-            Self::Opencode => Self::Gemini,
+            Self::Antigravity => Self::Gemini,
+            Self::Opencode => Self::Antigravity,
         }
     }
 
@@ -1891,6 +1895,7 @@ impl SpawnAgent {
                 format!("codex --dangerously-bypass-approvals-and-sandbox {quoted}")
             }
             Self::Gemini => format!("gemini --approval-mode yolo --skip-trust -i {quoted}"),
+            Self::Antigravity => format!("agy --dangerously-skip-permissions -i {quoted}"),
             Self::Opencode => format!("opencode --prompt {quoted}"),
         }
     }
@@ -12905,6 +12910,7 @@ pub(crate) fn agent_kind_short(kind: AgentKind) -> &'static str {
         AgentKind::ClaudeCode => "claude",
         AgentKind::Codex => "codex",
         AgentKind::GeminiCli => "gemini",
+        AgentKind::Antigravity => "agy",
         AgentKind::Opencode => "opencode",
         AgentKind::Task => "task",
         AgentKind::Unknown => "agent",

--- a/crates/muxa/src/adapters/antigravity.rs
+++ b/crates/muxa/src/adapters/antigravity.rs
@@ -57,11 +57,14 @@
 //! ## What agy cannot tell us
 //!
 //! There is no permission/notification hook, so an agy row never reaches
-//! `WaitingInput` from hooks alone. The bundled `agy` screen manifest covers
-//! that case for panes with no hooks wired; where hooks *are* wired they take
-//! precedence and the approval prompt is not observed. There is likewise no
-//! session-end hook — `Stop` is a turn boundary, not a session boundary — so
-//! agy rows are reaped by pane liveness like Codex's.
+//! `WaitingInput` from hooks alone — this adapter simply has no event to emit
+//! for it. That signal comes from the bundled `agy` screen manifest instead:
+//! `muxad`'s synthetic layer treats an agy row as *attention-blind* and keeps
+//! screen inference running on its pane, applying the attention state (and
+//! only that) to this row. See `muxad::synthetic::attention_refinement_events`.
+//!
+//! There is likewise no session-end hook — `Stop` is a turn boundary, not a
+//! session boundary — so agy rows are reaped by pane liveness like Codex's.
 
 use super::hook::{truncate, AdapterError, HookAdapter};
 use crate::event::{AgentEvent, AgentId, AgentKind, NotificationLevel};

--- a/crates/muxa/src/adapters/antigravity.rs
+++ b/crates/muxa/src/adapters/antigravity.rs
@@ -1,0 +1,529 @@
+//! Google Antigravity CLI (`agy`) adapter.
+//!
+//! agy is the successor to the Gemini CLI, and its hook system is **not** the
+//! Claude-compatible one [`super::gemini`] targets. Three things differ, and
+//! all three break the older adapter silently:
+//!
+//! 1. **Where.** Hooks live in their own `hooks.json` under a *customization
+//!    root* — `~/.gemini/config/hooks.json` globally, or
+//!    `<workspace>/.agents/hooks.json` for a trusted folder — not in the
+//!    `hooks` key of `~/.gemini/settings.json`.
+//! 2. **What.** The lifecycle is `SessionStart` / `PreInvocation` /
+//!    `PostInvocation` / `PreToolUse` / `PostToolUse` / `Stop`. There is no
+//!    `Notification` and no `SessionEnd`.
+//! 3. **Shape.** Payloads are protojson, so every key is camelCase, and the
+//!    session identifier is `conversationId`.
+//!
+//! Wire up in `~/.gemini/config/hooks.json` (what `muxa init` writes):
+//!
+//! ```json
+//! {
+//!   "muxa": {
+//!     "SessionStart":   [{ "type": "command", "command": "muxa hook agy --event session_start" }],
+//!     "PreInvocation":  [{ "type": "command", "command": "muxa hook agy --event pre_invocation" }],
+//!     "PostInvocation": [{ "type": "command", "command": "muxa hook agy --event post_invocation" }],
+//!     "Stop":           [{ "type": "command", "command": "muxa hook agy --event stop" }],
+//!     "PreToolUse":  [{ "matcher": "*", "hooks": [{ "type": "command", "command": "muxa hook agy --event pre_tool_use" }] }],
+//!     "PostToolUse": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "muxa hook agy --event post_tool_use" }] }]
+//!   }
+//! }
+//! ```
+//!
+//! ## `PreToolUse` MUST stay silent
+//!
+//! agy reads a hook's stdout as its verdict. An empty stdout means "no
+//! opinion" and the tool proceeds under agy's own permission policy — but
+//! printing *anything* JSON-shaped is read as a decision, and a `PreToolUse`
+//! reply without a valid `decision` field **blocks the tool call**
+//! (`tool call denied by pre-tool hook`). `muxa hook agy` therefore writes
+//! nothing to stdout on any event, and observation stays observation.
+//!
+//! ## Prompts and responses come from the transcript
+//!
+//! No agy hook payload carries the user's prompt or the model's reply; they
+//! carry a `transcriptPath` instead. `PreInvocation` and `Stop` read it via
+//! [`super::antigravity_transcript`], the same arrangement Claude Code's
+//! `Stop` hook uses.
+//!
+//! ## Turn boundaries
+//!
+//! `invocationNum` counts model calls **within one turn**, resetting to `0`
+//! for each new user request (verified against agy 1.1.17 across a two-turn
+//! session). `PreInvocation` with `invocationNum == 0` is therefore the turn
+//! boundary and the only place a `PromptSubmitted` may be emitted; later
+//! invocations in the same turn emit a [`AgentEvent::Heartbeat`] so the row
+//! stays warm and its model label stays current without restating the prompt.
+//!
+//! ## What agy cannot tell us
+//!
+//! There is no permission/notification hook, so an agy row never reaches
+//! `WaitingInput` from hooks alone. The bundled `agy` screen manifest covers
+//! that case for panes with no hooks wired; where hooks *are* wired they take
+//! precedence and the approval prompt is not observed. There is likewise no
+//! session-end hook — `Stop` is a turn boundary, not a session boundary — so
+//! agy rows are reaped by pane liveness like Codex's.
+
+use super::hook::{truncate, AdapterError, HookAdapter};
+use crate::event::{AgentEvent, AgentId, AgentKind, NotificationLevel};
+use serde::Deserialize;
+use std::path::Path;
+use time::OffsetDateTime;
+
+pub struct AntigravityAdapter;
+
+/// One agy hook payload. Every event shares the "common fields" block and
+/// adds its own; modelling them as one optional-heavy struct matches how the
+/// other adapters here handle their per-event supersets.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Input {
+    /// agy's conversation id — stable across turns of one session, and the
+    /// closest analog to the other adapters' `session_id`.
+    pub conversation_id: String,
+    /// Roots of the open workspace. Empty in print mode (`agy -p`) and
+    /// whenever no folder is open, hence `cwd` is best-effort.
+    #[serde(default)]
+    pub workspace_paths: Vec<String>,
+    #[serde(default)]
+    pub transcript_path: Option<String>,
+    #[serde(default)]
+    pub model_name: Option<String>,
+    /// `PreToolUse` / `PostToolUse`.
+    #[serde(default)]
+    pub tool_call: Option<ToolCall>,
+    /// `PreInvocation` / `PostInvocation`: 0-based, per turn.
+    #[serde(default)]
+    pub invocation_num: Option<i64>,
+    /// `PostToolUse` (tool failure) and `Stop` (turn failure). Empty string
+    /// when nothing went wrong — agy sends the key either way.
+    #[serde(default)]
+    pub error: Option<String>,
+    /// `Stop`: `NO_TOOL_CALL`, `ERROR`, `USER_CANCELED`, `MAX_INVOCATIONS`, …
+    #[serde(default)]
+    pub termination_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ToolCall {
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Event {
+    SessionStart,
+    PreInvocation,
+    PostInvocation,
+    PreToolUse,
+    PostToolUse,
+    Stop,
+}
+
+impl Input {
+    /// The workspace root, when agy knows one. `workspacePaths` is the only
+    /// cwd agy exposes: a hook's own process cwd is the directory holding
+    /// `hooks.json`, not the agent's, so there is nothing to fall back to.
+    fn cwd(&self) -> Option<String> {
+        self.workspace_paths.first().cloned()
+    }
+
+    fn tool_name(&self) -> String {
+        self.tool_call
+            .as_ref()
+            .and_then(|t| t.name.clone())
+            .unwrap_or_else(|| "unknown".into())
+    }
+
+    /// True when the payload reports a failure. agy sends `error: ""` on the
+    /// happy path, so presence alone proves nothing.
+    fn failed(&self) -> bool {
+        self.error.as_deref().is_some_and(|e| !e.trim().is_empty())
+    }
+
+    fn transcript(&self) -> Option<&Path> {
+        self.transcript_path
+            .as_deref()
+            .filter(|p| !p.is_empty())
+            .map(Path::new)
+    }
+
+    /// Is this `PreInvocation` the first model call of a new turn?
+    ///
+    /// A missing `invocationNum` is treated as a turn start on purpose. If a
+    /// future agy drops the field, the failure we want is a duplicated prompt
+    /// record — not a row stuck at `Idle` through a whole turn because the
+    /// only event that moves it to `Working` never fired.
+    fn is_turn_start(&self) -> bool {
+        self.invocation_num.is_none_or(|n| n <= 0)
+    }
+}
+
+impl HookAdapter for AntigravityAdapter {
+    type Event = Event;
+    type Input = Input;
+    const KIND: AgentKind = AgentKind::Antigravity;
+
+    fn parse_event(flag: &str) -> Result<Event, AdapterError> {
+        Ok(match flag {
+            "session_start" => Event::SessionStart,
+            "pre_invocation" => Event::PreInvocation,
+            "post_invocation" => Event::PostInvocation,
+            "pre_tool_use" => Event::PreToolUse,
+            "post_tool_use" => Event::PostToolUse,
+            "stop" => Event::Stop,
+            other => return Err(AdapterError::UnknownEvent(other.into())),
+        })
+    }
+
+    fn normalize(event: Event, input: Input, pane: Option<String>) -> AgentEvent {
+        let id = AgentId {
+            kind: AgentKind::Antigravity,
+            session_id: input.conversation_id.clone(),
+            surface: None,
+            pane,
+            tmux_socket: None,
+            cwd: input.cwd(),
+        };
+        let at = OffsetDateTime::now_utc();
+
+        match event {
+            Event::SessionStart => AgentEvent::Started { id, at },
+
+            // Turn boundary: recover the prompt from the transcript. When it
+            // can't be read we still emit `PromptSubmitted` — an empty prompt
+            // costs a blank history cell, whereas skipping the event would
+            // leave the row `Idle` for the whole turn.
+            Event::PreInvocation if input.is_turn_start() => {
+                let prompt = input
+                    .transcript()
+                    .and_then(super::antigravity_transcript::last_user_request)
+                    .unwrap_or_default();
+                AgentEvent::PromptSubmitted {
+                    id,
+                    prompt: truncate(prompt, 4_000),
+                    at,
+                }
+            }
+            // A later invocation of a turn already in flight, or the tail of
+            // any invocation: keep the row warm and refresh the model label
+            // without disturbing its state.
+            Event::PreInvocation | Event::PostInvocation => heartbeat(id, input.model_name, at),
+
+            Event::PreToolUse => AgentEvent::ToolStarted {
+                id,
+                tool: input.tool_name(),
+                subagent: None,
+                at,
+            },
+            Event::PostToolUse => AgentEvent::ToolCompleted {
+                id,
+                tool: input.tool_name(),
+                success: !input.failed(),
+                at,
+            },
+
+            // A failed turn surfaces as an error notification rather than a
+            // plain stop, so the row goes red instead of quietly idling. The
+            // next `PromptSubmitted` lifts it back out (see `state.rs`).
+            Event::Stop
+                if input.failed() || input.termination_reason.as_deref() == Some("ERROR") =>
+            {
+                let detail = input
+                    .error
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|e| !e.is_empty())
+                    .or(input.termination_reason.as_deref())
+                    .unwrap_or("turn failed");
+                AgentEvent::NotificationFired {
+                    id,
+                    level: NotificationLevel::Error,
+                    message: truncate(format!("agy: {detail}"), 1_000),
+                    at,
+                }
+            }
+            Event::Stop => AgentEvent::TurnStopped {
+                id,
+                response: input
+                    .transcript()
+                    .and_then(super::antigravity_transcript::last_assistant_text)
+                    .map(|t| truncate(t, 4_000)),
+                recap: None,
+                ai_title: None,
+                // agy's `Stop` payload carries `fullyIdle`, but `idle_confirmed`
+                // is reserved for SYNTHETIC producers that OBSERVED the pane go
+                // idle. A real hook must leave it false (see `state.rs`).
+                idle_confirmed: false,
+                at,
+            },
+        }
+    }
+}
+
+/// A model-label-only heartbeat. agy stamps `modelName` on every payload,
+/// which is more than Codex or the Gemini CLI expose; the rate-limit fields
+/// have no agy source and stay `None`.
+fn heartbeat(id: AgentId, model: Option<String>, at: OffsetDateTime) -> AgentEvent {
+    AgentEvent::Heartbeat {
+        id,
+        model: model.filter(|m| !m.is_empty()),
+        context_used_pct: None,
+        cost_usd: None,
+        rate_limit_5h_pct: None,
+        rate_limit_5h_resets_at: None,
+        rate_limit_7d_pct: None,
+        rate_limit_7d_resets_at: None,
+        at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::run_hook;
+
+    fn normalize(flag: &str, json: &str) -> AgentEvent {
+        let event = AntigravityAdapter::parse_event(flag).unwrap();
+        let input: Input = serde_json::from_str(json).unwrap();
+        AntigravityAdapter::normalize(event, input, Some("%1".into()))
+    }
+
+    /// The real agy 1.1.17 `SessionStart` payload, captured from a live run.
+    const SESSION_START: &str = r#"{
+        "artifactDirectoryPath": "/Users/x/.gemini/antigravity-cli/brain/63a62ba4",
+        "conversationId": "63a62ba4-d48d-4379-af4a-b70f78e3693d",
+        "modelName": "gemini-3.7-flash-high",
+        "transcriptPath": "/Users/x/.gemini/antigravity-cli/brain/63a62ba4/logs/transcript_full.jsonl",
+        "workspacePaths": []
+    }"#;
+
+    #[test]
+    fn parses_the_real_session_start_payload() {
+        let ev = normalize("session_start", SESSION_START);
+        let id = ev.id();
+        assert!(matches!(ev, AgentEvent::Started { .. }));
+        assert_eq!(id.kind, AgentKind::Antigravity);
+        assert_eq!(id.session_id, "63a62ba4-d48d-4379-af4a-b70f78e3693d");
+        assert_eq!(id.pane.as_deref(), Some("%1"));
+        // Print mode reports no workspace; cwd must be absent, not "".
+        assert_eq!(id.cwd, None);
+    }
+
+    /// protojson is camelCase throughout. A `snake_case` reader would fail on
+    /// the required key and take the whole hook down, which is exactly how
+    /// the Gemini CLI adapter fails against agy.
+    #[test]
+    fn requires_camel_case_conversation_id() {
+        assert!(serde_json::from_str::<Input>(r#"{"conversation_id":"x"}"#).is_err());
+        assert!(serde_json::from_str::<Input>(r#"{"conversationId":"x"}"#).is_ok());
+    }
+
+    #[test]
+    fn workspace_root_becomes_cwd() {
+        let ev = normalize(
+            "session_start",
+            r#"{"conversationId":"c","workspacePaths":["/repo/a","/repo/b"]}"#,
+        );
+        assert_eq!(ev.id().cwd.as_deref(), Some("/repo/a"));
+    }
+
+    #[test]
+    fn first_invocation_of_a_turn_submits_the_prompt() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            f.path(),
+            "{\"source\":\"USER_EXPLICIT\",\"type\":\"USER_INPUT\",\"content\":\"<USER_REQUEST>\\nship it\\n</USER_REQUEST>\"}\n",
+        )
+        .unwrap();
+        let json = format!(
+            r#"{{"conversationId":"c","invocationNum":0,"transcriptPath":"{}"}}"#,
+            f.path().display()
+        );
+        match normalize("pre_invocation", &json) {
+            AgentEvent::PromptSubmitted { prompt, .. } => assert_eq!(prompt, "ship it"),
+            other => panic!("expected PromptSubmitted, got {other:?}"),
+        }
+    }
+
+    /// An unreadable transcript must still move the row to `Working`.
+    #[test]
+    fn turn_start_without_a_transcript_still_submits() {
+        match normalize(
+            "pre_invocation",
+            r#"{"conversationId":"c","invocationNum":0}"#,
+        ) {
+            AgentEvent::PromptSubmitted { prompt, .. } => assert_eq!(prompt, ""),
+            other => panic!("expected PromptSubmitted, got {other:?}"),
+        }
+    }
+
+    /// Invocations 1..n belong to a turn already reported. Re-emitting
+    /// `PromptSubmitted` would duplicate the prompt in history once per model
+    /// call — agy made four in a single turn during capture.
+    #[test]
+    fn later_invocations_heartbeat_instead_of_resubmitting() {
+        let ev = normalize(
+            "pre_invocation",
+            r#"{"conversationId":"c","invocationNum":3,"modelName":"gemini-3.7-flash-high"}"#,
+        );
+        match ev {
+            AgentEvent::Heartbeat { model, .. } => {
+                assert_eq!(model.as_deref(), Some("gemini-3.7-flash-high"));
+            }
+            other => panic!("expected Heartbeat, got {other:?}"),
+        }
+    }
+
+    /// Defensive: a payload with no `invocationNum` counts as a turn start,
+    /// trading a possible duplicate for a row that never leaves `Idle`.
+    #[test]
+    fn missing_invocation_num_counts_as_a_turn_start() {
+        assert!(matches!(
+            normalize("pre_invocation", r#"{"conversationId":"c"}"#),
+            AgentEvent::PromptSubmitted { .. }
+        ));
+    }
+
+    #[test]
+    fn post_invocation_is_a_heartbeat() {
+        assert!(matches!(
+            normalize(
+                "post_invocation",
+                r#"{"conversationId":"c","invocationNum":0,"modelName":"m"}"#
+            ),
+            AgentEvent::Heartbeat { .. }
+        ));
+    }
+
+    #[test]
+    fn tool_events_carry_the_tool_call_name() {
+        let payload = r#"{
+            "conversationId":"c","stepIdx":7,
+            "toolCall":{"name":"run_command","args":{"CommandLine":"echo hi"}}
+        }"#;
+        match normalize("pre_tool_use", payload) {
+            AgentEvent::ToolStarted { tool, .. } => assert_eq!(tool, "run_command"),
+            other => panic!("expected ToolStarted, got {other:?}"),
+        }
+        match normalize("post_tool_use", payload) {
+            AgentEvent::ToolCompleted { tool, success, .. } => {
+                assert_eq!(tool, "run_command");
+                assert!(success, "empty/absent error means the tool succeeded");
+            }
+            other => panic!("expected ToolCompleted, got {other:?}"),
+        }
+    }
+
+    /// agy sends `error: ""` on success, so only a non-empty string may flip
+    /// `success` to false.
+    #[test]
+    fn empty_error_string_is_not_a_failure() {
+        for payload in [
+            r#"{"conversationId":"c","toolCall":{"name":"t"},"error":""}"#,
+            r#"{"conversationId":"c","toolCall":{"name":"t"},"error":"  "}"#,
+        ] {
+            match normalize("post_tool_use", payload) {
+                AgentEvent::ToolCompleted { success, .. } => assert!(success, "{payload}"),
+                other => panic!("expected ToolCompleted, got {other:?}"),
+            }
+        }
+        match normalize(
+            "post_tool_use",
+            r#"{"conversationId":"c","toolCall":{"name":"t"},"error":"exit status 1"}"#,
+        ) {
+            AgentEvent::ToolCompleted { success, .. } => assert!(!success),
+            other => panic!("expected ToolCompleted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stop_reads_the_response_from_the_transcript() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            f.path(),
+            "{\"source\":\"MODEL\",\"type\":\"PLANNER_RESPONSE\",\"content\":\"all done\"}\n",
+        )
+        .unwrap();
+        let json = format!(
+            r#"{{"conversationId":"c","terminationReason":"NO_TOOL_CALL","error":"","fullyIdle":true,"transcriptPath":"{}"}}"#,
+            f.path().display()
+        );
+        match normalize("stop", &json) {
+            AgentEvent::TurnStopped {
+                response,
+                idle_confirmed,
+                ..
+            } => {
+                assert_eq!(response.as_deref(), Some("all done"));
+                assert!(
+                    !idle_confirmed,
+                    "a real hook must never claim a synthetic idle observation",
+                );
+            }
+            other => panic!("expected TurnStopped, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_failed_turn_raises_an_error_notification() {
+        for payload in [
+            r#"{"conversationId":"c","terminationReason":"ERROR","error":"model unavailable"}"#,
+            r#"{"conversationId":"c","terminationReason":"ERROR","error":""}"#,
+            r#"{"conversationId":"c","terminationReason":"NO_TOOL_CALL","error":"boom"}"#,
+        ] {
+            match normalize("stop", payload) {
+                AgentEvent::NotificationFired { level, message, .. } => {
+                    assert_eq!(level, NotificationLevel::Error, "{payload}");
+                    assert!(message.starts_with("agy: "), "{message}");
+                }
+                other => panic!("expected NotificationFired for {payload}, got {other:?}"),
+            }
+        }
+    }
+
+    /// A cancelled or capped turn is not an error — it stops normally.
+    #[test]
+    fn a_cancelled_turn_is_an_ordinary_stop() {
+        assert!(matches!(
+            normalize(
+                "stop",
+                r#"{"conversationId":"c","terminationReason":"USER_CANCELED","error":""}"#
+            ),
+            AgentEvent::TurnStopped { .. }
+        ));
+    }
+
+    #[test]
+    fn unknown_event_flag_is_rejected() {
+        assert!(matches!(
+            AntigravityAdapter::parse_event("notification"),
+            Err(AdapterError::UnknownEvent(_)),
+        ));
+    }
+
+    /// Every flag `muxa init` writes into `hooks.json` must parse. A typo
+    /// here would only surface as a silent hook failure inside agy.
+    #[test]
+    fn every_wired_event_flag_parses() {
+        for flag in [
+            "session_start",
+            "pre_invocation",
+            "post_invocation",
+            "pre_tool_use",
+            "post_tool_use",
+            "stop",
+        ] {
+            assert!(
+                AntigravityAdapter::parse_event(flag).is_ok(),
+                "flag {flag} must parse",
+            );
+        }
+    }
+
+    #[test]
+    fn run_hook_reads_a_payload_from_stdin() {
+        let ev = run_hook::<AntigravityAdapter, _>("session_start", &mut SESSION_START.as_bytes())
+            .unwrap();
+        assert_eq!(ev.id().kind, AgentKind::Antigravity);
+    }
+}

--- a/crates/muxa/src/adapters/antigravity_transcript.rs
+++ b/crates/muxa/src/adapters/antigravity_transcript.rs
@@ -1,0 +1,244 @@
+//! Antigravity CLI (`agy`) transcript JSONL parser.
+//!
+//! agy's hook payloads carry neither the user's prompt nor the model's
+//! reply — they give a `transcriptPath` instead. Each line of that file is
+//! one conversation *step*:
+//!
+//! ```json
+//! {"step_index":9,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE",
+//!  "content":"<USER_REQUEST>\nNow run: echo hi\n</USER_REQUEST>\n<ADDITIONAL_METADATA>\n…\n</ADDITIONAL_METADATA>"}
+//! {"step_index":11,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE",
+//!  "tool_calls":[{"name":"run_command","args":{…}}]}
+//! {"step_index":13,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE",
+//!  "content":"```bash\n$ echo hi\nhi\n```"}
+//! ```
+//!
+//! [`last_user_request`] feeds the `PreInvocation` hook's `PromptSubmitted`
+//! and [`last_assistant_text`] feeds the `Stop` hook's `TurnStopped` — the
+//! same division of labour [`super::transcript`] performs for Claude Code.
+//!
+//! Both read only the tail of the file and fail silently: a hook handler runs
+//! synchronously inside the agent's loop, so a parse error must never become
+//! terminal noise (or a stall) for the user.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::path::Path;
+
+/// Read at most this many bytes from the tail of the transcript.
+///
+/// Mirrors the Claude transcript reader's window: agy appends a
+/// step per tool call and long sessions run to multi-MB, but the records we
+/// want are always within the last turn or two. The `USER_INPUT` we resolve
+/// on `PreInvocation` was appended moments earlier, and the trailing
+/// `PLANNER_RESPONSE` we resolve on `Stop` is the very last record.
+const TAIL_BYTES: u64 = 256 * 1024;
+
+/// One transcript line. Every field is optional so a record shape we don't
+/// recognize (or a newer agy build's extra keys) is skipped rather than
+/// aborting the scan.
+#[derive(Debug, serde::Deserialize)]
+struct Step {
+    #[serde(default)]
+    r#type: Option<String>,
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default)]
+    content: Option<String>,
+}
+
+/// The prompt text of the most recent *explicit user* turn.
+///
+/// agy wraps the prompt in `<USER_REQUEST>` and appends an
+/// `<ADDITIONAL_METADATA>` block holding the local time; both are stripped so
+/// the watch UI shows what the operator actually typed. Returns `None` when
+/// the file is unreadable, holds no user step in the tail window, or the
+/// prompt is empty after unwrapping.
+///
+/// `USER_EXPLICIT` is required: agy also writes `SYSTEM_MESSAGE` steps and
+/// system-sourced `USER_INPUT` (continuation nudges, injected reminders), and
+/// surfacing those as "the user's prompt" would be a lie.
+pub fn last_user_request(path: &Path) -> Option<String> {
+    last_matching(path, |s| {
+        if s.r#type.as_deref() != Some("USER_INPUT") || s.source.as_deref() != Some("USER_EXPLICIT")
+        {
+            return None;
+        }
+        let text = unwrap_user_request(s.content.as_deref()?);
+        (!text.is_empty()).then_some(text)
+    })
+}
+
+/// The user-visible text of the most recent model response.
+///
+/// Skips `PLANNER_RESPONSE` records that carry only `tool_calls` — those are
+/// the model *acting*, not answering — and the `GENERIC` records holding tool
+/// output. Returns `None` when nothing in the tail window qualifies.
+pub fn last_assistant_text(path: &Path) -> Option<String> {
+    last_matching(path, |s| {
+        if s.r#type.as_deref() != Some("PLANNER_RESPONSE") || s.source.as_deref() != Some("MODEL") {
+            return None;
+        }
+        let text = s.content.as_deref()?.trim();
+        (!text.is_empty()).then(|| text.to_string())
+    })
+}
+
+/// Scan the tail window and return `pick`'s value for the LAST line it
+/// accepted. Shared by both public readers so the seek/skip-fragment/parse
+/// handling lives in exactly one place.
+fn last_matching(path: &Path, pick: impl Fn(&Step) -> Option<String>) -> Option<String> {
+    let mut f = File::open(path).ok()?;
+    let len = f.metadata().ok()?.len();
+    let start = len.saturating_sub(TAIL_BYTES);
+    f.seek(SeekFrom::Start(start)).ok()?;
+
+    let mut found: Option<String> = None;
+    // Seeking into the middle of the file almost always lands mid-line. That
+    // first fragment fails to parse as JSON and is skipped here without a
+    // special case, exactly as in the Claude transcript reader.
+    for line in BufReader::new(f).lines().map_while(Result::ok) {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(step) = serde_json::from_str::<Step>(line) else {
+            continue;
+        };
+        if let Some(text) = pick(&step) {
+            found = Some(text);
+        }
+    }
+    found
+}
+
+/// Strip agy's `<USER_REQUEST>` wrapper and the `<ADDITIONAL_METADATA>` block
+/// that follows it.
+///
+/// Tolerant by design: a payload with no wrapper (a shape change, or a step
+/// written by a different agy surface) falls back to the trimmed content
+/// rather than yielding nothing.
+fn unwrap_user_request(content: &str) -> String {
+    const OPEN: &str = "<USER_REQUEST>";
+    const CLOSE: &str = "</USER_REQUEST>";
+
+    if let Some(rest) = content.find(OPEN).map(|i| &content[i + OPEN.len()..]) {
+        if let Some(end) = rest.find(CLOSE) {
+            return rest[..end].trim().to_string();
+        }
+        // Opened but never closed — take what's there minus any trailing
+        // metadata block rather than dropping the prompt entirely.
+        return strip_metadata(rest).trim().to_string();
+    }
+    strip_metadata(content).trim().to_string()
+}
+
+/// Drop everything from `<ADDITIONAL_METADATA>` onward.
+fn strip_metadata(s: &str) -> &str {
+    match s.find("<ADDITIONAL_METADATA>") {
+        Some(i) => &s[..i],
+        None => s,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_transcript(lines: &[&str]) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        for l in lines {
+            writeln!(f, "{l}").unwrap();
+        }
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn reads_last_explicit_user_request_unwrapped() {
+        let f = write_transcript(&[
+            r#"{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","content":"<USER_REQUEST>\nfirst\n</USER_REQUEST>"}"#,
+            r#"{"step_index":1,"source":"MODEL","type":"PLANNER_RESPONSE","content":"ok"}"#,
+            r#"{"step_index":2,"source":"USER_EXPLICIT","type":"USER_INPUT","content":"<USER_REQUEST>\nNow run: echo hi\n</USER_REQUEST>\n<ADDITIONAL_METADATA>\nThe current local time is: 2026-08-22T00:59:08+09:00.\n</ADDITIONAL_METADATA>"}"#,
+        ]);
+        assert_eq!(
+            last_user_request(f.path()).as_deref(),
+            Some("Now run: echo hi"),
+        );
+    }
+
+    /// agy writes system-authored steps into the same file. Reporting one as
+    /// "the user's prompt" would put text the operator never typed on the
+    /// watch row, so both the type and the source must match.
+    #[test]
+    fn ignores_system_sourced_steps() {
+        let f = write_transcript(&[
+            r#"{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","content":"<USER_REQUEST>\nreal prompt\n</USER_REQUEST>"}"#,
+            r#"{"step_index":1,"source":"SYSTEM","type":"SYSTEM_MESSAGE","content":"a nudge"}"#,
+            r#"{"step_index":2,"source":"SYSTEM","type":"USER_INPUT","content":"<USER_REQUEST>\ninjected\n</USER_REQUEST>"}"#,
+        ]);
+        assert_eq!(last_user_request(f.path()).as_deref(), Some("real prompt"));
+    }
+
+    /// A prompt with no wrapper still comes back — agy's shape is not a
+    /// contract muxa can enforce, and dropping the prompt is worse than
+    /// showing it verbatim.
+    #[test]
+    fn falls_back_when_wrapper_absent() {
+        let f = write_transcript(&[
+            r#"{"source":"USER_EXPLICIT","type":"USER_INPUT","content":"bare prompt\n<ADDITIONAL_METADATA>\ntime\n</ADDITIONAL_METADATA>"}"#,
+        ]);
+        assert_eq!(last_user_request(f.path()).as_deref(), Some("bare prompt"));
+    }
+
+    #[test]
+    fn reads_last_assistant_text_skipping_tool_call_steps() {
+        let f = write_transcript(&[
+            r#"{"step_index":0,"source":"MODEL","type":"PLANNER_RESPONSE","content":"earlier answer"}"#,
+            r#"{"step_index":1,"source":"MODEL","type":"PLANNER_RESPONSE","tool_calls":[{"name":"run_command"}]}"#,
+            r#"{"step_index":2,"source":"MODEL","type":"GENERIC","content":"The command exited with code 0."}"#,
+            r#"{"step_index":3,"source":"MODEL","type":"PLANNER_RESPONSE","content":"final answer"}"#,
+        ]);
+        assert_eq!(
+            last_assistant_text(f.path()).as_deref(),
+            Some("final answer"),
+        );
+    }
+
+    /// A tool-call-only step has no `content`; it must not shadow the real
+    /// response that came before it.
+    #[test]
+    fn tool_call_step_does_not_blank_the_response() {
+        let f = write_transcript(&[
+            r#"{"source":"MODEL","type":"PLANNER_RESPONSE","content":"the answer"}"#,
+            r#"{"source":"MODEL","type":"PLANNER_RESPONSE","tool_calls":[{"name":"view_file"}]}"#,
+        ]);
+        assert_eq!(last_assistant_text(f.path()).as_deref(), Some("the answer"));
+    }
+
+    /// Truncated/garbage lines are skipped, not fatal — the tail seek lands
+    /// mid-line on any real transcript.
+    #[test]
+    fn skips_unparseable_lines() {
+        let f = write_transcript(&[
+            r#"nal_response"}]}"#,
+            r#"{"source":"MODEL","type":"PLANNER_RESPONSE","content":"survived"}"#,
+        ]);
+        assert_eq!(last_assistant_text(f.path()).as_deref(), Some("survived"));
+    }
+
+    #[test]
+    fn missing_file_is_none() {
+        let p = Path::new("/nonexistent/muxa/agy-transcript.jsonl");
+        assert_eq!(last_user_request(p), None);
+        assert_eq!(last_assistant_text(p), None);
+    }
+
+    #[test]
+    fn empty_transcript_is_none() {
+        let f = write_transcript(&[]);
+        assert_eq!(last_user_request(f.path()), None);
+        assert_eq!(last_assistant_text(f.path()), None);
+    }
+}

--- a/crates/muxa/src/adapters/mod.rs
+++ b/crates/muxa/src/adapters/mod.rs
@@ -1,14 +1,18 @@
 //! Adapters translate each agent CLI's native events into `AgentEvent`.
 //!
-//! Three of the supported agents (Claude Code, Codex, Gemini CLI) expose a
-//! shell-hook system that delivers JSON on stdin. They all implement the
-//! [`HookAdapter`] trait, and callers invoke [`run_hook`] to do the
-//! boilerplate.
+//! Four of the supported agents (Claude Code, Codex, Gemini CLI, and the
+//! Antigravity CLI that replaced it) expose a shell-hook system that delivers
+//! JSON on stdin. They all implement the [`HookAdapter`] trait, and callers
+//! invoke [`run_hook`] to do the boilerplate. Their payload shapes are not
+//! interchangeable — see [`antigravity`] for why `agy` needs its own adapter
+//! rather than reusing [`gemini`].
 //!
 //! opencode does not expose shell hooks; its integration ships as an
 //! in-process TS plugin that forwards pre-normalized `AgentEvent`s — see the
 //! [`opencode`] module.
 
+pub mod antigravity;
+pub mod antigravity_transcript;
 pub mod claude;
 pub mod codex;
 pub mod codex_rollout;
@@ -20,6 +24,7 @@ pub mod transcript;
 
 pub use hook::{run_hook, AdapterError, HookAdapter};
 
+pub use antigravity::AntigravityAdapter;
 pub use claude::ClaudeAdapter;
 pub use codex::CodexAdapter;
 pub use gemini::GeminiAdapter;

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -1628,6 +1628,7 @@ fn parse_agent_kind(raw: &str) -> Result<AgentKind, String> {
         "claude_code" => Ok(AgentKind::ClaudeCode),
         "codex" => Ok(AgentKind::Codex),
         "gemini_cli" => Ok(AgentKind::GeminiCli),
+        "antigravity" => Ok(AgentKind::Antigravity),
         "opencode" => Ok(AgentKind::Opencode),
         "unknown" => Ok(AgentKind::Unknown),
         _ => Err(format!("unknown agent kind {raw:?}")),

--- a/crates/muxa/src/dashboard/web/main.js
+++ b/crates/muxa/src/dashboard/web/main.js
@@ -41,7 +41,7 @@ const TIMELINE_EVENT_DEBOUNCE_MS = 2000;
 const SESSION_PAGE_SIZE = 40;
 
 const AGENT_STATES = ["working", "waiting_input", "waiting_choice", "idle", "starting", "error", "stopped"];
-const AGENT_KINDS = ["claude_code", "codex", "gemini_cli", "opencode", "unknown"];
+const AGENT_KINDS = ["claude_code", "codex", "gemini_cli", "antigravity", "opencode", "unknown"];
 const TIMELINE_RANGES = ["24h", "today", "last week", "month", "last month", "7d", "30d", "12w"];
 const SESSION_SORTS = new Set(["priority", "latest", "name"]);
 

--- a/crates/muxa/src/discovery.rs
+++ b/crates/muxa/src/discovery.rs
@@ -56,6 +56,11 @@ pub fn classify_command(cmd: &str) -> Option<AgentKind> {
         "claude" => Some(AgentKind::ClaudeCode),
         "codex" => Some(AgentKind::Codex),
         "gemini" | "gemini-cli" => Some(AgentKind::GeminiCli),
+        // Antigravity ships a native binary, so it lands in tmux under its
+        // own name rather than behind a `node` shim. `antigravity` is
+        // accepted too: the installer's shell shim can be renamed, and the
+        // cost of the extra arm is one string compare.
+        "agy" | "antigravity" => Some(AgentKind::Antigravity),
         _ => None,
     }
 }
@@ -310,13 +315,14 @@ pub struct DiscoveryReport {
     pub claude_code: usize,
     pub codex: usize,
     pub gemini_cli: usize,
+    pub antigravity: usize,
     pub skipped_known: usize,
     pub failed: usize,
 }
 
 impl DiscoveryReport {
     pub fn total_ingested(&self) -> usize {
-        self.claude_code + self.codex + self.gemini_cli
+        self.claude_code + self.codex + self.gemini_cli + self.antigravity
     }
 
     fn bump(&mut self, kind: AgentKind) {
@@ -324,6 +330,7 @@ impl DiscoveryReport {
             AgentKind::ClaudeCode => self.claude_code += 1,
             AgentKind::Codex => self.codex += 1,
             AgentKind::GeminiCli => self.gemini_cli += 1,
+            AgentKind::Antigravity => self.antigravity += 1,
             // We never synthesize for Opencode/Unknown/Task today.
             AgentKind::Opencode | AgentKind::Unknown | AgentKind::Task => {}
         }
@@ -419,6 +426,17 @@ mod tests {
         assert_eq!(classify_command("codex"), Some(AgentKind::Codex));
         assert_eq!(classify_command("gemini"), Some(AgentKind::GeminiCli));
         assert_eq!(classify_command("gemini-cli"), Some(AgentKind::GeminiCli));
+        assert_eq!(classify_command("agy"), Some(AgentKind::Antigravity));
+        assert_eq!(
+            classify_command("antigravity"),
+            Some(AgentKind::Antigravity)
+        );
+        // agy is a native binary, so tmux reports the full path for a
+        // non-PATH install; the basename rule must still classify it.
+        assert_eq!(
+            classify_command("/Users/x/.local/bin/agy"),
+            Some(AgentKind::Antigravity),
+        );
         // Case-insensitive — some shells uppercase argv[0].
         assert_eq!(classify_command("CLAUDE"), Some(AgentKind::ClaudeCode));
         // macOS `ps -o comm=` can return the full executable path for a

--- a/crates/muxa/src/event.rs
+++ b/crates/muxa/src/event.rs
@@ -38,6 +38,37 @@ pub enum AgentKind {
     Unknown,
 }
 
+impl AgentKind {
+    /// Can this agent's hook stream tell muxa it is waiting on the operator?
+    ///
+    /// Claude Code (`Notification`), Codex (`PermissionRequest`), the Gemini
+    /// CLI (`Notification`) and opencode (`permission.asked`) all can, so their
+    /// rows reach [`AgentState::WaitingInput`] from hooks alone and screen
+    /// inference must stay out of the way.
+    ///
+    /// The Antigravity CLI cannot — it exposes no permission or notification
+    /// hook at all (see `docs/ANTIGRAVITY.md`), so for an agy row that one
+    /// signal is only ever available from the pane's screen. `muxad`'s
+    /// synthetic layer keys its attention-refinement path off this.
+    // The two `true` arms stay separate on purpose: they are true for
+    // opposite reasons (one has an attention hook, one is not an agent at
+    // all), and spelling every kind out is what makes a new `AgentKind` a
+    // compile error here rather than a silent default.
+    #[allow(clippy::match_same_arms)]
+    #[must_use]
+    pub fn hooks_report_attention(self) -> bool {
+        match self {
+            Self::ClaudeCode | Self::Codex | Self::GeminiCli | Self::Opencode => true,
+            Self::Antigravity => false,
+            // Neither is a hook-driven agent: `Task` rows have no attention
+            // states at all (only Working/Stopped), and `Unknown` is the kind
+            // synthetic rows themselves carry. `true` keeps both out of the
+            // refinement path, which is exactly where they belong.
+            Self::Task | Self::Unknown => true,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, strum::Display)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]

--- a/crates/muxa/src/event.rs
+++ b/crates/muxa/src/event.rs
@@ -21,7 +21,14 @@ pub enum AgentKind {
     ClaudeCode,
     Opencode,
     Codex,
+    /// The legacy Gemini CLI (`gemini`). Superseded by [`AgentKind::Antigravity`]
+    /// upstream, but kept first-class: its hook contract still works and
+    /// installs predate the switch.
     GeminiCli,
+    /// Google's Antigravity CLI (`agy`), the Gemini CLI's successor. A
+    /// separate kind rather than a rename — the two ship different hook
+    /// formats, different config locations, and can be installed side by side.
+    Antigravity,
     /// A non-agent background process (shell script, game, automation loop,
     /// or a `muxa run` PTY child) registered via `muxa register` / the
     /// `Register` IPC. Tracked by pid liveness rather than tmux pane
@@ -364,6 +371,8 @@ mod tests {
     fn kind_serializes_snake_case() {
         let json = serde_json::to_string(&AgentKind::GeminiCli).unwrap();
         assert_eq!(json, "\"gemini_cli\"");
+        let json = serde_json::to_string(&AgentKind::Antigravity).unwrap();
+        assert_eq!(json, "\"antigravity\"");
     }
 
     /// Older muxa peers emit `TurnStopped` without the `response` field.

--- a/crates/muxa/src/process_tree.rs
+++ b/crates/muxa/src/process_tree.rs
@@ -239,6 +239,7 @@ fn display_command(proc: &ProcessInfo, kind: WorkloadProcessKind) -> String {
                 AgentKind::ClaudeCode => "claude".to_string(),
                 AgentKind::Codex => "codex".to_string(),
                 AgentKind::GeminiCli => "gemini".to_string(),
+                AgentKind::Antigravity => "agy".to_string(),
                 AgentKind::Opencode => "opencode".to_string(),
                 AgentKind::Task | AgentKind::Unknown => command_name(&proc.comm).to_string(),
             };

--- a/crates/muxa/src/screen.rs
+++ b/crates/muxa/src/screen.rs
@@ -489,6 +489,9 @@ idle = ['^> $']
         let m = parse_manifest(include_str!("screen/agents/agy.toml")).unwrap();
         assert!(m.matches_command("agy"));
         assert!(m.matches_command("/Users/x/.local/bin/agy"));
+        // Kept in lockstep with `discovery::classify_command`: a pane that
+        // discovery calls Antigravity must never be one this manifest skips.
+        assert!(m.matches_command("antigravity"));
 
         // Verbatim tails of real captures, three seconds apart in one turn.
         assert_eq!(

--- a/crates/muxa/src/screen.rs
+++ b/crates/muxa/src/screen.rs
@@ -222,8 +222,9 @@ fn command_basename(cmd: &str) -> String {
 /// The bundled manifest sources, shipped in the binary via `include_str!`.
 /// These are muxa-authored and MUST parse — a parse failure is a build-time
 /// bug caught by [`tests::every_bundled_manifest_parses`].
-fn bundled_sources() -> [(&'static str, &'static str); 5] {
+fn bundled_sources() -> [(&'static str, &'static str); 6] {
     [
+        ("agy", include_str!("screen/agents/agy.toml")),
         ("cursor", include_str!("screen/agents/cursor.toml")),
         ("amp", include_str!("screen/agents/amp.toml")),
         ("copilot", include_str!("screen/agents/copilot.toml")),
@@ -461,7 +462,7 @@ idle = ['^> $']
     #[test]
     fn every_bundled_manifest_parses() {
         let set = bundled_manifests();
-        assert_eq!(set.len(), 5);
+        assert_eq!(set.len(), 6);
         for m in &set {
             assert!(!m.name.is_empty());
         }
@@ -479,6 +480,77 @@ idle = ['^> $']
             Some(ScreenState::Blocked)
         );
         assert_eq!(m.classify("\n> "), Some(ScreenState::Idle));
+    }
+
+    /// Fixtures captured from a live agy 1.1.17 pane (working/idle) and from
+    /// agy's own confirmation-widget labels (blocked).
+    #[test]
+    fn agy_fixtures() {
+        let m = parse_manifest(include_str!("screen/agents/agy.toml")).unwrap();
+        assert!(m.matches_command("agy"));
+        assert!(m.matches_command("/Users/x/.local/bin/agy"));
+
+        // Verbatim tails of real captures, three seconds apart in one turn.
+        assert_eq!(
+            m.classify("> Run the shell command: echo hi\n⡿  Generating...\n>\nesc to cancel"),
+            Some(ScreenState::Working),
+        );
+        assert_eq!(
+            m.classify(
+                "● Bash(echo hi) (ctrl+o to expand)\n⣷  Running command...\n>\nesc to cancel"
+            ),
+            Some(ScreenState::Working),
+        );
+
+        // The idle footer, and the bare prompt on its own.
+        assert_eq!(
+            m.classify("? for shortcuts                       Gemini 3.7 Flash · high"),
+            Some(ScreenState::Idle),
+        );
+        assert_eq!(m.classify("\n> "), Some(ScreenState::Idle));
+
+        // `working` is tested before `idle`, so the bare `>` input line that
+        // agy keeps drawing mid-turn cannot flip a busy pane to idle.
+        assert_eq!(
+            m.classify("⣻  Listing directory...\n>\nesc to cancel"),
+            Some(ScreenState::Working),
+            "the input line is drawn during generation too",
+        );
+
+        // agy's permission widget.
+        assert_eq!(
+            m.classify("Run command?\n> Yes, and always allow for commands that start with 'echo'\n  No, deny"),
+            Some(ScreenState::Blocked),
+        );
+        assert_eq!(
+            m.classify("Allow access to this file?\n> Yes, allow access\n  No, deny access"),
+            Some(ScreenState::Blocked),
+        );
+        // The folder-trust gate blocks the very first prompt of a session.
+        assert_eq!(
+            m.classify(
+                "Do you trust the contents of this project?\n> Yes, I trust this folder\n  No, exit"
+            ),
+            Some(ScreenState::Blocked),
+        );
+
+        // agy echoes tool output into the same pane, so prose that merely
+        // talks about allowing or generating must classify as nothing.
+        assert_eq!(
+            m.classify("These flags allow access to the cache and deny writes."),
+            None,
+            "prose about allow/deny must not read as an approval prompt",
+        );
+        assert_eq!(
+            m.classify("Generating the report is handled by the nightly job."),
+            None,
+            "`Generating` without agy's `...` suffix is prose, not a spinner",
+        );
+        assert_eq!(
+            m.classify("nothing to commit, working tree clean"),
+            None,
+            "the word `working` in prose must not read as busy",
+        );
     }
 
     #[test]

--- a/crates/muxa/src/screen.rs
+++ b/crates/muxa/src/screen.rs
@@ -520,7 +520,27 @@ idle = ['^> $']
             "the input line is drawn during generation too",
         );
 
-        // agy's permission widget.
+        // agy's real permission widget, captured verbatim from a live prompt.
+        // Note it keeps the `esc to cancel` working-footer on screen, so this
+        // also pins that `blocked` is tested BEFORE `working`.
+        let prompt = "● Bash(echo REFINE_TEST) (ctrl+o to expand)\n\
+             Requesting permission for:\n   echo REFINE_TEST\n\
+             Do you want to proceed?\n\
+             > 1. Yes\n  2. Yes, and always allow in this conversation\n  4. No\n\
+             ↑/↓ Navigate · tab Amend\nesc to cancel";
+        assert_eq!(m.classify(prompt), Some(ScreenState::Blocked));
+
+        // The header alone is enough: choice-row wording varies per request
+        // type, so the manifest must not depend on any one of them.
+        assert_eq!(
+            m.classify("Requesting permission for:\n   rm -rf build\n> 1. Yes\n  2. No"),
+            Some(ScreenState::Blocked),
+        );
+        // A numbered selection widget with none of the longer labels.
+        assert_eq!(
+            m.classify("Do you want to proceed?\n> 1. Yes\n  2. No"),
+            Some(ScreenState::Blocked),
+        );
         assert_eq!(
             m.classify("Run command?\n> Yes, and always allow for commands that start with 'echo'\n  No, deny"),
             Some(ScreenState::Blocked),
@@ -543,6 +563,13 @@ idle = ['^> $']
             m.classify("These flags allow access to the cache and deny writes."),
             None,
             "prose about allow/deny must not read as an approval prompt",
+        );
+        // A numbered list in ordinary output is not a selection widget: the
+        // `>` cursor marker is what makes it one.
+        assert_eq!(
+            m.classify("Steps:\n1. Yes it compiles\n2. No warnings remain"),
+            None,
+            "a plain numbered list must not read as an approval prompt",
         );
         assert_eq!(
             m.classify("Generating the report is handled by the nightly job."),

--- a/crates/muxa/src/screen/agents/agy.toml
+++ b/crates/muxa/src/screen/agents/agy.toml
@@ -1,14 +1,17 @@
 # Bundled screen-detection manifest — Google Antigravity CLI (`agy`).
 #
 # Unlike the other bundled manifests, these patterns were derived from a REAL
-# agy 1.1.17 session: the working/idle rules come from captured tmux panes and
-# the approval rules from agy's own confirmation-widget labels. See
+# agy 1.1.17 session: the working/idle rules and the permission-prompt header
+# come from captured tmux panes, the remaining approval rules from agy's own
+# confirmation-widget labels. See
 # docs/SCREEN_DETECTION.md. Override at $XDG_CONFIG_HOME/muxa/agents/agy.toml.
 #
-# muxa also ships hooks for agy (`muxa hook agy`), and hooks win: the daemon
-# never screen-infers a pane a live hook row owns. This manifest is what covers
-# an agy pane whose hooks aren't wired — and it is the ONLY way an agy row
-# reaches `WaitingInput`, because agy exposes no permission/notification hook.
+# muxa also ships hooks for agy (`muxa hook agy`), and hooks win everywhere
+# except one signal: agy exposes no permission/notification hook, so the
+# `blocked` rules below are the ONLY way an agy row ever reaches
+# `WaitingInput`. `muxad`'s synthetic layer therefore keeps this manifest live
+# even on a pane a real agy row owns, applying the attention signal (and
+# nothing else) to that row — see `muxad::synthetic::attention_refinement_events`.
 
 [agent]
 name = "agy"
@@ -22,6 +25,15 @@ command = ["agy", "antigravity"]
 # An over-broad `blocked` is the worst failure (a working agent shown as
 # "needs input"), and agy prints tool output verbatim into the same pane.
 blocked = [
+    # The header agy prints above EVERY permission request. Captured verbatim
+    # from a live prompt and by far the most robust anchor here — the choice
+    # rows below vary per request type (a command prompt renders numbered
+    # `1. Yes` / `4. No` rows, a file prompt renders `Yes, allow access`),
+    # but this line is constant.
+    '(?i)Requesting permission for:',
+    # The highlighted row of a numbered selection widget. Anchored to the
+    # cursor marker and the number so ordinary prose can never match.
+    '(?m)^\s*>\s*\d+\.\s+(?i:Yes|No)\b',
     # The choice rows of the permission widget. "always allow"/"always deny"
     # exist only in that widget, so they cannot come from tool output.
     '(?i)Yes, and always allow',

--- a/crates/muxa/src/screen/agents/agy.toml
+++ b/crates/muxa/src/screen/agents/agy.toml
@@ -12,7 +12,9 @@
 
 [agent]
 name = "agy"
-command = ["agy"]
+# Both spellings `discovery::classify_command` accepts, so a pane it calls an
+# Antigravity agent is never one screen detection then refuses to look at.
+command = ["agy", "antigravity"]
 
 [rules]
 # STRICT — agy's confirmation widget renders a fixed set of choice rows, so

--- a/crates/muxa/src/screen/agents/agy.toml
+++ b/crates/muxa/src/screen/agents/agy.toml
@@ -1,0 +1,53 @@
+# Bundled screen-detection manifest — Google Antigravity CLI (`agy`).
+#
+# Unlike the other bundled manifests, these patterns were derived from a REAL
+# agy 1.1.17 session: the working/idle rules come from captured tmux panes and
+# the approval rules from agy's own confirmation-widget labels. See
+# docs/SCREEN_DETECTION.md. Override at $XDG_CONFIG_HOME/muxa/agents/agy.toml.
+#
+# muxa also ships hooks for agy (`muxa hook agy`), and hooks win: the daemon
+# never screen-infers a pane a live hook row owns. This manifest is what covers
+# an agy pane whose hooks aren't wired — and it is the ONLY way an agy row
+# reaches `WaitingInput`, because agy exposes no permission/notification hook.
+
+[agent]
+name = "agy"
+command = ["agy"]
+
+[rules]
+# STRICT — agy's confirmation widget renders a fixed set of choice rows, so
+# these anchor on that literal UI rather than on generic approval phrasing.
+# An over-broad `blocked` is the worst failure (a working agent shown as
+# "needs input"), and agy prints tool output verbatim into the same pane.
+blocked = [
+    # The choice rows of the permission widget. "always allow"/"always deny"
+    # exist only in that widget, so they cannot come from tool output.
+    '(?i)Yes, and always allow',
+    '(?i)No, and always deny',
+    '(?i)Yes, (allow (access|creation)|approve|grant permission for)\b',
+    '(?i)No, (deny|reject this change)\b',
+    '(?i)Yes, accept this change',
+    # Folder-trust gate on first run in a new directory — agy will not accept
+    # a prompt until it is answered.
+    '(?i)Do you trust the contents of this project\?',
+    '(?i)Yes, I trust this folder',
+    # The question line above the rows.
+    '(?i)Allow (access to this file|creation of this file|remote debugging|sandbox bypass for command execution)\?',
+    '(?i)Allow agent to access files outside workspace',
+]
+# Active generation. agy pairs a braille spinner with a "<Verb>ing…" label
+# ("Generating...", "Running command...", "Listing directory...") and swaps the
+# footer hint to `esc to cancel` for the whole turn — that footer is the
+# steady signal, the spinner glyph the frame-by-frame one.
+working = [
+    '[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⣾⣽⣻⢿⡿⣟⣯⣷]',
+    '(?i)esc to (cancel|interrupt generation)',
+    '(?i)\b(Generating|Thinking|Running command|Listing directory)\.\.\.',
+]
+# Idle: agy swaps the footer back to the shortcut hint once the turn ends.
+# Listed after `working` on purpose — the bare `>` input line is drawn during
+# generation too, so it can only be trusted once the working rules have missed.
+idle = [
+    '(?i)\?\s+for shortcuts',
+    '(?m)^\s*>\s*$',
+]

--- a/crates/muxa/src/sinks/ohmyprompt.rs
+++ b/crates/muxa/src/sinks/ohmyprompt.rs
@@ -501,6 +501,10 @@ pub fn agent_kind_to_source(kind: AgentKind) -> Option<&'static str> {
         AgentKind::ClaudeCode => Some("claude-code"),
         AgentKind::Codex => Some("codex"),
         AgentKind::GeminiCli => Some("gemini"),
+        // Reported under its own slug rather than folded into `gemini`:
+        // labelling agy runs as the CLI they replaced would quietly corrupt
+        // any per-tool breakdown downstream.
+        AgentKind::Antigravity => Some("antigravity"),
         AgentKind::Opencode => Some("opencode"),
         AgentKind::Unknown | AgentKind::Task => None,
     }
@@ -512,6 +516,7 @@ pub fn agent_kind_to_cli_name(kind: AgentKind) -> Option<&'static str> {
         AgentKind::ClaudeCode => Some("claude"),
         AgentKind::Codex => Some("codex"),
         AgentKind::GeminiCli => Some("gemini"),
+        AgentKind::Antigravity => Some("agy"),
         AgentKind::Opencode => Some("opencode"),
         AgentKind::Unknown | AgentKind::Task => None,
     }
@@ -622,6 +627,13 @@ mod tests {
         );
         assert_eq!(agent_kind_to_source(AgentKind::Codex), Some("codex"));
         assert_eq!(agent_kind_to_source(AgentKind::GeminiCli), Some("gemini"));
+        // agy reports as itself. Folding it into `gemini` would silently
+        // merge two different tools in any downstream breakdown.
+        assert_eq!(
+            agent_kind_to_source(AgentKind::Antigravity),
+            Some("antigravity")
+        );
+        assert_eq!(agent_kind_to_cli_name(AgentKind::Antigravity), Some("agy"));
         assert_eq!(agent_kind_to_source(AgentKind::Opencode), Some("opencode"));
         assert_eq!(agent_kind_to_source(AgentKind::Unknown), None);
     }

--- a/crates/muxad/src/herdr_bridge.rs
+++ b/crates/muxad/src/herdr_bridge.rs
@@ -127,6 +127,8 @@ fn classify_agent(agent: &str) -> AgentKind {
         AgentKind::Codex
     } else if agent.contains("gemini") {
         AgentKind::GeminiCli
+    } else if agent.contains("antigravity") || agent == "agy" {
+        AgentKind::Antigravity
     } else if agent.contains("opencode") {
         AgentKind::Opencode
     } else {
@@ -660,6 +662,7 @@ fn agent_slug(kind: AgentKind) -> &'static str {
         AgentKind::ClaudeCode => "claude",
         AgentKind::Codex => "codex",
         AgentKind::GeminiCli => "gemini",
+        AgentKind::Antigravity => "agy",
         AgentKind::Opencode => "opencode",
         AgentKind::Task => "task",
         AgentKind::Unknown => "unknown",

--- a/crates/muxad/src/screen_detect.rs
+++ b/crates/muxad/src/screen_detect.rs
@@ -145,8 +145,13 @@ impl ScreenDetector {
         for pane_id in dropped {
             synthetic::stop_synthetic_row(&self.store, &pane_id).await;
             self.tracked.remove(&pane_id);
-            self.last_state.remove(&pane_id);
         }
+        // Drop the last-classified state for every pane that fell out of
+        // candidacy, tracked or not. Attention-refined panes are deliberately
+        // never `tracked` (their row is real and not ours to stop), so pruning
+        // off `tracked` alone would leak an entry per agy pane ever seen.
+        self.last_state
+            .retain(|pane_id, _| current.contains(pane_id));
 
         let mut changes = 0;
         for (backend_idx, pane, manifest) in candidates {
@@ -201,10 +206,12 @@ impl ScreenDetector {
     ) -> bool {
         let pane_id = pane.pane_id.clone();
 
-        // Hook-authoritative: a live real row owns the pane — don't even capture.
-        // Forget any tracking so a later stop-sweep doesn't touch the real row.
         let occupants = self.store.by_pane(&pane_id).await;
-        if occupants.iter().any(synthetic::occupant_is_authoritative) {
+        let ownership = synthetic::pane_ownership(&occupants);
+        if matches!(ownership, synthetic::PaneOwnership::Hooked) {
+            // Hook-authoritative: a live real row owns the pane and its hooks
+            // report every state — don't even capture. Forget any tracking so
+            // a later stop-sweep doesn't touch the real row.
             self.tracked.remove(&pane_id);
             self.last_state.remove(&pane_id);
             return false;
@@ -223,6 +230,39 @@ impl ScreenDetector {
         if self.last_state.get(&pane_id) == Some(&state) {
             return false; // no change since last capture
         }
+        self.last_state.insert(pane_id.clone(), state);
+
+        if let synthetic::PaneOwnership::AttentionBlind {
+            id,
+            state: owner_state,
+        } = ownership
+        {
+            // The owning agent's hooks cannot report attention, so this pane
+            // gets the attention signal ONLY — applied to the real row, and
+            // never tracked: `tracked` drives the stop-sweep, and a real row is
+            // not ours to stop.
+            let events = synthetic::attention_refinement_events(
+                id,
+                owner_state,
+                to_synthetic(state),
+                &manifest.name,
+                None,
+                OffsetDateTime::now_utc(),
+            );
+            if events.is_empty() {
+                return false;
+            }
+            for ev in &events {
+                self.store.apply(ev).await;
+            }
+            tracing::debug!(
+                pane = %pane_id,
+                agent = %manifest.name,
+                ?state,
+                "screen detection refined an attention-blind hook row",
+            );
+            return true;
+        }
 
         let id = synthetic_id(pane);
         let events = synthetic::state_events(
@@ -233,7 +273,6 @@ impl ScreenDetector {
             OffsetDateTime::now_utc(),
         );
         synthetic::apply_if_unowned(&self.store, &pane_id, &events).await;
-        self.last_state.insert(pane_id.clone(), state);
         self.tracked.insert(pane_id);
         true
     }
@@ -501,6 +540,190 @@ mod tests {
         let rows = store.by_pane("%1").await;
         assert_eq!(rows.len(), 1, "no synthetic row added");
         assert_eq!(rows[0].session_id, "real");
+    }
+
+    /// A hook-owned agy pane is the one exception to "hooks own the pane": agy
+    /// has no permission hook, so screen inference supplies `WaitingInput` and
+    /// nothing else. Driven through the real detector loop with the bundled
+    /// `agy` manifest and captures taken from a live agy 1.1.17 pane.
+    #[tokio::test]
+    async fn refines_attention_on_a_hook_owned_agy_pane() {
+        let captures = Arc::new(Mutex::new(HashMap::new()));
+        captures.lock().unwrap().insert(
+            "%1".into(),
+            "⣷  Running command...\n>\nesc to cancel".into(),
+        );
+        let backend: SharedBackend =
+            Arc::new(FakeBackend::tmux(vec![pane("%1", "agy")], captures.clone()));
+
+        let store = Store::shared();
+        let real = AgentId {
+            kind: AgentKind::Antigravity,
+            session_id: "conv-1".into(),
+            surface: None,
+            pane: Some("%1".into()),
+            tmux_socket: Some("default".into()),
+            cwd: None,
+        };
+        // Hooks put the row in Working and stamp the model, as they would.
+        store
+            .apply(&AgentEvent::Started {
+                id: real.clone(),
+                at: AT,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::Heartbeat {
+                id: real.clone(),
+                model: Some("gemini-3.7-flash-high".into()),
+                context_used_pct: None,
+                cost_usd: None,
+                rate_limit_5h_pct: None,
+                rate_limit_5h_resets_at: None,
+                rate_limit_7d_pct: None,
+                rate_limit_7d_resets_at: None,
+                at: AT,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::ToolStarted {
+                id: real.clone(),
+                tool: "run_command".into(),
+                subagent: None,
+                at: AT,
+            })
+            .await;
+
+        let mut det = detector(vec![backend], store.clone());
+
+        // A working screen adds nothing — hooks already own that transition.
+        assert_eq!(det.run_tick().await, 0);
+        assert_eq!(store.by_pane("%1").await[0].state, AgentState::Working);
+
+        // agy puts its permission widget up. Nothing in its hook stream can
+        // say so, so this tick is the only way the row learns it.
+        captures.lock().unwrap().insert(
+            "%1".into(),
+            "Run command?\n> Yes, and always allow for commands that start with 'echo'\n  No, deny"
+                .into(),
+        );
+        assert_eq!(det.run_tick().await, 1);
+        let rows = store.by_pane("%1").await;
+        assert_eq!(rows.len(), 1, "refinement must not mint a second row");
+        assert_eq!(rows[0].session_id, "conv-1");
+        assert_eq!(rows[0].state, AgentState::WaitingInput);
+        assert_eq!(
+            rows[0].model.as_deref(),
+            Some("gemini-3.7-flash-high"),
+            "the hook-supplied model must survive",
+        );
+
+        // The operator approves; agy's PostToolUse fires and releases the row
+        // without any help from the screen.
+        store
+            .apply(&AgentEvent::ToolCompleted {
+                id: real,
+                tool: "run_command".into(),
+                success: true,
+                at: AT,
+            })
+            .await;
+        assert_eq!(store.by_pane("%1").await[0].state, AgentState::Working);
+    }
+
+    /// The safety valve: if the hook stream stops arriving while the row sits
+    /// at `WaitingInput`, an idle screen releases it rather than freezing it.
+    #[tokio::test]
+    async fn idle_screen_releases_a_stuck_agy_wait() {
+        let captures = Arc::new(Mutex::new(HashMap::new()));
+        captures.lock().unwrap().insert(
+            "%1".into(),
+            "Allow access to this file?\n> Yes, allow access\n  No, deny access".into(),
+        );
+        let backend: SharedBackend =
+            Arc::new(FakeBackend::tmux(vec![pane("%1", "agy")], captures.clone()));
+        let store = Store::shared();
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    kind: AgentKind::Antigravity,
+                    session_id: "conv-1".into(),
+                    surface: None,
+                    pane: Some("%1".into()),
+                    tmux_socket: Some("default".into()),
+                    cwd: None,
+                },
+                at: AT,
+            })
+            .await;
+
+        let mut det = detector(vec![backend], store.clone());
+        assert_eq!(det.run_tick().await, 1);
+        assert_eq!(store.by_pane("%1").await[0].state, AgentState::WaitingInput);
+
+        // No further hook events ever arrive; the prompt is gone from screen.
+        captures
+            .lock()
+            .unwrap()
+            .insert("%1".into(), "? for shortcuts".into());
+        assert_eq!(det.run_tick().await, 1);
+        assert_eq!(store.by_pane("%1").await[0].state, AgentState::Idle);
+    }
+
+    /// A hook-owned agy pane must never be `tracked`: `tracked` drives the
+    /// stop-sweep, and driving a REAL row to `Stopped` because its foreground
+    /// command changed is not screen detection's call.
+    #[tokio::test]
+    async fn a_refined_pane_is_never_stopped_by_the_sweep() {
+        let captures = Arc::new(Mutex::new(HashMap::new()));
+        captures.lock().unwrap().insert(
+            "%1".into(),
+            "Run command?\n> Yes, and always allow\n  No, deny".into(),
+        );
+        let panes = Arc::new(Mutex::new(vec![pane("%1", "agy")]));
+        let backend: SharedBackend = Arc::new(FakeBackend::tmux(
+            panes.lock().unwrap().clone(),
+            captures.clone(),
+        ));
+        let store = Store::shared();
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    kind: AgentKind::Antigravity,
+                    session_id: "conv-1".into(),
+                    surface: None,
+                    pane: Some("%1".into()),
+                    tmux_socket: Some("default".into()),
+                    cwd: None,
+                },
+                at: AT,
+            })
+            .await;
+        let mut det = detector(vec![backend], store.clone());
+        assert_eq!(det.run_tick().await, 1);
+        assert!(
+            !det.tracked.contains("%1"),
+            "a real row is not ours to track or stop",
+        );
+
+        // The pane drops out of candidacy: the sweep must leave the real row be.
+        let empty: SharedBackend = Arc::new(FakeBackend::tmux(
+            vec![pane("%1", "bash")],
+            Arc::new(Mutex::new(HashMap::new())),
+        ));
+        det.backends = vec![empty];
+        det.run_tick().await;
+        let rows = store.by_pane("%1").await;
+        assert_eq!(rows[0].session_id, "conv-1");
+        assert_ne!(
+            rows[0].state,
+            AgentState::Stopped,
+            "the sweep must not stop a real row",
+        );
+        assert!(
+            !det.last_state.contains_key("%1"),
+            "last_state is pruned for refined panes too, not just tracked ones",
+        );
     }
 
     #[tokio::test]

--- a/crates/muxad/src/synthetic.rs
+++ b/crates/muxad/src/synthetic.rs
@@ -7,11 +7,20 @@
 //! mechanics live here once:
 //!
 //! * **Hook-authoritative precedence** ([`occupant_is_authoritative`],
-//!   [`apply_if_unowned`]): a live, non-synthetic (real hook) row owns its pane;
-//!   a synthetic producer must drop its update wholesale rather than clobber it.
-//!   And because these rows are synthetic, `Store::apply`'s synthetic-eviction
-//!   pass drops them the instant a real hook `Started` claims the pane — so the
-//!   hook-authoritative rule falls out of the existing machinery for free.
+//!   [`pane_ownership`], [`apply_if_unowned`]): a live, non-synthetic (real
+//!   hook) row owns its pane; a synthetic producer must drop its update
+//!   wholesale rather than clobber it. And because these rows are synthetic,
+//!   `Store::apply`'s synthetic-eviction pass drops them the instant a real
+//!   hook `Started` claims the pane — so the hook-authoritative rule falls out
+//!   of the existing machinery for free.
+//! * **Attention refinement** ([`attention_refinement_events`]): the one
+//!   documented exception. When the owning row's agent CLI has no hook that can
+//!   report "waiting on the operator"
+//!   (`AgentKind::hooks_report_attention`), dropping the update wholesale
+//!   would mean that agent can *never* show as `WaitingInput`. Such a pane
+//!   instead gets an attention-only update applied to the REAL row — never a
+//!   second synthetic one, which `Store::apply` would evict on the next hook
+//!   event and re-mint on the next tick, flapping a duplicate row forever.
 //! * **Row liveness** ([`stop_synthetic_row`]): when a producer stops seeing an
 //!   agent on a pane whose shell is still open, it drives the synthetic row to
 //!   `Stopped` so it doesn't freeze at its last state forever.
@@ -48,6 +57,108 @@ pub enum SyntheticState {
 #[must_use]
 pub fn occupant_is_authoritative(agent: &Agent) -> bool {
     !agent.session_id.starts_with(SYNTHETIC_SESSION_PREFIX) && agent.state != AgentState::Stopped
+}
+
+/// What a pane's current occupants permit a synthetic producer to do.
+///
+/// Not `PartialEq` — it carries an [`AgentId`], which isn't comparable; call
+/// sites and tests match on the variant instead.
+#[derive(Debug, Clone)]
+pub enum PaneOwnership {
+    /// No live real row. Mint and drive the synthetic row as usual.
+    Free,
+    /// A live real row owns the pane and its hooks can report every state muxa
+    /// tracks, attention included. Stay out entirely.
+    Hooked,
+    /// A live real row owns the pane, but its agent CLI exposes no hook that
+    /// can report "waiting on the operator". Screen inference is the only
+    /// source for that one signal, so the producer may refine THIS row's
+    /// attention state — and nothing else. See [`attention_refinement_events`].
+    AttentionBlind { id: AgentId, state: AgentState },
+}
+
+/// Classify `occupants` (as returned by `Store::by_pane`) into the update the
+/// producer is allowed to make.
+///
+/// The first authoritative occupant wins; in practice there is at most one,
+/// because `Store::apply` evicts synthetic rows from a pane a real row claims.
+#[must_use]
+pub fn pane_ownership(occupants: &[Agent]) -> PaneOwnership {
+    let Some(owner) = occupants.iter().find(|a| occupant_is_authoritative(a)) else {
+        return PaneOwnership::Free;
+    };
+    if owner.kind.hooks_report_attention() {
+        return PaneOwnership::Hooked;
+    }
+    PaneOwnership::AttentionBlind {
+        id: AgentId {
+            kind: owner.kind,
+            session_id: owner.session_id.clone(),
+            surface: owner.surface.clone(),
+            pane: owner.pane.clone(),
+            tmux_socket: owner.tmux_socket.clone(),
+            cwd: owner.cwd.clone(),
+        },
+        state: owner.state,
+    }
+}
+
+/// The events a screen observation may contribute to an
+/// [`PaneOwnership::AttentionBlind`] row. Empty means "the observation adds
+/// nothing" — the overwhelmingly common case.
+///
+/// Deliberately narrower than [`state_events`] in three ways:
+///
+/// 1. **No `Heartbeat`.** A real row's `model` is the model name its hooks
+///    reported (`gemini-3.7-flash-high`); stamping the manifest name over it
+///    would lose real information.
+/// 2. **`Working` contributes nothing.** Hooks own that transition and fire it
+///    within milliseconds of the tool starting, whereas a screen tick is
+///    seconds late. Racing them buys nothing and can only fight.
+/// 3. **`Idle` only ever *clears*.** It is the backstop for the one way a
+///    refined row could get stuck: hooks stop arriving (the CLI died mid-turn,
+///    or an event was lost) while the row sits at `WaitingInput`. An idle
+///    screen on a row that is NOT waiting is left to the hooks.
+#[must_use]
+pub fn attention_refinement_events(
+    id: AgentId,
+    owner_state: AgentState,
+    observed: SyntheticState,
+    name: &str,
+    message: Option<String>,
+    at: OffsetDateTime,
+) -> Vec<AgentEvent> {
+    let waiting = matches!(
+        owner_state,
+        AgentState::WaitingInput | AgentState::WaitingChoice
+    );
+    match observed {
+        // An approval prompt is on screen and the row doesn't know it yet.
+        // `Error` is left alone: it is a fact the hooks reported, and masking
+        // it with a wait would hide the failure the operator needs to see.
+        SyntheticState::Blocked if !waiting && owner_state != AgentState::Error => {
+            vec![AgentEvent::NotificationFired {
+                id,
+                level: NotificationLevel::NeedsInput,
+                message: message.unwrap_or_else(|| format!("{name} is waiting")),
+                at,
+            }]
+        }
+        // The prompt is gone and nothing is generating, yet the row is still
+        // waiting — release it. `idle_confirmed` is exactly this: positive
+        // evidence from a producer that OBSERVED the pane go idle.
+        SyntheticState::Idle if waiting => {
+            vec![AgentEvent::TurnStopped {
+                id,
+                response: None,
+                recap: None,
+                ai_title: None,
+                idle_confirmed: true,
+                at,
+            }]
+        }
+        SyntheticState::Blocked | SyntheticState::Idle | SyntheticState::Working => Vec::new(),
+    }
 }
 
 /// Apply `events` to the pane, enforcing hook-authoritative precedence: if a
@@ -239,6 +350,271 @@ mod tests {
             }
             other => panic!("expected TurnStopped, got {other:?}"),
         }
+    }
+
+    /// Build a bare `Agent` row for ownership tests.
+    fn row(kind: AgentKind, session_id: &str, state: AgentState) -> Agent {
+        Agent {
+            kind,
+            session_id: session_id.to_owned(),
+            surface: None,
+            pane: Some("%1".into()),
+            tmux_socket: None,
+            tmux_session: None,
+            cwd: None,
+            pid: None,
+            workload: muxa::WorkloadSummary::default(),
+            subagents: Vec::new(),
+            state,
+            last_prompt: None,
+            last_response: None,
+            recap: None,
+            ai_title: None,
+            last_notification: None,
+            model: None,
+            context_used_pct: None,
+            cost_usd: None,
+            rate_limit_5h_pct: None,
+            rate_limit_5h_resets_at: None,
+            rate_limit_7d_pct: None,
+            rate_limit_7d_resets_at: None,
+            rate_limited_until: None,
+            rate_limit_scope: None,
+            rate_limit_source: None,
+            started_at: AT,
+            last_activity_at: AT,
+            state_entered_at: AT,
+        }
+    }
+
+    #[test]
+    fn pane_ownership_free_when_no_live_real_row() {
+        assert!(matches!(pane_ownership(&[]), PaneOwnership::Free));
+        // A synthetic row does not own the pane...
+        let synth = row(
+            AgentKind::Unknown,
+            &format!("{SYNTHETIC_SESSION_PREFIX}%1"),
+            AgentState::Working,
+        );
+        assert!(matches!(pane_ownership(&[synth]), PaneOwnership::Free));
+        // ...and neither does a stopped real one.
+        let dead = row(AgentKind::ClaudeCode, "real", AgentState::Stopped);
+        assert!(matches!(pane_ownership(&[dead]), PaneOwnership::Free));
+    }
+
+    /// Every agent whose hooks can report a permission prompt keeps screen
+    /// inference fully out of the way — the pre-existing behavior.
+    #[test]
+    fn pane_ownership_hooked_for_agents_that_report_attention() {
+        for kind in [
+            AgentKind::ClaudeCode,
+            AgentKind::Codex,
+            AgentKind::GeminiCli,
+            AgentKind::Opencode,
+        ] {
+            let owner = row(kind, "real", AgentState::Working);
+            assert!(
+                matches!(pane_ownership(&[owner]), PaneOwnership::Hooked),
+                "{kind} hooks report attention, so nothing may refine it",
+            );
+        }
+    }
+
+    /// agy is the one kind with no permission hook, so its row is refinable —
+    /// and the refinement must target the REAL row's identity, never a
+    /// synthetic one (a second row would flap: `Store::apply` evicts it on the
+    /// next hook event and the next tick re-mints it).
+    #[test]
+    fn pane_ownership_attention_blind_for_antigravity() {
+        let owner = row(AgentKind::Antigravity, "conv-1", AgentState::Working);
+        match pane_ownership(&[owner]) {
+            PaneOwnership::AttentionBlind { id, state } => {
+                assert_eq!(id.session_id, "conv-1");
+                assert_eq!(id.kind, AgentKind::Antigravity);
+                assert!(!id.session_id.starts_with(SYNTHETIC_SESSION_PREFIX));
+                assert_eq!(state, AgentState::Working);
+            }
+            other => panic!("expected AttentionBlind, got {other:?}"),
+        }
+    }
+
+    fn refine(owner_state: AgentState, observed: SyntheticState) -> Vec<AgentEvent> {
+        attention_refinement_events(
+            AgentId {
+                kind: AgentKind::Antigravity,
+                session_id: "conv-1".into(),
+                surface: None,
+                pane: Some("%1".into()),
+                tmux_socket: None,
+                cwd: None,
+            },
+            owner_state,
+            observed,
+            "agy",
+            None,
+            AT,
+        )
+    }
+
+    #[test]
+    fn refinement_raises_attention_on_a_blocked_screen() {
+        for owner_state in [AgentState::Working, AgentState::Idle, AgentState::Starting] {
+            match refine(owner_state, SyntheticState::Blocked).as_slice() {
+                [AgentEvent::NotificationFired {
+                    level, message, id, ..
+                }] => {
+                    assert_eq!(*level, NotificationLevel::NeedsInput);
+                    assert_eq!(message, "agy is waiting");
+                    assert_eq!(id.session_id, "conv-1", "must target the real row");
+                }
+                other => panic!("expected one NotificationFired for {owner_state}, got {other:?}"),
+            }
+        }
+    }
+
+    /// No `Heartbeat` — the real row's `model` came from its hooks
+    /// (`gemini-3.7-flash-high`), and stamping the manifest name over it would
+    /// destroy real information. This is the difference from `state_events`.
+    #[test]
+    fn refinement_never_emits_a_heartbeat() {
+        for owner_state in [
+            AgentState::Working,
+            AgentState::Idle,
+            AgentState::WaitingInput,
+            AgentState::Error,
+        ] {
+            for observed in [
+                SyntheticState::Working,
+                SyntheticState::Blocked,
+                SyntheticState::Idle,
+            ] {
+                assert!(
+                    !refine(owner_state, observed)
+                        .iter()
+                        .any(|e| matches!(e, AgentEvent::Heartbeat { .. })),
+                    "{owner_state} + {observed:?} must not stamp the model field",
+                );
+            }
+        }
+    }
+
+    /// Hooks own `Working`: they report it in milliseconds, a screen tick is
+    /// seconds late, so racing them buys nothing and can only fight.
+    #[test]
+    fn refinement_ignores_a_working_screen() {
+        for owner_state in [
+            AgentState::Working,
+            AgentState::Idle,
+            AgentState::WaitingInput,
+        ] {
+            assert!(refine(owner_state, SyntheticState::Working).is_empty());
+        }
+    }
+
+    /// Idle only ever *clears* a stuck wait; on a row that isn't waiting it is
+    /// the hooks' business.
+    #[test]
+    fn refinement_idle_clears_only_a_waiting_row() {
+        for owner_state in [AgentState::WaitingInput, AgentState::WaitingChoice] {
+            match refine(owner_state, SyntheticState::Idle).as_slice() {
+                [AgentEvent::TurnStopped {
+                    idle_confirmed,
+                    response,
+                    id,
+                    ..
+                }] => {
+                    assert!(*idle_confirmed, "must be positive idle evidence");
+                    assert_eq!(*response, None);
+                    assert_eq!(id.session_id, "conv-1");
+                }
+                other => panic!("expected TurnStopped for {owner_state}, got {other:?}"),
+            }
+        }
+        for owner_state in [AgentState::Working, AgentState::Idle, AgentState::Error] {
+            assert!(refine(owner_state, SyntheticState::Idle).is_empty());
+        }
+    }
+
+    /// Re-observing the same prompt must not re-fire, and an `Error` the hooks
+    /// reported must not be masked by a wait.
+    #[test]
+    fn refinement_is_idempotent_and_preserves_error() {
+        assert!(refine(AgentState::WaitingInput, SyntheticState::Blocked).is_empty());
+        assert!(refine(AgentState::WaitingChoice, SyntheticState::Blocked).is_empty());
+        assert!(refine(AgentState::Error, SyntheticState::Blocked).is_empty());
+    }
+
+    /// The whole point, end to end against a real store: an agy row that hooks
+    /// drove to `Working` reaches `WaitingInput` from a blocked screen, and its
+    /// hook-supplied `model` survives.
+    #[tokio::test]
+    async fn refinement_moves_a_real_agy_row_into_waiting_input() {
+        let store = Store::shared();
+        let real = AgentId {
+            kind: AgentKind::Antigravity,
+            session_id: "conv-1".into(),
+            surface: None,
+            pane: Some("%1".into()),
+            tmux_socket: None,
+            cwd: None,
+        };
+        store
+            .apply(&AgentEvent::Started {
+                id: real.clone(),
+                at: AT,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::Heartbeat {
+                id: real.clone(),
+                model: Some("gemini-3.7-flash-high".into()),
+                context_used_pct: None,
+                cost_usd: None,
+                rate_limit_5h_pct: None,
+                rate_limit_5h_resets_at: None,
+                rate_limit_7d_pct: None,
+                rate_limit_7d_resets_at: None,
+                at: AT,
+            })
+            .await;
+        store
+            .apply(&AgentEvent::ToolStarted {
+                id: real.clone(),
+                tool: "run_command".into(),
+                subagent: None,
+                at: AT,
+            })
+            .await;
+        assert_eq!(store.by_pane("%1").await[0].state, AgentState::Working);
+
+        let occupants = store.by_pane("%1").await;
+        let PaneOwnership::AttentionBlind { id, state } = pane_ownership(&occupants) else {
+            panic!("an agy row must be attention-blind");
+        };
+        for ev in attention_refinement_events(id, state, SyntheticState::Blocked, "agy", None, AT) {
+            store.apply(&ev).await;
+        }
+
+        let rows = store.by_pane("%1").await;
+        assert_eq!(rows.len(), 1, "refinement must not mint a second row");
+        assert_eq!(rows[0].session_id, "conv-1");
+        assert_eq!(rows[0].state, AgentState::WaitingInput);
+        assert_eq!(
+            rows[0].model.as_deref(),
+            Some("gemini-3.7-flash-high"),
+            "the hook-supplied model must survive refinement",
+        );
+
+        // And the agy hook stream releases it again, unaided.
+        store
+            .apply(&AgentEvent::ToolCompleted {
+                id: real,
+                tool: "run_command".into(),
+                success: true,
+                at: AT,
+            })
+            .await;
+        assert_eq!(store.by_pane("%1").await[0].state, AgentState::Working);
     }
 
     #[tokio::test]

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -47,6 +47,11 @@ Entries written by agy's own `/hooks` command, by plugins, or by hand are never
 touched, and `muxa init --uninstall --component agy-hooks` drops only the `muxa`
 key.
 
+`muxa doctor` reports this line only when agy is actually installed, and it
+requires **all six** events to be wired — a block left over from an older muxa
+reports as broken rather than healthy, because a partial block yields a row
+that never shows a prompt or a tool.
+
 Two shapes matter and are easy to get backwards: `PreToolUse`/`PostToolUse`
 wrap their handlers in a `{matcher, hooks[]}` group, while the lifecycle events
 take a flat handler list. A handler in the wrong shape is dropped without an
@@ -97,6 +102,11 @@ exit. `muxa hook agy` therefore:
 - exits `0` even when the payload is unparseable, the event flag is unknown, or
   muxad is down.
 
+`muxa hook` as a whole also stops aborting on an unreadable `config.toml` — it
+degrades to defaults and reports the parse error on stderr — because that check
+runs before the handler and would otherwise defeat the guarantee above from
+outside it. Every non-hook subcommand still fails loudly on a bad config.
+
 Observation must never be able to block the agent. This is the one hook handler
 in muxa that swallows its own errors for that reason.
 
@@ -123,6 +133,6 @@ in muxa that swallows its own errors for that reason.
 | `muxa agent start --agent` | `agy` (alias `antigravity`) → `agy --dangerously-skip-permissions [-i <prompt>]` |
 | `muxa watch` spawn form | `agy` |
 | `muxa timeline --agent` | `antigravity` (alias `agy`) |
-| MCP `muxa_start_agent` | `"agy"` |
+| MCP `muxa_start_agent` / `muxa_call_peer` | `"agy"` |
 | Wire / dashboard kind | `antigravity` |
 | omp sink | `source: antigravity`, `cli_name: agy` |

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -91,6 +91,45 @@ muxa reads the tail of that JSONL: the last `USER_INPUT`/`USER_EXPLICIT` step
 silently — a hook runs synchronously inside agy's loop, so a missing or
 malformed transcript must cost a blank cell, never a stall.
 
+## Attention comes from the screen
+
+agy fires no hook when it puts an approval prompt up, so nothing in the event
+stream can say "this agent is waiting on you" — the single most important thing
+muxa exists to report.
+
+Normally hooks are absolute: `muxad` skips screen inference entirely on any
+pane a live hook row owns. agy is the one documented exception. Its rows are
+classified **attention-blind** (`AgentKind::hooks_report_attention` is `false`),
+and for those the screen detector keeps running and contributes exactly one
+signal — applied to the **real** row, never a second synthetic one:
+
+| Screen says | Row is | Result |
+| --- | --- | --- |
+| `Blocked` | not waiting, not `Error` | → `WaitingInput` |
+| `Idle` | waiting | → `Idle` (releases a stuck wait) |
+| anything else | — | nothing |
+
+Three things this deliberately does **not** do:
+
+- **No `Heartbeat`.** The row's `model` is what the hooks reported
+  (`gemini-3.7-flash-high`); stamping the manifest name `agy` over it would
+  destroy real information.
+- **`Working` contributes nothing.** Hooks report it in milliseconds; a screen
+  tick is seconds late. Racing them can only fight.
+- **A second row is never minted.** `Store::apply` evicts synthetic rows from a
+  pane a real row owns, so a synthetic row here would be evicted on the next
+  hook event and re-minted on the next tick — a duplicate row flapping forever.
+
+In practice the hooks release the wait on their own: approving the prompt fires
+`PostToolUse` → `ToolCompleted` → `Working`. The `Idle` rule above is the
+backstop for the one case they can't cover — the hook stream stopping
+altogether while the row sits at `WaitingInput`.
+
+Verified against a live agy 1.1.17 pane, on both prompt shapes agy renders
+(a numbered command prompt and a file-creation prompt):
+`working` → `waiting_input` → approve → `idle`, with the hook-supplied model
+and response intact throughout.
+
 ## `muxa hook agy` is fail-open and silent
 
 agy reads a hook's **stdout as a verdict**. An empty stdout means "no opinion";
@@ -112,10 +151,10 @@ in muxa that swallows its own errors for that reason.
 
 ## What agy does not expose
 
-- **No permission/notification hook.** An agy row cannot reach `WaitingInput`
-  from hooks. The bundled `agy` screen manifest covers that for panes with no
-  hooks wired; where hooks *are* wired they take precedence and the approval
-  prompt is not observed. See [SCREEN_DETECTION.md](SCREEN_DETECTION.md).
+- **No permission/notification hook.** No agy hook fires when it puts an
+  approval prompt up, so `WaitingInput` is unreachable from the hook stream.
+  muxa fills the gap from the screen instead — see
+  [Attention comes from the screen](#attention-comes-from-the-screen).
 - **No session-end hook.** `Stop` is a turn boundary, not a session boundary, so
   agy rows are reaped by pane liveness like Codex's.
 - **`workspacePaths` is empty in print mode.** `cwd` is populated for

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -1,0 +1,128 @@
+# Antigravity CLI (`agy`)
+
+Google's Antigravity CLI succeeded the Gemini CLI. It keeps the `~/.gemini`
+directory and it still runs Gemini models, which makes it easy to assume muxa's
+existing Gemini support carries over. It does not — **none** of the three things
+muxa needs is the same.
+
+| | Gemini CLI (`gemini`) | Antigravity CLI (`agy`) |
+| --- | --- | --- |
+| Hook config | `hooks` key inside `~/.gemini/settings.json` | its own `~/.gemini/config/hooks.json` |
+| Events | `SessionStart`, `BeforeAgent`, `AfterAgent`, `BeforeTool`, `AfterTool`, `Notification`, `SessionEnd` | `SessionStart`, `PreInvocation`, `PostInvocation`, `PreToolUse`, `PostToolUse`, `Stop` |
+| Payload | snake_case, `session_id` | camelCase protojson, `conversationId` |
+| muxa kind | `gemini_cli` | `antigravity` |
+| muxa hook | `muxa hook gemini` | `muxa hook agy` |
+
+The failure mode is silent in both directions: hooks written into
+`settings.json` make agy log `loaded 0 named hooks from 0 hooks.json file(s)`
+and carry on, and the Gemini adapter's required `session_id` would reject an agy
+payload outright. Hence a separate `AgentKind`, adapter, and init component
+rather than a rename. Both CLIs stay supported and can be installed side by
+side.
+
+## Install
+
+```sh
+muxa init --component agy-hooks
+muxa doctor          # → "Hooks · Antigravity — hook installed in …"
+```
+
+That writes a single `muxa` key into `~/.gemini/config/hooks.json`:
+
+```json
+{
+  "muxa": {
+    "SessionStart":   [{ "type": "command", "command": "muxa hook agy --event session_start",   "timeout": 10 }],
+    "PreInvocation":  [{ "type": "command", "command": "muxa hook agy --event pre_invocation",  "timeout": 10 }],
+    "PostInvocation": [{ "type": "command", "command": "muxa hook agy --event post_invocation", "timeout": 10 }],
+    "Stop":           [{ "type": "command", "command": "muxa hook agy --event stop",            "timeout": 10 }],
+    "PreToolUse":  [{ "matcher": "*", "hooks": [{ "type": "command", "command": "muxa hook agy --event pre_tool_use",  "timeout": 10 }] }],
+    "PostToolUse": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "muxa hook agy --event post_tool_use", "timeout": 10 }] }]
+  }
+}
+```
+
+`hooks.json` is keyed by hook **name**, so muxa owns exactly one top-level key.
+Entries written by agy's own `/hooks` command, by plugins, or by hand are never
+touched, and `muxa init --uninstall --component agy-hooks` drops only the `muxa`
+key.
+
+Two shapes matter and are easy to get backwards: `PreToolUse`/`PostToolUse`
+wrap their handlers in a `{matcher, hooks[]}` group, while the lifecycle events
+take a flat handler list. A handler in the wrong shape is dropped without an
+error.
+
+> **agy caches hooks in a long-lived backend process.** Editing `hooks.json`
+> does not take effect in an agy session that is already running — restart it.
+> The same cache means a stale hook can outlive the file that declared it.
+
+## Event mapping
+
+| agy event | muxa event | Row effect |
+| --- | --- | --- |
+| `SessionStart` | `Started` | `Idle`. Fires on a new session only — `agy -c` resumes without it. |
+| `PreInvocation`, `invocationNum == 0` | `PromptSubmitted` | `Working`, prompt read from the transcript |
+| `PreInvocation`, `invocationNum > 0` | `Heartbeat` | keeps the row warm, refreshes `model` |
+| `PreToolUse` | `ToolStarted` | `Working`, tool name from `toolCall.name` |
+| `PostToolUse` | `ToolCompleted` | `success` from a non-empty `error` |
+| `PostInvocation` | `Heartbeat` | refreshes `model` |
+| `Stop` (normal) | `TurnStopped` | `Idle`, response read from the transcript |
+| `Stop` (`terminationReason: ERROR`, or non-empty `error`) | `NotificationFired{Error}` | `Error` until the next prompt |
+
+### Turn boundaries
+
+`invocationNum` counts model calls **within one turn** and resets to `0` for
+each new user request — verified against agy 1.1.17 across a two-turn session,
+where one turn ran four invocations. `PreInvocation` at `0` is therefore the
+only place a prompt may be reported; treating every invocation as a turn start
+would restate the prompt once per model call.
+
+### Prompts and responses come from the transcript
+
+No agy payload carries prompt or response text — they carry a `transcriptPath`.
+muxa reads the tail of that JSONL: the last `USER_INPUT`/`USER_EXPLICIT` step
+(unwrapped from agy's `<USER_REQUEST>` envelope) for the prompt, and the last
+`PLANNER_RESPONSE` step with string `content` for the response. Both fail
+silently — a hook runs synchronously inside agy's loop, so a missing or
+malformed transcript must cost a blank cell, never a stall.
+
+## `muxa hook agy` is fail-open and silent
+
+agy reads a hook's **stdout as a verdict**. An empty stdout means "no opinion";
+a `PreToolUse` reply that is JSON but carries no valid `decision` blocks the
+call outright (`tool call denied by pre-tool hook`), and so does a non-zero
+exit. `muxa hook agy` therefore:
+
+- writes **zero bytes** to stdout on every event, and
+- exits `0` even when the payload is unparseable, the event flag is unknown, or
+  muxad is down.
+
+Observation must never be able to block the agent. This is the one hook handler
+in muxa that swallows its own errors for that reason.
+
+## What agy does not expose
+
+- **No permission/notification hook.** An agy row cannot reach `WaitingInput`
+  from hooks. The bundled `agy` screen manifest covers that for panes with no
+  hooks wired; where hooks *are* wired they take precedence and the approval
+  prompt is not observed. See [SCREEN_DETECTION.md](SCREEN_DETECTION.md).
+- **No session-end hook.** `Stop` is a turn boundary, not a session boundary, so
+  agy rows are reaped by pane liveness like Codex's.
+- **`workspacePaths` is empty in print mode.** `cwd` is populated for
+  interactive sessions with a folder open and absent for `agy -p`. A hook's own
+  process cwd is the directory holding `hooks.json`, so there is nothing to fall
+  back to.
+- **No rate-limit or cost signal.** `modelName` rides on every payload (more
+  than Codex or the Gemini CLI give), but the usage fields stay `None`.
+
+## Elsewhere in muxa
+
+| Surface | Value |
+| --- | --- |
+| Discovery (`pane_current_command`) | `agy`, `antigravity` |
+| `muxa agent start --agent` | `agy` (alias `antigravity`) → `agy --dangerously-skip-permissions [-i <prompt>]` |
+| `muxa watch` spawn form | `agy` |
+| `muxa timeline --agent` | `antigravity` (alias `agy`) |
+| MCP `muxa_start_agent` | `"agy"` |
+| Wire / dashboard kind | `antigravity` |
+| omp sink | `source: antigravity`, `cli_name: agy` |

--- a/docs/ARCHITECTURE.ko.md
+++ b/docs/ARCHITECTURE.ko.md
@@ -52,7 +52,7 @@ IPC로 `FleetStore` invalidation을 구독해 coalesce하고 revision이 바뀐 
 | --- | --- |
 | `muxad` | daemon. registry, IPC server, background task, optional dashboard 소유. |
 | `muxa` | status, watch, attend, recap, stats/report, activity query, init, hook CLI. |
-| Agent adapters | Claude/Codex/Gemini hook event를 muxa state transition으로 변환. |
+| Agent adapters | Claude/Codex/Gemini/Antigravity hook event를 muxa state transition으로 변환. |
 | tmux backend | pane/session, pane capture, foreground session activity 조회. |
 | Activity ledger | state/tmux/human interval의 append-only duration source. |
 | FleetManager | always-present local adapter, 독립 SSH relay state machine, node identity/권한, revision reconcile, host별 cache. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,7 +58,7 @@ slow full-snapshot reconciliation poll.
 | --- | --- |
 | `muxad` | Long-running daemon. Owns the registry, IPC server, background tasks, and optional dashboard. |
 | `muxa` | CLI for status, watch, attend, recap, stats, reports, activity queries, init, hook entrypoints, and the `mcp` control server. |
-| Agent adapters | Translate Claude/Codex/Gemini hook events into muxa state transitions. |
+| Agent adapters | Translate Claude/Codex/Gemini/Antigravity hook events into muxa state transitions. |
 | Pane backends | Resolve panes, sessions, captures, and foreground activity per host (tmux, rmux, herdr, zellij). The daemon can observe several at once; each non-tmux pane id is namespaced by host. |
 | herdr bridge | Translates herdr's own `agent_status` stream into synthetic rows for agents muxa has no hooks for. |
 | Screen detection | Classifies hook-less agents (cursor, amp, …) from pane captures against TOML manifests; synthetic, hook-authoritative. |

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -195,7 +195,7 @@ enabled = true
 interval_secs = 30
 ```
 
-discovery는 tmux pane을 훑어 알려진 agent CLI(`claude`/`codex`/`gemini`)를
+discovery는 tmux pane을 훑어 알려진 agent CLI(`claude`/`codex`/`gemini`/`agy`)를
 찾아 hook이 오기 전에 레지스트리를 채웁니다. 데몬 시작 시 1회 실행되고 이후
 `interval_secs`마다 재스캔하므로, 새 tmux 세션에서 갓 시작한 agent가 첫 hook을
 쏘기 전이라도 그 주기 안에 `muxa status`에 뜹니다. `interval_secs = 0`이면

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -200,7 +200,7 @@ interval_secs = 30
 ```
 
 Discovery scans tmux panes for known agent CLIs (`claude` / `codex` /
-`gemini`) and backfills the registry without waiting for a hook to fire. It
+`gemini`/`agy`) and backfills the registry without waiting for a hook to fire. It
 runs once at daemon startup and then every `interval_secs`, so a fresh agent
 session in a new tmux session shows up in `muxa status` within that window
 instead of only after its first hook. Set `interval_secs = 0` to keep the

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -255,7 +255,7 @@ shell pane in the window.
 The timeline panel calls `/api/timeline?since=7d` by default and can switch
 to `24h`, `today`, `last week`, `month`, `last month`, `30d`, `12w`, or a clicked `YYYY-MM-DD` calendar day in the
 browser. The endpoint also accepts `session=<name>` and `agent=<kind>`
-(`codex`, `claude_code`, `gemini_cli`, `opencode`, `unknown`).
+(`codex`, `claude_code`, `gemini_cli`, `antigravity`, `opencode`, `unknown`).
 API callers can also pass comma-separated `exclude-pane` / `exclude-session`
 case-sensitive globs, for example
 `/api/timeline?since=month&exclude-session=monitor*`.

--- a/docs/HERDR.md
+++ b/docs/HERDR.md
@@ -232,7 +232,8 @@ Rows are keyed by `herdr:<pane_id>` with the SYNTHETIC session id
 `synthetic-herdr:<pane_id>` (the same shape `discovery` mints for a
 socket-less pane), so a discovery placeholder and a bridge row collapse
 onto one registry key. herdr agent names map `claude`→`ClaudeCode`,
-`codex`→`Codex`, `gemini`→`GeminiCli`, `opencode`→`Opencode` (loose,
+`codex`→`Codex`, `gemini`→`GeminiCli`, `agy`/`antigravity`→`Antigravity`,
+`opencode`→`Opencode` (loose,
 lowercased substring match — herdr's exact slugs aren't pinned in the
 schema); everything else is `AgentKind::Unknown` with the herdr
 `display_agent`/`agent` name carried in the row's **`model`** field (set
@@ -292,7 +293,8 @@ the wire `pane_id`) *and* non-synthetic. Mapping:
 | `Starting`                     | — (transient; nothing reported)          |
 
 `agent` is a herdr-aligned slug (`ClaudeCode`→`claude`, `Codex`→`codex`,
-`GeminiCli`→`gemini`, `Opencode`→`opencode`, else the kind name), matching the
+`GeminiCli`→`gemini`, `Antigravity`→`agy`, `Opencode`→`opencode`, else the kind
+name), matching the
 forward bridge's `classify_agent` so the same pane carries the same label in
 both directions. `agent_session_id` is muxa's real session id, and a
 process-global monotonic `seq` lets herdr discard out-of-order reports. `blocked`

--- a/docs/INSTALL.ko.md
+++ b/docs/INSTALL.ko.md
@@ -7,7 +7,7 @@ README를 짧게 유지하기 위해 자세한 설치와 wiring 절차는 이 �
 - Rust 1.88+
 - tmux 3.x
 - Unix-like OS
-- Claude Code, OpenAI Codex, Google Gemini CLI 중 하나
+- Claude Code, OpenAI Codex, Google Gemini CLI, Google Antigravity CLI(`agy`) 중 하나
 
 ## 설치 전 체험
 
@@ -159,6 +159,7 @@ tmux source-file ~/.tmux.conf
 | Claude Code | `examples/claude-settings.json`을 `~/.claude/settings.json`에 merge. |
 | OpenAI Codex | `crates/muxa/src/adapters/codex.rs`의 module doc에 있는 `[[hooks.*]]` block 추가. |
 | Google Gemini CLI | `crates/muxa/src/adapters/gemini.rs`의 hook block을 `~/.gemini/settings.json`에 merge. |
+| Google Antigravity CLI | `crates/muxa/src/adapters/antigravity.rs`의 `muxa` block을 `~/.gemini/config/hooks.json`에 추가. Gemini CLI의 `settings.json`이 **아니라** agy 전용 `hooks.json`입니다. |
 
 ## 확인
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -7,7 +7,8 @@ This page keeps the detailed install and wiring notes out of the README.
 - Rust 1.88+
 - tmux 3.x
 - Unix-like OS
-- One supported agent CLI: Claude Code, OpenAI Codex, or Google Gemini CLI
+- One supported agent CLI: Claude Code, OpenAI Codex, Google Gemini CLI, or the
+  Google Antigravity CLI (`agy`)
 
 ## Try Before Installing
 
@@ -183,6 +184,7 @@ hook commands without overwriting existing user hooks.
 | Claude Code | Merge `examples/claude-settings.json` into `~/.claude/settings.json`. |
 | OpenAI Codex | Add the `[[hooks.*]]` blocks documented in `crates/muxa/src/adapters/codex.rs`. |
 | Google Gemini CLI | Merge the hooks from `crates/muxa/src/adapters/gemini.rs` into `~/.gemini/settings.json`. |
+| Google Antigravity CLI | Add the `muxa` block from `crates/muxa/src/adapters/antigravity.rs` to `~/.gemini/config/hooks.json`. Note this is agy's own `hooks.json`, **not** the Gemini CLI's `settings.json`. |
 
 ## Verify
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -281,7 +281,7 @@ muxa_manage_tmux(action="close_workspace", workspace="muxa", confirm=true)
 Terminate and close refuse unconfirmed or unmanaged targets. Muxa does not
 expose arbitrary shell or generic tmux commands.
 
-Profiles are allowlisted (`claude`, `codex`, `gemini`, `opencode`) rather than
+Profiles are allowlisted (`claude`, `codex`, `gemini`, `agy`, `opencode`) rather than
 accepting an arbitrary shell command. They intentionally use each CLI's
 bypass/yolo mode. In particular, `codex` expands the local `cx` behavior to
 `codex --yolo` directly, so it does not depend on an interactive shell loading

--- a/docs/SCREEN_DETECTION.md
+++ b/docs/SCREEN_DETECTION.md
@@ -3,10 +3,13 @@
 Status: **implemented.** Core in `muxa::screen`, daemon task in
 `muxad::screen_detect`, shared synthetic-row machinery in `muxad::synthetic`.
 
-muxa gets authoritative agent state from **hooks** (Claude Code, Codex, Gemini)
+muxa gets authoritative agent state from **hooks** (Claude Code, Codex, Gemini,
+Antigravity)
 and, on herdr hosts, from **herdr's own detection** bridged into synthetic rows
 (`docs/HERDR.md`). For every *other* agent CLI — cursor-agent, amp, copilot,
 aider, goose, and anything a user declares — there is no event stream at all.
+`agy` sits in both camps: muxa ships hooks for it, and a bundled manifest for
+panes where those hooks aren't wired.
 Screen-manifest detection is the last-resort fallback herdr validated: capture
 the pane and match TOML-declared regex rules against the visible tail to infer
 `Working` / `WaitingInput` / `Idle`.
@@ -133,8 +136,8 @@ so GC won't evict it). Pane *close* is still handled by the reconciler as usual.
 
 ## Manifest sources
 
-1. **Bundled** — `cursor`, `amp`, `copilot`, `aider`, `goose` ship in the binary
-   via `include_str!` (`crates/muxa/src/screen/agents/*.toml`).
+1. **Bundled** — `agy`, `cursor`, `amp`, `copilot`, `aider`, `goose` ship in the
+   binary via `include_str!` (`crates/muxa/src/screen/agents/*.toml`).
 2. **User overrides** — `$XDG_CONFIG_HOME/muxa/agents/*.toml`. `XDG_CONFIG_HOME`
    is honored **first and explicitly** so the path works cross-platform: on
    macOS `dirs::config_dir()` returns `~/Library/Application Support` and ignores
@@ -149,7 +152,10 @@ failures `warn` + skip.
 
 The bundled manifests are **best-effort and conservative**, written **without
 running** the CLIs (muxa's CI can't drive them), and every file says so in a
-header comment. The design bias when unsure is **no match over a wrong match** —
+header comment. `agy` is the exception: its patterns were derived from a real
+agy 1.1.17 session — captured tmux panes for `working`/`idle`, and agy's own
+confirmation-widget labels for `blocked` — so its confidence is materially
+higher than the rest of the table. The design bias when unsure is **no match over a wrong match** —
 an unmatched screen just keeps the row's previous state.
 
 | Pattern class | Confidence | Notes |
@@ -162,6 +168,8 @@ an unmatched screen just keeps the row's previous state.
 | copilot `❯ Yes` selection widget as `blocked` | **Low-medium** | The highlighted-row arrow is specific to an actual menu, not prose. |
 | Generic "do you want to allow/proceed/run", "approve this command", "permission to run" as `blocked` | **Low-medium** | Plausible phrasings; specific enough to avoid most prose, but not verified against each CLI's exact copy. |
 | goose "would like to call" / literal `Allow?` as `blocked` | **Low** | Speculative wording; `Allow?` requires the `?` affordance, not the bare word. |
+| agy's `Yes, and always allow` / `No, and always deny` choice rows as `blocked` | **High** | Verbatim strings from agy's permission widget; they exist nowhere else in its output. |
+| agy's `esc to cancel` footer + `Generating...`/`Running command...` as `working` | **High** | Captured from a live agy pane; the footer holds for the whole turn. |
 | bare `^> $` as `idle` | **Medium** | Common prompt shape; may miss CLIs with a richer prompt (model name, token count). |
 | **Excluded:** bare single English words (`working`, a lone `allow`) and loose `yes … no … ?` prose as a state marker | **Rejected** | Too common in ordinary output ("working tree clean", "these settings allow …", any sentence with yes/no/?); they falsely froze rows as busy or blocked. Removed in favor of spinner glyphs + unambiguous affordances above. `no match > wrong match`. |
 

--- a/docs/SCREEN_DETECTION.md
+++ b/docs/SCREEN_DETECTION.md
@@ -8,8 +8,10 @@ Antigravity)
 and, on herdr hosts, from **herdr's own detection** bridged into synthetic rows
 (`docs/HERDR.md`). For every *other* agent CLI — cursor-agent, amp, copilot,
 aider, goose, and anything a user declares — there is no event stream at all.
-`agy` sits in both camps: muxa ships hooks for it, and a bundled manifest for
-panes where those hooks aren't wired.
+`agy` sits in both camps: muxa ships hooks for it, *and* a bundled manifest —
+because agy's hooks cannot report an approval prompt, so screen inference stays
+live on agy panes even when hooks are wired. See
+[Attention refinement](#attention-refinement-the-one-exception).
 Screen-manifest detection is the last-resort fallback herdr validated: capture
 the pane and match TOML-declared regex rules against the visible tail to infer
 `Working` / `WaitingInput` / `Idle`.
@@ -134,6 +136,32 @@ task drives that synthetic row to `Stopped` via `synthetic::stop_synthetic_row`
 (the shell is alive, so the reconciler won't reap it; the row isn't `Stopped`,
 so GC won't evict it). Pane *close* is still handled by the reconciler as usual.
 
+## Attention refinement (the one exception)
+
+Hook-authoritative precedence has exactly one carve-out. An agent CLI whose
+hooks cannot report "waiting on the operator" would otherwise be able to reach
+`WaitingInput` only by *not* installing muxa's hooks — the wrong trade. Today
+that is the Antigravity CLI (`agy`); `AgentKind::hooks_report_attention()` is
+the predicate, and Claude Code, Codex, the Gemini CLI and opencode all return
+`true` and keep the original behavior unchanged.
+
+For an attention-blind row, `muxad::synthetic::pane_ownership` returns
+`AttentionBlind` instead of `Hooked`, and the detector applies
+`attention_refinement_events` to the **real** row:
+
+* `Blocked` on a row that isn't already waiting (and isn't `Error`) →
+  `NotificationFired(NeedsInput)`.
+* `Idle` on a row that *is* waiting → `TurnStopped { idle_confirmed: true }`,
+  the backstop for a hook stream that stopped arriving mid-wait.
+* Everything else → no events. `Working` in particular is left to the hooks,
+  which report it in milliseconds against a seconds-late screen tick.
+
+No `Heartbeat` is emitted (it would overwrite the row's hook-supplied `model`),
+and no synthetic row is minted — `Store::apply` evicts synthetic rows from a
+pane a real row owns, so one would flap in and out on every hook event. Such
+panes are also never added to the detector's `tracked` set: that set drives the
+stop-sweep, and a real row is not screen detection's to stop.
+
 ## Manifest sources
 
 1. **Bundled** — `agy`, `cursor`, `amp`, `copilot`, `aider`, `goose` ship in the
@@ -168,6 +196,8 @@ an unmatched screen just keeps the row's previous state.
 | copilot `❯ Yes` selection widget as `blocked` | **Low-medium** | The highlighted-row arrow is specific to an actual menu, not prose. |
 | Generic "do you want to allow/proceed/run", "approve this command", "permission to run" as `blocked` | **Low-medium** | Plausible phrasings; specific enough to avoid most prose, but not verified against each CLI's exact copy. |
 | goose "would like to call" / literal `Allow?` as `blocked` | **Low** | Speculative wording; `Allow?` requires the `?` affordance, not the bare word. |
+| agy's `Requesting permission for:` header as `blocked` | **High** | Captured verbatim from a live prompt; agy prints it above every permission request, whatever the choice rows look like. |
+| agy's `> N. Yes` / `> N. No` selection row as `blocked` | **High** | Requires the cursor marker AND the number, so a plain numbered list in tool output cannot match. |
 | agy's `Yes, and always allow` / `No, and always deny` choice rows as `blocked` | **High** | Verbatim strings from agy's permission widget; they exist nowhere else in its output. |
 | agy's `esc to cancel` footer + `Generating...`/`Running command...` as `working` | **High** | Captured from a live agy pane; the footer holds for the whole turn. |
 | bare `^> $` as `idle` | **Medium** | Common prompt shape; may miss CLIs with a richer prompt (model name, token count). |

--- a/docs/SINKS.md
+++ b/docs/SINKS.md
@@ -20,7 +20,7 @@ required credentials.
 [oh-my-prompt](https://github.com/jiunbae/oh-my-prompt) (omp) is a small
 self-hostable service that stores prompts from coding-agent CLIs for
 search and analytics. muxa already watches the same three-adapter set
-(Claude Code, Codex, Gemini CLI), so the sink ships the prompts it's
+(Claude Code, Codex, Gemini CLI, Antigravity CLI), so the sink ships the prompts it's
 already capturing — omp owns history, muxa owns realtime. opencode
 integration is deferred — see the README's Agent support table for
 status.
@@ -38,8 +38,8 @@ record to your omp endpoint:
 | `prompt_length`  | yes          | UTF-8 char count                                            |
 | `word_count`     | yes          | whitespace-split                                            |
 | `token_estimate` | yes          | `prompt_length / 4` (matches omp's own heuristic)           |
-| `source`         | yes          | `claude-code` / `codex` / `gemini` / `opencode`             |
-| `cli_name`       | yes          | `claude` / `codex` / `gemini` / `opencode`                  |
+| `source`         | yes          | `claude-code` / `codex` / `gemini` / `antigravity` / `opencode` |
+| `cli_name`       | yes          | `claude` / `codex` / `gemini` / `agy` / `opencode`          |
 | `cli_version`    | yes          | muxa's own version (the CLI version isn't always reachable) |
 | `role`           | yes          | always `user` — muxa never sees response text               |
 | `session_id`     | yes          | agent-reported session id                                   |

--- a/docs/TIMELINE.ko.md
+++ b/docs/TIMELINE.ko.md
@@ -36,7 +36,7 @@ muxa timeline --since today --format json
 | `--session` | tmux session 이름, tmux session id, pane id. |
 | `--exclude-pane` | case-sensitive glob에 맞는 pane id를 제외합니다. 반복하거나 comma-separated로 줄 수 있습니다. |
 | `--exclude-session` | case-sensitive glob에 맞는 tmux session name/id를 제외합니다. 반복하거나 comma-separated로 줄 수 있습니다. |
-| `--agent` | `codex`, `claude-code`, `gemini-cli`, `opencode`, `unknown`. |
+| `--agent` | `codex`, `claude-code`, `gemini-cli`, `antigravity`(별칭 `agy`), `opencode`, `unknown`. |
 | `--view` | 기본값 `timeline`, 또는 terminal contribution-map summary인 `heatmap`. |
 | `--group-by` | 기본값 `session`, 또는 `kind`, `flat`. TUI 전용. |
 | `--sort` | 기본값 `latest`, 또는 `name`, `duration`, `working`, `waiting`, `error`, `human`, `foreground`. `dur`, `work`, `wait`, `err`, `tmux` alias도 지원. |

--- a/docs/TIMELINE.md
+++ b/docs/TIMELINE.md
@@ -35,7 +35,7 @@ The default overview is grouped by tmux session. Each session group can show:
 | `--session` | tmux session name, tmux session id, or pane id. |
 | `--exclude-pane` | Drop pane ids matching a case-sensitive glob. Repeat or comma-separate values. |
 | `--exclude-session` | Drop tmux session names or ids matching a case-sensitive glob. Repeat or comma-separate values. |
-| `--agent` | `codex`, `claude-code`, `gemini-cli`, `opencode`, `unknown`. |
+| `--agent` | `codex`, `claude-code`, `gemini-cli`, `antigravity` (alias `agy`), `opencode`, `unknown`. |
 | `--view` | `timeline` default, or `heatmap` for a terminal contribution-map summary. |
 | `--group-by` | `session` default, `kind`, or `flat`. TUI only. |
 | `--sort` | `latest` default, `name`, `duration`, `working`, `waiting`, `error`, `human`, or `foreground`. Also accepts aliases like `dur`, `work`, `wait`, `err`, and `tmux`. |


### PR DESCRIPTION
## Why

The Gemini CLI is EOL upstream; Google replaced it with the **Antigravity CLI (`agy`)**. Because agy keeps the `~/.gemini` directory and still runs Gemini models, muxa's existing Gemini support *looks* like it carries over. It doesn't — and every mismatch fails silently.

| | Gemini CLI (`gemini`) | Antigravity CLI (`agy`) |
| --- | --- | --- |
| Hook config | `hooks` key in `~/.gemini/settings.json` | its own `~/.gemini/config/hooks.json` |
| Events | `SessionStart`, `Before/AfterAgent`, `Before/AfterTool`, `Notification`, `SessionEnd` | `SessionStart`, `Pre/PostInvocation`, `Pre/PostToolUse`, `Stop` |
| Payload | snake_case, `session_id` | camelCase protojson, `conversationId` |

Confirmed against a live install: hooks written to `settings.json` make agy log `loaded 0 named hooks from 0 hooks.json file(s)` and carry on, and the Gemini adapter's required `session_id` would reject an agy payload outright. Meanwhile `pane_current_command` is `agy`, which `classify_command` didn't recognise — so agy panes weren't even discovered.

## What

`AgentKind::Antigravity` as a **separate kind, not a rename** — both CLIs still work and can be installed side by side.

- **Adapter** (`adapters/antigravity.rs`) covering all six events.
- **`muxa hook agy`** CLI handler.
- **Transcript reader** (`adapters/antigravity_transcript.rs`). No agy payload carries prompt or response text — they carry a `transcriptPath`. `PreInvocation` and `Stop` read it, mirroring what Claude Code's `Stop` hook already does here.
- **`muxa init --component agy-hooks`** writing `~/.gemini/config/hooks.json`, plus a matching `muxa doctor` check.
- **Bundled `agy` screen manifest**, which supplies the one state agy's hooks cannot — see below.
- Wired through everything else that enumerates agents: discovery, `muxa agent start --agent agy`, the watch spawn form, `muxa timeline`, MCP `muxa_start_agent` / `muxa_call_peer`, the dashboard kind filter, the herdr bridge, and the omp sink.

Docs: [`docs/ANTIGRAVITY.md`](docs/ANTIGRAVITY.md), plus updates to README (en/ko), INSTALL, SCREEN_DETECTION, SINKS, MCP, TIMELINE, HERDR, CONFIGURATION, ARCHITECTURE, DASHBOARD.

## Four findings that shaped the design

**1. `muxa hook agy` must be fail-open and byte-silent.**
agy reads a hook's **stdout as a verdict**. Empty stdout means "no opinion"; JSON without a valid `decision` blocks the call, and so does a non-zero exit. I hit this by accident during probing:

```
Encountered error in tool execution: tool call denied by pre-tool hook
```

So this handler writes zero bytes to stdout and exits `0` even on an unparseable payload, an unknown event flag, or a down daemon.

That guarantee was then being defeated from *outside* the handler: `main()` loads `config.toml` with `?` before dispatching, so one TOML typo made every hook exit non-zero and blocked every tool call in every agy session. `muxa hook …` now degrades to defaults and reports the parse error on stderr; every other subcommand still fails loudly. (Released 0.8.34 → `exit 1`; this branch → `exit 0`.)

**2. `invocationNum` is per-turn, not per-session.**
Captured across a two-turn session: turn one ran invocations `0,1,2,3`, turn two reset to `0,1`. So `PreInvocation` at `0` is the turn boundary and the only place a prompt is reported; later invocations emit a `Heartbeat` (which also refreshes `model` — agy stamps `modelName` on every payload, more than Codex or the Gemini CLI give us).

**3. Hook-authoritative precedence needed its first carve-out.**
agy fires no hook when it raises an approval prompt, so an agy row could not reach `WaitingInput` at all. And because `muxad` skips screen inference on any pane a live hook row owns, *installing* muxa's agy hooks actively removed the one signal the manifest could have given. Hooks-or-attention is the wrong trade for the single most important thing muxa reports.

New `AgentKind::hooks_report_attention()` keys the exception. Claude Code, Codex, the Gemini CLI and opencode all return `true` and are **completely unaffected**; agy returns `false`, and for those rows the detector contributes exactly one signal — applied to the **real** row:

| Screen says | Row is | Result |
| --- | --- | --- |
| `Blocked` | not waiting, not `Error` | → `WaitingInput` |
| `Idle` | waiting | → `Idle` (releases a stuck wait) |
| anything else | — | nothing |

Three exclusions, each a bug if reversed: no `Heartbeat` (it would overwrite the hook-supplied `model`), `Working` is left to the hooks (milliseconds vs a seconds-late tick), and **no synthetic row is minted** — `Store::apply` evicts synthetic rows from a pane a real row owns, so one would flap in and out on every hook event. Refined panes are also never `tracked`, since that set drives the stop-sweep and a real row isn't ours to stop.

**4. Seeing the real prompts fixed the manifest.**
agy's command prompt renders numbered `> 1. Yes` / `4. No` rows — the label-based patterns would have missed it had option 2 not happened to contain "always allow". Now anchored on `Requesting permission for:`, the header agy prints above every request whatever the rows look like, plus the cursor-marked numbered row.

## Testing

**End to end against agy 1.1.17**, isolated `muxad`, real tmux panes:

- Fresh session: `idle → working → idle`, with prompt, response, model, cwd, conversation id and tool events all landing on the row.
- Resumed session (`agy -c`, no `SessionStart` fires): lands on the **same** row via `conversationId`, prompts recovered from the transcript for both turns.
- Attention refinement, on both prompt shapes agy renders (numbered command prompt and file-creation prompt): `working → waiting_input → approve → idle`, with the hook-supplied model and response intact throughout.
- All four fail-open paths: valid payload, malformed JSON, daemon down, unknown event → `exit=0`, `0` bytes on stdout.
- `muxa init --component agy-hooks` → `muxa doctor` → `--uninstall` round-trip in an isolated `HOME`; `doctor` is silent when agy isn't installed and requires all six events when it is.
- `muxa agent start --agent agy` launches `agy --dangerously-skip-permissions`.

**Suite:** `cargo test --workspace --no-fail-fast` — everything green except `upgrade::tests::dry_run_renders_plan`, which asserts `systemctl --user restart muxad` and already fails on `main` under macOS. ~60 new unit tests. `cargo clippy --workspace --all-targets` introduces no new diagnostics versus `main` (`client_kind_from_arg` dead-code is pre-existing).

> Note for reviewers: `tests/e2e.rs` locates `muxad` at `target/debug/muxad`, so on a tree that has only ever been release-built it fails to spawn and takes 10 tests down with it. `cargo build -p muxad` first.

## Known gaps (agy-side, documented not worked around)

- **No session-end hook** — `Stop` is a turn boundary. agy rows are reaped by pane liveness, like Codex's.
- **`workspacePaths` is empty in print mode**, so `cwd` is absent for `agy -p`. A hook's own cwd is the `hooks.json` directory, so there's nothing to fall back to.
- **No rate-limit or cost signal.** `modelName` rides on every payload; the usage fields stay `None`.
- **agy caches hooks in a long-lived backend process** — editing `hooks.json` needs an agy restart to take effect. Called out in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
