### PR TITLE
feat(work): pipeline edges, spend confirmation, and a visible finish line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Work pipelines now have daemon-owned, generation-aware Run state.** The
+  selected pipeline, rendered desired aliases, dependency graph, Run
+  generation, and each alias's `pending`/`running`/`blocked`/`done`/`failed`
+  state persist in an owner-only store. `work done` is an atomic
+  alias-generation event, automatically reconciles newly-ready downstream
+  aliases, and rejects stale completions; restart/re-prompt invalidates the
+  affected downstream closure. `work list` and `watch` render this durable
+  state, including aliases that do not have panes yet. Local IPC protocol 5
+  advertises this contract as `pipeline_runs_v1`.
 - **Peer reply waits and idle wake delivery are event-driven.** Durable
   collaboration mutations now advance a retained mailbox revision that wakes
   every interested waiter. `muxa_wait_reply`, `muxa_call_peer(wait=true)`, and

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -3,7 +3,7 @@
 This document describes the wire protocol spoken between
 `muxa` (the CLI), third-party adapters, and `muxad` (the daemon).
 
-Current version: **`2`** (defined in `muxa-core/src/event.rs`).
+Current version: **`5`** (defined in `crates/muxa/src/event.rs`).
 
 ## Stability
 
@@ -82,6 +82,29 @@ Response:
 ```json
 { "ok": true, "protocol": 1, "agents": [ <Agent>, ... ] }
 ```
+
+#### Durable pipeline Runs (v5)
+
+The `pipeline_runs_v1` capability covers the daemon-owned Work pipeline
+state machine. A Run persists its logical Work identity, pipeline, rendered
+desired agents, monotonic generation, window binding, and each alias's
+`pending | running | blocked | done | failed` state.
+
+- `pipeline_runs` returns every durable Run.
+- `pipeline_register` upserts desired state and live-pane observations.
+- `pipeline_done` atomically accepts `identity`, `alias`, and that alias's
+  expected `generation`; stale events are rejected.
+- `pipeline_invalidate` generation-checks the target alias, advances the Run
+  generation, and clears completion for it and its transitive downstream
+  closure.
+- `pipeline_claim` atomically reserves dependency-ready aliases, preventing
+  concurrent reconcilers from launching duplicates.
+- `pipeline_report` records a claimed launch/re-prompt as `running`,
+  `blocked`, or `failed` and binds its pane/window.
+
+All mutations are committed to `pipeline-runs.json` before a successful
+response. The rendered prompts in this file are user content; the file and
+IPC socket are owner-only (`0600`).
 
 #### `fleet_snapshot`
 
@@ -694,3 +717,8 @@ is gone.
 - Added `AgentState::waiting_choice` — menu-style user block, distinct
   from `waiting_input`.
 - Added `NotificationLevel::needs_choice` — routes to `waiting_choice`.
+
+### v4 → v5 (2026-08-25)
+
+- Added generation-aware durable pipeline Run request variants and the
+  `pipeline_runs_v1` capability.

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Korean is selected automatically for a Korean locale, can be requested with
 | `muxa sync` | Backfill the registry by scanning active pane hosts. |
 | `muxa register --name X [--pid N]` | Surface an arbitrary background process (script, game, automation loop) as a pid-tracked row in `muxa status`. |
 | `muxa run --detach --name X -- <cmd>` | Run a command in a muxa-owned PTY; it also appears in `muxa status` as a task. |
+| `muxa work init` | Describe a work pipeline in your own words; an agent writes the `[ticket]`/`[[route]]`/`[pipeline.*]` config, validated and shown before anything is written. |
 | `muxa work up cal-1234 --body "..."` | Resolve the ticket, route it to a workspace, and create whichever pipeline agent panes are missing — delivering the request to the ones already running. Re-running converges; also `muxa_start_work` over MCP. See [docs/PIPELINE.md](docs/PIPELINE.md). |
 | `muxa work start muxa-onboarding --workspace muxa --agent codex ...` | Create/reuse workspace session `muxa`, create/reuse its work window, and add an agent pane. |
 | `muxa workspace list/show/close` | Inspect or explicitly close workspace/project sessions. |

--- a/crates/muxa-cli/src/agent_launch.rs
+++ b/crates/muxa-cli/src/agent_launch.rs
@@ -330,6 +330,7 @@ pub fn start(mut request: StartRequest) -> Result<StartResult> {
         work,
         created_workspace,
         created_work,
+        adopted_session,
     } = prepare_launch(&mut request)?;
     let prompt = request
         .prompt
@@ -369,6 +370,9 @@ pub fn start(mut request: StartRequest) -> Result<StartResult> {
         .transpose()?;
 
     let mark = (|| {
+        if let (Some(session), Some(workspace)) = (&adopted_session, workspace.as_deref()) {
+            crate::tmux_work::adopt_workspace(session, workspace)?;
+        }
         if created_workspace {
             crate::tmux_work::mark_workspace(
                 session
@@ -427,6 +431,9 @@ pub fn start(mut request: StartRequest) -> Result<StartResult> {
 
 struct PreparedLaunch {
     cwd: PathBuf,
+    /// Session muxa put this work into without having created it. It gets a
+    /// workspace identity, never the managed flag.
+    adopted_session: Option<String>,
     workspace: Option<String>,
     work: Option<String>,
     created_workspace: bool,
@@ -497,7 +504,15 @@ fn prepare_launch(request: &mut StartRequest) -> Result<PreparedLaunch> {
         }
     }
 
-    let created_workspace = workspace.is_some() && existing_workspace.is_none();
+    // A session already named after this workspace is this workspace. Making
+    // `callabo-2` beside it splits one workspace across two sessions, which
+    // is the opposite of what session=workspace means.
+    let adopted_session = match (&workspace, &existing_workspace) {
+        (Some(workspace), None) => crate::tmux_work::adoptable_session(workspace)?,
+        _ => None,
+    };
+    let created_workspace =
+        workspace.is_some() && existing_workspace.is_none() && adopted_session.is_none();
     let created_work = work.is_some() && existing_work.is_none();
     if let Some(existing) = &existing_work {
         request.placement = Placement::Pane;
@@ -506,6 +521,12 @@ fn prepare_launch(request: &mut StartRequest) -> Result<PreparedLaunch> {
     } else if let Some(existing) = &existing_workspace {
         request.placement = Placement::Window;
         request.target = Some(existing.session.clone());
+        request.name = Some(crate::tmux_work::window_name_for_work(
+            work.as_deref().expect("managed work has id"),
+        )?);
+    } else if let Some(session) = adopted_session.as_deref() {
+        request.placement = Placement::Window;
+        request.target = Some(session.to_string());
         request.name = Some(crate::tmux_work::window_name_for_work(
             work.as_deref().expect("managed work has id"),
         )?);
@@ -518,6 +539,7 @@ fn prepare_launch(request: &mut StartRequest) -> Result<PreparedLaunch> {
     resolve_placement_target(request, &cwd)?;
     Ok(PreparedLaunch {
         cwd,
+        adopted_session,
         workspace,
         work,
         created_workspace,

--- a/crates/muxa-cli/src/agent_launch.rs
+++ b/crates/muxa-cli/src/agent_launch.rs
@@ -214,6 +214,9 @@ pub struct StartRequest {
     pub role: Option<String>,
     pub task: Option<String>,
     pub alias: Option<String>,
+    /// Durable pipeline generation stamped on an aliased pane. A later
+    /// `work done` reads it back so an old pane cannot complete a new run.
+    pub generation: Option<u64>,
     pub direction: SplitDirection,
 }
 
@@ -231,6 +234,7 @@ impl From<&StartArgs> for StartRequest {
             role: args.role.clone(),
             task: args.task.clone(),
             alias: args.alias.clone(),
+            generation: None,
             direction: args.direction,
         }
     }
@@ -297,6 +301,7 @@ pub fn run_work_start(args: WorkStartArgs) -> Result<()> {
         role: args.role,
         task: args.task,
         alias: args.alias,
+        generation: None,
         direction: args.direction,
     })?;
     if json {
@@ -323,6 +328,7 @@ pub fn run_work_start(args: WorkStartArgs) -> Result<()> {
 /// Start one allowlisted agent in a detached tmux surface and return its exact
 /// pane id. The operation is synchronous and should be wrapped in
 /// `spawn_blocking` by async callers.
+#[allow(clippy::too_many_lines)] // launch, metadata stamping, and rollback form one physical transaction
 pub fn start(mut request: StartRequest) -> Result<StartResult> {
     let PreparedLaunch {
         cwd,
@@ -403,6 +409,7 @@ pub fn start(mut request: StartRequest) -> Result<StartResult> {
             request.role.as_deref(),
             request.task.as_deref(),
             request.alias.as_deref(),
+            request.generation,
         )
     })();
     if let Err(error) = mark {
@@ -759,6 +766,7 @@ mod tests {
             role: None,
             task: None,
             alias: None,
+            generation: None,
             direction: SplitDirection::Right,
         }
     }

--- a/crates/muxa-cli/src/attend.rs
+++ b/crates/muxa-cli/src/attend.rs
@@ -385,6 +385,8 @@ mod tests {
 
     fn pane(id: &str, session: &str, window: u32, idx: u32) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa-cli/src/attend.rs
+++ b/crates/muxa-cli/src/attend.rs
@@ -387,6 +387,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa-cli/src/dashboard_tui.rs
+++ b/crates/muxa-cli/src/dashboard_tui.rs
@@ -5185,6 +5185,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: pane_id.to_string(),
             session_id: String::new(),

--- a/crates/muxa-cli/src/dashboard_tui.rs
+++ b/crates/muxa-cli/src/dashboard_tui.rs
@@ -5183,6 +5183,8 @@ mod tests {
 
     fn fake_pane(pane_id: &str, session: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: pane_id.to_string(),
             session_id: String::new(),

--- a/crates/muxa-cli/src/fleet_watch.rs
+++ b/crates/muxa-cli/src/fleet_watch.rs
@@ -4117,6 +4117,7 @@ mod tests {
                 panes: vec![PaneInfo {
                     agent_role: None,
                     agent_alias: None,
+                    work_done: Vec::new(),
                     pane_id: "%1".into(),
                     session_id: "$1".into(),
                     session: "work".into(),

--- a/crates/muxa-cli/src/fleet_watch.rs
+++ b/crates/muxa-cli/src/fleet_watch.rs
@@ -4115,6 +4115,8 @@ mod tests {
                 observed_at: OffsetDateTime::now_utc(),
                 agents: Vec::new(),
                 panes: vec![PaneInfo {
+                    agent_role: None,
+                    agent_alias: None,
                     pane_id: "%1".into(),
                     session_id: "$1".into(),
                     session: "work".into(),

--- a/crates/muxa-cli/src/init/apply.rs
+++ b/crates/muxa-cli/src/init/apply.rs
@@ -240,7 +240,10 @@ fn ensure_parent(p: &Path) -> Result<()> {
     Ok(())
 }
 
-fn atomic_write(path: &Path, contents: &str) -> Result<()> {
+/// Replace a file's contents without a window where it is truncated,
+/// preserving its mode. Shared with `muxa work init`, which edits the same
+/// `config.toml` this module does.
+pub(crate) fn atomic_write(path: &Path, contents: &str) -> Result<()> {
     let permissions = match fs::metadata(path) {
         Ok(metadata) => Some(metadata.permissions()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -2650,6 +2650,7 @@ mod tests {
         muxa::tmux::PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -567,7 +567,7 @@ async fn run_work_cmd(
 ) -> Result<()> {
     match action {
         WorkCmd::Init(args) => work_init::run(args, cfg, config_path).await,
-        WorkCmd::Up(args) => work_up::run(args, cfg, Some(client)).await,
+        WorkCmd::Up(args) => work_up::run(args, cfg, config_path, Some(client)).await,
         WorkCmd::Start(args) => agent_launch::run_work_start(args),
         WorkCmd::List(args) => tmux_work::run_work_list(args),
         WorkCmd::Show(args) => tmux_work::run_work_show(args),

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -2648,6 +2648,8 @@ mod tests {
 
     fn pane(id: &str, session: &str) -> muxa::tmux::PaneInfo {
         muxa::tmux::PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -408,6 +408,9 @@ enum WorkCmd {
     List(tmux_work::WorkListArgs),
     /// Show one work window and its agent panes.
     Show(tmux_work::WorkShowArgs),
+    /// Report that this agent finished its part of the work, which opens
+    /// any `after` edge waiting on it. Run it from the agent's own pane.
+    Done(tmux_work::WorkDoneArgs),
     /// Close a work window and every agent pane in it.
     Close(tmux_work::WorkCloseArgs),
     /// Counterpart to `up`: close the work window and every agent in it.
@@ -571,6 +574,7 @@ async fn run_work_cmd(
         WorkCmd::Start(args) => agent_launch::run_work_start(args),
         WorkCmd::List(args) => tmux_work::run_work_list(args),
         WorkCmd::Show(args) => tmux_work::run_work_show(args),
+        WorkCmd::Done(args) => tmux_work::run_work_done(args),
         WorkCmd::Close(args) | WorkCmd::Down(args) => tmux_work::run_work_close(args),
     }
 }

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -21,6 +21,7 @@ mod timeline;
 mod tmux_work;
 mod upgrade;
 mod watch;
+mod work_init;
 mod work_up;
 
 use anyhow::{Context, Result};
@@ -393,6 +394,10 @@ enum WindowCmd {
 
 #[derive(Debug, Subcommand)]
 enum WorkCmd {
+    /// Describe a work pipeline in your own words and let an agent write
+    /// the `[ticket]`/`[[route]]`/`[pipeline.*]` config for you. Validated
+    /// and shown before anything is written.
+    Init(work_init::InitArgs),
     /// Converge a Work's current Run to its pipeline: optionally link an
     /// external issue, route the Work, and create missing agent sessions.
     /// Re-running converges instead of duplicating.
@@ -554,8 +559,9 @@ fn run_window_cmd(action: WindowCmd) -> Result<()> {
     }
 }
 
-async fn run_work_cmd(action: WorkCmd, cfg: &Config) -> Result<()> {
+async fn run_work_cmd(action: WorkCmd, cfg: &Config, config_path: Option<PathBuf>) -> Result<()> {
     match action {
+        WorkCmd::Init(args) => work_init::run(args, cfg, config_path).await,
         WorkCmd::Up(args) => work_up::run(args, cfg).await,
         WorkCmd::Start(args) => agent_launch::run_work_start(args),
         WorkCmd::List(args) => tmux_work::run_work_list(args),
@@ -637,7 +643,7 @@ async fn main() -> Result<()> {
         Cmd::Fleet(a) => fleet_cli::run_fleet(a, &client, &cfg, config_path.as_deref()).await,
         Cmd::Agent { action } => run_agent_cmd(action),
         Cmd::Window { action } => run_window_cmd(action),
-        Cmd::Work { action } => run_work_cmd(action, &cfg).await,
+        Cmd::Work { action } => run_work_cmd(action, &cfg, config_path).await,
         Cmd::Workspace { action } => run_workspace_cmd(action),
         Cmd::Identity { action } => cmd_identity(&client, action).await,
         Cmd::Stats(stats_args) => stats::run(&client, &cfg, stats_args).await,

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -559,10 +559,15 @@ fn run_window_cmd(action: WindowCmd) -> Result<()> {
     }
 }
 
-async fn run_work_cmd(action: WorkCmd, cfg: &Config, config_path: Option<PathBuf>) -> Result<()> {
+async fn run_work_cmd(
+    action: WorkCmd,
+    cfg: &Config,
+    config_path: Option<PathBuf>,
+    client: &Client,
+) -> Result<()> {
     match action {
         WorkCmd::Init(args) => work_init::run(args, cfg, config_path).await,
-        WorkCmd::Up(args) => work_up::run(args, cfg).await,
+        WorkCmd::Up(args) => work_up::run(args, cfg, Some(client)).await,
         WorkCmd::Start(args) => agent_launch::run_work_start(args),
         WorkCmd::List(args) => tmux_work::run_work_list(args),
         WorkCmd::Show(args) => tmux_work::run_work_show(args),
@@ -643,7 +648,7 @@ async fn main() -> Result<()> {
         Cmd::Fleet(a) => fleet_cli::run_fleet(a, &client, &cfg, config_path.as_deref()).await,
         Cmd::Agent { action } => run_agent_cmd(action),
         Cmd::Window { action } => run_window_cmd(action),
-        Cmd::Work { action } => run_work_cmd(action, &cfg, config_path).await,
+        Cmd::Work { action } => run_work_cmd(action, &cfg, config_path, &client).await,
         Cmd::Workspace { action } => run_workspace_cmd(action),
         Cmd::Identity { action } => cmd_identity(&client, action).await,
         Cmd::Stats(stats_args) => stats::run(&client, &cfg, stats_args).await,

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -411,6 +411,9 @@ enum WorkCmd {
     /// Report that this agent finished its part of the work, which opens
     /// any `after` edge waiting on it. Run it from the agent's own pane.
     Done(tmux_work::WorkDoneArgs),
+    /// Internal daemon callback: launch dependency-ready durable aliases.
+    #[command(hide = true)]
+    Reconcile(work_up::ReconcileArgs),
     /// Close a work window and every agent pane in it.
     Close(tmux_work::WorkCloseArgs),
     /// Counterpart to `up`: close the work window and every agent in it.
@@ -572,9 +575,10 @@ async fn run_work_cmd(
         WorkCmd::Init(args) => work_init::run(args, cfg, config_path).await,
         WorkCmd::Up(args) => work_up::run(args, cfg, config_path, Some(client)).await,
         WorkCmd::Start(args) => agent_launch::run_work_start(args),
-        WorkCmd::List(args) => tmux_work::run_work_list(args),
+        WorkCmd::List(args) => tmux_work::run_work_list(args, client).await,
         WorkCmd::Show(args) => tmux_work::run_work_show(args),
-        WorkCmd::Done(args) => tmux_work::run_work_done(args),
+        WorkCmd::Done(args) => tmux_work::run_work_done(args, client).await,
+        WorkCmd::Reconcile(args) => work_up::run_reconcile(args, client).await,
         WorkCmd::Close(args) | WorkCmd::Down(args) => tmux_work::run_work_close(args),
     }
 }

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -1545,7 +1545,7 @@ async fn start_work(client: &Client, args: &Value, config: &muxa::config::Config
         context: text("context"),
         dry_run: flag("dry_run"),
         show_prompts: false,
-        graph: false,
+        yes: true,
         no_ticket: flag("no_ticket"),
         refresh: flag("refresh"),
         json: true,

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -1056,7 +1056,7 @@ async fn call_tool(
             })
         }
         "muxa_call_peer" => Ok(call_peer(client, &args, &config.message.skills).await),
-        "muxa_start_work" => Ok(start_work(&args, config).await),
+        "muxa_start_work" => Ok(start_work(client, &args, config).await),
         "muxa_peer_report" => Ok(peer_report(client, &args).await),
         "muxa_set_identity" => {
             let alias = args.get("alias").and_then(Value::as_str);
@@ -1522,7 +1522,7 @@ fn peer_call_contract(args: &Value) -> std::result::Result<(RequestKind, WorkMod
 /// Resolution is async (it may spend a headless agent turn looking the
 /// ticket up); everything after it shells out to tmux and is therefore
 /// handed to `spawn_blocking` rather than run on the reactor.
-async fn start_work(args: &Value, config: &muxa::config::Config) -> Value {
+async fn start_work(client: &Client, args: &Value, config: &muxa::config::Config) -> Value {
     let text = |key: &str| {
         args.get(key)
             .and_then(Value::as_str)
@@ -1544,11 +1544,12 @@ async fn start_work(args: &Value, config: &muxa::config::Config) -> Value {
         skill: text("skill"),
         context: text("context"),
         dry_run: flag("dry_run"),
+        show_prompts: false,
         no_ticket: flag("no_ticket"),
         refresh: flag("refresh"),
         json: true,
     };
-    let resolved = match crate::work_up::resolve(&up, config).await {
+    let resolved = match crate::work_up::resolve(&up, config, Some(client)).await {
         Ok(resolved) => resolved,
         Err(error) => return error_result(&format!("{error:#}")),
     };

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -1545,6 +1545,7 @@ async fn start_work(client: &Client, args: &Value, config: &muxa::config::Config
         context: text("context"),
         dry_run: flag("dry_run"),
         show_prompts: false,
+        graph: false,
         no_ticket: flag("no_ticket"),
         refresh: flag("refresh"),
         json: true,

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -2627,6 +2627,9 @@ mod tests {
 
     fn registration_pane(pane_id: &str, pane_index: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
+            work_done: Vec::new(),
             pane_id: pane_id.into(),
             session_id: "$1".into(),
             session: "registration".into(),

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -893,6 +893,7 @@ async fn call_tool(
                     .and_then(Value::as_str)
                     .map(str::to_string),
                 task: args.get("task").and_then(Value::as_str).map(str::to_string),
+                generation: None,
                 direction,
             };
             Ok(
@@ -1554,13 +1555,25 @@ async fn start_work(client: &Client, args: &Value, config: &muxa::config::Config
         Ok(resolved) => resolved,
         Err(error) => return error_result(&format!("{error:#}")),
     };
-    let dry_run = up.dry_run;
-    let result =
-        match tokio::task::spawn_blocking(move || crate::work_up::apply(resolved, dry_run)).await {
+    let result = if up.dry_run {
+        match tokio::task::spawn_blocking(move || crate::work_up::apply(resolved, true)).await {
             Ok(Ok(result)) => result,
             Ok(Err(error)) => return error_result(&format!("{error:#}")),
             Err(error) => return error_result(&format!("muxa_start_work worker failed: {error}")),
-        };
+        }
+    } else {
+        let runtime = tokio::runtime::Handle::current();
+        let client = client.clone();
+        match tokio::task::spawn_blocking(move || {
+            runtime.block_on(crate::work_up::apply_durable(resolved, &client))
+        })
+        .await
+        {
+            Ok(Ok(result)) => result,
+            Ok(Err(error)) => return error_result(&format!("{error:#}")),
+            Err(error) => return error_result(&format!("muxa_start_work worker failed: {error}")),
+        }
+    };
     match serde_json::to_value(&result) {
         Ok(value) => json_result(&value),
         Err(error) => error_result(&format!("muxa_start_work could not serialize: {error}")),
@@ -1828,6 +1841,7 @@ async fn spawn_peer(
         // unaliased and `muxa work up` reports it as unclaimed rather than
         // mistaking it for a role it should own.
         alias: None,
+        generation: None,
         direction: crate::agent_launch::SplitDirection::Right,
     };
     // Arm the daemon transition subscription before creating the pane. A

--- a/crates/muxa-cli/src/onboarding.rs
+++ b/crates/muxa-cli/src/onboarding.rs
@@ -2016,7 +2016,7 @@ mod tests {
         assert!(shortcuts.contains("m / M"));
         assert!(shortcuts.contains("a / A"));
         assert!(shortcuts.contains("Alt-K"));
-        assert!(shortcuts.contains("n              new window or sibling agent pane"));
+        assert!(shortcuts.contains("n / w          new window or agent pane / work up a pipeline"));
     }
 
     #[test]

--- a/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_help_overlay.snap
+++ b/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_help_overlay.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/muxa-cli/src/watch.rs
+assertion_line: 24495
 expression: "snapshot_helpers::buffer_string(&terminal)"
 ---
  muxa watch   1 agent  + 0 panes   sort PANE ID   <clock>
@@ -15,7 +16,7 @@ j/k move  ·  type or / filter  ·  : commands  ·  ? help
 │                           │  gg/G · Home/End first / last selectable row                                     │                           │
 │                           │  PgUp/PgDn       page; Ctrl-U/Ctrl-D half page                                   │                           │
 │                           │  Enter          attach via active window/pane or exact pane                      │                           │
-│                           │  n              new window or sibling agent pane                                 │                           │
+│                           │  n / w          new window or agent pane / work up a pipeline                    │                           │
 │                           │  a / A          ask / history; d deletes one · D clears all in A                 │                           │
 │                           │                                                                                  │                           │
 │                           │Commands & inspection                                                             │                           │

--- a/crates/muxa-cli/src/tmux_work.rs
+++ b/crates/muxa-cli/src/tmux_work.rs
@@ -107,6 +107,13 @@ pub struct ExternalItemInfo {
 pub struct WorkspaceInfo {
     pub workspace: String,
     pub session: String,
+    /// Whether muxa created this session, as opposed to adopting one the
+    /// operator already had.
+    ///
+    /// Identity and ownership are different facts. A session muxa adopted
+    /// carries a workspace id so its work windows are findable, but muxa
+    /// must never close it: it is full of windows muxa did not open.
+    pub managed: bool,
     pub cwd: PathBuf,
     pub attached_clients: u32,
     pub windows: u32,
@@ -673,6 +680,21 @@ pub fn list_workspaces() -> Result<Vec<WorkspaceInfo>> {
     Ok(parse_workspaces(&sessions, &windows, &panes))
 }
 
+/// A session muxa may put this workspace's work windows into without
+/// having created it: one already named after the workspace.
+///
+/// Refusing to adopt splits a workspace across `callabo` and `callabo-2`,
+/// which contradicts the whole model — one session is one workspace. The
+/// safety that mattered was never "do not touch it"; it is that
+/// `close_workspace` refuses a session muxa did not create.
+pub fn adoptable_session(workspace: &str) -> Result<Option<String>> {
+    let normalized = normalize_workspace_id(workspace)?;
+    let wanted = sanitize_session_name(&normalized.to_ascii_lowercase());
+    Ok(all_session_names()?
+        .into_iter()
+        .find(|name| name == &wanted))
+}
+
 pub fn session_name_for_workspace(workspace: &str) -> Result<String> {
     let normalized = normalize_workspace_id(workspace)?;
     let base = sanitize_session_name(&normalized.to_ascii_lowercase());
@@ -793,6 +815,21 @@ fn set_window_automatic_rename(window: &str, enabled: bool) -> Result<()> {
         window,
         "automatic-rename",
         if enabled { "on" } else { "off" },
+    )
+}
+
+/// Give an adopted session a workspace identity without claiming it.
+///
+/// Deliberately does not set `@muxa_managed_workspace`: that flag is what
+/// `close_workspace` reads, and muxa must not offer to kill a session full
+/// of windows somebody else opened.
+pub fn adopt_workspace(session: &str, workspace: &str) -> Result<()> {
+    let workspace = normalize_workspace_id(workspace)?;
+    set_option(
+        OptionScope::Session,
+        session,
+        WORKSPACE_ID_OPTION,
+        &workspace,
     )
 }
 
@@ -1049,6 +1086,13 @@ fn close_workspace(raw: &str, confirm: bool) -> Result<ManageResult> {
     }
     let workspace = find_workspace(raw)?
         .ok_or_else(|| anyhow::anyhow!("managed workspace {raw:?} not found"))?;
+    if !workspace.managed {
+        bail!(
+            "workspace {raw:?} lives in session {:?}, which muxa adopted rather than created; \
+             close its work windows instead, or kill the session yourself",
+            workspace.session
+        );
+    }
     tmux_status(&["kill-session", "-t", &format!("={}", workspace.session)])?;
     Ok(ManageResult::WorkspaceClosed {
         workspace: workspace.workspace,
@@ -1117,7 +1161,9 @@ fn parse_workspaces(sessions: &str, windows: &str, panes: &str) -> Vec<Workspace
     let mut workspaces = Vec::new();
     for line in sessions.lines() {
         let fields: Vec<&str> = line.split('\t').collect();
-        if fields.len() < 7 || fields[2].trim().is_empty() || fields[4] != "1" {
+        // A workspace id is enough to be findable; `managed` decides what
+        // muxa may do to the session, not whether it can see it.
+        if fields.len() < 7 || fields[2].trim().is_empty() {
             continue;
         }
         let session = fields[0].to_string();
@@ -1131,6 +1177,7 @@ fn parse_workspaces(sessions: &str, windows: &str, panes: &str) -> Vec<Workspace
         workspaces.push(WorkspaceInfo {
             workspace,
             session,
+            managed: fields[4] == "1",
             cwd: PathBuf::from(fields[3]),
             attached_clients: fields[5].parse().unwrap_or(0),
             windows: fields[6].parse().unwrap_or(0),
@@ -1571,6 +1618,26 @@ mod tests {
             external_option_value(Some("  Needs\n review  "), 32),
             "Needs review"
         );
+    }
+
+    #[test]
+    fn an_adopted_session_is_findable_but_not_closable() {
+        // Identity and ownership are separate facts. muxa must be able to
+        // find work in a session it adopted, and must never offer to kill
+        // it — it is full of windows muxa did not open.
+        let sessions = "callabo\t$1\tcallabo\t/repo\t\t1\t3\n\
+                        owned\t$2\towned\t/repo\t1\t1\t1\n";
+        let workspaces = parse_workspaces(sessions, "", "");
+        let adopted = workspaces
+            .iter()
+            .find(|w| w.workspace == "callabo")
+            .expect("an adopted session is still visible");
+        assert!(!adopted.managed, "adoption must not claim ownership");
+        let owned = workspaces
+            .iter()
+            .find(|w| w.workspace == "owned")
+            .expect("a created session is visible too");
+        assert!(owned.managed);
     }
 
     #[test]

--- a/crates/muxa-cli/src/tmux_work.rs
+++ b/crates/muxa-cli/src/tmux_work.rs
@@ -35,13 +35,20 @@ const PANE_WORK_OPTION: &str = "@muxa_agent_work_id";
 const EXTERNAL_SOURCE_OPTION: &str = "@muxa_external_source";
 const EXTERNAL_SCOPE_OPTION: &str = "@muxa_external_scope";
 const EXTERNAL_STABLE_ID_OPTION: &str = "@muxa_external_stable_id";
+/// Comma-separated pipeline aliases that have reported finishing.
+///
+/// On the window rather than the pane: an agent that has finished may well
+/// have exited, and the fact that it finished has to outlive it. This is
+/// the only completion signal muxa has — agent state cannot supply one,
+/// because `idle` means both "done" and "paused mid-thought".
+const WORK_DONE_OPTION: &str = "@muxa_work_done";
 const EXTERNAL_KEY_OPTION: &str = "@muxa_external_key";
 const EXTERNAL_TITLE_OPTION: &str = "@muxa_external_title";
 const EXTERNAL_URL_OPTION: &str = "@muxa_external_url";
 const EXTERNAL_STATUS_OPTION: &str = "@muxa_external_status";
 
 const SESSION_FORMAT: &str = "#{session_name}\t#{session_id}\t#{@muxa_workspace_id}\t#{@muxa_workspace_cwd}\t#{@muxa_managed_workspace}\t#{session_attached}\t#{session_windows}";
-const WINDOW_FORMAT: &str = "#{session_name}\t#{session_id}\t#{window_id}\t#{window_index}\t#{window_name}\t#{@muxa_work_id}\t#{@muxa_work_cwd}\t#{@muxa_managed_work}\t#{@muxa_external_source}\t#{@muxa_external_scope}\t#{@muxa_external_stable_id}\t#{@muxa_external_key}\t#{@muxa_external_title}\t#{@muxa_external_url}\t#{@muxa_external_status}";
+const WINDOW_FORMAT: &str = "#{session_name}\t#{session_id}\t#{window_id}\t#{window_index}\t#{window_name}\t#{@muxa_work_id}\t#{@muxa_work_cwd}\t#{@muxa_managed_work}\t#{@muxa_external_source}\t#{@muxa_external_scope}\t#{@muxa_external_stable_id}\t#{@muxa_external_key}\t#{@muxa_external_title}\t#{@muxa_external_url}\t#{@muxa_external_status}\t#{@muxa_work_done}";
 const PANE_FORMAT: &str = "#{session_name}\t#{window_id}\t#{pane_id}\t#{@muxa_agent}\t#{@muxa_agent_role}\t#{@muxa_agent_task}\t#{pane_current_command}\t#{pane_current_path}\t#{@muxa_managed_agent}\t#{@muxa_agent_workspace_id}\t#{@muxa_agent_work_id}\t#{@muxa_agent_alias}";
 const WINDOW_IDENTITY_FORMAT: &str =
     "#{window_id}\t#{session_id}\t#{session_name}\t#{window_name}\t#{automatic-rename}";
@@ -74,6 +81,9 @@ pub struct WorkInfo {
     pub cwd: PathBuf,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_item: Option<Box<ExternalItemInfo>>,
+    /// Pipeline aliases that reported finishing, in the order recorded.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub done: Vec<String>,
     pub agents: Vec<ManagedAgentPane>,
 }
 
@@ -229,6 +239,24 @@ pub struct WindowRenameArgs {
 }
 
 #[derive(Debug, clap::Args)]
+pub struct WorkDoneArgs {
+    /// Pipeline alias reporting done. Defaults to the alias recorded on
+    /// the calling pane, so an agent can just run `muxa work done`.
+    #[arg(long)]
+    pub alias: Option<String>,
+    /// tmux pane to read the alias and work from. Defaults to `TMUX_PANE`.
+    #[arg(long)]
+    pub pane: Option<String>,
+    /// Take the report back, so the next `muxa work up` holds dependants
+    /// again.
+    #[arg(long)]
+    pub undo: bool,
+    /// Emit JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, clap::Args)]
 pub struct WorkListArgs {
     /// Limit work windows to one managed workspace.
     #[arg(long)]
@@ -323,6 +351,50 @@ pub fn run_window_rename(args: WindowRenameArgs) -> Result<()> {
         );
     }
     Ok(())
+}
+
+/// Report that this agent has finished its part, which is what opens an
+/// `after` edge for whatever waits on it.
+///
+/// muxa cannot observe "done" any other way: agent state says `idle` both
+/// when an agent has finished and when it is between thoughts, and a pane
+/// stays open either way. So the agent says so, and muxa records the claim
+/// rather than inferring one.
+pub fn run_work_done(args: WorkDoneArgs) -> Result<()> {
+    let pane = args
+        .pane
+        .clone()
+        .or_else(|| std::env::var("TMUX_PANE").ok())
+        .filter(|pane| !pane.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("no pane to read; run inside tmux or pass --pane"))?;
+    validate_pane_id(&pane)?;
+    let alias = match args.alias.clone() {
+        Some(alias) => alias,
+        None => pane_option(&pane, AGENT_ALIAS_OPTION)?
+            .ok_or_else(|| anyhow::anyhow!("pane {pane} has no pipeline alias; pass --alias"))?,
+    };
+    let window = window_id_for_pane(&pane)?;
+    let done = mark_done(&window, &alias, !args.undo)?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "window": window,
+                "alias": alias,
+                "done": done,
+            }))?
+        );
+    } else if args.undo {
+        println!("{alias} is no longer reported done");
+    } else {
+        println!("{alias} reported done ({})", done.join(", "));
+    }
+    Ok(())
+}
+
+fn pane_option(pane: &str, key: &str) -> Result<Option<String>> {
+    let raw = tmux_output(&["display-message", "-p", "-t", pane, &format!("#{{{key}}}")])?;
+    Ok(option(raw.trim()))
 }
 
 pub fn run_work_list(args: WorkListArgs) -> Result<()> {
@@ -873,6 +945,44 @@ fn stage_suffix(work: &WorkInfo, records: &[WorkRecord]) -> String {
         .map_or_else(String::new, |stage| format!("  stage={}", stage.label()))
 }
 
+fn parse_done(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|alias| !alias.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect()
+}
+
+/// Record that `alias` has finished its part of this work, or take it back.
+///
+/// Idempotent: a second report is not an error, because an agent re-reading
+/// its own instructions and reporting twice is likelier than a bug.
+pub fn mark_done(window: &str, alias: &str, done: bool) -> Result<Vec<String>> {
+    let alias = metadata(alias, 64)?.to_ascii_lowercase();
+    let current = tmux_output(&[
+        "display-message",
+        "-p",
+        "-t",
+        window,
+        &format!("#{{{WORK_DONE_OPTION}}}"),
+    ])?;
+    let mut aliases = parse_done(current.trim());
+    if done {
+        if !aliases.iter().any(|existing| existing == &alias) {
+            aliases.push(alias);
+        }
+    } else {
+        aliases.retain(|existing| existing != &alias);
+    }
+    set_option(
+        OptionScope::Window,
+        window,
+        WORK_DONE_OPTION,
+        &aliases.join(","),
+    )?;
+    Ok(aliases)
+}
+
 pub fn window_id_for_pane(pane: &str) -> Result<String> {
     validate_pane_id(pane)?;
     let window = tmux_output(&["display-message", "-p", "-t", pane, "#{window_id}"])?;
@@ -1061,6 +1171,7 @@ fn parse_work_window(
         window_name: fields[4].to_string(),
         cwd: PathBuf::from(fields[6]),
         external_item: parse_external_item(&fields),
+        done: parse_done(fields.get(15).copied().unwrap_or_default()),
         agents,
     })
 }
@@ -1408,6 +1519,7 @@ mod tests {
             window_name: work.into(),
             cwd: PathBuf::from("/work"),
             external_item: None,
+            done: Vec::new(),
             agents: Vec::new(),
         }
     }

--- a/crates/muxa-cli/src/tmux_work.rs
+++ b/crates/muxa-cli/src/tmux_work.rs
@@ -8,6 +8,7 @@
 //! Identity is stored in tmux user options so it survives muxad and MCP
 //! process restarts without adding another database.
 
+use crate::theme::TableTone;
 use anyhow::{bail, Context, Result};
 use clap::ValueEnum;
 use muxa::work::{WorkRecord, WorkStage};
@@ -416,21 +417,151 @@ pub fn run_work_list(args: WorkListArgs) -> Result<()> {
     } else if works.is_empty() {
         println!("no muxa-managed work windows");
     } else {
-        let records = work_annotations();
-        for work in works {
-            println!(
-                "{}  workspace={}  session={}  window={}  agents={}  cwd={}{}",
-                work.work,
-                work.workspace,
-                work.session,
-                work.window,
-                work.agents.len(),
-                work.cwd.display(),
-                stage_suffix(&work, &records)
-            );
-        }
+        let theme = crate::theme::for_theme(
+            muxa::config::Config::load_or_default(None)
+                .map(|cfg| cfg.ui.theme)
+                .unwrap_or_default(),
+            crate::use_colors(),
+        );
+        print!("{}", work_list_table(&works, &work_annotations(), theme));
     }
     Ok(())
+}
+
+/// Render the work table.
+///
+/// Pure on its inputs so the layout is testable without a tmux server; the
+/// caller supplies the works, their annotations, and the theme.
+fn work_list_table(
+    works: &[WorkInfo],
+    records: &[WorkRecord],
+    theme: crate::theme::CliTheme,
+) -> String {
+    use comfy_table::{ContentArrangement, Table};
+
+    let staged: Vec<Option<String>> = works
+        .iter()
+        .map(|work| {
+            stage_for(work, records)
+                .filter(|stage| *stage != WorkStage::Auto)
+                .map(|stage| stage.label().to_string())
+        })
+        .collect();
+    // The column only earns its width when something is actually staged.
+    let show_stage = staged.iter().any(Option::is_some);
+
+    let mut header = vec!["WORK", "WORKSPACE", "AGENTS", "DONE"];
+    if show_stage {
+        header.push("STAGE");
+    }
+    header.push("CWD");
+
+    let mut table = Table::new();
+    table
+        .load_preset(comfy_table::presets::UTF8_BORDERS_ONLY)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(
+            header
+                .into_iter()
+                .map(|label| theme.cell(label, TableTone::Header))
+                .collect::<Vec<_>>(),
+        );
+
+    for (work, stage) in works.iter().zip(&staged) {
+        let (done, total) = done_ratio(work);
+        let mut row = vec![
+            theme.cell(&work.work, TableTone::Accent),
+            theme.cell(&work.workspace, TableTone::Dim),
+            theme.cell(agent_summary(work), TableTone::Tmux),
+            match total {
+                // Not a pipeline: nothing ever reports, so a ratio would
+                // read as "0 of 1 finished" for work that is simply running.
+                0 => theme.right_cell("-", TableTone::Dim),
+                total if done == total => {
+                    theme.right_cell(format!("{done}/{total}"), TableTone::Good)
+                }
+                total => theme.right_cell(format!("{done}/{total}"), TableTone::Warn),
+            },
+        ];
+        if show_stage {
+            row.push(theme.cell(stage.as_deref().unwrap_or("-"), TableTone::Dim));
+        }
+        row.push(theme.cell(shorten_home(&work.cwd), TableTone::Dim));
+        table.add_row(row);
+    }
+    format!("{table}\n")
+}
+
+/// How many of this work's pipeline agents have reported finishing.
+///
+/// Counted over *aliased* panes only: `done` records aliases, so a pane the
+/// operator opened by hand could never be in it and must not inflate the
+/// denominator.
+fn done_ratio(work: &WorkInfo) -> (usize, usize) {
+    let aliases: Vec<&str> = work
+        .agents
+        .iter()
+        .filter_map(|agent| agent.alias.as_deref())
+        .collect();
+    let done = aliases
+        .iter()
+        .filter(|alias| {
+            work.done
+                .iter()
+                .any(|reported| reported.eq_ignore_ascii_case(alias))
+        })
+        .count();
+    (done, aliases.len())
+}
+
+/// Who is in the window: pipeline aliases when it has them, otherwise the
+/// agent programs, collapsed so three claudes read as `claude x3` rather than
+/// as a list.
+fn agent_summary(work: &WorkInfo) -> String {
+    let aliases: Vec<&str> = work
+        .agents
+        .iter()
+        .filter_map(|agent| agent.alias.as_deref())
+        .collect();
+    if !aliases.is_empty() {
+        return aliases.join(" \u{b7} ");
+    }
+    let mut counts: Vec<(&str, usize)> = Vec::new();
+    for agent in &work.agents {
+        match counts.iter_mut().find(|(name, _)| *name == agent.agent) {
+            Some((_, count)) => *count += 1,
+            None => counts.push((agent.agent.as_str(), 1)),
+        }
+    }
+    counts
+        .into_iter()
+        .map(|(name, count)| {
+            if count > 1 {
+                format!("{name} x{count}")
+            } else {
+                name.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" \u{b7} ")
+}
+
+/// `/home/june/x` -> `~/x`, so the column spends its width on the part that
+/// differs between rows.
+fn shorten_home(path: &Path) -> String {
+    let Some(home) = dirs::home_dir() else {
+        return path.display().to_string();
+    };
+    path.strip_prefix(&home).map_or_else(
+        |_| path.display().to_string(),
+        |rest| {
+            if rest.as_os_str().is_empty() {
+                "~".to_string()
+            } else {
+                format!("~/{}", rest.display())
+            }
+        },
+    )
 }
 
 pub fn run_work_show(args: WorkShowArgs) -> Result<()> {
@@ -980,6 +1111,119 @@ fn stage_suffix(work: &WorkInfo, records: &[WorkRecord]) -> String {
     stage_for(work, records)
         .filter(|stage| *stage != WorkStage::Auto)
         .map_or_else(String::new, |stage| format!("  stage={}", stage.label()))
+}
+
+#[cfg(test)]
+mod work_list_view_tests {
+    use super::*;
+
+    fn agent(pane: &str, program: &str, alias: Option<&str>) -> ManagedAgentPane {
+        ManagedAgentPane {
+            pane: pane.into(),
+            agent: program.into(),
+            alias: alias.map(Into::into),
+            role: None,
+            task: None,
+            command: program.into(),
+            cwd: PathBuf::from("/repo"),
+        }
+    }
+
+    fn work(name: &str, agents: Vec<ManagedAgentPane>, done: &[&str]) -> WorkInfo {
+        WorkInfo {
+            work: name.into(),
+            workspace: "callabo".into(),
+            session: "callabo".into(),
+            session_id: "$1".into(),
+            window: "@1".into(),
+            window_index: 0,
+            window_name: name.into(),
+            cwd: PathBuf::from("/repo"),
+            external_item: None,
+            done: done.iter().map(|d| (*d).to_string()).collect(),
+            agents,
+        }
+    }
+
+    /// `done` records aliases, so only aliased panes can ever be in it. A pane
+    /// the operator split by hand must not inflate the denominator and make a
+    /// converged pipeline read as unfinished.
+    #[test]
+    fn done_counts_only_pipeline_agents() {
+        let piped = work(
+            "CAL-1",
+            vec![
+                agent("%1", "claude", Some("impl")),
+                agent("%2", "codex", Some("review")),
+                agent("%3", "codex", None),
+            ],
+            &["impl", "review"],
+        );
+        assert_eq!(done_ratio(&piped), (2, 2));
+
+        let partial = work(
+            "CAL-2",
+            vec![
+                agent("%1", "claude", Some("impl")),
+                agent("%2", "codex", Some("review")),
+            ],
+            &["impl"],
+        );
+        assert_eq!(done_ratio(&partial), (1, 2));
+
+        // Hand-built window: no aliases at all, so there is no ratio to show.
+        let manual = work("ad-hoc", vec![agent("%1", "claude", None)], &[]);
+        assert_eq!(done_ratio(&manual), (0, 0));
+    }
+
+    #[test]
+    fn agents_read_as_aliases_or_collapsed_programs() {
+        let piped = work(
+            "CAL-1",
+            vec![
+                agent("%1", "claude", Some("impl")),
+                agent("%2", "codex", Some("review")),
+            ],
+            &[],
+        );
+        assert_eq!(agent_summary(&piped), "impl \u{b7} review");
+
+        let manual = work(
+            "RELEASE-1",
+            vec![
+                agent("%1", "claude", None),
+                agent("%2", "claude", None),
+                agent("%3", "codex", None),
+            ],
+            &[],
+        );
+        assert_eq!(agent_summary(&manual), "claude x2 \u{b7} codex");
+    }
+
+    /// A converged pipeline and a stalled one differ by one cell, so that cell
+    /// has to be present and correct.
+    #[test]
+    fn table_shows_the_completion_ratio() {
+        let works = vec![
+            work(
+                "CAL-1",
+                vec![
+                    agent("%1", "claude", Some("impl")),
+                    agent("%2", "codex", Some("review")),
+                ],
+                &["impl", "review"],
+            ),
+            work("RELEASE-1", vec![agent("%3", "claude", None)], &[]),
+        ];
+        let out = work_list_table(&works, &[], crate::theme::CliTheme::plain());
+        assert!(out.contains("CAL-1"), "{out}");
+        assert!(out.contains("2/2"), "{out}");
+        assert!(out.contains("impl \u{b7} review"), "{out}");
+        // No pipeline aliases, so no ratio — not `0/1`.
+        assert!(!out.contains("0/1"), "{out}");
+        // The stage column stays out of the way when nothing is staged.
+        assert!(!out.contains("STAGE"), "{out}");
+    }
 }
 
 fn parse_done(raw: &str) -> Vec<String> {

--- a/crates/muxa-cli/src/tmux_work.rs
+++ b/crates/muxa-cli/src/tmux_work.rs
@@ -31,6 +31,7 @@ const AGENT_TASK_OPTION: &str = "@muxa_agent_task";
 /// than in the daemon: it has to outlive muxad, the CLI process, and
 /// the agent restarting inside the pane.
 const AGENT_ALIAS_OPTION: &str = "@muxa_agent_alias";
+const AGENT_GENERATION_OPTION: &str = "@muxa_pipeline_generation";
 const PANE_WORKSPACE_OPTION: &str = "@muxa_agent_workspace_id";
 const PANE_WORK_OPTION: &str = "@muxa_agent_work_id";
 const EXTERNAL_SOURCE_OPTION: &str = "@muxa_external_source";
@@ -42,7 +43,6 @@ const EXTERNAL_STABLE_ID_OPTION: &str = "@muxa_external_stable_id";
 /// have exited, and the fact that it finished has to outlive it. This is
 /// the only completion signal muxa has — agent state cannot supply one,
 /// because `idle` means both "done" and "paused mid-thought".
-const WORK_DONE_OPTION: &str = "@muxa_work_done";
 const EXTERNAL_KEY_OPTION: &str = "@muxa_external_key";
 const EXTERNAL_TITLE_OPTION: &str = "@muxa_external_title";
 const EXTERNAL_URL_OPTION: &str = "@muxa_external_url";
@@ -255,8 +255,12 @@ pub struct WorkDoneArgs {
     /// tmux pane to read the alias and work from. Defaults to `TMUX_PANE`.
     #[arg(long)]
     pub pane: Option<String>,
-    /// Take the report back, so the next `muxa work up` holds dependants
-    /// again.
+    /// Run generation being completed. Defaults to the generation stamped on
+    /// the calling pane. Useful when automation supplies an explicit pane.
+    #[arg(long)]
+    pub generation: Option<u64>,
+    /// Restart this alias's completion generation and hold/reconcile its
+    /// downstream aliases again.
     #[arg(long)]
     pub undo: bool,
     /// Emit JSON.
@@ -368,7 +372,7 @@ pub fn run_window_rename(args: WindowRenameArgs) -> Result<()> {
 /// when an agent has finished and when it is between thoughts, and a pane
 /// stays open either way. So the agent says so, and muxa records the claim
 /// rather than inferring one.
-pub fn run_work_done(args: WorkDoneArgs) -> Result<()> {
+pub async fn run_work_done(args: WorkDoneArgs, client: &muxa::ipc::Client) -> Result<()> {
     let pane = args
         .pane
         .clone()
@@ -380,15 +384,55 @@ pub fn run_work_done(args: WorkDoneArgs) -> Result<()> {
         Some(alias) => alias,
         None => pane_option(&pane, AGENT_ALIAS_OPTION)?
             .ok_or_else(|| anyhow::anyhow!("pane {pane} has no pipeline alias; pass --alias"))?,
+    }
+    .trim()
+    .to_ascii_lowercase();
+    let workspace = pane_option(&pane, PANE_WORKSPACE_OPTION)?.ok_or_else(|| {
+        anyhow::anyhow!("pane {pane} has no pipeline workspace; run `muxa work up` first")
+    })?;
+    let work = pane_option(&pane, PANE_WORK_OPTION)?.ok_or_else(|| {
+        anyhow::anyhow!("pane {pane} has no pipeline Work; run `muxa work up` first")
+    })?;
+    let generation = match args.generation {
+        Some(generation) => generation,
+        None => pane_option(&pane, AGENT_GENERATION_OPTION)?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "pane {pane} has no pipeline generation; run `muxa work up` to adopt it"
+                )
+            })?
+            .parse::<u64>()
+            .with_context(|| format!("pane {pane} has an invalid pipeline generation"))?,
     };
-    let window = window_id_for_pane(&pane)?;
-    let done = mark_done(&window, &alias, !args.undo)?;
+    let identity = muxa::work::WorkIdentity::new(workspace, work);
+    let run = if args.undo {
+        client
+            .pipeline_invalidate(&identity, &alias, generation)
+            .await
+            .with_context(|| format!("invalidate pipeline alias {alias:?}"))?
+    } else {
+        client
+            .pipeline_done(&identity, &alias, generation)
+            .await
+            .with_context(|| format!("atomically complete pipeline alias {alias:?}"))?
+    };
+    // Completion is the event that drives reconciliation; callers never need
+    // to remember a second `work up`. The daemon also subscribes to this same
+    // durable revision as a crash/restart safety net.
+    crate::work_up::reconcile_run(client, &identity, run.generation).await?;
+    let done = run
+        .aliases
+        .values()
+        .filter(|state| state.status == muxa::pipeline_run::PipelineAliasStatus::Done)
+        .map(|state| state.alias.clone())
+        .collect::<Vec<_>>();
     if args.json {
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
-                "window": window,
+                "work": identity,
                 "alias": alias,
+                "generation": run.generation,
                 "done": done,
             }))?
         );
@@ -405,17 +449,34 @@ fn pane_option(pane: &str, key: &str) -> Result<Option<String>> {
     Ok(option(raw.trim()))
 }
 
-pub fn run_work_list(args: WorkListArgs) -> Result<()> {
+pub async fn run_work_list(args: WorkListArgs, client: &muxa::ipc::Client) -> Result<()> {
     let works = match args.workspace.as_deref() {
         Some(workspace) => find_workspace(workspace)?
             .map(|workspace| workspace.works)
             .unwrap_or_default(),
         None => list_works()?,
     };
+    let visible_runs = client
+        .pipeline_runs()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|run| {
+            args.workspace
+                .as_deref()
+                .is_none_or(|workspace| run.identity.workspace_id == workspace)
+        })
+        .collect::<Vec<_>>();
     if args.json {
-        println!("{}", serde_json::to_string_pretty(&json_works(&works))?);
-    } else if works.is_empty() {
-        println!("no muxa-managed work windows");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "works": works,
+                "pipeline_runs": visible_runs,
+            }))?
+        );
+    } else if works.is_empty() && visible_runs.is_empty() {
+        println!("no muxa-managed work or durable pipeline Runs");
     } else {
         let theme = crate::theme::for_theme(
             muxa::config::Config::load_or_default(None)
@@ -423,7 +484,10 @@ pub fn run_work_list(args: WorkListArgs) -> Result<()> {
                 .unwrap_or_default(),
             crate::use_colors(),
         );
-        print!("{}", work_list_table(&works, &work_annotations(), theme));
+        print!(
+            "{}",
+            work_list_table(&works, &work_annotations(), &visible_runs, theme)
+        );
     }
     Ok(())
 }
@@ -435,6 +499,7 @@ pub fn run_work_list(args: WorkListArgs) -> Result<()> {
 fn work_list_table(
     works: &[WorkInfo],
     records: &[WorkRecord],
+    runs: &[muxa::pipeline_run::PipelineRun],
     theme: crate::theme::CliTheme,
 ) -> String {
     use comfy_table::{ContentArrangement, Table};
@@ -447,10 +512,18 @@ fn work_list_table(
                 .map(|stage| stage.label().to_string())
         })
         .collect();
+    let run_stages = runs
+        .iter()
+        .map(|run| {
+            stage_for_identity(&run.identity, records)
+                .filter(|stage| *stage != WorkStage::Auto)
+                .map(|stage| stage.label().to_string())
+        })
+        .collect::<Vec<_>>();
     // The column only earns its width when something is actually staged.
-    let show_stage = staged.iter().any(Option::is_some);
+    let show_stage = staged.iter().chain(&run_stages).any(Option::is_some);
 
-    let mut header = vec!["WORK", "WORKSPACE", "AGENTS", "DONE"];
+    let mut header = vec!["WORK", "WORKSPACE", "GEN", "ALIASES", "DONE"];
     if show_stage {
         header.push("STAGE");
     }
@@ -468,11 +541,24 @@ fn work_list_table(
         );
 
     for (work, stage) in works.iter().zip(&staged) {
-        let (done, total) = done_ratio(work);
+        let run = runs.iter().find(|run| {
+            run.identity.workspace_id == work.workspace && run.identity.work_id == work.work
+        });
+        let (done, total) = run.map_or_else(
+            || done_ratio(work),
+            muxa::pipeline_run::PipelineRun::completion,
+        );
         let mut row = vec![
             theme.cell(&work.work, TableTone::Accent),
             theme.cell(&work.workspace, TableTone::Dim),
-            theme.cell(agent_summary(work), TableTone::Tmux),
+            run.map_or_else(
+                || theme.right_cell("-", TableTone::Dim),
+                |run| theme.right_cell(run.generation, TableTone::Dim),
+            ),
+            theme.cell(
+                run.map_or_else(|| agent_summary(work), pipeline_alias_summary),
+                TableTone::Tmux,
+            ),
             match total {
                 // Not a pipeline: nothing ever reports, so a ratio would
                 // read as "0 of 1 finished" for work that is simply running.
@@ -489,7 +575,42 @@ fn work_list_table(
         row.push(theme.cell(shorten_home(&work.cwd), TableTone::Dim));
         table.add_row(row);
     }
+    for (run, stage) in runs.iter().zip(&run_stages).filter(|(run, _)| {
+        !works.iter().any(|work| {
+            run.identity.workspace_id == work.workspace && run.identity.work_id == work.work
+        })
+    }) {
+        let (done, total) = run.completion();
+        let mut row = vec![
+            theme.cell(&run.identity.work_id, TableTone::Accent),
+            theme.cell(&run.identity.workspace_id, TableTone::Dim),
+            theme.right_cell(run.generation, TableTone::Dim),
+            theme.cell(pipeline_alias_summary(run), TableTone::Tmux),
+            if done == total {
+                theme.right_cell(format!("{done}/{total}"), TableTone::Good)
+            } else {
+                theme.right_cell(format!("{done}/{total}"), TableTone::Warn)
+            },
+        ];
+        if show_stage {
+            row.push(theme.cell(stage.as_deref().unwrap_or("-"), TableTone::Dim));
+        }
+        row.push(theme.cell(shorten_home(&run.cwd), TableTone::Dim));
+        table.add_row(row);
+    }
     format!("{table}\n")
+}
+
+fn pipeline_alias_summary(run: &muxa::pipeline_run::PipelineRun) -> String {
+    run.desired
+        .iter()
+        .filter_map(|agent| {
+            run.aliases
+                .get(&agent.alias)
+                .map(|state| format!("{}:{}", agent.alias, state.status))
+        })
+        .collect::<Vec<_>>()
+        .join(" \u{b7} ")
 }
 
 /// How many of this work's pipeline agents have reported finishing.
@@ -1033,6 +1154,7 @@ pub fn mark_work_external(window: &str, ticket: &muxa::pipeline::Ticket) -> Resu
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)] // pane metadata is an explicit flat tmux option contract
 pub fn mark_agent(
     pane: &str,
     agent: &str,
@@ -1041,6 +1163,7 @@ pub fn mark_agent(
     role: Option<&str>,
     task: Option<&str>,
     alias: Option<&str>,
+    generation: Option<u64>,
 ) -> Result<()> {
     validate_pane_id(pane)?;
     set_option(OptionScope::Pane, pane, AGENT_OPTION, &metadata(agent, 64)?)?;
@@ -1085,18 +1208,44 @@ pub fn mark_agent(
             &metadata(alias, 64)?,
         )?;
     }
+    if let Some(generation) = generation {
+        set_option(
+            OptionScope::Pane,
+            pane,
+            AGENT_GENERATION_OPTION,
+            &generation.to_string(),
+        )?;
+    }
     Ok(())
+}
+
+pub fn mark_agent_generation(pane: &str, generation: u64) -> Result<()> {
+    validate_pane_id(pane)?;
+    set_option(
+        OptionScope::Pane,
+        pane,
+        AGENT_GENERATION_OPTION,
+        &generation.to_string(),
+    )
 }
 
 /// The stage a human (or the dashboard) recorded for this logical Work.
 /// A new Run in another tmux window retains the same stage because execution
 /// coordinates are deliberately not part of Work identity.
 fn stage_for(work: &WorkInfo, records: &[WorkRecord]) -> Option<WorkStage> {
+    stage_for_identity(
+        &muxa::work::WorkIdentity::new(&work.workspace, &work.work),
+        records,
+    )
+}
+
+fn stage_for_identity(
+    identity: &muxa::work::WorkIdentity,
+    records: &[WorkRecord],
+) -> Option<WorkStage> {
     records
         .iter()
-        .find(|record| {
-            record.identity.workspace_id == work.workspace && record.identity.work_id == work.work
-        })
+        .find(|record| &record.identity == identity)
         .map(|record| record.metadata.stage)
 }
 
@@ -1142,6 +1291,53 @@ mod work_list_view_tests {
             external_item: None,
             done: done.iter().map(|d| (*d).to_string()).collect(),
             agents,
+        }
+    }
+
+    fn durable_run() -> muxa::pipeline_run::PipelineRun {
+        use muxa::pipeline_run::{PipelineAliasState, PipelineAliasStatus, PipelineRun};
+        let now = time::OffsetDateTime::UNIX_EPOCH;
+        let desired = [("impl", Vec::new()), ("review", vec!["impl".to_string()])]
+            .into_iter()
+            .map(|(alias, after)| muxa::pipeline::DesiredAgent {
+                alias: alias.to_string(),
+                program: "codex".to_string(),
+                role: None,
+                task: None,
+                prompt: None,
+                direction: None,
+                after,
+            })
+            .collect();
+        let state = |alias: &str, status, completion_generation| PipelineAliasState {
+            alias: alias.to_string(),
+            status,
+            generation: 1,
+            completion_generation,
+            pane: (alias == "impl").then(|| "%1".to_string()),
+            error: None,
+            reconcile_pending: false,
+            claim_started_at: None,
+            updated_at: now,
+        };
+        PipelineRun {
+            identity: muxa::work::WorkIdentity::new("callabo", "CAL-1"),
+            pipeline: "delivery".to_string(),
+            desired,
+            cwd: PathBuf::from("/repo"),
+            generation: 1,
+            window_id: Some("@1".to_string()),
+            aliases: std::collections::BTreeMap::from([
+                (
+                    "impl".to_string(),
+                    state("impl", PipelineAliasStatus::Done, Some(1)),
+                ),
+                (
+                    "review".to_string(),
+                    state("review", PipelineAliasStatus::Pending, None),
+                ),
+            ]),
+            updated_at: now,
         }
     }
 
@@ -1215,7 +1411,7 @@ mod work_list_view_tests {
             ),
             work("RELEASE-1", vec![agent("%3", "claude", None)], &[]),
         ];
-        let out = work_list_table(&works, &[], crate::theme::CliTheme::plain());
+        let out = work_list_table(&works, &[], &[], crate::theme::CliTheme::plain());
         assert!(out.contains("CAL-1"), "{out}");
         assert!(out.contains("2/2"), "{out}");
         assert!(out.contains("impl \u{b7} review"), "{out}");
@@ -1223,6 +1419,35 @@ mod work_list_view_tests {
         assert!(!out.contains("0/1"), "{out}");
         // The stage column stays out of the way when nothing is staged.
         assert!(!out.contains("STAGE"), "{out}");
+    }
+
+    #[test]
+    fn table_uses_durable_desired_aliases_before_downstream_has_a_pane() {
+        let works = vec![work(
+            "CAL-1",
+            vec![agent("%1", "codex", Some("impl"))],
+            &["impl"],
+        )];
+        let out = work_list_table(
+            &works,
+            &[],
+            &[durable_run()],
+            crate::theme::CliTheme::plain(),
+        );
+        assert!(out.contains("1/2"), "{out}");
+        assert!(out.contains("impl:done"), "{out}");
+        assert!(out.contains("review:pending"), "{out}");
+        assert!(!out.contains("1/1"), "{out}");
+    }
+
+    #[test]
+    fn table_keeps_a_durable_run_visible_without_a_tmux_window() {
+        let out = work_list_table(&[], &[], &[durable_run()], crate::theme::CliTheme::plain());
+        assert!(out.contains("CAL-1"), "{out}");
+        assert!(out.contains("callabo"), "{out}");
+        assert!(out.contains("impl:done"), "{out}");
+        assert!(out.contains("review:pending"), "{out}");
+        assert!(out.contains("1/2"), "{out}");
     }
 }
 
@@ -1232,36 +1457,6 @@ fn parse_done(raw: &str) -> Vec<String> {
         .filter(|alias| !alias.is_empty())
         .map(str::to_ascii_lowercase)
         .collect()
-}
-
-/// Record that `alias` has finished its part of this work, or take it back.
-///
-/// Idempotent: a second report is not an error, because an agent re-reading
-/// its own instructions and reporting twice is likelier than a bug.
-pub fn mark_done(window: &str, alias: &str, done: bool) -> Result<Vec<String>> {
-    let alias = metadata(alias, 64)?.to_ascii_lowercase();
-    let current = tmux_output(&[
-        "display-message",
-        "-p",
-        "-t",
-        window,
-        &format!("#{{{WORK_DONE_OPTION}}}"),
-    ])?;
-    let mut aliases = parse_done(current.trim());
-    if done {
-        if !aliases.iter().any(|existing| existing == &alias) {
-            aliases.push(alias);
-        }
-    } else {
-        aliases.retain(|existing| existing != &alias);
-    }
-    set_option(
-        OptionScope::Window,
-        window,
-        WORK_DONE_OPTION,
-        &aliases.join(","),
-    )?;
-    Ok(aliases)
 }
 
 pub fn window_id_for_pane(pane: &str) -> Result<String> {
@@ -1676,10 +1871,6 @@ fn required<'a>(value: Option<&'a str>, message: &str) -> Result<&'a str> {
     value
         .filter(|value| !value.trim().is_empty())
         .ok_or_else(|| anyhow::anyhow!(message.to_string()))
-}
-
-fn json_works(works: &[WorkInfo]) -> serde_json::Value {
-    serde_json::json!({ "works": works })
 }
 
 fn json_workspaces(workspaces: &[WorkspaceInfo]) -> serde_json::Value {

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -827,6 +827,13 @@ pub(crate) struct WorkRow {
     pub pane_count: usize,
     pub bare_summary: Option<String>,
     pub activity: Option<SessionActivity>,
+    /// `(reported, total)` over this work's pipeline agents, or `None` when
+    /// the window has none — a hand-split pane never reports, so a ratio
+    /// there would read as unfinished work that was never a pipeline.
+    ///
+    /// Without this a converged pipeline and a stalled one are the same
+    /// picture: every agent idle, nothing to say the review already landed.
+    pub completion: Option<(usize, usize)>,
     agent_states: HashMap<(AgentKind, String), AgentState>,
 }
 
@@ -5170,6 +5177,7 @@ fn finish_work_row(mut builder: WorkRowBuilder, sort_context: &SortContext<'_>) 
             },
         )
     });
+    let completion = work_completion(&builder.panes);
     WorkRow {
         display_name,
         group_key: builder.group_key,
@@ -5186,8 +5194,39 @@ fn finish_work_row(mut builder: WorkRowBuilder, sort_context: &SortContext<'_>) 
         pane_count: builder.panes.len(),
         bare_summary,
         activity: builder.activity,
+        completion,
         agent_states,
     }
+}
+
+/// `(reported, total)` over the pipeline agents among `panes`.
+///
+/// Only aliased panes count: `@muxa_work_done` records aliases, so a pane the
+/// operator split by hand can never appear in it and must not drag the ratio
+/// down. `None` when nothing in the window is aliased — that window is not a
+/// pipeline and has no completion to report.
+fn work_completion(panes: &[PaneInfo]) -> Option<(usize, usize)> {
+    let aliases: Vec<&str> = panes
+        .iter()
+        .filter_map(|pane| pane.agent_alias.as_deref())
+        .collect();
+    if aliases.is_empty() {
+        return None;
+    }
+    // Every pane of one work carries the same window-scoped list.
+    let done = panes
+        .iter()
+        .find(|pane| !pane.work_done.is_empty())
+        .map(|pane| pane.work_done.clone())
+        .unwrap_or_default();
+    let reported = aliases
+        .iter()
+        .filter(|alias| {
+            done.iter()
+                .any(|reported| reported.eq_ignore_ascii_case(alias))
+        })
+        .count();
+    Some((reported, aliases.len()))
 }
 
 fn build_work_rows(
@@ -5606,6 +5645,72 @@ fn state_summary_gutter_spans(
     spans
 }
 
+#[cfg(test)]
+mod work_completion_tests {
+    use super::*;
+
+    fn pane(id: &str, alias: Option<&str>, done: &[&str]) -> PaneInfo {
+        PaneInfo {
+            agent_role: None,
+            agent_alias: alias.map(Into::into),
+            work_done: done.iter().map(|d| (*d).to_string()).collect(),
+            pane_id: id.into(),
+            session_id: "$1".into(),
+            session: "callabo".into(),
+            window_id: "@1".into(),
+            window_name: "CAL-1".into(),
+            window_index: "0".into(),
+            pane_index: "0".into(),
+            tty: String::new(),
+            current_command: "claude".into(),
+            title: String::new(),
+            pane_pid: 0,
+            current_path: "/repo".into(),
+            socket: Some("default".into()),
+        }
+    }
+
+    /// The signal the TUI was missing: idle-and-converged looked exactly like
+    /// idle-and-stalled.
+    #[test]
+    fn a_converged_pipeline_reports_every_alias() {
+        let panes = vec![
+            pane("%1", Some("impl"), &["impl", "review"]),
+            pane("%2", Some("review"), &["impl", "review"]),
+        ];
+        assert_eq!(work_completion(&panes), Some((2, 2)));
+    }
+
+    #[test]
+    fn a_half_finished_pipeline_is_not_complete() {
+        let panes = vec![
+            pane("%1", Some("impl"), &["impl"]),
+            pane("%2", Some("review"), &["impl"]),
+        ];
+        assert_eq!(work_completion(&panes), Some((1, 2)));
+    }
+
+    /// A hand-split pane can never report, so counting it would show a
+    /// converged pair as 2/3 forever.
+    #[test]
+    fn hand_split_panes_stay_out_of_the_ratio() {
+        let panes = vec![
+            pane("%1", Some("impl"), &["impl", "review"]),
+            pane("%2", Some("review"), &["impl", "review"]),
+            pane("%3", None, &["impl", "review"]),
+        ];
+        assert_eq!(work_completion(&panes), Some((2, 2)));
+    }
+
+    /// A window with no pipeline at all has no completion to show — `0/1`
+    /// would libel an agent that was never asked to report.
+    #[test]
+    fn a_window_without_a_pipeline_has_no_ratio() {
+        assert_eq!(work_completion(&[pane("%1", None, &[])]), None);
+        assert_eq!(work_completion(&[]), None);
+    }
+}
+
 fn state_summary_spans_from_parts(parts: &[StateSummaryPart]) -> Vec<Span<'static>> {
     parts
         .iter()
@@ -5624,6 +5729,16 @@ fn state_summary_spans_from_parts(parts: &[StateSummaryPart]) -> Vec<Span<'stati
 fn work_label(s: &WorkRow, theme: WatchThemeSpec, spin: Spinner) -> Text<'static> {
     let mut spans = state_summary_gutter_spans(s.agent_states.values().copied(), theme, spin);
     spans.push(Span::raw(s.display_name.clone()));
+    if let Some((done, total)) = s.completion {
+        // Complete reads as a finished thing, not as another dim detail: this
+        // badge is the only place the TUI says a pipeline converged.
+        let style = if done == total {
+            Style::default().fg(theme.state_idle)
+        } else {
+            Style::default().fg(theme.dim)
+        };
+        spans.push(Span::styled(format!("  {done}/{total}"), style));
+    }
 
     Text::from(Line::from(spans))
 }
@@ -6186,6 +6301,8 @@ fn apply_single_agent_to_work(app: &mut App, agent: Agent) {
         pane_count: 0,
         bare_summary: None,
         activity: None,
+        // No pane topology behind this row, so nothing to read aliases from.
+        completion: None,
         agent_states,
     })));
 }
@@ -15047,6 +15164,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: pane.into(),
             session_id: String::new(),
@@ -15077,6 +15195,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: Some(socket.into()),
             pane_id: pane_id.into(),
             session_id: session_id.into(),
@@ -19497,6 +19616,7 @@ sort = ["state"]
         let panes = vec![PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: "%42".into(),
             session_id: String::new(),

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -5212,34 +5212,22 @@ fn finish_work_row(mut builder: WorkRowBuilder, sort_context: &SortContext<'_>) 
     }
 }
 
-/// `(reported, total)` over the pipeline agents among `panes`.
-///
-/// Only aliased panes count: `@muxa_work_done` records aliases, so a pane the
-/// operator split by hand can never appear in it and must not drag the ratio
-/// down. `None` when nothing in the window is aliased — that window is not a
-/// pipeline and has no completion to report.
+/// Completion for the flat work row, over the same rule the topology uses —
+/// deferred to rather than restated, so the tree and the list can never
+/// disagree about whether a pipeline finished.
 fn work_completion(panes: &[PaneInfo]) -> Option<(usize, usize)> {
-    let aliases: Vec<&str> = panes
-        .iter()
-        .filter_map(|pane| pane.agent_alias.as_deref())
-        .collect();
-    if aliases.is_empty() {
-        return None;
-    }
-    // Every pane of one work carries the same window-scoped list.
+    // `@muxa_work_done` is a window option, so whichever pane carries it speaks
+    // for the window.
     let done = panes
         .iter()
         .find(|pane| !pane.work_done.is_empty())
         .map(|pane| pane.work_done.clone())
         .unwrap_or_default();
-    let reported = aliases
-        .iter()
-        .filter(|alias| {
-            done.iter()
-                .any(|reported| reported.eq_ignore_ascii_case(alias))
-        })
-        .count();
-    Some((reported, aliases.len()))
+    muxa::topology::work_completion(
+        panes.iter().filter_map(|pane| pane.agent_alias.as_deref()),
+        &done,
+    )
+    .map(|completion| (completion.done, completion.total))
 }
 
 fn build_work_rows(
@@ -13612,6 +13600,21 @@ fn tree_node_label(
         ));
     } else {
         spans.push(Span::raw(label));
+    }
+    // A work window that has finished looks exactly like one that stalled —
+    // every agent idle — unless the row says so.
+    if let TopologyNodeRef::Window(window) = node {
+        if let Some(completion) = window.completion {
+            let style = if completion.is_complete() {
+                Style::default().fg(theme.state_idle)
+            } else {
+                theme.dim_style()
+            };
+            spans.push(Span::styled(
+                format!("  {}/{}", completion.done, completion.total),
+                style,
+            ));
+        }
     }
     Text::from(Line::from(spans))
 }

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -834,6 +834,7 @@ pub(crate) struct WorkRow {
     /// Without this a converged pipeline and a stalled one are the same
     /// picture: every agent idle, nothing to say the review already landed.
     pub completion: Option<(usize, usize)>,
+    pub pipeline_run: Option<muxa::pipeline_run::PipelineRunSummary>,
     agent_states: HashMap<(AgentKind, String), AgentState>,
 }
 
@@ -1423,6 +1424,7 @@ impl Effects for RealEffects {
                 agent,
                 Some(&workspace),
                 Some(&work),
+                None,
                 None,
                 None,
                 None,
@@ -2629,6 +2631,8 @@ pub(crate) struct App {
     pub sessions: Vec<SessionInfo>,
     /// Persisted cumulative attached-time counters keyed by tmux session id.
     pub session_activity: Vec<SessionActivity>,
+    /// Daemon-owned pipeline Runs from the last coherent refresh.
+    pub pipeline_runs: Vec<muxa::pipeline_run::PipelineRun>,
     /// True between a user-triggered refresh request (`r`) and the
     /// matching outcome landing on the channel. Surfaces a brief
     /// "↻ refreshing…" hint in the header so mashing `r` during a
@@ -2936,6 +2940,7 @@ impl App {
             panes: Vec::new(),
             sessions: Vec::new(),
             session_activity: Vec::new(),
+            pipeline_runs: Vec::new(),
             refresh_pending: false,
             initial_pane: None,
             preview: None,
@@ -3112,7 +3117,7 @@ impl App {
         // Build the shared topology before presentation-specific filtering.
         // This retains paneless/ambiguous agents in `unassigned_agents` and
         // gives every tree action a collision-free target.
-        self.topology = build_watch_topology(&agents, &panes, &sessions);
+        self.topology = build_watch_topology(&agents, &panes, &sessions, &self.pipeline_runs);
         self.reconcile_tree_expansion(&previous_topology_keys);
 
         // Filter out paneless agents up front when the user has opted in
@@ -3147,6 +3152,7 @@ impl App {
                 &session_activity,
                 &self.watch_cfg.sort,
             );
+            annotate_work_rows(&mut self.rows, &self.pipeline_runs);
             self.panes = panes;
             self.sessions = sessions;
             self.session_activity = session_activity;
@@ -5026,6 +5032,7 @@ fn build_watch_topology(
     agents: &[Agent],
     panes: &[PaneInfo],
     session_info: &[SessionInfo],
+    pipeline_runs: &[muxa::pipeline_run::PipelineRun],
 ) -> TopologySnapshot {
     let mut panes_by_host: HashMap<muxa::HostKind, Vec<PaneInfo>> = HashMap::new();
     for pane in panes {
@@ -5074,6 +5081,40 @@ fn build_watch_topology(
             if matches.next().is_none() {
                 node.name.clone_from(&info.name);
                 node.attached_clients = Some(info.attached_clients);
+            }
+        }
+    }
+    let window_id_counts = snapshot
+        .sessions
+        .iter()
+        .flat_map(|session| &session.windows)
+        .fold(HashMap::<String, usize>::new(), |mut counts, window| {
+            *counts.entry(window.key.window_id.clone()).or_default() += 1;
+            counts
+        });
+    for session in &mut snapshot.sessions {
+        for window in &mut session.windows {
+            // Durable Runs are launched on the locally scoped tmux server.
+            // Raw `@N` ids repeat across backends and sockets, so an
+            // ambiguous id must remain unjoined instead of displaying one
+            // Work's state on another window.
+            if window.key.session.endpoint.host != muxa::HostKind::Tmux
+                || window_id_counts
+                    .get(window.key.window_id.as_str())
+                    .copied()
+                    .unwrap_or_default()
+                    != 1
+            {
+                continue;
+            }
+            if let Some(run) = pipeline_runs
+                .iter()
+                .filter(|run| run.window_id.as_deref() == Some(window.key.window_id.as_str()))
+                .max_by_key(|run| run.updated_at)
+            {
+                let (done, total) = run.completion();
+                window.completion = Some(muxa::topology::WorkCompletion { done, total });
+                window.pipeline_run = Some(run.summary());
             }
         }
     }
@@ -5208,7 +5249,73 @@ fn finish_work_row(mut builder: WorkRowBuilder, sort_context: &SortContext<'_>) 
         bare_summary,
         activity: builder.activity,
         completion,
+        pipeline_run: None,
         agent_states,
+    }
+}
+
+fn annotate_work_rows(rows: &mut Vec<WatchRow>, runs: &[muxa::pipeline_run::PipelineRun]) {
+    let window_id_counts = rows
+        .iter()
+        .filter_map(|row| match row {
+            WatchRow::Work(work) => work.window_key.as_ref(),
+            WatchRow::Agent(_) | WatchRow::BarePane(_) => None,
+        })
+        .fold(HashMap::<String, usize>::new(), |mut counts, window| {
+            *counts.entry(window.window_id.clone()).or_default() += 1;
+            counts
+        });
+    let mut displayed = std::collections::BTreeSet::new();
+    for row in rows.iter_mut() {
+        let WatchRow::Work(work) = row else {
+            continue;
+        };
+        let Some(window) = work.window_key.as_ref() else {
+            continue;
+        };
+        if window.session.endpoint.host != muxa::HostKind::Tmux
+            || window_id_counts
+                .get(window.window_id.as_str())
+                .copied()
+                .unwrap_or_default()
+                != 1
+        {
+            continue;
+        }
+        let Some(run) = runs
+            .iter()
+            .filter(|run| run.window_id.as_deref() == Some(window.window_id.as_str()))
+            .max_by_key(|run| run.updated_at)
+        else {
+            continue;
+        };
+        work.completion = Some(run.completion());
+        work.pipeline_run = Some(run.summary());
+        displayed.insert(run.identity.key());
+    }
+    // The Run is the durable object; a tmux window is only its current
+    // binding. Keep a prompt-free row visible after that binding disappears
+    // so watch and list tell the same operational truth.
+    for run in runs
+        .iter()
+        .filter(|run| !displayed.contains(&run.identity.key()))
+    {
+        rows.push(WatchRow::Work(Box::new(WorkRow {
+            session: run.identity.workspace_id.clone(),
+            group_key: format!("pipeline:{}", run.identity.key()),
+            window_key: None,
+            display_name: format!("{} › {}", run.identity.workspace_id, run.identity.work_id),
+            pane_ids: Vec::new(),
+            representative_pane: None,
+            latest_agent: None,
+            agents: Vec::new(),
+            pane_count: 0,
+            bare_summary: Some("durable Run · no live window".to_string()),
+            activity: None,
+            completion: Some(run.completion()),
+            pipeline_run: Some(run.summary()),
+            agent_states: HashMap::new(),
+        })));
     }
 }
 
@@ -5868,6 +5975,12 @@ fn work_label(s: &WorkRow, theme: WatchThemeSpec, spin: Spinner) -> Text<'static
         };
         spans.push(Span::styled(format!("  {done}/{total}"), style));
     }
+    if let Some(run) = s.pipeline_run.as_ref() {
+        spans.push(Span::styled(
+            format!("  {}", pipeline_status_label(run)),
+            theme.dim_style(),
+        ));
+    }
 
     Text::from(Line::from(spans))
 }
@@ -6183,6 +6296,7 @@ pub(crate) struct FullRefresh {
     pub sessions: Vec<SessionInfo>,
     pub session_activity: Vec<SessionActivity>,
     pub error: Option<DaemonError>,
+    pub pipeline_runs: Vec<muxa::pipeline_run::PipelineRun>,
 }
 
 pub(crate) struct MessageComposerConfig {
@@ -6233,7 +6347,12 @@ fn apply_outcome_inner(app: &mut App, outcome: RefreshOutcome) {
         RefreshOutcome::Full(full) => apply_full(app, full),
         RefreshOutcome::SingleAgent(agent) => {
             apply_single_agent(app, agent);
-            app.topology = build_watch_topology(&app.current_agents(), &app.panes, &app.sessions);
+            app.topology = build_watch_topology(
+                &app.current_agents(),
+                &app.panes,
+                &app.sessions,
+                &app.pipeline_runs,
+            );
             // Re-sort immediately so a pushed state/activity change moves the
             // row to its sorted position now instead of waiting for the 5 s
             // `Full` fallback tick. This matters most for `sort = ["state",
@@ -6432,6 +6551,7 @@ fn apply_single_agent_to_work(app: &mut App, agent: Agent) {
         activity: None,
         // No pane topology behind this row, so nothing to read aliases from.
         completion: None,
+        pipeline_run: None,
         agent_states,
     })));
 }
@@ -6443,9 +6563,11 @@ fn apply_full(app: &mut App, full: FullRefresh) {
         sessions,
         session_activity,
         error,
+        pipeline_runs,
     } = full;
 
     app.last_error = error;
+    app.pipeline_runs = pipeline_runs;
 
     // Build a lookup of the previously-known agents so the merge can
     // distinguish a genuine daemon-driven change from a transient
@@ -6554,7 +6676,12 @@ async fn compute_refresh(
 
     // The blocking tasks already run concurrently on the blocking pool;
     // await the daemon snapshot + ledger load alongside them, then collect.
-    let (session_activity, snapshot) = tokio::join!(session_activity_task, client.snapshot());
+    let (session_activity, snapshot, pipeline_runs) = tokio::join!(
+        session_activity_task,
+        client.snapshot(),
+        client.pipeline_runs()
+    );
+    let pipeline_runs = pipeline_runs.unwrap_or_default();
 
     let mut panes: Vec<PaneInfo> = Vec::new();
     for task in pane_tasks {
@@ -6572,6 +6699,7 @@ async fn compute_refresh(
             sessions,
             session_activity,
             error: None,
+            pipeline_runs,
         },
         Err(e) => FullRefresh {
             agents: Vec::new(),
@@ -6582,6 +6710,7 @@ async fn compute_refresh(
                 self_describing: matches!(e, RuntimeError::NotConnected(_)),
                 message: e.to_string(),
             }),
+            pipeline_runs,
         },
     };
     RefreshOutcome::Full(full)
@@ -13274,6 +13403,16 @@ fn render_topology_inspector(
     }
 }
 
+fn pipeline_status_label(run: &muxa::pipeline_run::PipelineRunSummary) -> String {
+    let aliases = run
+        .aliases
+        .iter()
+        .map(|alias| format!("{}:{}", alias.alias, alias.status))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("{} g{} {aliases}", run.pipeline, run.generation)
+}
+
 // cli-spinners frames: `dots` for parent agents, `dots2` (denser) for
 // subagents, and a half-circle set for starting.
 const SWARM_DOTS: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -13679,6 +13818,12 @@ fn tree_node_label(
             spans.push(Span::styled(
                 format!("  {}/{}", completion.done, completion.total),
                 style,
+            ));
+        }
+        if let Some(run) = window.pipeline_run.as_ref() {
+            spans.push(Span::styled(
+                format!("  {}", pipeline_status_label(run)),
+                theme.dim_style(),
             ));
         }
     }
@@ -20556,6 +20701,7 @@ sort = ["state"]
             panes: vec![],
             sessions: vec![],
             session_activity: vec![],
+            pipeline_runs: vec![],
             error: None,
         })
     }
@@ -21354,6 +21500,7 @@ sort = ["state"]
             panes: vec![fake_pane("%99", "side", 0, 0, "vim")],
             sessions: vec![],
             session_activity: vec![],
+            pipeline_runs: vec![],
             error: Some(DaemonError {
                 self_describing: false,
                 message: "boom".into(),
@@ -21394,6 +21541,7 @@ sort = ["state"]
                 panes: vec![fake_pane("%1", "main", 0, 0, "claude")],
                 sessions: vec![],
                 session_activity: vec![],
+                pipeline_runs: vec![],
                 error: None,
             }),
         );
@@ -21423,6 +21571,7 @@ sort = ["state"]
                 panes: vec![fake_pane("%1", "main", 0, 0, "claude")],
                 sessions: vec![],
                 session_activity: vec![],
+                pipeline_runs: vec![],
                 error: None,
             }),
         );
@@ -21455,6 +21604,7 @@ sort = ["state"]
                 panes: vec![fake_pane("%1", "main", 0, 0, "claude")],
                 sessions: vec![],
                 session_activity: vec![],
+                pipeline_runs: vec![],
                 error: None,
             }),
         );
@@ -21487,6 +21637,7 @@ sort = ["state"]
                 panes: vec![fake_pane("%1", "main", 0, 0, "claude")],
                 sessions: vec![],
                 session_activity: vec![],
+                pipeline_runs: vec![],
                 error: None,
             }),
         );
@@ -21536,6 +21687,7 @@ sort = ["state"]
                 ],
                 sessions: vec![],
                 session_activity: vec![],
+                pipeline_runs: vec![],
                 error: None,
             }),
         );
@@ -21622,6 +21774,7 @@ sort = ["state"]
                 panes: vec![fake_pane("%1", "main", 0, 0, "claude")],
                 sessions: vec![],
                 session_activity: vec![],
+                pipeline_runs: vec![],
                 error: None,
             }),
         );
@@ -21676,6 +21829,7 @@ sort = ["state"]
                 panes: vec![fake_pane("%1", "main", 0, 0, "claude")],
                 sessions: vec![],
                 session_activity: vec![],
+                pipeline_runs: vec![],
                 error: None,
             }),
         );
@@ -21697,6 +21851,7 @@ sort = ["state"]
                 panes: vec![fake_pane("%1", "main", 0, 0, "claude")],
                 sessions: vec![],
                 session_activity: vec![],
+                pipeline_runs: vec![],
                 error: None,
             }),
         );
@@ -21747,6 +21902,7 @@ sort = ["state"]
                 panes: vec![fake_pane("%1", "main", 0, 0, "claude")],
                 sessions: vec![],
                 session_activity: vec![],
+                pipeline_runs: vec![],
                 error: None,
             }),
         );

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -1690,7 +1690,7 @@ pub(crate) fn help_overlay_text() -> Vec<&'static str> {
         "  gg/G · Home/End first / last selectable row",
         "  PgUp/PgDn       page; Ctrl-U/Ctrl-D half page",
         "  Enter          attach via active window/pane or exact pane",
-        "  n              new window or sibling agent pane",
+        "  n / w          new window or agent pane / work up a pipeline",
         "  a / A          ask / history; d deletes one · D clears all in A",
         "",
         "Commands & inspection",
@@ -1759,6 +1759,17 @@ struct AskComposer {
     /// Ask shares the reusable text palette with message composition, but
     /// selection never changes the daemon-owned agent/permission contract.
     skill_palette: Option<MessageSkillPalette>,
+}
+
+/// The `w` composer: a work id, nothing else.
+///
+/// Deliberately not folded into [`AskComposer`]. Ask is a read-only question
+/// to a headless agent; this one spends money and creates panes, and the two
+/// wanting the same text box is not a reason to give them the same key.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct WorkComposer {
+    input: String,
+    cursor: usize,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -2688,6 +2699,7 @@ pub(crate) struct App {
     spawn: Option<SpawnComposer>,
     /// `Some` while the `a` ask composer is open.
     ask_composer: Option<AskComposer>,
+    work_composer: Option<WorkComposer>,
     ask_panel: AskPanelState,
     ask_entries: Vec<muxa::ask::AskEntry>,
     /// Agent the next question goes to, as the daemon reports it.
@@ -2943,6 +2955,7 @@ impl App {
             collaboration_compose_defaults,
             spawn: None,
             ask_composer: None,
+            work_composer: None,
             ask_panel: AskPanelState::default(),
             ask_entries: Vec::new(),
             ask_agent: "claude".into(),
@@ -5646,6 +5659,82 @@ fn state_summary_gutter_spans(
 }
 
 #[cfg(test)]
+mod work_up_key_tests {
+    use super::*;
+
+    /// `normalize_work_id` only rejects tabs, newlines and over-long input, so
+    /// anything else a work id carries reaches a shell. It must arrive as one
+    /// argument, not as a second command.
+    #[test]
+    fn a_work_id_cannot_break_out_of_the_shell_command() {
+        let nasty = "cal-1'; rm -rf ~; echo '";
+        let args = work_up_window_args("/usr/bin/muxa", nasty);
+        let command = args.last().expect("command").clone();
+        // Every embedded quote is closed, escaped and reopened, so the whole
+        // id stays one word.
+        assert!(command.contains(&shell_quote(nasty)), "{command}");
+        // The only `; printf` is the one this function wrote.
+        assert_eq!(command.matches("; printf").count(), 1, "{command}");
+        assert!(!command.contains("; rm -rf ~; echo ';"), "{command}");
+    }
+
+    /// An install path with a space is ordinary on macOS.
+    #[test]
+    fn the_binary_path_is_quoted_too() {
+        let command = work_up_window_args("/Applications/My Tools/muxa", "CAL-1")
+            .last()
+            .expect("command")
+            .clone();
+        assert!(
+            command.starts_with("'/Applications/My Tools/muxa' work up 'CAL-1'"),
+            "{command}",
+        );
+    }
+
+    /// The window has to outlive the command, or the plan `work up` prints
+    /// scrolls past before it can be read.
+    #[test]
+    fn the_window_waits_before_closing() {
+        let args = work_up_window_args("/usr/bin/muxa", "CAL-1");
+        assert_eq!(args[0], "new-window");
+        assert!(args.last().expect("command").ends_with("read _"));
+    }
+
+    /// Enter on an empty field must not spawn anything.
+    #[test]
+    fn an_empty_work_id_is_refused_before_it_spends_anything() {
+        let mut app = App::new();
+        app.work_composer = Some(WorkComposer::default());
+        assert!(matches!(
+            handle_work_composer_event(KeyCode::Enter, KeyModifiers::NONE, &mut app),
+            Action::None
+        ));
+        assert!(app.work_composer.is_some(), "the composer stays open");
+
+        app.work_composer = Some(WorkComposer {
+            input: "cal-7229".into(),
+            cursor: 8,
+        });
+        assert!(matches!(
+            handle_work_composer_event(KeyCode::Enter, KeyModifiers::NONE, &mut app),
+            Action::SubmitWorkUp
+        ));
+    }
+
+    /// Backspace on an empty field closes the composer, matching `a`.
+    #[test]
+    fn backspace_on_an_empty_field_closes_the_composer() {
+        let mut app = App::new();
+        app.work_composer = Some(WorkComposer::default());
+        assert!(matches!(
+            handle_work_composer_event(KeyCode::Backspace, KeyModifiers::NONE, &mut app),
+            Action::None
+        ));
+        assert!(app.work_composer.is_none());
+    }
+}
+
+#[cfg(test)]
 mod work_completion_tests {
     use super::*;
 
@@ -6927,6 +7016,20 @@ pub async fn run(
                 Action::AskConfirm(popup) => {
                     app.confirm = Some(popup);
                 }
+                Action::OpenWorkUp => {
+                    app.work_composer = Some(WorkComposer::default());
+                }
+                Action::SubmitWorkUp => {
+                    if let Some(work) = app.work_composer.take() {
+                        match open_work_up_window(&work.input) {
+                            Ok(id) => app.set_hint(
+                                format!("work up {id} — confirm in the new window"),
+                                HintLevel::Ok,
+                            ),
+                            Err(e) => app.set_hint(format!("work up failed: {e}"), HintLevel::Err),
+                        }
+                    }
+                }
                 Action::OpenAsk => {
                     if let Ok(agent) = client.ask_agent(None).await {
                         app.ask_agent = agent;
@@ -8183,6 +8286,10 @@ fn drain_pending_events() -> io::Result<Vec<Event>> {
 
 #[derive(Debug)]
 pub(crate) enum Action {
+    /// Open the work composer (`w`).
+    OpenWorkUp,
+    /// Run `muxa work up` for whatever the composer holds.
+    SubmitWorkUp,
     None,
     Quit,
     Refresh,
@@ -8517,6 +8624,9 @@ fn handle_event(ev: Event, app: &mut App) -> Action {
         return handle_spawn_event(code, modifiers, app);
     }
 
+    if app.work_composer.is_some() {
+        return handle_work_composer_event(code, modifiers, app);
+    }
     if app.ask_composer.is_some() {
         return handle_ask_composer_event(code, modifiers, app);
     }
@@ -8721,6 +8831,7 @@ fn handle_event(ev: Event, app: &mut App) -> Action {
             Action::InspectorSplitChanged
         }
         KeyCode::Char('a') if app.browse_keys_active() => Action::OpenAsk,
+        KeyCode::Char('w') if app.browse_keys_active() => Action::OpenWorkUp,
         KeyCode::Char('A') if app.browse_keys_active() => Action::OpenAskPanel,
         KeyCode::Char('h') if app.browse_keys_active() => {
             app.move_to_work_parent();
@@ -8857,6 +8968,92 @@ fn handle_command_event(code: KeyCode, modifiers: KeyModifiers, app: &mut App) -
 
 /// Ask composer: one field, Enter submits, `Ctrl-V` pastes. `/` opens the
 /// shared text-skill palette; it does not alter the daemon-owned ask contract.
+/// Open a tmux window running `muxa work up <id>` and hand the operator over
+/// to it.
+///
+/// Watch does not run the pipeline itself on purpose. `work up` resolves a
+/// ticket, which costs money, and the CLI already owns the flow that says so
+/// and waits for a yes. Re-implementing that inside the TUI would mean two
+/// places where muxa decides whether it may spend the operator's money, and
+/// the second one would be the one nobody reviewed. So the TUI's job ends at
+/// putting the operator in front of the real thing.
+fn open_work_up_window(raw: &str) -> std::result::Result<String, String> {
+    let work = crate::tmux_work::normalize_work_id(raw).map_err(|error| error.to_string())?;
+    let exe = std::env::current_exe()
+        .map_err(|error| format!("locate the muxa binary: {error}"))?
+        .display()
+        .to_string();
+    let args = work_up_window_args(&exe, &work);
+    let output = muxa::tmux::tmux_command_scoped()
+        .args(&args)
+        .output()
+        .map_err(|error| format!("tmux: {error}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    Ok(work)
+}
+
+/// The tmux argv for that window.
+///
+/// Split out to be tested without a tmux server, because the interesting part
+/// is the quoting: `normalize_work_id` rejects only tabs, newlines and
+/// over-long input, so a work id can still carry a quote or a semicolon and
+/// this string is handed to a shell.
+fn work_up_window_args(exe: &str, work: &str) -> Vec<String> {
+    let command = format!(
+        "{} work up {}; printf '\\n-- enter to close --'; read _",
+        shell_quote(exe),
+        shell_quote(work),
+    );
+    vec!["new-window".into(), "-n".into(), "work-up".into(), command]
+}
+
+/// POSIX single-quote quoting: wrap in `'`, and close/escape/reopen around any
+/// embedded `'`.
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn handle_work_composer_event(code: KeyCode, modifiers: KeyModifiers, app: &mut App) -> Action {
+    if code == KeyCode::Backspace
+        && app
+            .work_composer
+            .as_ref()
+            .is_some_and(|work| work.input.is_empty())
+    {
+        app.work_composer = None;
+        return Action::None;
+    }
+    let Some(work) = app.work_composer.as_mut() else {
+        return Action::None;
+    };
+    match code {
+        KeyCode::Esc => {
+            app.work_composer = None;
+            Action::None
+        }
+        KeyCode::Enter => {
+            if work.input.trim().is_empty() {
+                app.set_hint("work up needs a work id", HintLevel::Warn);
+                Action::None
+            } else {
+                Action::SubmitWorkUp
+            }
+        }
+        KeyCode::Char('v') if modifiers.contains(KeyModifiers::CONTROL) => {
+            if let Some(pasted) = system_clipboard_text() {
+                insert_str_at(&mut work.input, &mut work.cursor, &pasted);
+            }
+            Action::None
+        }
+        other => {
+            spawn_edit_text(other, modifiers, &mut work.input, &mut work.cursor);
+            Action::None
+        }
+    }
+}
+
 fn handle_ask_composer_event(code: KeyCode, modifiers: KeyModifiers, app: &mut App) -> Action {
     if app
         .ask_composer
@@ -10090,6 +10287,7 @@ pub(crate) fn render(f: &mut Frame, app: &mut App) {
         f.render_widget(Clear, popup_area);
         render_ask_panel(f, popup_area, app);
     }
+    render_work_composer_overlay(f, chunks[1], app);
     if app.ask_composer.is_some() {
         let skills_open = app
             .ask_composer
@@ -10356,6 +10554,55 @@ fn spawn_popup_rect(r: Rect, spawn: &SpawnComposer) -> Rect {
         y: r.y + r.height - height,
         width: r.width,
         height,
+    }
+}
+
+/// Draw the `w` composer over `area`, or nothing when it is closed. Folded
+/// into one call so `render` stays inside its line budget.
+fn render_work_composer_overlay(f: &mut Frame, area: Rect, app: &App) {
+    if app.work_composer.is_none() {
+        return;
+    }
+    let popup_area = message_composer_rect(area, false);
+    f.render_widget(Clear, popup_area);
+    render_work_composer(f, popup_area, app);
+}
+
+fn render_work_composer(f: &mut Frame, area: Rect, app: &App) {
+    use unicode_width::UnicodeWidthStr;
+    let theme = watch_theme(app.watch_cfg.theme.unwrap_or_default());
+    let Some(work) = app.work_composer.as_ref() else {
+        return;
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.action))
+        .border_type(theme.border_type)
+        .title(Span::styled(
+            " work up ",
+            theme.action_badge().add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(area);
+    let view = truncate_prompt_input(&work.input, usize::from(inner.width.saturating_sub(2)));
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw("> "),
+            Span::raw(view.text.clone()),
+        ]))
+        .block(block),
+        area,
+    );
+    let before: String = view
+        .text
+        .chars()
+        .take(work.cursor.saturating_sub(view.skipped_chars))
+        .collect();
+    let x = inner
+        .x
+        .saturating_add(2)
+        .saturating_add(u16::try_from(before.width()).unwrap_or(u16::MAX));
+    if x < inner.x + inner.width {
+        f.set_cursor_position((x, inner.y));
     }
 }
 
@@ -21859,6 +22106,10 @@ sort = ["state"]
                 app.preview = None;
                 app.pane_capture = None;
             }
+            Action::OpenWorkUp => app.work_composer = Some(WorkComposer::default()),
+            // The real handler shells out to tmux; the test harness stops at
+            // the state change so nothing spawns a window.
+            Action::SubmitWorkUp => app.work_composer = None,
             Action::TogglePreviewMode => {
                 if let Some(p) = app.preview.as_mut() {
                     p.mode = match p.mode {
@@ -22975,6 +23226,7 @@ sort = ["state"]
         assert!(body.contains("m / M          message selected agent / mailbox (b alias)"));
         assert!(body.contains("i / e          (in mailbox) claim inbox / reply"));
         assert!(body.contains("a / A          ask / history; d deletes one · D clears all in A"));
+        assert!(body.contains("n / w          new window or agent pane / work up a pipeline"));
         // The exit keys deliberately live in the overlay's border rather
         // than the matrix — the body is clipped by terminal height, and
         // "how to leave" must not be the row that falls off.

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -15045,6 +15045,8 @@ mod tests {
 
     fn fake_pane(pane: &str, session: &str, window: u32, pane_idx: u32, cmd: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: pane.into(),
             session_id: String::new(),
@@ -15073,6 +15075,8 @@ mod tests {
         pane_index: u32,
     ) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: Some(socket.into()),
             pane_id: pane_id.into(),
             session_id: session_id.into(),
@@ -19491,6 +19495,8 @@ sort = ["state"]
     #[test]
     fn pane_display_resolves_against_cached_panes() {
         let panes = vec![PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: "%42".into(),
             session_id: String::new(),

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -5647,6 +5647,58 @@ fn state_summary_gutter_spans(
 }
 
 #[cfg(test)]
+mod pane_label_tests {
+    use super::*;
+    use muxa::topology::{BackendEndpoint, PaneKey, PaneNode, SessionKey, WindowKey};
+
+    fn pane(alias: Option<&str>, command: &str, agent: Option<Agent>) -> PaneNode {
+        PaneNode {
+            key: PaneKey {
+                window: WindowKey {
+                    session: SessionKey {
+                        endpoint: BackendEndpoint {
+                            host: muxa::HostKind::Tmux,
+                            socket: "default".into(),
+                        },
+                        session_id: "$1".into(),
+                    },
+                    window_id: "@1".into(),
+                },
+                pane_id: "%1".into(),
+            },
+            index: "0".into(),
+            tty: String::new(),
+            current_command: command.into(),
+            title: String::new(),
+            cwd: "/repo".into(),
+            pane_pid: 0,
+            agent,
+            agent_alias: alias.map(Into::into),
+        }
+    }
+
+    /// The case the program name cannot express: one work, two claudes. Both
+    /// rows read `claude` and the tree stops telling them apart.
+    #[test]
+    fn the_pipeline_alias_names_the_pane() {
+        assert_eq!(
+            pane_label_owner(&pane(Some("impl"), "claude", None)),
+            "impl"
+        );
+        assert_eq!(
+            pane_label_owner(&pane(Some("review"), "claude", None)),
+            "review",
+        );
+    }
+
+    /// A pane nobody aliased still says what is running in it.
+    #[test]
+    fn an_unaliased_pane_falls_back_to_its_command() {
+        assert_eq!(pane_label_owner(&pane(None, "vim", None)), "vim");
+    }
+}
+
+#[cfg(test)]
 mod work_up_key_tests {
     use super::*;
 
@@ -13533,6 +13585,23 @@ fn tree_state_is_redundant(target: &TreeTarget, node: TopologyNodeRef<'_>) -> bo
     }
 }
 
+/// What to call a pane in the tree, after its id.
+///
+/// The pipeline alias wins when there is one. `claude` and `codex` name the
+/// CLI, which stops distinguishing anything the moment one work runs two of
+/// the same kind — and a pair whose reviewer and implementer are both claude
+/// then reads as two identical rows. `impl` and `review` say what the pane is
+/// *for*. The CLI stays visible on the row (state glyph, model column) and in
+/// the inspector, so nothing is lost.
+fn pane_label_owner(pane: &muxa::topology::PaneNode) -> String {
+    pane.agent_alias.clone().unwrap_or_else(|| {
+        pane.agent.as_ref().map_or_else(
+            || pane.current_command.clone(),
+            |agent| agent_kind_short(agent.kind).to_string(),
+        )
+    })
+}
+
 fn tree_node_label(
     target: &TreeTarget,
     node: TopologyNodeRef<'_>,
@@ -13582,10 +13651,7 @@ fn tree_node_label(
         TopologyNodeRef::Session(session) => session.name.clone(),
         TopologyNodeRef::Window(window) => window.name.clone(),
         TopologyNodeRef::Pane(pane) => {
-            let owner = pane.agent.as_ref().map_or_else(
-                || pane.current_command.clone(),
-                |agent| agent_kind_short(agent.kind).to_string(),
-            );
+            let owner = pane_label_owner(pane);
             if owner.trim().is_empty() {
                 pane.key.pane_id.clone()
             } else {

--- a/crates/muxa-cli/src/work_init.rs
+++ b/crates/muxa-cli/src/work_init.rs
@@ -1,0 +1,319 @@
+//! `muxa work init` — describe a work pipeline in words and let an agent
+//! write the config.
+//!
+//! `[ticket]`, `[[route]]`, and `[pipeline.*]` are the most structured
+//! configuration muxa asks for, and the least guessable: nested tables, an
+//! ordered array of routes, regexes, placeholder templates. Hand-editing it
+//! from documentation is exactly the friction that stops the feature being
+//! used at all.
+//!
+//! So muxa does here what it already does for tickets: it asks an agent.
+//! The operator says "callabo tickets get a codex planner, a codex
+//! implementer and a claude reviewer", one headless turn turns that into
+//! TOML, and muxa's job is to be the part that does *not* trust the answer
+//! — parse it, compile every regex, check every pipeline a route names
+//! exists and every agent it lists could actually launch, show what it
+//! would change, and only then write.
+//!
+//! Nothing outside those three keys is touched, and the file is rewritten
+//! through `toml_edit`, so comments and hand-tuned sections survive.
+
+use anyhow::{bail, Context, Result};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use muxa::config::Config;
+use muxa::pipeline::{self, ProposalSummary};
+
+/// The three keys this command owns. Anything else in the file is left
+/// exactly as it was.
+const OWNED_KEYS: [&str; 3] = ["ticket", "route", "pipeline"];
+
+#[derive(Debug, clap::Args)]
+pub struct InitArgs {
+    /// Describe the setup in your own words. Omit to be asked.
+    #[arg(long)]
+    pub describe: Option<String>,
+    /// Resolver agent: claude or codex. Defaults to `[ticket].agent`.
+    #[arg(long)]
+    pub agent: Option<String>,
+    /// Print the proposed config and change nothing.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Skip the confirmation prompt.
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+}
+
+/// What the model is told about the shape it must produce. Kept next to the
+/// command rather than in the docs directory so the two cannot drift: if
+/// the schema changes, this is in the same diff.
+const SCHEMA: &str = r#"
+muxa work pipeline configuration. Three top-level keys, all optional except
+as noted:
+
+[ticket]                      # how a work id becomes ticket context
+agent = "claude"              # or "codex" — the resolver CLI
+cwd = "~"                     # where the resolver runs
+timeout_secs = 300
+cache_secs = 900              # 0 disables the cache
+additional_dirs = ["/path"]   # extra roots the resolver may read
+
+[ticket.source.<name>]        # tried in sorted-key order, first match wins
+match = '^cal-\d+$'           # regex against the work id, case-insensitive
+prompt = '''...'''            # asks an agent to answer with ticket JSON.
+                              # {{id}} is the lowercased work id. muxa reads
+                              # id/identifier/key, title/name/summary,
+                              # body/description, url, state, branch.
+
+[[route]]                     # REQUIRED: ordered, first match wins
+match     = '^cal-'           # regex against the work id
+workspace = 'callabo'         # the tmux session; defaults to the cwd name
+pipeline  = 'triad'           # must name a [pipeline.*] below
+cwd       = '~/src/{{id}}'    # optional; omit to use the current directory
+[route.worktree]              # optional: a git worktree per work item
+repo   = '~/src/repo'
+branch = '{{id}}'
+
+[pipeline.<name>]             # REQUIRED: at least one
+layout = 'main-vertical'      # tmux layout, applied once every pane exists
+prompt = '''...'''            # context every agent in this pipeline gets
+
+[[pipeline.<name>.agent]]     # one per pane, at least one
+alias   = 'impl'              # unique within the pipeline; keys the pane diff
+program = 'codex'             # ONLY claude, codex, gemini, or opencode
+role    = 'implementer'       # optional; peers address it as role:<role>
+prompt  = '...'               # optional; this agent's own instructions
+direction = 'right'           # optional: right (default) or down
+
+Placeholders, usable in any prompt/path/workspace string:
+{{id}} lowercased work id, {{work}} as muxa stores it, {{workspace}},
+{{cwd}}, {{alias}}, {{role}}, {{program}}, {{request}} (the caller's
+--body/--skill/--context), and {{ticket.title|body|url|state|id|branch}}.
+
+Unknown keys are a hard error, so do not invent any.
+"#;
+
+pub async fn run(args: InitArgs, config: &Config, config_path: Option<PathBuf>) -> Result<()> {
+    let path = config_path
+        .or_else(muxa::paths::default_config_file)
+        .context("no config directory is available on this system")?;
+    let describe = match args.describe.as_deref().map(str::trim) {
+        Some(text) if !text.is_empty() => text.to_string(),
+        _ => ask_operator()?,
+    };
+
+    let agent = args
+        .agent
+        .as_deref()
+        .unwrap_or(config.ticket.agent.as_str())
+        .to_string();
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let prompt = compose_prompt(&describe, &existing);
+
+    println!("asking {agent} to write the config…");
+    let answer = muxa::ask::one_shot(muxa::ask::OneShot {
+        agent: &agent,
+        prompt: &prompt,
+        cwd: &dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")),
+        permission_mode: config.ticket.permission_mode,
+        additional_dirs: &config.ticket.additional_dirs,
+        timeout: Duration::from_secs(config.ticket.timeout_secs.max(60)),
+    })
+    .await
+    .context("asking an agent to write the pipeline config")?;
+
+    let block = pipeline::extract_toml_block(&answer.text)
+        .ok_or_else(|| anyhow::anyhow!("{agent} answered without any TOML"))?
+        .trim()
+        .to_string();
+    // Refuse before writing: Config denies unknown fields, so a model's
+    // typo would take the daemon down at its next start.
+    let (_, summary) = pipeline::validate_proposal(&block)
+        .with_context(|| format!("{agent} produced a config muxa will not write"))?;
+
+    let (merged, replaced) = merge(&existing, &block)?;
+    report(&block, &summary, &replaced, &path);
+
+    if args.dry_run {
+        println!("\ndry run: nothing was written.");
+        return Ok(());
+    }
+    if !args.yes && !confirm(&replaced)? {
+        println!("left {} unchanged.", path.display());
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    crate::init::apply::atomic_write(&path, &merged)
+        .with_context(|| format!("writing {}", path.display()))?;
+    println!("wrote {}", path.display());
+    println!("try it:  muxa work up <ticket-id> --dry-run");
+    Ok(())
+}
+
+fn ask_operator() -> Result<String> {
+    use std::io::IsTerminal;
+    if !std::io::stdin().is_terminal() {
+        bail!("no description given; pass --describe \"...\" when stdin is not a terminal");
+    }
+    let text: String = cliclack::input("Describe the work pipeline you want")
+        .placeholder("cal-* tickets: codex planner, codex implementer, claude reviewer")
+        .interact()?;
+    let text = text.trim().to_string();
+    if text.is_empty() {
+        bail!("description cannot be empty");
+    }
+    Ok(text)
+}
+
+fn compose_prompt(describe: &str, existing: &str) -> String {
+    // The current file goes in so the model extends what is there rather
+    // than proposing a config that contradicts it — and so it can see which
+    // of the three keys already exist.
+    let current = if existing.trim().is_empty() {
+        "(the config file is empty or absent)".to_string()
+    } else {
+        format!("Current config.toml:\n```toml\n{}\n```", existing.trim())
+    };
+    format!(
+        "You are writing muxa work pipeline configuration.\n\n\
+         SCHEMA\n{SCHEMA}\n\n\
+         {current}\n\n\
+         WHAT THE OPERATOR WANTS\n{describe}\n\n\
+         Answer with ONE ```toml block containing only the [ticket], [[route]], and\n\
+         [pipeline.*] sections. Do not repeat other sections of the current config.\n\
+         Include at least one [[route]] and one [pipeline.*]. End routes with a\n\
+         catch-all `match = '.*'` unless the operator said otherwise. Prefer omitting\n\
+         `cwd` so the work runs where the operator invoked it. No prose outside the\n\
+         block."
+    )
+}
+
+/// Copy the three owned keys from the proposal into the existing document,
+/// leaving every other key and all formatting alone. Returns the merged
+/// text and which keys were overwritten rather than added.
+fn merge(existing: &str, proposal: &str) -> Result<(String, Vec<String>)> {
+    let mut doc: toml_edit::DocumentMut = if existing.trim().is_empty() {
+        toml_edit::DocumentMut::new()
+    } else {
+        existing
+            .parse()
+            .context("your existing config.toml does not parse")?
+    };
+    let incoming: toml_edit::DocumentMut = proposal
+        .parse()
+        .context("the proposed config does not parse")?;
+    let mut replaced = Vec::new();
+    for key in OWNED_KEYS {
+        if let Some(item) = incoming.get(key) {
+            if doc.contains_key(key) {
+                replaced.push(key.to_string());
+            }
+            doc.insert(key, item.clone());
+        }
+    }
+    Ok((doc.to_string(), replaced))
+}
+
+fn report(block: &str, summary: &ProposalSummary, replaced: &[String], path: &std::path::Path) {
+    println!("\n{block}\n");
+    println!("this configures:");
+    if !summary.ticket_sources.is_empty() {
+        println!("  ticket sources  {}", summary.ticket_sources.join(", "));
+    }
+    for route in &summary.routes {
+        println!("  route           {route}");
+    }
+    for (name, agents) in &summary.pipelines {
+        println!("  pipeline        {name} ({agents} agents)");
+    }
+    println!("  target          {}", path.display());
+    if !replaced.is_empty() {
+        println!(
+            "  REPLACES        existing [{}] — everything else in the file is kept",
+            replaced.join("], [")
+        );
+    }
+}
+
+fn confirm(replaced: &[String]) -> Result<bool> {
+    use std::io::IsTerminal;
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        bail!("confirmation requires an interactive terminal; pass --yes");
+    }
+    let prompt = if replaced.is_empty() {
+        "Write this to your config?".to_string()
+    } else {
+        format!("Replace existing [{}] with this?", replaced.join("], ["))
+    };
+    Ok(cliclack::confirm(prompt).initial_value(false).interact()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PROPOSAL: &str = r"
+[[route]]
+match = '.*'
+pipeline = 'solo'
+
+[pipeline.solo]
+[[pipeline.solo.agent]]
+alias = 'main'
+program = 'claude'
+";
+
+    #[test]
+    fn merging_keeps_every_section_it_does_not_own() {
+        let existing = "[watch]\ntheme = \"classic\"\n\n[ask]\nenabled = true\n";
+        let (merged, replaced) = merge(existing, PROPOSAL).expect("merge");
+        assert!(replaced.is_empty());
+        // Untouched sections survive verbatim, comments and all.
+        assert!(merged.contains("theme = \"classic\""), "{merged}");
+        assert!(merged.contains("[ask]"), "{merged}");
+        assert!(merged.contains("[pipeline.solo]"), "{merged}");
+        // And the result is still a config muxa can load.
+        let parsed: Config = toml::from_str(&merged).expect("merged config parses");
+        assert_eq!(parsed.route.len(), 1);
+        assert!(parsed.ask.enabled);
+    }
+
+    #[test]
+    fn merging_reports_which_owned_keys_it_overwrites() {
+        let existing = "[pipeline.old]\n[[pipeline.old.agent]]\nalias = 'x'\nprogram = 'codex'\n";
+        let (merged, replaced) = merge(existing, PROPOSAL).expect("merge");
+        assert_eq!(replaced, vec!["pipeline".to_string()]);
+        // Replaced wholesale, not merged key-by-key: a half-old, half-new
+        // pipeline set is harder to reason about than a stated replacement.
+        assert!(!merged.contains("pipeline.old"), "{merged}");
+    }
+
+    #[test]
+    fn a_comment_in_the_operators_config_survives() {
+        let existing = "# my notes\n[watch]\ntheme = \"classic\"\n";
+        let (merged, _) = merge(existing, PROPOSAL).expect("merge");
+        assert!(merged.contains("# my notes"), "{merged}");
+    }
+
+    #[test]
+    fn a_broken_existing_config_is_reported_not_overwritten() {
+        let error = merge("[watch\n", PROPOSAL).unwrap_err().to_string();
+        assert!(error.contains("existing config.toml"), "{error}");
+    }
+
+    #[test]
+    fn the_prompt_carries_the_schema_and_the_current_file() {
+        let prompt = compose_prompt("cal tickets get three agents", "[watch]\ntheme = \"ops\"\n");
+        assert!(
+            prompt.contains("[[pipeline.<name>.agent]]"),
+            "schema missing"
+        );
+        assert!(prompt.contains("theme = \"ops\""), "current config missing");
+        assert!(prompt.contains("cal tickets get three agents"));
+        // An empty file says so rather than sending an empty fence.
+        assert!(compose_prompt("x", "  ").contains("empty or absent"));
+    }
+}

--- a/crates/muxa-cli/src/work_init.rs
+++ b/crates/muxa-cli/src/work_init.rs
@@ -73,8 +73,14 @@ match     = '^cal-'           # regex against the work id
 workspace = 'callabo'         # the tmux session; defaults to the cwd name
 pipeline  = 'triad'           # must name a [pipeline.*] below
 cwd       = '~/src/{{id}}'    # optional; omit to use the current directory
-[route.worktree]              # optional: a git worktree per work item
-repo   = '~/src/repo'
+prepare   = 'mk-ws {{id}} {{ticket.branch}}'
+                              # optional: command that provisions this work's
+                              # environment, run once when the work window does
+                              # not exist yet. Pair it with `cwd`, since the
+                              # directory usually does not exist until it has
+                              # run. Cannot be combined with [route.worktree].
+[route.worktree]              # optional: a git worktree per work item.
+repo   = '~/src/repo'         # Use this OR prepare, never both.
 branch = '{{id}}'
 
 [pipeline.<name>]             # REQUIRED: at least one
@@ -85,6 +91,7 @@ prompt = '''...'''            # context every agent in this pipeline gets
 alias   = 'impl'              # unique within the pipeline; keys the pane diff
 program = 'codex'             # ONLY claude, codex, gemini, or opencode
 role    = 'implementer'       # optional; peers address it as role:<role>
+task    = 'fix the reaper'    # optional; short label in `muxa work show`/`watch`
 prompt  = '...'               # optional; this agent's own instructions
 direction = 'right'           # optional: right (default) or down
 
@@ -362,6 +369,34 @@ pipeline = 'solo'
 alias = 'main'
 program = 'claude'
 ";
+
+    #[test]
+    fn the_schema_documents_every_key_a_route_accepts() {
+        // A key the schema omits is a key the model will not use — it is
+        // told not to invent any, and it obeys. `prepare` shipped once
+        // without being documented here and simply never appeared in a
+        // generated config, so this locks the two together.
+        let route = serde_json::to_value(muxa::config::RouteConfig::default())
+            .expect("RouteConfig serializes");
+        for key in route.as_object().expect("an object").keys() {
+            assert!(
+                SCHEMA.contains(key.as_str()),
+                "route key `{key}` is not in the schema the model is shown"
+            );
+        }
+    }
+
+    #[test]
+    fn the_schema_documents_every_key_a_pipeline_agent_accepts() {
+        let agent = serde_json::to_value(muxa::config::PipelineAgentConfig::default())
+            .expect("PipelineAgentConfig serializes");
+        for key in agent.as_object().expect("an object").keys() {
+            assert!(
+                SCHEMA.contains(key.as_str()),
+                "pipeline agent key `{key}` is not in the schema the model is shown"
+            );
+        }
+    }
 
     #[test]
     fn the_notice_names_the_command_and_that_it_costs_money() {

--- a/crates/muxa-cli/src/work_init.rs
+++ b/crates/muxa-cli/src/work_init.rs
@@ -22,6 +22,7 @@ use anyhow::{bail, Context, Result};
 use std::path::PathBuf;
 use std::time::Duration;
 
+use crate::work_up::expand_tilde;
 use muxa::config::Config;
 use muxa::pipeline::{self, ProposalSummary};
 
@@ -37,7 +38,8 @@ pub struct InitArgs {
     /// Resolver agent: claude or codex. Defaults to `[ticket].agent`.
     #[arg(long)]
     pub agent: Option<String>,
-    /// Print the proposed config and change nothing.
+    /// Print the proposed config and write nothing. The agent turn still
+    /// runs and is still billed — only the file write is skipped.
     #[arg(long)]
     pub dry_run: bool,
     /// Skip the confirmation prompt.
@@ -111,17 +113,31 @@ pub async fn run(args: InitArgs, config: &Config, config_path: Option<PathBuf>) 
     let existing = std::fs::read_to_string(&path).unwrap_or_default();
     let prompt = compose_prompt(&describe, &existing);
 
-    println!("asking {agent} to write the config…");
+    let resolver_cwd = config
+        .ticket
+        .cwd
+        .clone()
+        .map(|cwd| PathBuf::from(expand_tilde(&cwd.to_string_lossy())))
+        .or_else(dirs::home_dir)
+        .unwrap_or_else(|| PathBuf::from("."));
+    announce(&agent, &resolver_cwd, config, args.dry_run);
+    if !args.yes && !confirm_spend()? {
+        println!("nothing was called.");
+        return Ok(());
+    }
     let answer = muxa::ask::one_shot(muxa::ask::OneShot {
         agent: &agent,
         prompt: &prompt,
-        cwd: &dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")),
+        cwd: &resolver_cwd,
         permission_mode: config.ticket.permission_mode,
         additional_dirs: &config.ticket.additional_dirs,
         timeout: Duration::from_secs(config.ticket.timeout_secs.max(60)),
     })
     .await
     .context("asking an agent to write the pipeline config")?;
+    if let Some(cost) = answer.cost_usd {
+        println!("that turn cost ${cost:.4}.");
+    }
 
     let block = pipeline::extract_toml_block(&answer.text)
         .ok_or_else(|| anyhow::anyhow!("{agent} answered without any TOML"))?
@@ -151,6 +167,50 @@ pub async fn run(args: InitArgs, config: &Config, config_path: Option<PathBuf>) 
     println!("wrote {}", path.display());
     println!("try it:  muxa work up <ticket-id> --dry-run");
     Ok(())
+}
+
+/// Say what is about to be spawned, and that it costs money, before
+/// spawning it.
+///
+/// `--dry-run` is the reason this exists rather than being obvious: it
+/// skips the *file write*, not the agent turn, so "dry run" must not be
+/// read as "nothing happens". The expensive half happens either way.
+fn announce(agent: &str, cwd: &std::path::Path, config: &Config, dry_run: bool) {
+    for line in notice_lines(agent, cwd, config, dry_run) {
+        println!("{line}");
+    }
+}
+
+fn notice_lines(agent: &str, cwd: &std::path::Path, config: &Config, dry_run: bool) -> Vec<String> {
+    let mut lines = vec![
+        format!("muxa is about to run one headless {agent} turn to write your config."),
+        format!("  command   {agent} (print mode)"),
+        format!("  runs in   {}", cwd.display()),
+        format!(
+            "  policy    {:?} permissions, {}s ceiling",
+            config.ticket.permission_mode, config.ticket.timeout_secs
+        ),
+        format!("  cost      billed to your {agent} account, like any other turn"),
+    ];
+    if dry_run {
+        lines.push(
+            "  note      --dry-run skips writing the file; the turn still runs and still bills"
+                .to_string(),
+        );
+    }
+    lines
+}
+
+/// Ask before spending. Non-interactive callers must say `--yes`, matching
+/// how the rest of muxa gates an action the operator cannot take back.
+fn confirm_spend() -> Result<bool> {
+    use std::io::IsTerminal;
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        bail!("this spends a billed agent turn; pass --yes to confirm non-interactively");
+    }
+    Ok(cliclack::confirm("Spend one agent turn?")
+        .initial_value(true)
+        .interact()?)
 }
 
 fn ask_operator() -> Result<String> {
@@ -265,6 +325,40 @@ pipeline = 'solo'
 alias = 'main'
 program = 'claude'
 ";
+
+    #[test]
+    fn the_notice_names_the_command_and_that_it_costs_money() {
+        let config = Config::default();
+        let lines = notice_lines("claude", std::path::Path::new("/home/june"), &config, false);
+        let text = lines.join("\n");
+        assert!(text.contains("claude (print mode)"), "{text}");
+        assert!(text.contains("/home/june"), "{text}");
+        assert!(text.contains("billed"), "{text}");
+        // Nothing about dry-run when this is a real run.
+        assert!(!text.contains("--dry-run"), "{text}");
+    }
+
+    #[test]
+    fn dry_run_says_the_turn_still_bills() {
+        // The whole point: --dry-run skips the file write, not the agent
+        // turn, so it must not read as "nothing happens".
+        let config = Config::default();
+        let text = notice_lines("codex", std::path::Path::new("/tmp"), &config, true).join("\n");
+        assert!(text.contains("--dry-run skips writing the file"), "{text}");
+        assert!(text.contains("still runs and still bills"), "{text}");
+    }
+
+    #[test]
+    fn a_non_interactive_run_refuses_before_spending_anything() {
+        // Tests run without a tty, which is exactly the case that must not
+        // silently spend a turn.
+        let error = confirm_spend().unwrap_err().to_string();
+        assert!(error.contains("billed"), "{error}");
+        assert!(
+            error.contains("--yes"),
+            "should name the way through: {error}"
+        );
+    }
 
     #[test]
     fn merging_keeps_every_section_it_does_not_own() {

--- a/crates/muxa-cli/src/work_init.rs
+++ b/crates/muxa-cli/src/work_init.rs
@@ -120,11 +120,16 @@ pub async fn run(args: InitArgs, config: &Config, config_path: Option<PathBuf>) 
         .map(|cwd| PathBuf::from(expand_tilde(&cwd.to_string_lossy())))
         .or_else(dirs::home_dir)
         .unwrap_or_else(|| PathBuf::from("."));
-    announce(&agent, &resolver_cwd, config, args.dry_run);
-    if !args.yes && !confirm_spend()? {
-        println!("nothing was called.");
-        return Ok(());
-    }
+    announce(&resolver_cwd, config, args.dry_run);
+    let agent = if args.yes {
+        agent
+    } else {
+        let Some(chosen) = choose_agent(&agent)? else {
+            println!("nothing was called.");
+            return Ok(());
+        };
+        chosen
+    };
     let answer = muxa::ask::one_shot(muxa::ask::OneShot {
         agent: &agent,
         prompt: &prompt,
@@ -175,22 +180,21 @@ pub async fn run(args: InitArgs, config: &Config, config_path: Option<PathBuf>) 
 /// `--dry-run` is the reason this exists rather than being obvious: it
 /// skips the *file write*, not the agent turn, so "dry run" must not be
 /// read as "nothing happens". The expensive half happens either way.
-fn announce(agent: &str, cwd: &std::path::Path, config: &Config, dry_run: bool) {
-    for line in notice_lines(agent, cwd, config, dry_run) {
+fn announce(cwd: &std::path::Path, config: &Config, dry_run: bool) {
+    for line in notice_lines(cwd, config, dry_run) {
         println!("{line}");
     }
 }
 
-fn notice_lines(agent: &str, cwd: &std::path::Path, config: &Config, dry_run: bool) -> Vec<String> {
+fn notice_lines(cwd: &std::path::Path, config: &Config, dry_run: bool) -> Vec<String> {
     let mut lines = vec![
-        format!("muxa is about to run one headless {agent} turn to write your config."),
-        format!("  command   {agent} (print mode)"),
+        "muxa is about to run one headless agent turn to write your config.".to_string(),
         format!("  runs in   {}", cwd.display()),
         format!(
             "  policy    {:?} permissions, {}s ceiling",
             config.ticket.permission_mode, config.ticket.timeout_secs
         ),
-        format!("  cost      billed to your {agent} account, like any other turn"),
+        "  cost      billed to that agent's account, like any other turn".to_string(),
     ];
     if dry_run {
         lines.push(
@@ -201,16 +205,49 @@ fn notice_lines(agent: &str, cwd: &std::path::Path, config: &Config, dry_run: bo
     lines
 }
 
-/// Ask before spending. Non-interactive callers must say `--yes`, matching
-/// how the rest of muxa gates an action the operator cannot take back.
-fn confirm_spend() -> Result<bool> {
+/// Which agent to spend the turn on — and, by answering, whether to spend
+/// it at all. One prompt rather than "confirm?" then "which?": picking the
+/// agent is already the decision.
+///
+/// Only agents that can actually do the job are listed: the bridge needs a
+/// print mode ([`muxa::ask::supported_agents`]) and the binary has to be on
+/// PATH. Offering one that would fail after the operator picked it is worse
+/// than not offering it at all.
+fn choose_agent(default: &str) -> Result<Option<String>> {
     use std::io::IsTerminal;
+    let available = available_agents(&|name| which::which(name).is_ok());
+    if available.is_empty() {
+        bail!(
+            "no headless-capable agent is installed; muxa needs one of: {}",
+            muxa::ask::supported_agents().join(", ")
+        );
+    }
     if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
         bail!("this spends a billed agent turn; pass --yes to confirm non-interactively");
     }
-    Ok(cliclack::confirm("Spend one agent turn?")
-        .initial_value(true)
-        .interact()?)
+    let mut select = cliclack::select("Spend one agent turn on…");
+    for name in &available {
+        select = select.item(
+            Some((*name).to_string()),
+            *name,
+            if *name == default { "configured" } else { "" },
+        );
+    }
+    select = select.item(None, "Cancel", "call nothing");
+    if available.contains(&default) {
+        select = select.initial_value(Some(default.to_string()));
+    }
+    Ok(select.interact()?)
+}
+
+/// Supported by the bridge *and* present on this machine, in the bridge's
+/// preference order.
+fn available_agents(installed: &dyn Fn(&str) -> bool) -> Vec<&'static str> {
+    muxa::ask::supported_agents()
+        .iter()
+        .copied()
+        .filter(|name| installed(name))
+        .collect()
 }
 
 fn ask_operator() -> Result<String> {
@@ -329,9 +366,8 @@ program = 'claude'
     #[test]
     fn the_notice_names_the_command_and_that_it_costs_money() {
         let config = Config::default();
-        let lines = notice_lines("claude", std::path::Path::new("/home/june"), &config, false);
+        let lines = notice_lines(std::path::Path::new("/home/june"), &config, false);
         let text = lines.join("\n");
-        assert!(text.contains("claude (print mode)"), "{text}");
         assert!(text.contains("/home/june"), "{text}");
         assert!(text.contains("billed"), "{text}");
         // Nothing about dry-run when this is a real run.
@@ -343,7 +379,7 @@ program = 'claude'
         // The whole point: --dry-run skips the file write, not the agent
         // turn, so it must not read as "nothing happens".
         let config = Config::default();
-        let text = notice_lines("codex", std::path::Path::new("/tmp"), &config, true).join("\n");
+        let text = notice_lines(std::path::Path::new("/tmp"), &config, true).join("\n");
         assert!(text.contains("--dry-run skips writing the file"), "{text}");
         assert!(text.contains("still runs and still bills"), "{text}");
     }
@@ -351,13 +387,29 @@ program = 'claude'
     #[test]
     fn a_non_interactive_run_refuses_before_spending_anything() {
         // Tests run without a tty, which is exactly the case that must not
-        // silently spend a turn.
-        let error = confirm_spend().unwrap_err().to_string();
-        assert!(error.contains("billed"), "{error}");
+        // silently spend a turn. Whether it lands on the "no agent
+        // installed" or the "not a terminal" refusal depends on the
+        // machine; both stop before anything is spawned.
+        let error = choose_agent("claude").unwrap_err().to_string();
         assert!(
-            error.contains("--yes"),
-            "should name the way through: {error}"
+            error.contains("--yes") || error.contains("no headless-capable agent"),
+            "{error}"
         );
+    }
+
+    #[test]
+    fn only_agents_that_could_actually_run_are_offered() {
+        // The launcher knows gemini/agy/opencode; the headless bridge does
+        // not, so they must never appear here however installed.
+        let all = available_agents(&|_| true);
+        assert_eq!(all, muxa::ask::supported_agents().to_vec());
+        assert!(!all.contains(&"gemini"), "{all:?}");
+        assert!(!all.contains(&"agy"), "{all:?}");
+
+        // Supported but absent from PATH is still not offered: picking it
+        // would fail after the operator chose it.
+        assert_eq!(available_agents(&|name| name == "codex"), vec!["codex"]);
+        assert!(available_agents(&|_| false).is_empty());
     }
 
     #[test]

--- a/crates/muxa-cli/src/work_init.rs
+++ b/crates/muxa-cli/src/work_init.rs
@@ -310,15 +310,60 @@ fn merge(existing: &str, proposal: &str) -> Result<(String, Vec<String>)> {
         .parse()
         .context("the proposed config does not parse")?;
     let mut replaced = Vec::new();
+    let mut next = last_position(&doc) + 1;
     for key in OWNED_KEYS {
         if let Some(item) = incoming.get(key) {
             if doc.contains_key(key) {
                 replaced.push(key.to_string());
             }
-            doc.insert(key, item.clone());
+            let mut item = item.clone();
+            // Append rather than splice. A comment written before a header
+            // belongs to that header and lives in the *previous* section's
+            // span; inserting a table between the two silently re-homes it,
+            // so `# allow_work_start = true` under `[dashboard]` would come
+            // back as a key of `[[route]]` the moment someone uncommented
+            // it — and unknown keys are a hard error.
+            next = place_after(&mut item, next);
+            doc.insert(key, item);
         }
     }
     Ok((doc.to_string(), replaced))
+}
+
+/// Highest render position any top-level table currently occupies.
+fn last_position(doc: &toml_edit::DocumentMut) -> usize {
+    doc.iter()
+        .filter_map(|(_, item)| match item {
+            toml_edit::Item::Table(table) => table.position(),
+            toml_edit::Item::ArrayOfTables(array) => {
+                array.iter().filter_map(toml_edit::Table::position).max()
+            }
+            _ => None,
+        })
+        .max()
+        .unwrap_or(0)
+}
+
+/// Pin an incoming item to render after everything already in the file,
+/// returning the next free position.
+fn place_after(item: &mut toml_edit::Item, mut next: usize) -> usize {
+    match item {
+        toml_edit::Item::Table(table) => {
+            table.set_position(next);
+            next += 1;
+            for (_, child) in table.iter_mut() {
+                next = place_after(child, next);
+            }
+        }
+        toml_edit::Item::ArrayOfTables(array) => {
+            for table in array.iter_mut() {
+                table.set_position(next);
+                next += 1;
+            }
+        }
+        _ => {}
+    }
+    next
 }
 
 fn report(block: &str, summary: &ProposalSummary, replaced: &[String], path: &std::path::Path) {
@@ -470,6 +515,29 @@ program = 'claude'
         // Replaced wholesale, not merged key-by-key: a half-old, half-new
         // pipeline set is harder to reason about than a stated replacement.
         assert!(!merged.contains("pipeline.old"), "{merged}");
+    }
+
+    #[test]
+    fn a_comment_keeps_the_section_it_was_written_for() {
+        // A comment before a header belongs to that header. Inserting a new
+        // table between them leaves the comment stranded under the new
+        // section, where uncommenting it would mean something else entirely
+        // — and, for a key the new section does not accept, break config
+        // loading outright.
+        let existing =
+            "[watch]\ntheme = \"classic\"\n\n# allow_work_start = true\n[ask]\nenabled = true\n";
+        let (merged, _) = merge(existing, PROPOSAL).expect("merge");
+        let comment = merged.find("# allow_work_start").expect("comment survives");
+        let ask = merged.find("[ask]").expect("[ask] survives");
+        // The comment must stay inside the span of the section it was
+        // written for, which means nothing new may be spliced above it.
+        let route = merged.find("[[route]]").expect("route written");
+        assert!(
+            route > ask,
+            "new sections must be appended, not spliced above existing ones:\n{merged}"
+        );
+        let between = &merged[comment..ask];
+        assert!(!between.contains('['), "{merged}");
     }
 
     #[test]

--- a/crates/muxa-cli/src/work_init.rs
+++ b/crates/muxa-cli/src/work_init.rs
@@ -94,6 +94,14 @@ role    = 'implementer'       # optional; peers address it as role:<role>
 task    = 'fix the reaper'    # optional; short label in `muxa work show`/`watch`
 prompt  = '...'               # optional; this agent's own instructions
 direction = 'right'           # optional: right (default) or down
+after   = ['impl']            # optional: aliases that must report finishing
+                              # before this one starts. Omit for work that is
+                              # genuinely parallel; use it when one agent must
+                              # not see a tree the other is still changing —
+                              # a reviewer after its implementer, say. The
+                              # upstream agent opens the edge by running
+                              # `muxa work done` from its own pane, so tell it
+                              # to in that agent's prompt.
 
 Placeholders, usable in any prompt/path/workspace string:
 {{id}} lowercased work id, {{work}} as muxa stores it, {{workspace}},

--- a/crates/muxa-cli/src/work_up.rs
+++ b/crates/muxa-cli/src/work_up.rs
@@ -79,10 +79,9 @@ pub struct UpArgs {
     /// anything on it.
     #[arg(long)]
     pub show_prompts: bool,
-    /// Draw the pipeline as a dependency graph: what runs together, what
-    /// waits, and where this work currently sits in it.
-    #[arg(long)]
-    pub graph: bool,
+    /// Skip the confirmation before a billed ticket lookup.
+    #[arg(long, short = 'y')]
+    pub yes: bool,
     /// Emit the structured result as JSON.
     #[arg(long)]
     pub json: bool,
@@ -119,6 +118,10 @@ pub struct UpResult {
     /// The composed request, when the caller supplied one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request: Option<ComposedRequest>,
+    /// Dependency layout of the pipeline that produced this plan, so a
+    /// reader (or the dashboard) sees what runs together without
+    /// re-deriving it from the config.
+    pub graph: Vec<muxa::pipeline::GraphNode>,
     pub plan: Plan,
     pub launched: Vec<LaunchedAgent>,
     /// Aliases that were sent `--prompt`.
@@ -161,13 +164,9 @@ pub async fn run(
     let json = args.json;
     let dry_run = args.dry_run;
     let show_prompts = args.show_prompts;
-    let args_graph = args.graph;
     let resolved = resolve_or_onboard(&args, config, config_path, client).await?;
     if show_prompts {
         print_prompts(&resolved.desired);
-    }
-    if args_graph {
-        print_graph(&resolved.desired);
     }
     let result = apply(resolved, dry_run)?;
     if json {
@@ -268,6 +267,7 @@ fn finish(
         window,
         layout: resolved.layout,
         request: resolved.request,
+        graph: muxa::pipeline::graph(&resolved.desired),
         plan,
         launched,
         reprompted,
@@ -316,10 +316,14 @@ pub(crate) async fn resolve(
         }
     };
 
+    // Ask for the request first: it is free, and it is the last thing the
+    // operator can change once money starts moving.
+    let request = compose_request(args, config, &work)?;
+
     let ticket = if args.no_ticket {
         None
     } else {
-        resolve_ticket(&config.ticket, external_lookup, args.refresh).await?
+        resolve_ticket(&config.ticket, external_lookup, args.refresh, args.yes).await?
     };
 
     // Two ids because the two forms are both load-bearing: `work` is what
@@ -330,13 +334,6 @@ pub(crate) async fn resolve(
         vars = vars.with_ticket(ticket);
     }
 
-    // The caller's request is a var like any other, so a pipeline template
-    // can place it — and so it reaches the ticket-less path unchanged.
-    //
-    // Asked for when nothing was supplied: muxa has no idea what
-    // "cal-7210 callabo resolve" means and does not need to. It is opaque
-    // text the operator writes, carried to every agent verbatim.
-    let request = compose_request(args, config, &work)?;
     vars.set_opt(
         REQUEST_KEY,
         request.as_ref().map(|request| request.text.as_str()),
@@ -528,7 +525,12 @@ struct CachedTicket {
     ticket: Ticket,
 }
 
-async fn resolve_ticket(config: &TicketConfig, id: &str, refresh: bool) -> Result<Option<Ticket>> {
+async fn resolve_ticket(
+    config: &TicketConfig,
+    id: &str,
+    refresh: bool,
+    assume_yes: bool,
+) -> Result<Option<Ticket>> {
     let Some((source_name, source)) = pipeline::select_source(config, id)? else {
         return Ok(None);
     };
@@ -538,12 +540,13 @@ async fn resolve_ticket(config: &TicketConfig, id: &str, refresh: bool) -> Resul
             return Ok(Some(ticket));
         }
     }
-    // Say what is being spawned before spawning it. Only on a cache miss:
-    // the common re-run costs nothing and does not need announcing.
-    eprintln!(
-        "resolving {id} via ticket source {source_name:?} — one headless {} turn, billed to your account",
-        config.agent
-    );
+    // Ask before spending, not after. Only on a cache miss: the common
+    // re-run costs nothing, so the prompt appears exactly when money would
+    // move — including under `--dry-run`, which skips creating panes but
+    // still pays for the lookup.
+    if !confirm_lookup(id, source_name, &config.agent, assume_yes)? {
+        return Ok(None);
+    }
     let prompt = Vars::new().set("id", id).render(&source.prompt);
     let cwd = config
         .cwd
@@ -833,6 +836,25 @@ fn compose_request(args: &UpArgs, config: &Config, work: &str) -> Result<Option<
     )?)
 }
 
+/// Ask before the lookup spends a turn.
+///
+/// `--dry-run` does not exempt this: it skips creating panes, not the
+/// agent turn that resolves the ticket, and an operator who reads "dry
+/// run" as "nothing happens" would be paying without being asked.
+fn confirm_lookup(id: &str, source: &str, agent: &str, assume_yes: bool) -> Result<bool> {
+    use std::io::IsTerminal;
+    println!("{id} is not cached. Looking it up costs one headless {agent} turn, billed to your account (source {source:?}).");
+    if assume_yes {
+        return Ok(true);
+    }
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        bail!("looking up {id} spends a billed agent turn; pass --yes, or --no-ticket to skip it");
+    }
+    Ok(cliclack::confirm("Look it up?")
+        .initial_value(true)
+        .interact()?)
+}
+
 /// Ask what the agents should work on. Empty is a valid answer: a
 /// ticket-driven pipeline already knows the task.
 fn ask_for_request(work: &str) -> Result<Option<String>> {
@@ -880,49 +902,98 @@ fn launch(agent: &DesiredAgent, resolved: &Resolved) -> Result<LaunchedAgent> {
     })
 }
 
-/// One line per pipeline alias: what it is, and what it is doing.
+/// One line per pipeline alias, grouped by dependency depth.
+///
+/// The graph and the plan used to print as two blocks, so every agent
+/// appeared twice — once as a shape, once as a row — and neither view was
+/// complete on its own. They are the same thing: what runs when, and where
+/// it currently is. Grouping only kicks in when the pipeline actually has
+/// edges; a flat pipeline stays a flat list rather than gaining ceremony
+/// it does not need.
+///
+/// Glyphs stay inside Geometric Shapes U+25A0–25CF. The half-filled
+/// circles just past that range fall back to a different font in most
+/// terminals and render at the wrong size.
 fn print_plan_rows(result: &UpResult) {
-    for step in &result.plan.steps {
-        match step {
-            PlanStep::Launch(agent) => {
-                let pane = result
-                    .launched
-                    .iter()
-                    .find(|launched| launched.alias == agent.alias)
-                    .map_or_else(|| "-".to_string(), |launched| launched.pane.clone());
-                println!(
-                    "  + {:<10} {:<9} {:<12} {pane}",
-                    agent.alias,
-                    agent.program,
-                    agent.role.as_deref().unwrap_or("-")
-                );
-            }
-            PlanStep::Reprompt { alias, pane, .. } => {
-                println!("  » {alias:<10} {:<9} {:<12} {pane}", "prompted", "");
-            }
-            PlanStep::Keep { alias, pane, state } => {
-                println!(
-                    "  = {alias:<10} {:<9} {:<12} {pane}",
-                    state.map_or("running", state_label),
-                    ""
-                );
-            }
-            PlanStep::Waiting { alias, waiting_on } => {
-                println!(
-                    "  ⋯ {alias:<10} {:<9} {:<12} {}",
-                    "waiting",
-                    "after",
-                    waiting_on.join(", ")
-                );
-            }
-            PlanStep::Attention { alias, pane, state } => {
-                println!(
-                    "  ! {alias:<10} {:<9} {:<12} {pane}",
-                    state.map_or("blocked", state_label),
-                    "needs you"
-                );
-            }
+    let nodes = &result.graph;
+    let layered = nodes.iter().any(|node| node.depth > 0);
+    let mut depth = usize::MAX;
+    for node in nodes {
+        let Some(step) = result
+            .plan
+            .steps
+            .iter()
+            .find(|step| step.alias() == node.alias)
+        else {
+            continue;
+        };
+        if layered && node.depth != depth {
+            depth = node.depth;
+            println!(
+                "  {}",
+                if depth == 0 {
+                    "now".to_string()
+                } else {
+                    format!("then · after {}", node.after.join(", "))
+                }
+            );
         }
+        let indent = if layered { "   " } else { "  " };
+        let (glyph, status, detail) = describe(step, result);
+        println!(
+            "{indent}{glyph} {:<10} {:<8} {:<10} {status:<9} {detail}",
+            node.alias,
+            node.program,
+            node.role.as_deref().unwrap_or("-"),
+        );
+    }
+    for extra in &result.plan.unclaimed {
+        println!(
+            "  ◇ {:<10} {:<8} {:<10} {:<9} {}",
+            extra.alias.as_deref().unwrap_or("(no alias)"),
+            extra.program,
+            "-",
+            "unclaimed",
+            extra.pane
+        );
+    }
+}
+
+/// Glyph, status word, and trailing detail for one alias.
+fn describe(step: &PlanStep, result: &UpResult) -> (char, String, String) {
+    match step {
+        PlanStep::Launch(agent) => {
+            let pane = result
+                .launched
+                .iter()
+                .find(|launched| launched.alias == agent.alias)
+                .map_or_else(String::new, |launched| launched.pane.clone());
+            (
+                '●',
+                if result.dry_run {
+                    "will start".into()
+                } else {
+                    "started".into()
+                },
+                pane,
+            )
+        }
+        PlanStep::Keep { pane, state, .. } => (
+            '●',
+            state.map_or("running", state_label).to_string(),
+            pane.clone(),
+        ),
+        PlanStep::Reprompt { pane, .. } => ('●', "prompted".into(), pane.clone()),
+        PlanStep::Waiting { waiting_on, .. } => (
+            '○',
+            "waiting".into(),
+            format!("for {}", waiting_on.join(", ")),
+        ),
+        PlanStep::Attention { pane, state, .. } => (
+            '◆',
+            state.map_or("blocked", state_label).to_string(),
+            format!("{pane}  needs you"),
+        ),
     }
 }
 
@@ -990,46 +1061,6 @@ fn print_prompts(desired: &[DesiredAgent]) {
             None => println!("(no prompt — starts interactive)\n"),
         }
     }
-}
-
-/// Draw the pipeline as layers of a dependency graph.
-///
-/// The config lists agents in a flat table array and buries the ordering
-/// in an `after` key, so the one thing an operator wants to know before
-/// paying for a run — what starts now and what waits — is the one thing
-/// the file does not show. Equal depth means parallel.
-///
-/// Glyphs stay inside Geometric Shapes U+25A0–25CF: the half-filled
-/// circles just past that range fall back to a different font in most
-/// terminals and render at the wrong size.
-fn print_graph(desired: &[DesiredAgent]) {
-    let nodes = muxa::pipeline::graph(desired);
-    println!("pipeline graph:\n");
-    let mut depth = usize::MAX;
-    for node in &nodes {
-        if node.depth != depth {
-            depth = node.depth;
-            let label = if depth == 0 {
-                "starts immediately".to_string()
-            } else {
-                format!("waits for depth {}", depth - 1)
-            };
-            println!("  ── {label} ──");
-        }
-        let glyph = if node.after.is_empty() { '●' } else { '○' };
-        println!(
-            "   {glyph} {:<10} {:<9} {:<12}{}",
-            node.alias,
-            node.program,
-            node.role.as_deref().unwrap_or("-"),
-            if node.after.is_empty() {
-                String::new()
-            } else {
-                format!("after {}", node.after.join(", "))
-            }
-        );
-    }
-    println!();
 }
 
 fn print_result(result: &UpResult) {
@@ -1127,7 +1158,7 @@ mod tests {
             context: None,
             dry_run: false,
             show_prompts: false,
-            graph: false,
+            yes: false,
             no_ticket: true,
             refresh: false,
             json: false,

--- a/crates/muxa-cli/src/work_up.rs
+++ b/crates/muxa-cli/src/work_up.rs
@@ -21,10 +21,12 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use muxa::config::{Config, TicketConfig};
+use muxa::event::AgentState;
 use muxa::pipeline::{
     self, DesiredAgent, ExistingAgent, Plan, PlanStep, Ticket, Vars, WorktreePlan, REQUEST_KEY,
 };
 use muxa::request::{ComposedRequest, RequestParts};
+use std::collections::HashMap;
 
 use crate::agent_launch::{AgentProgram, Placement, SplitDirection, StartRequest};
 
@@ -73,6 +75,10 @@ pub struct UpArgs {
     /// Ignore a cached external issue and ask the resolver again.
     #[arg(long)]
     pub refresh: bool,
+    /// Print the exact prompt each agent would receive, before spending
+    /// anything on it.
+    #[arg(long)]
+    pub show_prompts: bool,
     /// Emit the structured result as JSON.
     #[arg(long)]
     pub json: bool,
@@ -136,12 +142,20 @@ pub(crate) struct Resolved {
     layout: Option<String>,
     request: Option<ComposedRequest>,
     desired: Vec<DesiredAgent>,
+    /// pane → what the daemon says that agent is doing. Empty when the
+    /// daemon is unreachable, which degrades to the old pane-only view
+    /// rather than failing the launch.
+    states: HashMap<String, AgentState>,
 }
 
-pub async fn run(args: UpArgs, config: &Config) -> Result<()> {
+pub async fn run(args: UpArgs, config: &Config, client: Option<&muxa::ipc::Client>) -> Result<()> {
     let json = args.json;
     let dry_run = args.dry_run;
-    let resolved = resolve(&args, config).await?;
+    let show_prompts = args.show_prompts;
+    let resolved = resolve(&args, config, client).await?;
+    if show_prompts {
+        print_prompts(&resolved.desired);
+    }
     let result = apply(resolved, dry_run)?;
     if json {
         println!("{}", serde_json::to_string_pretty(&result)?);
@@ -154,7 +168,7 @@ pub async fn run(args: UpArgs, config: &Config) -> Result<()> {
 /// The blocking half: read the window, diff it against the pipeline, and
 /// act on the difference.
 pub(crate) fn apply(resolved: Resolved, dry_run: bool) -> Result<UpResult> {
-    let existing = existing_agents(&resolved.work, &resolved.workspace)?;
+    let existing = existing_agents(&resolved.work, &resolved.workspace, &resolved.states)?;
     let broadcast = resolved
         .request
         .as_ref()
@@ -187,7 +201,7 @@ pub(crate) fn apply(resolved: Resolved, dry_run: bool) -> Result<UpResult> {
                     .with_context(|| format!("send --prompt to {alias} in pane {pane}"))?;
                 reprompted.push(alias.clone());
             }
-            PlanStep::Keep { .. } => {}
+            PlanStep::Keep { .. } | PlanStep::Attention { .. } => {}
         }
     }
 
@@ -244,7 +258,12 @@ fn finish(
 
 // ---------------------------------------------------------------- resolve
 
-pub(crate) async fn resolve(args: &UpArgs, config: &Config) -> Result<Resolved> {
+pub(crate) async fn resolve(
+    args: &UpArgs,
+    config: &Config,
+    client: Option<&muxa::ipc::Client>,
+) -> Result<Resolved> {
+    let states = agent_states(client).await;
     let work = crate::tmux_work::normalize_work_id(&args.work)?;
     let id = work.to_ascii_lowercase();
     if args.no_ticket
@@ -295,14 +314,11 @@ pub(crate) async fn resolve(args: &UpArgs, config: &Config) -> Result<Resolved> 
 
     // The caller's request is a var like any other, so a pipeline template
     // can place it — and so it reaches the ticket-less path unchanged.
-    let request = muxa::request::compose(
-        RequestParts {
-            skill: args.skill.as_deref(),
-            body: args.body.as_deref(),
-            context: args.context.as_deref(),
-        },
-        &config.message.skills,
-    )?;
+    //
+    // Asked for when nothing was supplied: muxa has no idea what
+    // "cal-7210 callabo resolve" means and does not need to. It is opaque
+    // text the operator writes, carried to every agent verbatim.
+    let request = compose_request(args, config, &work)?;
     vars.set_opt(
         REQUEST_KEY,
         request.as_ref().map(|request| request.text.as_str()),
@@ -362,6 +378,7 @@ pub(crate) async fn resolve(args: &UpArgs, config: &Config) -> Result<Resolved> 
         layout: spec.layout.clone(),
         request,
         desired,
+        states,
     })
 }
 
@@ -679,12 +696,43 @@ fn git(repo: &Path, args: &[String]) -> Result<String> {
 
 // ----------------------------------------------------------------- apply
 
-fn existing_agents(work: &str, workspace: &str) -> Result<Vec<ExistingAgent>> {
+/// Read the window's panes and, for each, what the daemon says the agent
+/// on it is doing.
+///
+/// A pane proves someone was started there. Whether they are working,
+/// idle, or stuck on a permission prompt is a different question, and the
+/// daemon is the only thing that can answer it.
+/// Ask the daemon what every tracked agent is doing, keyed by pane.
+///
+/// Best-effort: `muxa work up` does not otherwise need the daemon, and a
+/// launch should not fail because the control plane is down. Without it,
+/// the plan falls back to "a pane exists", which is what it always did.
+async fn agent_states(client: Option<&muxa::ipc::Client>) -> HashMap<String, AgentState> {
+    let Some(client) = client else {
+        return HashMap::new();
+    };
+    client.snapshot().await.map_or_else(
+        |_| HashMap::new(),
+        |agents| {
+            agents
+                .into_iter()
+                .filter_map(|agent| agent.pane.map(|pane| (pane, agent.state)))
+                .collect()
+        },
+    )
+}
+
+fn existing_agents(
+    work: &str,
+    workspace: &str,
+    states: &HashMap<String, AgentState>,
+) -> Result<Vec<ExistingAgent>> {
     Ok(crate::tmux_work::find_work_in(work, Some(workspace))?
         .map(|info| {
             info.agents
                 .into_iter()
                 .map(|agent| ExistingAgent {
+                    state: states.get(&agent.pane).copied(),
                     pane: agent.pane,
                     program: agent.agent,
                     alias: agent.alias,
@@ -692,6 +740,38 @@ fn existing_agents(work: &str, workspace: &str) -> Result<Vec<ExistingAgent>> {
                 .collect()
         })
         .unwrap_or_default())
+}
+
+/// Build the caller's request, asking for one when nothing was supplied.
+fn compose_request(args: &UpArgs, config: &Config, work: &str) -> Result<Option<ComposedRequest>> {
+    let body = match args.body.clone() {
+        Some(body) => Some(body),
+        None if args.skill.is_none() && args.context.is_none() => ask_for_request(work)?,
+        None => None,
+    };
+    Ok(muxa::request::compose(
+        RequestParts {
+            skill: args.skill.as_deref(),
+            body: body.as_deref(),
+            context: args.context.as_deref(),
+        },
+        &config.message.skills,
+    )?)
+}
+
+/// Ask what the agents should work on. Empty is a valid answer: a
+/// ticket-driven pipeline already knows the task.
+fn ask_for_request(work: &str) -> Result<Option<String>> {
+    use std::io::IsTerminal;
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        return Ok(None);
+    }
+    let text: String = cliclack::input(format!("What should the agents do for {work}?"))
+        .placeholder("leave empty to use the pipeline's own instructions")
+        .required(false)
+        .interact()?;
+    let text = text.trim().to_string();
+    Ok((!text.is_empty()).then_some(text))
 }
 
 fn launch(agent: &DesiredAgent, resolved: &Resolved) -> Result<LaunchedAgent> {
@@ -726,6 +806,56 @@ fn launch(agent: &DesiredAgent, resolved: &Resolved) -> Result<LaunchedAgent> {
     })
 }
 
+/// One line per pipeline alias: what it is, and what it is doing.
+fn print_plan_rows(result: &UpResult) {
+    for step in &result.plan.steps {
+        match step {
+            PlanStep::Launch(agent) => {
+                let pane = result
+                    .launched
+                    .iter()
+                    .find(|launched| launched.alias == agent.alias)
+                    .map_or_else(|| "-".to_string(), |launched| launched.pane.clone());
+                println!(
+                    "  + {:<10} {:<9} {:<12} {pane}",
+                    agent.alias,
+                    agent.program,
+                    agent.role.as_deref().unwrap_or("-")
+                );
+            }
+            PlanStep::Reprompt { alias, pane, .. } => {
+                println!("  » {alias:<10} {:<9} {:<12} {pane}", "prompted", "");
+            }
+            PlanStep::Keep { alias, pane, state } => {
+                println!(
+                    "  = {alias:<10} {:<9} {:<12} {pane}",
+                    state.map_or("running", state_label),
+                    ""
+                );
+            }
+            PlanStep::Attention { alias, pane, state } => {
+                println!(
+                    "  ! {alias:<10} {:<9} {:<12} {pane}",
+                    state.map_or("blocked", state_label),
+                    "needs you"
+                );
+            }
+        }
+    }
+}
+
+fn state_label(state: AgentState) -> &'static str {
+    match state {
+        AgentState::Starting => "starting",
+        AgentState::Working => "working",
+        AgentState::Idle => "idle",
+        AgentState::WaitingInput => "waiting",
+        AgentState::WaitingChoice => "choosing",
+        AgentState::Error => "error",
+        AgentState::Stopped => "stopped",
+    }
+}
+
 fn send_prompt(pane: &str, text: &str) -> Result<()> {
     if !muxa::tmux::send_text(pane, text) {
         bail!("tmux refused the prompt; the pane may be gone");
@@ -756,6 +886,29 @@ fn apply_layout(window: &str, layout: &str) -> Result<()> {
 }
 
 // ---------------------------------------------------------------- output
+
+/// Show what each agent would actually receive. The rendered prompt is
+/// the thing worth reviewing before spending a turn on it — a leftover
+/// `{{ticket.title}}` or a role instruction that says the wrong thing is
+/// obvious here and invisible in the plan summary.
+fn print_prompts(desired: &[DesiredAgent]) {
+    println!("prompts that would be sent:\n");
+    for agent in desired {
+        println!(
+            "─── {} ({}{}) ───",
+            agent.alias,
+            agent.program,
+            agent
+                .role
+                .as_deref()
+                .map_or_else(String::new, |role| format!(", {role}"))
+        );
+        match agent.prompt.as_deref() {
+            Some(prompt) => println!("{prompt}\n"),
+            None => println!("(no prompt — starts interactive)\n"),
+        }
+    }
+}
 
 fn print_result(result: &UpResult) {
     let verb = if result.dry_run { "would be" } else { "is" };
@@ -804,29 +957,7 @@ fn print_result(result: &UpResult) {
             }
         );
     }
-    for step in &result.plan.steps {
-        match step {
-            PlanStep::Launch(agent) => {
-                let pane = result
-                    .launched
-                    .iter()
-                    .find(|launched| launched.alias == agent.alias)
-                    .map_or_else(|| "-".to_string(), |launched| launched.pane.clone());
-                println!(
-                    "  + {:<10} {:<9} {:<12} {pane}",
-                    agent.alias,
-                    agent.program,
-                    agent.role.as_deref().unwrap_or("-")
-                );
-            }
-            PlanStep::Reprompt { alias, pane, .. } => {
-                println!("  » {alias:<10} {:<9} {:<12} {pane}", "prompted", "");
-            }
-            PlanStep::Keep { alias, pane } => {
-                println!("  = {alias:<10} {:<9} {:<12} {pane}", "running", "");
-            }
-        }
-    }
+    print_plan_rows(result);
     for extra in &result.plan.unclaimed {
         println!(
             "  ? {:<10} {:<9} {:<12} {}",
@@ -838,6 +969,12 @@ fn print_result(result: &UpResult) {
     }
     if let Some(layout) = &result.layout {
         println!("  layout   {layout}");
+    }
+    if result.plan.attention() > 0 {
+        println!(
+            "\n{} agent(s) are waiting on you; muxa did not type over their prompt.",
+            result.plan.attention()
+        );
     }
     if result.dry_run {
         println!("\ndry run: nothing was created. Re-run without --dry-run to apply.");
@@ -861,6 +998,7 @@ mod tests {
             skill: None,
             context: None,
             dry_run: false,
+            show_prompts: false,
             no_ticket: true,
             refresh: false,
             json: false,

--- a/crates/muxa-cli/src/work_up.rs
+++ b/crates/muxa-cli/src/work_up.rs
@@ -126,6 +126,11 @@ pub struct UpResult {
     pub launched: Vec<LaunchedAgent>,
     /// Aliases that were sent `--prompt`.
     pub reprompted: Vec<String>,
+    /// Aliases that have reported `muxa work done` on this work, newest run
+    /// included. Carried so a reader can tell a converged pipeline from a
+    /// stalled one: both leave every pane `idle`, and without this the two
+    /// render identically.
+    pub done: Vec<String>,
 }
 
 /// Everything decided before a single tmux command runs.
@@ -201,6 +206,7 @@ pub(crate) fn apply(resolved: Resolved, dry_run: bool) -> Result<UpResult> {
             None,
             None,
             true,
+            done,
         ));
     }
 
@@ -240,7 +246,7 @@ pub(crate) fn apply(resolved: Resolved, dry_run: bool) -> Result<UpResult> {
         apply_layout(window, layout)?;
     }
     Ok(finish(
-        resolved, plan, launched, reprompted, session, window, false,
+        resolved, plan, launched, reprompted, session, window, false, done,
     ))
 }
 
@@ -253,6 +259,7 @@ fn finish(
     session: Option<String>,
     window: Option<String>,
     dry_run: bool,
+    done: Vec<String>,
 ) -> UpResult {
     UpResult {
         work: resolved.work,
@@ -271,6 +278,7 @@ fn finish(
         plan,
         launched,
         reprompted,
+        done,
     }
 }
 
@@ -978,11 +986,21 @@ fn describe(step: &PlanStep, result: &UpResult) -> (char, String, String) {
                 pane,
             )
         }
-        PlanStep::Keep { pane, state, .. } => (
-            '●',
-            state.map_or("running", state_label).to_string(),
-            pane.clone(),
-        ),
+        PlanStep::Keep { pane, state, .. } => {
+            // Only while it is actually at rest: an agent that reported done
+            // and was then re-prompted is working again, and saying `done`
+            // over live work would be a lie the operator acts on.
+            let at_rest = state.is_none_or(|state| state == AgentState::Idle);
+            if at_rest && result.done.iter().any(|alias| alias == step.alias()) {
+                ('◉', "done".into(), pane.clone())
+            } else {
+                (
+                    '●',
+                    state.map_or("running", state_label).to_string(),
+                    pane.clone(),
+                )
+            }
+        }
         PlanStep::Reprompt { pane, .. } => ('●', "prompted".into(), pane.clone()),
         PlanStep::Waiting { waiting_on, .. } => (
             '○',
@@ -994,6 +1012,70 @@ fn describe(step: &PlanStep, result: &UpResult) -> (char, String, String) {
             state.map_or("blocked", state_label).to_string(),
             format!("{pane}  needs you"),
         ),
+    }
+}
+
+#[cfg(test)]
+mod done_view_tests {
+    use super::*;
+
+    fn result_with(done: &[&str]) -> UpResult {
+        UpResult {
+            work: "CAL-1".into(),
+            workspace: "ws".into(),
+            pipeline: "pair".into(),
+            cwd: std::path::PathBuf::from("/repo"),
+            dry_run: false,
+            ticket: None,
+            worktree: None,
+            created_worktree: false,
+            session: None,
+            window: None,
+            layout: None,
+            request: None,
+            graph: Vec::new(),
+            plan: Plan {
+                steps: Vec::new(),
+                unclaimed: Vec::new(),
+            },
+            launched: Vec::new(),
+            reprompted: Vec::new(),
+            done: done.iter().map(|alias| (*alias).to_string()).collect(),
+        }
+    }
+
+    fn kept(alias: &str, state: Option<AgentState>) -> PlanStep {
+        PlanStep::Keep {
+            alias: alias.to_string(),
+            pane: "%9".into(),
+            state,
+        }
+    }
+
+    /// The gap this closes: a converged pipeline and a stalled one both leave
+    /// every pane `idle`, so the plan view rendered them identically and a
+    /// finished review sat unnoticed.
+    #[test]
+    fn a_reported_agent_reads_as_done_not_idle() {
+        let result = result_with(&["review"]);
+        let (glyph, status, _) = describe(&kept("review", Some(AgentState::Idle)), &result);
+        assert_eq!(status, "done");
+        assert_eq!(glyph, '\u{25c9}');
+
+        let (_, status, _) = describe(&kept("impl", Some(AgentState::Idle)), &result);
+        assert_eq!(status, "idle", "an alias that never reported is just idle");
+    }
+
+    /// Done is a claim about work at rest. An agent re-prompted after
+    /// reporting is working again, and rendering that as `done` would be a
+    /// lie the operator acts on.
+    #[test]
+    fn live_work_outranks_a_stale_done_marker() {
+        let result = result_with(&["review"]);
+        for state in [AgentState::Working, AgentState::Starting] {
+            let (_, status, _) = describe(&kept("review", Some(state)), &result);
+            assert_eq!(status, state_label(state));
+        }
     }
 }
 

--- a/crates/muxa-cli/src/work_up.rs
+++ b/crates/muxa-cli/src/work_up.rs
@@ -174,11 +174,16 @@ pub async fn run(
 /// act on the difference.
 pub(crate) fn apply(resolved: Resolved, dry_run: bool) -> Result<UpResult> {
     let existing = existing_agents(&resolved.work, &resolved.workspace, &resolved.states)?;
+    // The completion set lives on the work window, so a re-run reads what
+    // previous runs' agents reported even though none of them still exist.
+    let done = crate::tmux_work::find_work_in(&resolved.work, Some(&resolved.workspace))?
+        .map(|info| info.done)
+        .unwrap_or_default();
     let broadcast = resolved
         .request
         .as_ref()
         .map(|request| request.text.as_str());
-    let plan = pipeline::plan(&resolved.desired, &existing, broadcast);
+    let plan = pipeline::plan(&resolved.desired, &existing, broadcast, &done);
 
     if dry_run {
         return Ok(finish(
@@ -206,7 +211,7 @@ pub(crate) fn apply(resolved: Resolved, dry_run: bool) -> Result<UpResult> {
                     .with_context(|| format!("send --prompt to {alias} in pane {pane}"))?;
                 reprompted.push(alias.clone());
             }
-            PlanStep::Keep { .. } | PlanStep::Attention { .. } => {}
+            PlanStep::Keep { .. } | PlanStep::Attention { .. } | PlanStep::Waiting { .. } => {}
         }
     }
 
@@ -894,6 +899,14 @@ fn print_plan_rows(result: &UpResult) {
                     ""
                 );
             }
+            PlanStep::Waiting { alias, waiting_on } => {
+                println!(
+                    "  ⋯ {alias:<10} {:<9} {:<12} {}",
+                    "waiting",
+                    "after",
+                    waiting_on.join(", ")
+                );
+            }
             PlanStep::Attention { alias, pane, state } => {
                 println!(
                     "  ! {alias:<10} {:<9} {:<12} {pane}",
@@ -1031,6 +1044,12 @@ fn print_result(result: &UpResult) {
     if let Some(layout) = &result.layout {
         println!("  layout   {layout}");
     }
+    if result.plan.waiting() > 0 {
+        println!(
+            "\n{} agent(s) wait on an upstream alias; they start once it reports `muxa work done`.",
+            result.plan.waiting()
+        );
+    }
     if result.plan.attention() > 0 {
         println!(
             "\n{} agent(s) are waiting on you; muxa did not type over their prompt.",
@@ -1136,6 +1155,7 @@ mod tests {
             window_name: "CAL-1".into(),
             cwd: PathBuf::from("/tmp/already-here"),
             external_item: None,
+            done: Vec::new(),
             agents: Vec::new(),
         };
         let (cwd, worktree, created) =

--- a/crates/muxa-cli/src/work_up.rs
+++ b/crates/muxa-cli/src/work_up.rs
@@ -62,7 +62,9 @@ pub struct UpArgs {
     /// it from the instruction.
     #[arg(long)]
     pub context: Option<String>,
-    /// Resolve and diff, then print what would happen and change nothing.
+    /// Resolve and diff, then print what would happen and create nothing.
+    /// Ticket lookup still runs on a cache miss, and that is a billed agent
+    /// turn; `--no-ticket` skips it entirely.
     #[arg(long)]
     pub dry_run: bool,
     /// Skip external issue lookup and launch on the Work id alone.
@@ -468,7 +470,7 @@ fn run_prepare(command: &str) -> Result<()> {
     Ok(())
 }
 
-fn expand_tilde(value: &str) -> String {
+pub(crate) fn expand_tilde(value: &str) -> String {
     let Some(rest) = value.strip_prefix('~') else {
         return value.to_string();
     };
@@ -501,6 +503,12 @@ async fn resolve_ticket(config: &TicketConfig, id: &str, refresh: bool) -> Resul
             return Ok(Some(ticket));
         }
     }
+    // Say what is being spawned before spawning it. Only on a cache miss:
+    // the common re-run costs nothing and does not need announcing.
+    eprintln!(
+        "resolving {id} via ticket source {source_name:?} — one headless {} turn, billed to your account",
+        config.agent
+    );
     let prompt = Vars::new().set("id", id).render(&source.prompt);
     let cwd = config
         .cwd
@@ -520,6 +528,9 @@ async fn resolve_ticket(config: &TicketConfig, id: &str, refresh: bool) -> Resul
     .with_context(|| {
         format!("ticket source {source_name:?} could not look up {id} (use --no-ticket to launch without it)")
     })?;
+    if let Some(cost) = answer.cost_usd {
+        eprintln!("that lookup cost ${cost:.4}.");
+    }
     let mut ticket = Ticket::parse_reply(id, &answer.text).with_context(|| {
         format!("ticket source {source_name:?} answered for {id} but not with a ticket")
     })?;

--- a/crates/muxa-cli/src/work_up.rs
+++ b/crates/muxa-cli/src/work_up.rs
@@ -79,6 +79,10 @@ pub struct UpArgs {
     /// anything on it.
     #[arg(long)]
     pub show_prompts: bool,
+    /// Draw the pipeline as a dependency graph: what runs together, what
+    /// waits, and where this work currently sits in it.
+    #[arg(long)]
+    pub graph: bool,
     /// Emit the structured result as JSON.
     #[arg(long)]
     pub json: bool,
@@ -157,9 +161,13 @@ pub async fn run(
     let json = args.json;
     let dry_run = args.dry_run;
     let show_prompts = args.show_prompts;
+    let args_graph = args.graph;
     let resolved = resolve_or_onboard(&args, config, config_path, client).await?;
     if show_prompts {
         print_prompts(&resolved.desired);
+    }
+    if args_graph {
+        print_graph(&resolved.desired);
     }
     let result = apply(resolved, dry_run)?;
     if json {
@@ -984,6 +992,46 @@ fn print_prompts(desired: &[DesiredAgent]) {
     }
 }
 
+/// Draw the pipeline as layers of a dependency graph.
+///
+/// The config lists agents in a flat table array and buries the ordering
+/// in an `after` key, so the one thing an operator wants to know before
+/// paying for a run — what starts now and what waits — is the one thing
+/// the file does not show. Equal depth means parallel.
+///
+/// Glyphs stay inside Geometric Shapes U+25A0–25CF: the half-filled
+/// circles just past that range fall back to a different font in most
+/// terminals and render at the wrong size.
+fn print_graph(desired: &[DesiredAgent]) {
+    let nodes = muxa::pipeline::graph(desired);
+    println!("pipeline graph:\n");
+    let mut depth = usize::MAX;
+    for node in &nodes {
+        if node.depth != depth {
+            depth = node.depth;
+            let label = if depth == 0 {
+                "starts immediately".to_string()
+            } else {
+                format!("waits for depth {}", depth - 1)
+            };
+            println!("  ── {label} ──");
+        }
+        let glyph = if node.after.is_empty() { '●' } else { '○' };
+        println!(
+            "   {glyph} {:<10} {:<9} {:<12}{}",
+            node.alias,
+            node.program,
+            node.role.as_deref().unwrap_or("-"),
+            if node.after.is_empty() {
+                String::new()
+            } else {
+                format!("after {}", node.after.join(", "))
+            }
+        );
+    }
+    println!();
+}
+
 fn print_result(result: &UpResult) {
     let verb = if result.dry_run { "would be" } else { "is" };
     println!(
@@ -1079,6 +1127,7 @@ mod tests {
             context: None,
             dry_run: false,
             show_prompts: false,
+            graph: false,
             no_ticket: true,
             refresh: false,
             json: false,

--- a/crates/muxa-cli/src/work_up.rs
+++ b/crates/muxa-cli/src/work_up.rs
@@ -148,11 +148,16 @@ pub(crate) struct Resolved {
     states: HashMap<String, AgentState>,
 }
 
-pub async fn run(args: UpArgs, config: &Config, client: Option<&muxa::ipc::Client>) -> Result<()> {
+pub async fn run(
+    args: UpArgs,
+    config: &Config,
+    config_path: Option<PathBuf>,
+    client: Option<&muxa::ipc::Client>,
+) -> Result<()> {
     let json = args.json;
     let dry_run = args.dry_run;
     let show_prompts = args.show_prompts;
-    let resolved = resolve(&args, config, client).await?;
+    let resolved = resolve_or_onboard(&args, config, config_path, client).await?;
     if show_prompts {
         print_prompts(&resolved.desired);
     }
@@ -740,6 +745,62 @@ fn existing_agents(
                 .collect()
         })
         .unwrap_or_default())
+}
+
+/// Resolve, and on a first run with nothing configured, offer to set it
+/// up rather than failing with instructions the operator then has to
+/// follow by hand.
+///
+/// "No route matches" is only an error for someone who already has a
+/// config. For everyone else it is the first thing muxa ever says to
+/// them, and answering it with TOML syntax is how a feature goes unused.
+/// `muxa work init` is already the conversation that fixes it, so this
+/// hands over to it and retries once with the config it wrote.
+async fn resolve_or_onboard(
+    args: &UpArgs,
+    config: &Config,
+    config_path: Option<PathBuf>,
+    client: Option<&muxa::ipc::Client>,
+) -> Result<Resolved> {
+    let error = match resolve(args, config, client).await {
+        Ok(resolved) => return Ok(resolved),
+        Err(error) => error,
+    };
+    let unconfigured = error
+        .downcast_ref::<pipeline::PipelineError>()
+        .is_some_and(|error| matches!(error, pipeline::PipelineError::NoRoute(_)));
+    if !unconfigured || !offer_onboarding()? {
+        return Err(error);
+    }
+    crate::work_init::run(
+        crate::work_init::InitArgs {
+            describe: None,
+            agent: None,
+            dry_run: false,
+            yes: false,
+        },
+        config,
+        config_path.clone(),
+    )
+    .await?;
+    // Reload: the file just changed underneath the config this process
+    // started with.
+    let config = Config::load_or_default(config_path.as_deref())
+        .context("re-reading the config muxa work init just wrote")?;
+    resolve(args, &config, client).await
+}
+
+/// Ask whether to set muxa up now. Non-interactive callers keep the plain
+/// error — a script wants a failure it can read, not a prompt.
+fn offer_onboarding() -> Result<bool> {
+    use std::io::IsTerminal;
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        return Ok(false);
+    }
+    println!("muxa has no work pipeline configured yet.");
+    Ok(cliclack::confirm("Set one up now?")
+        .initial_value(true)
+        .interact()?)
 }
 
 /// Build the caller's request, asking for one when nothing was supplied.

--- a/crates/muxa-cli/src/work_up.rs
+++ b/crates/muxa-cli/src/work_up.rs
@@ -25,7 +25,9 @@ use muxa::event::AgentState;
 use muxa::pipeline::{
     self, DesiredAgent, ExistingAgent, Plan, PlanStep, Ticket, Vars, WorktreePlan, REQUEST_KEY,
 };
+use muxa::pipeline_run::{PipelineAliasObservation, PipelineAliasStatus, PipelineRunRegistration};
 use muxa::request::{ComposedRequest, RequestParts};
+use muxa::work::WorkIdentity;
 use std::collections::HashMap;
 
 use crate::agent_launch::{AgentProgram, Placement, SplitDirection, StartRequest};
@@ -85,6 +87,17 @@ pub struct UpArgs {
     /// Emit the structured result as JSON.
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct ReconcileArgs {
+    /// Reconcile every durable Run with a dependency-ready alias.
+    #[arg(long)]
+    pub all: bool,
+    #[arg(long, requires = "work")]
+    pub workspace: Option<String>,
+    #[arg(long, requires = "workspace")]
+    pub work: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -154,6 +167,9 @@ pub(crate) struct Resolved {
     layout: Option<String>,
     request: Option<ComposedRequest>,
     desired: Vec<DesiredAgent>,
+    /// Existing daemon-owned state, used by dry-run rendering. A real apply
+    /// performs an atomic register and reads the returned Run instead.
+    durable_run: Option<muxa::pipeline_run::PipelineRun>,
     /// pane → what the daemon says that agent is doing. Empty when the
     /// daemon is unreachable, which degrades to the old pane-only view
     /// rather than failing the launch.
@@ -173,7 +189,14 @@ pub async fn run(
     if show_prompts {
         print_prompts(&resolved.desired);
     }
-    let result = apply(resolved, dry_run)?;
+    let result = if dry_run {
+        apply(resolved, true)?
+    } else {
+        let client = client.ok_or_else(|| {
+            anyhow::anyhow!("muxa work up requires muxad for durable pipeline state")
+        })?;
+        apply_durable(resolved, client).await?
+    };
     if json {
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
@@ -185,52 +208,208 @@ pub async fn run(
 /// The blocking half: read the window, diff it against the pipeline, and
 /// act on the difference.
 pub(crate) fn apply(resolved: Resolved, dry_run: bool) -> Result<UpResult> {
+    if !dry_run {
+        bail!("non-dry pipeline reconciliation must use muxad's durable Run state");
+    }
     let existing = existing_agents(&resolved.work, &resolved.workspace, &resolved.states)?;
     // The completion set lives on the work window, so a re-run reads what
     // previous runs' agents reported even though none of them still exist.
-    let done = crate::tmux_work::find_work_in(&resolved.work, Some(&resolved.workspace))?
-        .map(|info| info.done)
-        .unwrap_or_default();
+    let done = if let Some(run) = resolved.durable_run.as_ref() {
+        run.aliases
+            .values()
+            .filter(|state| state.status == PipelineAliasStatus::Done)
+            .map(|state| state.alias.clone())
+            .collect()
+    } else {
+        crate::tmux_work::find_work_in(&resolved.work, Some(&resolved.workspace))?
+            .map(|info| info.done)
+            .unwrap_or_default()
+    };
     let broadcast = resolved
         .request
         .as_ref()
         .map(|request| request.text.as_str());
     let plan = pipeline::plan(&resolved.desired, &existing, broadcast, &done);
 
-    if dry_run {
-        return Ok(finish(
-            resolved,
-            plan,
-            Vec::new(),
-            Vec::new(),
-            None,
-            None,
-            true,
-            done,
-        ));
-    }
+    Ok(finish(
+        resolved,
+        plan,
+        Vec::new(),
+        Vec::new(),
+        None,
+        None,
+        true,
+        done,
+    ))
+}
 
+/// Register desired state with muxad, atomically claim dependency-ready
+/// aliases, then report the physical launch/re-prompt result. Completion and
+/// dependency gating are never inferred from the live pane set here.
+#[allow(clippy::too_many_lines)] // register, claim, physical apply, and report are one reconciliation flow
+pub(crate) async fn apply_durable(
+    resolved: Resolved,
+    client: &muxa::ipc::Client,
+) -> Result<UpResult> {
+    let existing = existing_agents(&resolved.work, &resolved.workspace, &resolved.states)?;
+    let work_info = crate::tmux_work::find_work_in(&resolved.work, Some(&resolved.workspace))?;
+    let observed = existing
+        .iter()
+        .filter_map(|agent| {
+            let alias = agent.alias.clone()?;
+            Some(PipelineAliasObservation {
+                alias,
+                pane: agent.pane.clone(),
+                status: match agent.state {
+                    Some(AgentState::WaitingInput | AgentState::WaitingChoice) => {
+                        PipelineAliasStatus::Blocked
+                    }
+                    Some(AgentState::Error | AgentState::Stopped) => PipelineAliasStatus::Failed,
+                    Some(AgentState::Starting | AgentState::Working | AgentState::Idle) | None => {
+                        PipelineAliasStatus::Running
+                    }
+                },
+            })
+        })
+        .collect::<Vec<_>>();
+    // `--body`/`--prompt` is a real restart of every existing pipeline
+    // participant. The store expands these roots transitively and advances
+    // the Run generation before any prompt can be delivered.
+    let mut invalidate = resolved.request.as_ref().map_or_else(Vec::new, |_| {
+        existing
+            .iter()
+            .filter_map(|agent| agent.alias.clone())
+            .collect()
+    });
+    // An explicit `work up` is also the retry control for a launch that
+    // failed before producing a pane. Pane-backed failures remain visible
+    // for the operator to inspect/close; blindly typing a prompt into a
+    // stopped shell could execute it as a command.
+    if let Some(previous) = resolved.durable_run.as_ref() {
+        invalidate.extend(
+            previous
+                .aliases
+                .values()
+                .filter(|state| state.status == PipelineAliasStatus::Failed && state.pane.is_none())
+                .map(|state| state.alias.clone()),
+        );
+    }
+    invalidate.sort();
+    invalidate.dedup();
+    let identity = WorkIdentity::new(resolved.workspace.clone(), resolved.work.clone());
+    let registration = PipelineRunRegistration {
+        identity: identity.clone(),
+        pipeline: resolved.pipeline.clone(),
+        desired: resolved.desired.clone(),
+        cwd: resolved.cwd.clone(),
+        window_id: work_info.as_ref().map(|work| work.window.clone()),
+        observed,
+        invalidate,
+    };
+    let mut run = client
+        .pipeline_register(&registration)
+        .await
+        .context("register durable pipeline Run with muxad")?;
+    // Migration/adoption path: panes created before durable Runs have no
+    // generation option yet. Stamp every active alias with its own expected
+    // generation; pending invalidated descendants keep the old value until
+    // dependency reconciliation reaches them.
+    for agent in &existing {
+        let Some(alias) = agent.alias.as_deref() else {
+            continue;
+        };
+        let Some(state) = run.aliases.get(alias) else {
+            continue;
+        };
+        if !state.reconcile_pending {
+            crate::tmux_work::mark_agent_generation(&agent.pane, state.generation)
+                .with_context(|| format!("stamp pipeline generation on alias {alias:?}"))?;
+        }
+    }
+    let done = run
+        .aliases
+        .values()
+        .filter(|state| state.status == PipelineAliasStatus::Done)
+        .map(|state| state.alias.clone())
+        .collect::<Vec<_>>();
+    let broadcast = resolved
+        .request
+        .as_ref()
+        .map(|request| request.text.as_str());
+    let plan = pipeline::plan(&resolved.desired, &existing, broadcast, &done);
+    let claims = client
+        .pipeline_claim(&identity, run.generation)
+        .await
+        .context("claim dependency-ready pipeline aliases")?;
     let mut launched = Vec::new();
     let mut reprompted = Vec::new();
-    for step in &plan.steps {
-        match step {
-            PlanStep::Launch(agent) => launched.push(launch(agent, &resolved)?),
-            PlanStep::Reprompt {
-                alias,
-                pane,
-                prompt,
-            } => {
-                send_prompt(pane, prompt)
-                    .with_context(|| format!("send --prompt to {alias} in pane {pane}"))?;
-                reprompted.push(alias.clone());
+    for claim in claims {
+        let outcome = if let Some(pane) = claim.pane.as_deref() {
+            let result = (|| {
+                crate::tmux_work::mark_agent_generation(pane, claim.generation)?;
+                if let Some(prompt) = claim.agent.prompt.as_deref() {
+                    send_prompt(pane, prompt).with_context(|| {
+                        format!(
+                            "re-prompt pipeline alias {:?} in pane {pane}",
+                            claim.agent.alias
+                        )
+                    })?;
+                }
+                reprompted.push(claim.agent.alias.clone());
+                Ok((pane.to_string(), run.window_id.clone()))
+            })();
+            result
+        } else {
+            match recover_unreported_alias(&identity, &claim.agent.alias, claim.generation) {
+                Ok(Some(target)) => Ok(target),
+                Ok(None) => launch(&claim.agent, &resolved, claim.generation).map(|agent| {
+                    let pane = agent.pane.clone();
+                    launched.push(agent);
+                    let window =
+                        crate::tmux_work::find_work_in(&resolved.work, Some(&resolved.workspace))
+                            .ok()
+                            .flatten()
+                            .map(|work| work.window);
+                    (pane, window)
+                }),
+                Err(error) => Err(error),
             }
-            PlanStep::Keep { .. } | PlanStep::Attention { .. } | PlanStep::Waiting { .. } => {}
+        };
+        match outcome {
+            Ok((pane, window)) => {
+                run = client
+                    .pipeline_report(
+                        &identity,
+                        &claim.agent.alias,
+                        claim.generation,
+                        PipelineAliasStatus::Running,
+                        Some(&pane),
+                        None,
+                        window.as_deref(),
+                    )
+                    .await
+                    .with_context(|| {
+                        format!("report pipeline alias {:?} running", claim.agent.alias)
+                    })?;
+            }
+            Err(error) => {
+                let detail = format!("{error:#}");
+                let _ = client
+                    .pipeline_report(
+                        &identity,
+                        &claim.agent.alias,
+                        claim.generation,
+                        PipelineAliasStatus::Failed,
+                        claim.pane.as_deref(),
+                        Some(&detail),
+                        run.window_id.as_deref(),
+                    )
+                    .await;
+                return Err(error);
+            }
         }
     }
 
-    // Read identity back from tmux rather than from the launch results:
-    // when every agent was already running, nothing was launched and there
-    // is no result to read it from.
     let (session, window) =
         match crate::tmux_work::find_work_in(&resolved.work, Some(&resolved.workspace))? {
             Some(info) => (Some(info.session), Some(info.window)),
@@ -241,13 +420,154 @@ pub(crate) fn apply(resolved: Resolved, dry_run: bool) -> Result<UpResult> {
             .with_context(|| format!("record external issue on work window {window}"))?;
     }
     if let (Some(window), Some(layout)) = (window.as_deref(), resolved.layout.as_deref()) {
-        // Splitting an existing window repeatedly halves whichever pane was
-        // active, so geometry is only sane once every pane exists.
         apply_layout(window, layout)?;
     }
+    let done = run
+        .aliases
+        .values()
+        .filter(|state| state.status == PipelineAliasStatus::Done)
+        .map(|state| state.alias.clone())
+        .collect();
     Ok(finish(
         resolved, plan, launched, reprompted, session, window, false, done,
     ))
+}
+
+/// Reconcile one already-registered Run from its persisted desired agents.
+/// This is used immediately after a completion event and by muxad's restart
+/// safety-net worker, so neither path needs to resolve the ticket again.
+pub(crate) async fn reconcile_run(
+    client: &muxa::ipc::Client,
+    identity: &WorkIdentity,
+    generation: u64,
+) -> Result<Vec<LaunchedAgent>> {
+    let claims = client
+        .pipeline_claim(identity, generation)
+        .await
+        .context("claim dependency-ready pipeline aliases")?;
+    let mut launched = Vec::new();
+    for claim in claims {
+        let outcome: Result<(String, Option<String>)> = if let Some(pane) = claim.pane.as_deref() {
+            (|| {
+                crate::tmux_work::mark_agent_generation(pane, claim.generation)?;
+                if let Some(prompt) = claim.agent.prompt.as_deref() {
+                    send_prompt(pane, prompt).with_context(|| {
+                        format!(
+                            "re-prompt pipeline alias {:?} in pane {pane}",
+                            claim.agent.alias
+                        )
+                    })?;
+                }
+                Ok((pane.to_string(), claim.window_id.clone()))
+            })()
+        } else {
+            (|| {
+                if let Some(target) =
+                    recover_unreported_alias(identity, &claim.agent.alias, claim.generation)?
+                {
+                    return Ok(target);
+                }
+                {
+                    let program = AgentProgram::parse(&claim.agent.program).map_err(|error| {
+                        anyhow::anyhow!("pipeline agent {:?}: {error}", claim.agent.alias)
+                    })?;
+                    let direction = SplitDirection::parse(claim.agent.direction.as_deref())
+                        .map_err(|error| {
+                            anyhow::anyhow!("pipeline agent {:?}: {error}", claim.agent.alias)
+                        })?;
+                    crate::agent_launch::start(StartRequest {
+                        agent: program,
+                        placement: Placement::Pane,
+                        target: None,
+                        cwd: Some(claim.cwd.clone()),
+                        prompt: claim.agent.prompt.clone(),
+                        name: None,
+                        workspace: Some(identity.workspace_id.clone()),
+                        work: Some(identity.work_id.clone()),
+                        role: claim.agent.role.clone(),
+                        task: claim.agent.task.clone(),
+                        alias: Some(claim.agent.alias.clone()),
+                        generation: Some(claim.generation),
+                        direction,
+                    })
+                    .with_context(|| format!("launch pipeline agent {:?}", claim.agent.alias))
+                    .map(|result| {
+                        launched.push(LaunchedAgent {
+                            alias: claim.agent.alias.clone(),
+                            pane: result.pane.clone(),
+                            program: claim.agent.program.clone(),
+                            role: claim.agent.role.clone(),
+                        });
+                        (result.pane, result.window)
+                    })
+                }
+            })()
+        };
+        match outcome {
+            Ok((pane, window)) => {
+                client
+                    .pipeline_report(
+                        identity,
+                        &claim.agent.alias,
+                        claim.generation,
+                        PipelineAliasStatus::Running,
+                        Some(&pane),
+                        None,
+                        window.as_deref(),
+                    )
+                    .await
+                    .with_context(|| {
+                        format!("report pipeline alias {:?} running", claim.agent.alias)
+                    })?;
+            }
+            Err(error) => {
+                let detail = format!("{error:#}");
+                let _ = client
+                    .pipeline_report(
+                        identity,
+                        &claim.agent.alias,
+                        claim.generation,
+                        PipelineAliasStatus::Failed,
+                        claim.pane.as_deref(),
+                        Some(&detail),
+                        claim.window_id.as_deref(),
+                    )
+                    .await;
+                return Err(error);
+            }
+        }
+    }
+    Ok(launched)
+}
+
+pub async fn run_reconcile(args: ReconcileArgs, client: &muxa::ipc::Client) -> Result<()> {
+    let runs = client
+        .pipeline_runs()
+        .await
+        .context("list durable pipeline Runs")?;
+    let selected = runs.into_iter().filter(|run| {
+        if args.all {
+            return run.has_ready_alias();
+        }
+        args.workspace
+            .as_deref()
+            .zip(args.work.as_deref())
+            .is_some_and(|(workspace, work)| {
+                run.identity.workspace_id.eq_ignore_ascii_case(workspace)
+                    && run.identity.work_id.eq_ignore_ascii_case(work)
+            })
+    });
+    for run in selected {
+        if let Err(error) = reconcile_run(client, &run.identity, run.generation).await {
+            tracing::warn!(
+                work = %run.identity.key(),
+                generation = run.generation,
+                %error,
+                "pipeline reconciliation failed",
+            );
+        }
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -388,6 +708,13 @@ pub(crate) async fn resolve(
         anyhow::Error::from(pipeline::PipelineError::UnknownPipeline(name.clone()))
     })?;
     let desired = pipeline::desired_agents(&name, spec, &vars)?;
+    let durable_run = match client {
+        Some(client) => client.pipeline_runs().await.ok().and_then(|runs| {
+            runs.into_iter()
+                .find(|run| run.identity.workspace_id == workspace && run.identity.work_id == work)
+        }),
+        None => None,
+    };
 
     Ok(Resolved {
         work,
@@ -401,6 +728,7 @@ pub(crate) async fn resolve(
         layout: spec.layout.clone(),
         request,
         desired,
+        durable_run,
         states,
     })
 }
@@ -878,7 +1206,7 @@ fn ask_for_request(work: &str) -> Result<Option<String>> {
     Ok((!text.is_empty()).then_some(text))
 }
 
-fn launch(agent: &DesiredAgent, resolved: &Resolved) -> Result<LaunchedAgent> {
+fn launch(agent: &DesiredAgent, resolved: &Resolved, generation: u64) -> Result<LaunchedAgent> {
     let program = AgentProgram::parse(&agent.program)
         .map_err(|error| anyhow::anyhow!("pipeline agent {:?}: {error}", agent.alias))?;
     let direction = SplitDirection::parse(agent.direction.as_deref())
@@ -899,6 +1227,7 @@ fn launch(agent: &DesiredAgent, resolved: &Resolved) -> Result<LaunchedAgent> {
         role: agent.role.clone(),
         task: agent.task.clone(),
         alias: Some(agent.alias.clone()),
+        generation: Some(generation),
         direction,
     })
     .with_context(|| format!("launch pipeline agent {:?}", agent.alias))?;
@@ -908,6 +1237,35 @@ fn launch(agent: &DesiredAgent, resolved: &Resolved) -> Result<LaunchedAgent> {
         program: agent.program.clone(),
         role: agent.role.clone(),
     })
+}
+
+/// Recover the pane created in the narrow crash window between physical
+/// launch and `pipeline_report`. The durable claim lease is intentionally
+/// retryable, but retrying must adopt that pane instead of launching the
+/// same alias twice.
+fn recover_unreported_alias(
+    identity: &WorkIdentity,
+    alias: &str,
+    generation: u64,
+) -> Result<Option<(String, Option<String>)>> {
+    let Some(work) =
+        crate::tmux_work::find_work_in(&identity.work_id, Some(&identity.workspace_id))?
+    else {
+        return Ok(None);
+    };
+    let mut matching = work
+        .agents
+        .iter()
+        .filter(|agent| agent.alias.as_deref() == Some(alias));
+    let Some(agent) = matching.next() else {
+        return Ok(None);
+    };
+    if matching.next().is_some() {
+        bail!("cannot recover pipeline alias {alias:?}: multiple matching panes already exist");
+    }
+    crate::tmux_work::mark_agent_generation(&agent.pane, generation)
+        .with_context(|| format!("adopt pipeline alias {alias:?} in pane {}", agent.pane))?;
+    Ok(Some((agent.pane.clone(), Some(work.window))))
 }
 
 /// One line per pipeline alias, grouped by dependency depth.

--- a/crates/muxa/src/ask.rs
+++ b/crates/muxa/src/ask.rs
@@ -424,6 +424,17 @@ pub struct OneShot<'a> {
     pub timeout: Duration,
 }
 
+/// Agent CLIs this bridge can drive headlessly, in preference order.
+///
+/// Membership is not "muxa knows this agent" — the launcher knows more
+/// (gemini, agy, opencode) — but "it has a print mode that reports
+/// completion as a fact": an exit code plus a parseable envelope. Without
+/// that, reading an answer back means screen-scraping a moving target.
+#[must_use]
+pub fn supported_agents() -> &'static [&'static str] {
+    &["claude", "codex"]
+}
+
 /// Run one headless turn and return its answer.
 ///
 /// # Errors

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -502,6 +502,8 @@ fn to_pane_info(pane: &HerdrPaneInfo, process: Option<&HerdrProcessInfo>) -> Pan
         None => (String::new(), 0, String::new()),
     };
     PaneInfo {
+        agent_role: None,
+        agent_alias: None,
         pane_id: format!("{PANE_ID_PREFIX}{}", pane.pane_id),
         session_id: pane.workspace_id.clone(),
         session: pane.workspace_id.clone(),

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -504,6 +504,7 @@ fn to_pane_info(pane: &HerdrPaneInfo, process: Option<&HerdrProcessInfo>) -> Pan
     PaneInfo {
         agent_role: None,
         agent_alias: None,
+        work_done: Vec::new(),
         pane_id: format!("{PANE_ID_PREFIX}{}", pane.pane_id),
         session_id: pane.workspace_id.clone(),
         session: pane.workspace_id.clone(),

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -963,6 +963,8 @@ mod tests {
 
     fn fake_pane(id: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -965,6 +965,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/backend/zellij.rs
+++ b/crates/muxa/src/backend/zellij.rs
@@ -220,6 +220,8 @@ mod tests {
 
     fn fake_pane(id: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/backend/zellij.rs
+++ b/crates/muxa/src/backend/zellij.rs
@@ -222,6 +222,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -614,13 +614,19 @@ impl CollaborationStore {
 
     /// Attach persisted aliases and roles only to the exact live agent
     /// generation that registered them. A later process reusing the same pane
-    /// remains anonymous until it registers its own identity.
+    /// inherits no *self-registered* identity — it stays anonymous until it
+    /// registers its own.
+    ///
+    /// What it does keep is whatever `participants_from` read off the pane's
+    /// muxa options. That is a different kind of claim: the launcher's
+    /// declaration about the slot ("this pane is the pipeline's reviewer"),
+    /// not an agent's statement about itself, and it remains true for whoever
+    /// occupies the slot. So a registered identity overwrites it, and its
+    /// absence leaves it standing.
     pub async fn enrich_participants(&self, participants: &mut [Participant]) {
         let _transaction = self.transaction_lock.lock().await;
         let identities = self.identities.read().await;
         for participant in participants {
-            participant.alias = None;
-            participant.roles.clear();
             if let Some(identity) = identities
                 .iter()
                 .find(|identity| identity.matches(participant))
@@ -1182,8 +1188,14 @@ pub fn participants_from(agents: &[Agent], panes: &[PaneInfo]) -> Vec<Participan
             window_name: (!pane.window_name.is_empty()).then(|| pane.window_name.clone()),
             state: agent.state,
             cwd: agent.cwd.clone(),
-            alias: None,
-            roles: Vec::new(),
+            // Seeded from what the launcher stamped on the pane. A pipeline
+            // agent is addressable as `role:reviewer` / `@review` from the
+            // moment its pane exists, without waiting for it to run
+            // `muxa identity set` — which it never does, and could not do
+            // before its first turn anyway. `enrich_participants` replaces
+            // both if the agent registered an identity of its own.
+            alias: pane.agent_alias.clone(),
+            roles: pane.agent_role.clone().into_iter().collect(),
             console: false,
         };
         let key = (socket, pane_id.clone());
@@ -1524,6 +1536,8 @@ mod tests {
 
     fn pane_info(pane_id: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             pane_id: pane_id.into(),
             session_id: "$1".into(),
             session: "main".into(),
@@ -1550,6 +1564,115 @@ mod tests {
                 disclosure: AirLocatorDisclosure::LocalOnly,
             }),
         }
+    }
+
+    fn managed_pane(pane_id: &str, role: &str, alias: &str) -> PaneInfo {
+        PaneInfo {
+            agent_role: Some(role.into()),
+            agent_alias: Some(alias.into()),
+            ..pane_info(pane_id)
+        }
+    }
+
+    /// The bug this closes: `muxa work up` stamps `@muxa_agent_role` on the
+    /// pane, but the room only knew about identities an agent registered for
+    /// itself — which a pipeline agent never does. `role:implementer` matched
+    /// nobody, so the reviewer's handoff was dropped and the pair stalled with
+    /// the work looking finished.
+    #[tokio::test]
+    async fn pipeline_roles_from_pane_metadata_resolve_a_target() {
+        let store = crate::Store::shared();
+        for (session, pane) in [("impl-session", "%1"), ("review-session", "%2")] {
+            store
+                .apply(&crate::event::AgentEvent::Started {
+                    id: crate::event::AgentId {
+                        kind: AgentKind::Codex,
+                        session_id: session.into(),
+                        surface: None,
+                        pane: Some(pane.into()),
+                        tmux_socket: Some("default".into()),
+                        cwd: Some("/repo".into()),
+                    },
+                    at: OffsetDateTime::now_utc(),
+                })
+                .await;
+        }
+        let panes = vec![
+            managed_pane("%1", "implementer", "impl"),
+            managed_pane("%2", "reviewer", "review"),
+        ];
+        let participants = participants_from(&store.snapshot().await, &panes);
+        assert_eq!(participants.len(), 2);
+
+        let reviewer = participants
+            .iter()
+            .find(|p| p.pane == "%2")
+            .expect("reviewer participant");
+
+        for selector in [
+            "role:implementer",
+            "role:IMPLEMENTER",
+            "@impl",
+            "alias:impl",
+        ] {
+            let target = resolve_target(
+                reviewer,
+                selector,
+                &participants,
+                crate::config::CollaborationScope::Window,
+            )
+            .unwrap_or_else(|e| panic!("{selector} must resolve: {e}"));
+            assert_eq!(target.pane, "%1", "{selector} routed to the wrong pane");
+        }
+    }
+
+    /// Pane metadata is the launcher's claim about the slot; an identity the
+    /// agent registered for itself is more specific and must win. Registering
+    /// only an alias must not leave the launcher's role behind, or an agent
+    /// could never shed a role it was launched with.
+    #[tokio::test]
+    async fn self_registered_identity_overrides_pane_metadata() {
+        let collab = CollaborationStore::in_memory(CollaborationOptions::default());
+        let panes = vec![managed_pane("%1", "implementer", "impl")];
+        let store = crate::Store::shared();
+        store
+            .apply(&crate::event::AgentEvent::Started {
+                id: crate::event::AgentId {
+                    kind: AgentKind::Codex,
+                    session_id: "impl-session".into(),
+                    surface: None,
+                    pane: Some("%1".into()),
+                    tmux_socket: Some("default".into()),
+                    cwd: Some("/repo".into()),
+                },
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+        let mut participants = participants_from(&store.snapshot().await, &panes);
+
+        // No registration yet: the launcher's claim stands.
+        collab.enrich_participants(&mut participants).await;
+        assert_eq!(participants[0].roles, vec!["implementer".to_string()]);
+        assert_eq!(participants[0].alias.as_deref(), Some("impl"));
+
+        let caller = participants[0].clone();
+        collab
+            .set_identity(
+                &caller,
+                &participants.clone(),
+                Some("driver".into()),
+                vec!["rust".into()],
+            )
+            .await
+            .expect("identity registers");
+
+        collab.enrich_participants(&mut participants).await;
+        assert_eq!(participants[0].alias.as_deref(), Some("driver"));
+        assert_eq!(
+            participants[0].roles,
+            vec!["rust".to_string()],
+            "the registered role set replaces the launcher's, never merges",
+        );
     }
 
     #[tokio::test]

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -1538,6 +1538,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             pane_id: pane_id.into(),
             session_id: "$1".into(),
             session: "main".into(),

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -468,6 +468,15 @@ pub struct PipelineAgentConfig {
     /// Split direction when this pane joins an existing window: `right`
     /// (default) or `down`.
     pub direction: Option<String>,
+    /// Aliases in this pipeline that must report finishing before this
+    /// agent is launched at all.
+    ///
+    /// Without it every agent starts at once, which is right for work that
+    /// is genuinely parallel and wrong for work that is not: a reviewer
+    /// launched beside its implementer reviews a tree that changes while it
+    /// reads, and spends its rounds rediscovering that the code moved. An
+    /// edge here is what makes the difference expressible.
+    pub after: Vec<String>,
 }
 
 /// `[collaboration]` config — same-window durable agent request/reply.

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -2348,6 +2348,8 @@ mod tests {
         window_name: &str,
     ) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: pane_id.into(),
             session_id: session_id.into(),
@@ -2715,6 +2717,8 @@ mod tests {
             fetched_at: OffsetDateTime::now_utc(),
         };
         let herdr = scanner::herdr_scan_result(vec![crate::tmux::PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: "herdr:p1".into(),
             session_id: "ws1".into(),
@@ -2742,6 +2746,8 @@ mod tests {
         let scan = backend_scan_result(
             HostKind::Rmux,
             vec![crate::tmux::PaneInfo {
+                agent_role: None,
+                agent_alias: None,
                 socket: Some("/tmp/rmux-user/default".into()),
                 pane_id: "rmux:%4".into(),
                 session_id: "$1".into(),
@@ -2771,6 +2777,8 @@ mod tests {
         let rmux: SharedBackend = Arc::new(InventoryBackend {
             kind: HostKind::Rmux,
             panes: vec![crate::tmux::PaneInfo {
+                agent_role: None,
+                agent_alias: None,
                 socket: Some("/tmp/rmux-secondary/default".into()),
                 pane_id: "rmux:%8".into(),
                 session_id: "$2".into(),

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -3155,11 +3155,17 @@ mod tests {
         assert_eq!(mine["stage"], "review");
         assert_eq!(mine["runs"].as_array().unwrap().len(), 1);
 
+        // Reload from disk and look for this test's own record. Counting is
+        // not safe here: `GET /api/works` upserts an external item for every
+        // pane it discovers, and the scan includes the host's real tmux — so
+        // the file legitimately holds a row per work running on the machine.
         let reloaded = WorkStore::load(Some(path));
-        assert_eq!(reloaded.records().len(), 1);
-        assert_eq!(
-            reloaded.records()[0].metadata.title.as_deref(),
-            Some("Repair auth")
+        assert!(
+            reloaded
+                .records()
+                .iter()
+                .any(|record| record.metadata.title.as_deref() == Some("Repair auth")),
+            "the annotated work survived the round trip"
         );
     }
 

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -3141,9 +3141,19 @@ mod tests {
             .unwrap();
         let snapshot = body_json(snapshot).await;
         assert_eq!(snapshot["schema_version"], work::WORK_SCHEMA_VERSION);
-        assert_eq!(snapshot["works"].as_array().unwrap().len(), 1);
-        assert_eq!(snapshot["works"][0]["stage"], "review");
-        assert_eq!(snapshot["works"][0]["runs"].as_array().unwrap().len(), 1);
+        // Select the work this test created rather than asserting a global
+        // count. The pane scan always includes the host's own tmux server,
+        // so a machine with any muxa-managed work of its own would fail an
+        // assertion about how many works exist — a real failure this test
+        // hit once the developer's box had one.
+        let mine = snapshot["works"]
+            .as_array()
+            .expect("works array")
+            .iter()
+            .find(|work| work["title"] == "Repair auth")
+            .expect("the work this test annotated is present");
+        assert_eq!(mine["stage"], "review");
+        assert_eq!(mine["runs"].as_array().unwrap().len(), 1);
 
         let reloaded = WorkStore::load(Some(path));
         assert_eq!(reloaded.records().len(), 1);

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -2350,6 +2350,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: pane_id.into(),
             session_id: session_id.into(),
@@ -2719,6 +2720,7 @@ mod tests {
         let herdr = scanner::herdr_scan_result(vec![crate::tmux::PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: "herdr:p1".into(),
             session_id: "ws1".into(),
@@ -2748,6 +2750,7 @@ mod tests {
             vec![crate::tmux::PaneInfo {
                 agent_role: None,
                 agent_alias: None,
+                work_done: Vec::new(),
                 socket: Some("/tmp/rmux-user/default".into()),
                 pane_id: "rmux:%4".into(),
                 session_id: "$1".into(),
@@ -2779,6 +2782,7 @@ mod tests {
             panes: vec![crate::tmux::PaneInfo {
                 agent_role: None,
                 agent_alias: None,
+                work_done: Vec::new(),
                 socket: Some("/tmp/rmux-secondary/default".into()),
                 pane_id: "rmux:%8".into(),
                 session_id: "$2".into(),

--- a/crates/muxa/src/discovery.rs
+++ b/crates/muxa/src/discovery.rs
@@ -407,6 +407,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/discovery.rs
+++ b/crates/muxa/src/discovery.rs
@@ -405,6 +405,8 @@ mod tests {
 
     fn pane(id: &str, cmd: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/discovery.rs
+++ b/crates/muxa/src/discovery.rs
@@ -79,7 +79,8 @@ pub fn command_name(cmd: &str) -> &str {
 /// example, lands in tmux as `node` (the JS shim) with the real
 /// `codex` binary one or two `fork()`s deep — `classify_command` alone
 /// misses that, so callers fall through to a process-tree walk.
-fn is_wrapper_command(cmd: &str) -> bool {
+#[must_use]
+pub fn is_wrapper_command(cmd: &str) -> bool {
     matches!(
         command_name(cmd).to_ascii_lowercase().as_str(),
         "node" | "deno" | "bun" | "python" | "python3" | "ruby"

--- a/crates/muxa/src/event.rs
+++ b/crates/muxa/src/event.rs
@@ -39,6 +39,25 @@ pub enum AgentKind {
 }
 
 impl AgentKind {
+    /// Name of the bundled screen-detection manifest for this kind, if one
+    /// exists.
+    ///
+    /// This is the registry's answer to "which agent occupies the pane", and
+    /// it beats `pane_current_command`: an npm-installed codex runs as `node`,
+    /// which names no manifest, so command-only selection silently skipped
+    /// every such pane. Kinds whose hooks cover attention entirely (Claude,
+    /// opencode, the Gemini CLI) ship no manifest and return `None`.
+    #[must_use]
+    pub fn screen_manifest_name(self) -> Option<&'static str> {
+        match self {
+            Self::Codex => Some("codex"),
+            Self::Antigravity => Some("agy"),
+            Self::ClaudeCode | Self::Opencode | Self::GeminiCli | Self::Task | Self::Unknown => {
+                None
+            }
+        }
+    }
+
     /// Can this agent's hook stream tell muxa it is waiting on the operator?
     ///
     /// Claude Code (`Notification`), Codex (`PermissionRequest`), the Gemini

--- a/crates/muxa/src/event.rs
+++ b/crates/muxa/src/event.rs
@@ -12,7 +12,7 @@ use time::OffsetDateTime;
 /// when the IPC envelope schema evolves. Pinning to a specific value across
 /// muxa upgrades is not supported; treat it as a runtime negotiation token,
 /// not a stable API constant.
-pub const PROTOCOL_VERSION: u32 = 4;
+pub const PROTOCOL_VERSION: u32 = 5;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, strum::Display)]
 #[serde(rename_all = "snake_case")]

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -3592,6 +3592,8 @@ mod tests {
 
     fn collaboration_test_pane(pane_id: &str, pane_index: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             pane_id: pane_id.into(),
             session_id: "$1".into(),
             session: "collaboration".into(),
@@ -4755,6 +4757,8 @@ mod tests {
         assert!(backend.list_panes().is_empty());
 
         let pane = PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: "zellij:3".into(),
             session_id: String::new(),

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -34,12 +34,16 @@ use crate::event::{AgentEvent, PROTOCOL_VERSION};
 use crate::fleet::{
     FleetCommandResult, FleetOperation, FleetRuntime, FleetSnapshot, FleetUpdate, LabelSelector,
 };
+use crate::pipeline_run::{
+    PipelineAliasStatus, PipelineClaim, PipelineRun, PipelineRunRegistration, PipelineRunStore,
+};
 use crate::session::{
     PtySessionBackend, SessionBackend, SessionOutput, SessionRef, SharedSessionBackend,
     SpawnSession, TerminalSnapshot,
 };
 use crate::state::{Agent, SharedStore};
 use crate::tmux::PaneInfo;
+use crate::work::WorkIdentity;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::os::unix::fs::PermissionsExt;
@@ -141,6 +145,42 @@ enum RequestBody {
         event: AgentEvent,
     },
     Snapshot,
+    /// Durable desired graph and per-alias execution state for every Work Run.
+    PipelineRuns,
+    /// Create or update one desired Run and reconcile live pane evidence.
+    PipelineRegister {
+        registration: PipelineRunRegistration,
+    },
+    /// Atomic, generation-checked completion event.
+    PipelineDone {
+        identity: WorkIdentity,
+        alias: String,
+        generation: u64,
+    },
+    /// Start a new generation for an alias and its downstream closure.
+    PipelineInvalidate {
+        identity: WorkIdentity,
+        alias: String,
+        generation: u64,
+    },
+    /// Atomically reserve every dependency-ready pending alias.
+    PipelineClaim {
+        identity: WorkIdentity,
+        generation: u64,
+    },
+    /// Report the physical outcome of a claimed launch or re-prompt.
+    PipelineReport {
+        identity: WorkIdentity,
+        alias: String,
+        generation: u64,
+        status: PipelineAliasStatus,
+        #[serde(default)]
+        pane: Option<String>,
+        #[serde(default)]
+        error: Option<String>,
+        #[serde(default)]
+        window_id: Option<String>,
+    },
     /// Snapshot of every configured physical SSH host. `selector` follows
     /// Kubernetes label-selector syntax and is evaluated against central
     /// inventory metadata, never against untrusted remote data.
@@ -408,6 +448,7 @@ const CAPABILITIES: &[&str] = &[
     "collaboration_provenance",
     "fleet_v1",
     "fleet_subscribe",
+    "pipeline_runs_v1",
 ];
 
 /// Advertised only when the server has the controller required to come back
@@ -481,6 +522,12 @@ pub struct Response {
     pub fleet: Option<FleetSnapshot>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fleet_result: Option<FleetCommandResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pipeline_runs: Option<Vec<PipelineRun>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pipeline_run: Option<PipelineRun>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pipeline_claims: Option<Vec<PipelineClaim>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -518,6 +565,9 @@ impl Response {
             ask_agent: None,
             fleet: None,
             fleet_result: None,
+            pipeline_runs: None,
+            pipeline_run: None,
+            pipeline_claims: None,
         }
     }
     fn err(msg: impl Into<String>) -> Self {
@@ -539,6 +589,21 @@ impl Response {
     fn with_fleet_result(result: FleetCommandResult) -> Self {
         let mut response = Self::ok();
         response.fleet_result = Some(result);
+        response
+    }
+    fn with_pipeline_runs(runs: Vec<PipelineRun>) -> Self {
+        let mut response = Self::ok();
+        response.pipeline_runs = Some(runs);
+        response
+    }
+    fn with_pipeline_run(run: PipelineRun) -> Self {
+        let mut response = Self::ok();
+        response.pipeline_run = Some(run);
+        response
+    }
+    fn with_pipeline_claims(claims: Vec<PipelineClaim>) -> Self {
+        let mut response = Self::ok();
+        response.pipeline_claims = Some(claims);
         response
     }
     fn with_prompts(prompts: Vec<crate::history::HistoryEntry>) -> Self {
@@ -720,6 +785,7 @@ pub struct Server {
     ask: Arc<AskStore>,
     restart: Option<Arc<RestartController>>,
     fleet: Option<FleetRuntime>,
+    pipeline_runs: Arc<PipelineRunStore>,
     handler_limit: usize,
 }
 
@@ -737,6 +803,7 @@ impl Server {
             ask: crate::ask::AskStore::in_memory(crate::ask::AskOptions::default()),
             restart: None,
             fleet: None,
+            pipeline_runs: PipelineRunStore::in_memory(),
             handler_limit: MAX_INFLIGHT_HANDLERS,
         }
     }
@@ -805,6 +872,12 @@ impl Server {
     #[must_use]
     pub fn with_fleet(mut self, fleet: FleetRuntime) -> Self {
         self.fleet = Some(fleet);
+        self
+    }
+
+    #[must_use]
+    pub fn with_pipeline_runs(mut self, pipeline_runs: Arc<PipelineRunStore>) -> Self {
+        self.pipeline_runs = pipeline_runs;
         self
     }
 
@@ -902,6 +975,7 @@ impl Server {
                     let ask = self.ask.clone();
                     let restart = self.restart.clone();
                     let fleet = self.fleet.clone();
+                    let pipeline_runs = self.pipeline_runs.clone();
                     handlers.spawn(async move {
                         // Held for the handler's lifetime; released here on exit.
                         let _permit = permit;
@@ -917,6 +991,7 @@ impl Server {
                                 ask,
                                 restart,
                                 fleet,
+                                pipeline_runs,
                             ))
                             .await
                         {
@@ -1599,7 +1674,8 @@ async fn record_collaboration_audit(
         collaboration_audit,
         ask,
         restart,
-        fleet
+        fleet,
+        pipeline_runs
     )
 )]
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)] // IPC dispatch table and its shared daemon state
@@ -1614,6 +1690,7 @@ async fn handle(
     ask: Arc<AskStore>,
     restart: Option<Arc<RestartController>>,
     fleet: Option<FleetRuntime>,
+    pipeline_runs: Arc<PipelineRunStore>,
 ) -> Result<(), RuntimeError> {
     let mut collaboration_actor = observe_collaboration_actor(&stream);
     let (reader, mut writer) = stream.into_split();
@@ -1773,6 +1850,72 @@ async fn handle(
                 RequestBody::Snapshot => {
                     kind = "snapshot";
                     Response::with_agents(store.snapshot().await)
+                }
+                RequestBody::PipelineRuns => {
+                    kind = "pipeline_runs";
+                    Response::with_pipeline_runs(pipeline_runs.list().await)
+                }
+                RequestBody::PipelineRegister { registration } => {
+                    kind = "pipeline_register";
+                    match pipeline_runs.register(registration).await {
+                        Ok(run) => Response::with_pipeline_run(run),
+                        Err(error) => Response::err(error.to_string()),
+                    }
+                }
+                RequestBody::PipelineDone {
+                    identity,
+                    alias,
+                    generation,
+                } => {
+                    kind = "pipeline_done";
+                    match pipeline_runs.done(&identity, &alias, generation).await {
+                        Ok(run) => Response::with_pipeline_run(run),
+                        Err(error) => Response::err(error.to_string()),
+                    }
+                }
+                RequestBody::PipelineInvalidate {
+                    identity,
+                    alias,
+                    generation,
+                } => {
+                    kind = "pipeline_invalidate";
+                    match pipeline_runs
+                        .invalidate(&identity, &alias, generation)
+                        .await
+                    {
+                        Ok(run) => Response::with_pipeline_run(run),
+                        Err(error) => Response::err(error.to_string()),
+                    }
+                }
+                RequestBody::PipelineClaim {
+                    identity,
+                    generation,
+                } => {
+                    kind = "pipeline_claim";
+                    match pipeline_runs.claim_ready(&identity, generation).await {
+                        Ok(claims) => Response::with_pipeline_claims(claims),
+                        Err(error) => Response::err(error.to_string()),
+                    }
+                }
+                RequestBody::PipelineReport {
+                    identity,
+                    alias,
+                    generation,
+                    status,
+                    pane,
+                    error,
+                    window_id,
+                } => {
+                    kind = "pipeline_report";
+                    match pipeline_runs
+                        .report(
+                            &identity, &alias, generation, status, pane, error, window_id,
+                        )
+                        .await
+                    {
+                        Ok(run) => Response::with_pipeline_run(run),
+                        Err(error) => Response::err(error.to_string()),
+                    }
                 }
                 RequestBody::FleetSnapshot { selector } => {
                     kind = "fleet_snapshot";
@@ -3147,6 +3290,103 @@ impl Client {
         Ok(decode_agents(&resp))
     }
 
+    pub async fn pipeline_runs(&self) -> Result<Vec<PipelineRun>, RuntimeError> {
+        let req = serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "pipeline_runs",
+        });
+        let response = self.call_checked(&req).await?;
+        serde_json::from_value(response["pipeline_runs"].clone()).map_err(RuntimeError::Json)
+    }
+
+    pub async fn pipeline_register(
+        &self,
+        registration: &PipelineRunRegistration,
+    ) -> Result<PipelineRun, RuntimeError> {
+        let req = serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "pipeline_register",
+            "registration": registration,
+        });
+        let response = self.call_checked(&req).await?;
+        serde_json::from_value(response["pipeline_run"].clone()).map_err(RuntimeError::Json)
+    }
+
+    pub async fn pipeline_done(
+        &self,
+        identity: &WorkIdentity,
+        alias: &str,
+        generation: u64,
+    ) -> Result<PipelineRun, RuntimeError> {
+        let req = serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "pipeline_done",
+            "identity": identity,
+            "alias": alias,
+            "generation": generation,
+        });
+        let response = self.call_checked(&req).await?;
+        serde_json::from_value(response["pipeline_run"].clone()).map_err(RuntimeError::Json)
+    }
+
+    pub async fn pipeline_invalidate(
+        &self,
+        identity: &WorkIdentity,
+        alias: &str,
+        generation: u64,
+    ) -> Result<PipelineRun, RuntimeError> {
+        let req = serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "pipeline_invalidate",
+            "identity": identity,
+            "alias": alias,
+            "generation": generation,
+        });
+        let response = self.call_checked(&req).await?;
+        serde_json::from_value(response["pipeline_run"].clone()).map_err(RuntimeError::Json)
+    }
+
+    pub async fn pipeline_claim(
+        &self,
+        identity: &WorkIdentity,
+        generation: u64,
+    ) -> Result<Vec<PipelineClaim>, RuntimeError> {
+        let req = serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "pipeline_claim",
+            "identity": identity,
+            "generation": generation,
+        });
+        let response = self.call_checked(&req).await?;
+        serde_json::from_value(response["pipeline_claims"].clone()).map_err(RuntimeError::Json)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn pipeline_report(
+        &self,
+        identity: &WorkIdentity,
+        alias: &str,
+        generation: u64,
+        status: PipelineAliasStatus,
+        pane: Option<&str>,
+        error: Option<&str>,
+        window_id: Option<&str>,
+    ) -> Result<PipelineRun, RuntimeError> {
+        let req = serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "pipeline_report",
+            "identity": identity,
+            "alias": alias,
+            "generation": generation,
+            "status": status,
+            "pane": pane,
+            "error": error,
+            "window_id": window_id,
+        });
+        let response = self.call_checked(&req).await?;
+        serde_json::from_value(response["pipeline_run"].clone()).map_err(RuntimeError::Json)
+    }
+
     pub async fn by_pane(&self, pane: &str) -> Result<Vec<Agent>, RuntimeError> {
         let req = serde_json::json!({
             "protocol": PROTOCOL_VERSION,
@@ -4102,6 +4342,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pipeline_done_is_atomic_and_opens_downstream_over_ipc() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-pipeline.sock");
+        let pipeline_runs = PipelineRunStore::in_memory();
+        let server =
+            Server::new(sock.clone(), Store::shared()).with_pipeline_runs(pipeline_runs.clone());
+        let (tx, rx) = broadcast::channel(1);
+        let handle = tokio::spawn(async move { server.run(rx).await.unwrap() });
+        for _ in 0..50 {
+            if sock.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let desired = |alias: &str, after: Vec<String>| crate::pipeline::DesiredAgent {
+            alias: alias.to_string(),
+            program: "codex".to_string(),
+            role: None,
+            task: None,
+            prompt: None,
+            direction: None,
+            after,
+        };
+        let identity = WorkIdentity::new("ws", "WORK-1");
+        let client = Client::new(sock.clone());
+        let run = client
+            .pipeline_register(&PipelineRunRegistration {
+                identity: identity.clone(),
+                pipeline: "chain".to_string(),
+                desired: vec![
+                    desired("plan", Vec::new()),
+                    desired("impl", vec!["plan".to_string()]),
+                ],
+                cwd: PathBuf::from("/tmp"),
+                window_id: Some("@1".to_string()),
+                observed: Vec::new(),
+                invalidate: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let root = client
+            .pipeline_claim(&identity, run.generation)
+            .await
+            .unwrap();
+        assert_eq!(root.len(), 1);
+        assert_eq!(root[0].agent.alias, "plan");
+
+        client
+            .pipeline_done(&identity, "plan", run.generation)
+            .await
+            .unwrap();
+        let downstream = client
+            .pipeline_claim(&identity, run.generation)
+            .await
+            .unwrap();
+        assert_eq!(downstream.len(), 1);
+        assert_eq!(downstream[0].agent.alias, "impl");
+
+        let invalidated = client
+            .pipeline_invalidate(&identity, "plan", run.generation)
+            .await
+            .unwrap();
+        assert!(client
+            .pipeline_done(&identity, "plan", run.generation)
+            .await
+            .is_err());
+        assert_eq!(
+            invalidated.aliases["impl"].status,
+            PipelineAliasStatus::Pending
+        );
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn not_connected_when_socket_missing() {
         // ENOENT path: tempdir exists but the socket file doesn't.
         let dir = tempdir().unwrap();
@@ -4247,6 +4564,7 @@ mod tests {
             crate::ask::AskStore::in_memory(crate::ask::AskOptions::default()),
             None,
             None,
+            PipelineRunStore::in_memory(),
         ));
 
         let req = serde_json::json!({

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -3594,6 +3594,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             pane_id: pane_id.into(),
             session_id: "$1".into(),
             session: "collaboration".into(),
@@ -4759,6 +4760,7 @@ mod tests {
         let pane = PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: "zellij:3".into(),
             session_id: String::new(),

--- a/crates/muxa/src/lib.rs
+++ b/crates/muxa/src/lib.rs
@@ -51,6 +51,7 @@ pub mod metrics;
 pub mod notify;
 pub mod paths;
 pub mod pipeline;
+pub mod pipeline_run;
 mod process_snapshot;
 pub mod process_tree;
 pub mod reconcile;

--- a/crates/muxa/src/paths.rs
+++ b/crates/muxa/src/paths.rs
@@ -14,6 +14,7 @@ pub const COLLABORATION_AUDIT_FILENAME: &str = "collaboration-audit.ndjson";
 pub const ASK_FILENAME: &str = "ask.json";
 pub const NODE_ID_FILENAME: &str = "host-id";
 pub const DASHBOARD_WORK_FILENAME: &str = "dashboard-work.json";
+pub const PIPELINE_RUN_FILENAME: &str = "pipeline-runs.json";
 
 /// Default daemon socket path. Prefers `$XDG_RUNTIME_DIR/muxa.sock`; falls
 /// back to `/tmp/muxa-<uid>.sock` when the runtime dir is unset.
@@ -87,6 +88,11 @@ pub fn default_collaboration_audit_file() -> Option<PathBuf> {
 /// references keyed by `{workspace_id, work_id}`.
 pub fn default_dashboard_work_file() -> Option<PathBuf> {
     dirs::data_dir().map(|d| d.join(CONFIG_DIRNAME).join(DASHBOARD_WORK_FILENAME))
+}
+
+/// Durable desired graph and generation-aware state for Work pipeline Runs.
+pub fn default_pipeline_run_file() -> Option<PathBuf> {
+    dirs::data_dir().map(|d| d.join(CONFIG_DIRNAME).join(PIPELINE_RUN_FILENAME))
 }
 
 fn posix_uid() -> u32 {

--- a/crates/muxa/src/pipeline.rs
+++ b/crates/muxa/src/pipeline.rs
@@ -63,6 +63,14 @@ pub enum PipelineError {
     EmptyPipeline(String),
     #[error("pipeline {pipeline:?} uses alias {alias:?} twice; aliases key the pane diff and must be unique")]
     DuplicateAlias { pipeline: String, alias: String },
+    #[error("pipeline {pipeline:?} agent {alias:?} waits on {missing:?}, which is not an alias in this pipeline")]
+    UnknownDependency {
+        pipeline: String,
+        alias: String,
+        missing: String,
+    },
+    #[error("pipeline {pipeline:?} has a cycle through {alias:?}; nothing in it could ever start")]
+    DependencyCycle { pipeline: String, alias: String },
     #[error("{scope} pattern {pattern:?} is not a valid regex: {source}")]
     BadPattern {
         scope: &'static str,
@@ -586,6 +594,9 @@ pub struct DesiredAgent {
     pub prompt: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub direction: Option<String>,
+    /// Aliases that must report done before this one may start.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub after: Vec<String>,
 }
 
 /// Render a pipeline into the panes it asks for.
@@ -619,7 +630,49 @@ pub fn desired_agents(
             vars,
         ));
     }
+    check_dependencies(name, &agents)?;
     Ok(agents)
+}
+
+/// Refuse an edge set that could never run: an edge to an alias this
+/// pipeline does not define, or a cycle. Both fail silently otherwise —
+/// the dependent agent simply never launches, and `work up` keeps
+/// reporting a window that will not converge without saying why.
+fn check_dependencies(pipeline: &str, agents: &[DesiredAgent]) -> Result<(), PipelineError> {
+    let known: BTreeSet<&str> = agents.iter().map(|agent| agent.alias.as_str()).collect();
+    for agent in agents {
+        for dependency in &agent.after {
+            if !known.contains(dependency.as_str()) {
+                return Err(PipelineError::UnknownDependency {
+                    pipeline: pipeline.to_string(),
+                    alias: agent.alias.clone(),
+                    missing: dependency.clone(),
+                });
+            }
+        }
+    }
+    // Kahn's algorithm: whatever cannot be peeled off is in a cycle.
+    let mut remaining: Vec<&DesiredAgent> = agents.iter().collect();
+    let mut settled: BTreeSet<&str> = BTreeSet::new();
+    while !remaining.is_empty() {
+        let (ready, blocked): (Vec<_>, Vec<_>) = remaining.into_iter().partition(|agent| {
+            agent
+                .after
+                .iter()
+                .all(|dependency| settled.contains(dependency.as_str()))
+        });
+        if ready.is_empty() {
+            return Err(PipelineError::DependencyCycle {
+                pipeline: pipeline.to_string(),
+                alias: blocked[0].alias.clone(),
+            });
+        }
+        for agent in ready {
+            settled.insert(agent.alias.as_str());
+        }
+        remaining = blocked;
+    }
+    Ok(())
 }
 
 fn render_agent(
@@ -662,6 +715,12 @@ fn render_agent(
         task: agent.task.as_deref().map(|task| vars.render(task)),
         prompt,
         direction: agent.direction.clone(),
+        after: agent
+            .after
+            .iter()
+            .map(|alias| alias.trim().to_ascii_lowercase())
+            .filter(|alias| !alias.is_empty())
+            .collect(),
     }
 }
 
@@ -715,6 +774,12 @@ pub enum PlanStep {
         #[serde(skip_serializing_if = "Option::is_none")]
         state: Option<AgentState>,
     },
+    /// The alias is not started yet because something it waits on has not
+    /// reported finishing. Not a failure — the next `work up` launches it.
+    Waiting {
+        alias: String,
+        waiting_on: Vec<String>,
+    },
     /// The alias is blocked on a person — an approval prompt or an error.
     /// Never prompted over: the dialog would eat the message, and the
     /// operator would be left believing it was delivered.
@@ -732,6 +797,7 @@ impl PlanStep {
             Self::Launch(agent) => &agent.alias,
             Self::Reprompt { alias, .. }
             | Self::Keep { alias, .. }
+            | Self::Waiting { alias, .. }
             | Self::Attention { alias, .. } => alias,
         }
     }
@@ -768,6 +834,16 @@ impl Plan {
     /// say to any of them.
     /// Aliases blocked on a person. Converging is not possible until
     /// somebody answers them, so they are counted separately.
+    /// Aliases held back by an unmet edge. The window is not converged
+    /// while any remain, but nothing is wrong — the next run starts them.
+    #[must_use]
+    pub fn waiting(&self) -> usize {
+        self.steps
+            .iter()
+            .filter(|step| matches!(step, PlanStep::Waiting { .. }))
+            .count()
+    }
+
     #[must_use]
     pub fn attention(&self) -> usize {
         self.steps
@@ -778,7 +854,10 @@ impl Plan {
 
     #[must_use]
     pub fn converged(&self) -> bool {
-        self.launches() == 0 && self.reprompts() == 0 && self.attention() == 0
+        self.launches() == 0
+            && self.reprompts() == 0
+            && self.attention() == 0
+            && self.waiting() == 0
     }
 }
 
@@ -790,7 +869,12 @@ impl Plan {
 /// prompt into an agent that is mid-turn is disruptive enough to deserve
 /// an explicit ask.
 #[must_use]
-pub fn plan(desired: &[DesiredAgent], existing: &[ExistingAgent], broadcast: Option<&str>) -> Plan {
+pub fn plan(
+    desired: &[DesiredAgent],
+    existing: &[ExistingAgent],
+    broadcast: Option<&str>,
+    done: &[String],
+) -> Plan {
     let steps = desired
         .iter()
         .map(|agent| {
@@ -800,6 +884,29 @@ pub fn plan(desired: &[DesiredAgent], existing: &[ExistingAgent], broadcast: Opt
                     .as_deref()
                     .is_some_and(|alias| alias.eq_ignore_ascii_case(&agent.alias))
             });
+            // An edge only gates the *start*. Once an agent exists it is
+            // managed like any other; re-gating it would tear down work
+            // already in flight every time an upstream alias was re-opened.
+            let waiting_on = if live.is_none() {
+                agent
+                    .after
+                    .iter()
+                    .filter(|dependency| {
+                        !done
+                            .iter()
+                            .any(|alias| alias.eq_ignore_ascii_case(dependency))
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>()
+            } else {
+                Vec::new()
+            };
+            if !waiting_on.is_empty() {
+                return PlanStep::Waiting {
+                    alias: agent.alias.clone(),
+                    waiting_on,
+                };
+            }
             match (live, broadcast) {
                 (None, _) => PlanStep::Launch(agent.clone()),
                 // Blocked on a person beats everything: do not type at it,
@@ -1124,6 +1231,7 @@ program = 'claude'
                 task: None,
                 prompt: None,
                 direction: None,
+                after: Vec::new(),
             })
             .collect()
     }
@@ -1143,16 +1251,113 @@ program = 'claude'
             .collect()
     }
 
+    /// `plan` with nothing reported done — the shape every pre-edge test
+    /// was written against.
+    fn plan_at(
+        desired: &[DesiredAgent],
+        existing: &[ExistingAgent],
+        broadcast: Option<&str>,
+    ) -> Plan {
+        plan(desired, existing, broadcast, &[])
+    }
+
+    fn desired_after(alias: &str, after: &[&str]) -> DesiredAgent {
+        DesiredAgent {
+            alias: alias.to_string(),
+            program: "codex".into(),
+            role: None,
+            task: None,
+            prompt: None,
+            direction: None,
+            after: after.iter().map(|a| (*a).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn an_edge_holds_an_agent_back_until_its_upstream_reports_done() {
+        let agents = vec![
+            desired_after("impl", &[]),
+            desired_after("review", &["impl"]),
+        ];
+
+        // Nothing reported: the reviewer is not launched beside the
+        // implementer, which is the whole point — it would be reviewing a
+        // tree that changes while it reads.
+        let held = plan(&agents, &[], None, &[]);
+        assert_eq!(held.launches(), 1);
+        assert_eq!(held.waiting(), 1);
+        assert!(!held.converged(), "a held-back agent is not convergence");
+        assert!(matches!(
+            held.steps.iter().find(|s| s.alias() == "review"),
+            Some(PlanStep::Waiting { waiting_on, .. }) if waiting_on == &["impl".to_string()]
+        ));
+
+        // Reported: the edge opens and the next run starts it.
+        let opened = plan(&agents, &[], None, &["impl".to_string()]);
+        assert_eq!(opened.launches(), 2);
+        assert_eq!(opened.waiting(), 0);
+    }
+
+    #[test]
+    fn an_edge_gates_the_start_only_not_an_agent_already_running() {
+        // Re-gating a live agent would tear down work in flight whenever an
+        // upstream alias was re-opened.
+        let agents = vec![desired_after("review", &["impl"])];
+        let live = existing(&[("%1", Some("review"))]);
+        let plan = plan(&agents, &live, None, &[]);
+        assert_eq!(plan.waiting(), 0);
+        assert!(plan.converged());
+    }
+
+    #[test]
+    fn an_edge_to_an_alias_nobody_defines_is_refused() {
+        let config: Config = toml::from_str(
+            r"
+[[pipeline.p.agent]]
+alias = 'review'
+program = 'codex'
+after = ['ghost']
+",
+        )
+        .unwrap();
+        let error = desired_agents("p", &config.pipeline["p"], &Vars::new())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("ghost"), "{error}");
+    }
+
+    #[test]
+    fn a_cycle_is_refused_rather_than_deadlocking_forever() {
+        let config: Config = toml::from_str(
+            r"
+[[pipeline.p.agent]]
+alias = 'a'
+program = 'codex'
+after = ['b']
+
+[[pipeline.p.agent]]
+alias = 'b'
+program = 'codex'
+after = ['a']
+",
+        )
+        .unwrap();
+        let error = desired_agents("p", &config.pipeline["p"], &Vars::new())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("cycle"), "{error}");
+    }
+
     #[test]
     fn an_empty_window_launches_everything() {
-        let plan = plan(&desired(&["plan", "impl"]), &[], None);
+        let plan = plan_at(&desired(&["plan", "impl"]), &[], None);
         assert_eq!(plan.launches(), 2);
         assert!(!plan.converged());
     }
 
     #[test]
     fn re_running_a_staffed_window_is_a_no_op() {
-        let plan = plan(
+        let plan = plan_at(
             &desired(&["plan", "impl"]),
             &existing(&[("%1", Some("plan")), ("%2", Some("impl"))]),
             None,
@@ -1163,7 +1368,7 @@ program = 'claude'
 
     #[test]
     fn only_the_missing_alias_is_launched() {
-        let plan = plan(
+        let plan = plan_at(
             &desired(&["plan", "impl", "review"]),
             &existing(&[("%1", Some("plan")), ("%2", Some("impl"))]),
             None,
@@ -1177,7 +1382,7 @@ program = 'claude'
 
     #[test]
     fn a_broadcast_reaches_live_panes_and_still_launches_missing_ones() {
-        let plan = plan(
+        let plan = plan_at(
             &desired(&["plan", "review"]),
             &existing(&[("%1", Some("plan"))]),
             Some("rebase onto main first"),
@@ -1200,7 +1405,7 @@ program = 'claude'
             AgentState::WaitingChoice,
             AgentState::Error,
         ] {
-            let plan = plan(
+            let plan = plan_at(
                 &desired(&["impl"]),
                 &existing_in(&[("%1", Some("impl"))], Some(state)),
                 Some("carry on"),
@@ -1214,9 +1419,9 @@ program = 'claude'
     #[test]
     fn a_working_agent_is_kept_and_a_broadcast_still_reaches_it() {
         let working = existing_in(&[("%1", Some("impl"))], Some(AgentState::Working));
-        assert!(plan(&desired(&["impl"]), &working, None).converged());
+        assert!(plan_at(&desired(&["impl"]), &working, None).converged());
         assert_eq!(
-            plan(&desired(&["impl"]), &working, Some("go")).reprompts(),
+            plan_at(&desired(&["impl"]), &working, Some("go")).reprompts(),
             1
         );
 
@@ -1224,8 +1429,11 @@ program = 'claude'
         // Distinguishing it from Working is the operator's call, not a
         // reason to relaunch.
         let idle = existing_in(&[("%1", Some("impl"))], Some(AgentState::Idle));
-        assert!(plan(&desired(&["impl"]), &idle, None).converged());
-        assert_eq!(plan(&desired(&["impl"]), &idle, Some("go")).reprompts(), 1);
+        assert!(plan_at(&desired(&["impl"]), &idle, None).converged());
+        assert_eq!(
+            plan_at(&desired(&["impl"]), &idle, Some("go")).reprompts(),
+            1
+        );
     }
 
     #[test]
@@ -1239,7 +1447,7 @@ program = 'claude'
 
     #[test]
     fn a_pane_no_alias_claims_is_reported_and_left_alone() {
-        let plan = plan(
+        let plan = plan_at(
             &desired(&["plan"]),
             &existing(&[("%1", Some("plan")), ("%9", None), ("%8", Some("retired"))]),
             None,

--- a/crates/muxa/src/pipeline.rs
+++ b/crates/muxa/src/pipeline.rs
@@ -34,7 +34,8 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use crate::config::{
-    PipelineAgentConfig, PipelineConfig, RouteConfig, TicketConfig, TicketSource, WorktreeConfig,
+    Config, PipelineAgentConfig, PipelineConfig, RouteConfig, TicketConfig, TicketSource,
+    WorktreeConfig,
 };
 
 /// Ticket body characters kept in a rendered prompt. A description can run
@@ -71,6 +72,18 @@ pub enum PipelineError {
     NoTicketJson(String),
     #[error("the ticket resolver answered with JSON that is not a ticket: {0}")]
     BadTicketJson(String),
+    #[error("the reply carried no TOML; it began: {0}")]
+    NoToml(String),
+    #[error("the generated TOML does not parse: {0}")]
+    BadToml(String),
+    #[error("the generated config configures nothing: expected at least one [[route]] and one [pipeline.*]")]
+    EmptyProposal,
+    #[error("pipeline {pipeline:?} agent {alias:?} names program {program:?}, which is not an allowlisted agent CLI (claude, codex, gemini, opencode)")]
+    UnknownProgram {
+        pipeline: String,
+        alias: String,
+        program: String,
+    },
 }
 
 /// Ticket context, as the resolver agent reported it.
@@ -208,6 +221,136 @@ pub fn extract_json_object(text: &str) -> Option<&str> {
     }
     let (start, end) = best?;
     text.get(start..end)
+}
+
+/// Agent CLIs a pipeline may name. Kept here so a generated config can be
+/// rejected before it reaches tmux, rather than failing one pane at a time.
+pub const ALLOWLISTED_PROGRAMS: [&str; 4] = ["claude", "codex", "gemini", "opencode"];
+
+/// Pull a TOML document out of an agent's reply.
+///
+/// Prefers a fenced `toml` code block, because that is what the prompt asks
+/// for and what models reliably produce. Falls back to the whole reply so
+/// a model that answered with bare TOML still works.
+#[must_use]
+pub fn extract_toml_block(reply: &str) -> Option<&str> {
+    let mut rest = reply;
+    while let Some(open) = rest.find("```") {
+        let after = &rest[open + 3..];
+        let (tag, body) = after.split_once('\n')?;
+        let tag = tag.trim();
+        let Some(close) = body.find("```") else {
+            // Unterminated fence: take what is there rather than nothing.
+            return (tag.is_empty() || tag.eq_ignore_ascii_case("toml"))
+                .then_some(body)
+                .filter(|body| !body.trim().is_empty());
+        };
+        if tag.is_empty() || tag.eq_ignore_ascii_case("toml") {
+            let block = &body[..close];
+            if !block.trim().is_empty() {
+                return Some(block);
+            }
+        }
+        rest = &body[close + 3..];
+    }
+    (!reply.trim().is_empty()).then_some(reply)
+}
+
+/// What a generated config actually configures, for the confirmation the
+/// operator sees before anything is written.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProposalSummary {
+    pub ticket_sources: Vec<String>,
+    pub routes: Vec<String>,
+    /// `name → agent count`, in the order a pipeline's agents are declared.
+    pub pipelines: Vec<(String, usize)>,
+}
+
+/// Parse and check a generated `[ticket]`/`[[route]]`/`[pipeline.*]` block
+/// before it is allowed anywhere near the operator's config file.
+///
+/// A model that invents a key, a bad regex, or a pipeline nobody defined
+/// would otherwise take the daemon down at its next start —
+/// [`crate::config::Config`] denies unknown fields, so a typo is a parse
+/// error rather than a shrug. Better to refuse here, while the text is
+/// still just text.
+///
+/// # Errors
+/// [`PipelineError::BadToml`] when the text is not a valid config,
+/// [`PipelineError::EmptyProposal`] when it configures nothing,
+/// [`PipelineError::BadPattern`] for a regex that will not compile,
+/// [`PipelineError::UnknownPipeline`] for a route naming a pipeline that
+/// does not exist, [`PipelineError::EmptyPipeline`] /
+/// [`PipelineError::DuplicateAlias`] / [`PipelineError::UnknownProgram`]
+/// for a line-up that could never launch.
+pub fn validate_proposal(toml_text: &str) -> Result<(Config, ProposalSummary), PipelineError> {
+    let config: Config =
+        toml::from_str(toml_text).map_err(|error| PipelineError::BadToml(error.to_string()))?;
+    if config.route.is_empty() || config.pipeline.is_empty() {
+        return Err(PipelineError::EmptyProposal);
+    }
+    for source in config.ticket.source.values() {
+        if !source.pattern.is_empty() {
+            compile("ticket source", &source.pattern)?;
+        }
+    }
+    for route in &config.route {
+        if !route.pattern.is_empty() {
+            compile("route", &route.pattern)?;
+        }
+        if let Some(name) = route.pipeline.as_deref() {
+            if !config.pipeline.contains_key(name) {
+                return Err(PipelineError::UnknownPipeline(name.to_string()));
+            }
+        }
+    }
+    for (name, pipeline) in &config.pipeline {
+        // Rendering with empty vars is the cheapest way to reuse the same
+        // emptiness and duplicate-alias rules the launcher enforces.
+        desired_agents(name, pipeline, &Vars::new())?;
+        for agent in &pipeline.agent {
+            let program = agent.program.trim().to_ascii_lowercase();
+            if !ALLOWLISTED_PROGRAMS.contains(&program.as_str()) {
+                return Err(PipelineError::UnknownProgram {
+                    pipeline: name.clone(),
+                    alias: agent.alias.clone(),
+                    program: agent.program.clone(),
+                });
+            }
+        }
+    }
+    let summary = ProposalSummary {
+        ticket_sources: config.ticket.source.keys().cloned().collect(),
+        routes: config
+            .route
+            .iter()
+            .map(|route| {
+                format!(
+                    "{} → {}",
+                    route.pattern,
+                    route.pipeline.as_deref().unwrap_or("(no pipeline)")
+                )
+            })
+            .collect(),
+        pipelines: config
+            .pipeline
+            .iter()
+            .map(|(name, pipeline)| (name.clone(), pipeline.agent.len()))
+            .collect(),
+    };
+    Ok((config, summary))
+}
+
+fn compile(scope: &'static str, pattern: &str) -> Result<(), PipelineError> {
+    regex::RegexBuilder::new(pattern)
+        .case_insensitive(true)
+        .build()
+        .map(|_| ())
+        .map_err(|source| PipelineError::BadPattern {
+            scope,
+            pattern: pattern.to_string(),
+            source,
+        })
 }
 
 /// Placeholder values available to `[ticket.source]` prompts, `[[route]]`
@@ -1051,6 +1194,128 @@ program = 'claude'
         assert_eq!(plan.path, Path::new("/wt/cal-7"));
         assert_eq!(plan.branch, "june/cal-7");
         assert_eq!(plan.base.as_deref(), Some("origin/main"));
+    }
+
+    const GOOD: &str = r"
+[[route]]
+match = '^cal-'
+pipeline = 'triad'
+
+[pipeline.triad]
+[[pipeline.triad.agent]]
+alias = 'impl'
+program = 'codex'
+[[pipeline.triad.agent]]
+alias = 'review'
+program = 'claude'
+";
+
+    #[test]
+    fn a_fenced_toml_block_is_lifted_out_of_the_prose_around_it() {
+        let reply = format!("Sure, here you go:\n\n```toml{GOOD}```\n\nPaste that in.");
+        let block = extract_toml_block(&reply).expect("block");
+        assert!(block.contains("[pipeline.triad]"), "{block}");
+        assert!(!block.contains("Paste that in"), "{block}");
+    }
+
+    #[test]
+    fn bare_toml_with_no_fence_still_works() {
+        let block = extract_toml_block(GOOD).expect("block");
+        assert!(block.contains("[[route]]"));
+        assert!(extract_toml_block("   ").is_none());
+    }
+
+    #[test]
+    fn a_valid_proposal_reports_what_it_configures() {
+        let (_, summary) = validate_proposal(GOOD).expect("valid");
+        assert_eq!(summary.routes, vec!["^cal- → triad"]);
+        assert_eq!(summary.pipelines, vec![("triad".to_string(), 2)]);
+        assert!(summary.ticket_sources.is_empty());
+    }
+
+    #[test]
+    fn an_invented_key_is_refused_before_it_reaches_the_config_file() {
+        // Config denies unknown fields, so a model's typo would take the
+        // daemon down at its next start. Catch it while it is still text.
+        let error = validate_proposal(
+            r"
+[[route]]
+match = '.*'
+piepline = 'triad'
+",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("does not parse"), "{error}");
+    }
+
+    #[test]
+    fn a_route_naming_a_pipeline_nobody_defined_is_refused() {
+        let error = validate_proposal(
+            r"
+[[route]]
+match = '.*'
+pipeline = 'ghost'
+
+[pipeline.real]
+[[pipeline.real.agent]]
+alias = 'a'
+program = 'codex'
+",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("ghost"), "{error}");
+    }
+
+    #[test]
+    fn a_program_that_is_not_an_agent_cli_is_refused() {
+        let error = validate_proposal(
+            r"
+[[route]]
+match = '.*'
+pipeline = 'p'
+
+[pipeline.p]
+[[pipeline.p.agent]]
+alias = 'a'
+program = 'vim'
+",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("vim"), "{error}");
+        assert!(
+            error.contains("claude"),
+            "should list what is allowed: {error}"
+        );
+    }
+
+    #[test]
+    fn an_uncompilable_pattern_is_refused_with_the_pattern_named() {
+        let error = validate_proposal(
+            r"
+[[route]]
+match = 'cal-['
+pipeline = 'p'
+
+[pipeline.p]
+[[pipeline.p.agent]]
+alias = 'a'
+program = 'codex'
+",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("cal-["), "{error}");
+    }
+
+    #[test]
+    fn a_proposal_that_configures_nothing_is_refused() {
+        assert!(matches!(
+            validate_proposal("[ticket]\nagent = 'claude'\n"),
+            Err(PipelineError::EmptyProposal)
+        ));
     }
 
     #[test]

--- a/crates/muxa/src/pipeline.rs
+++ b/crates/muxa/src/pipeline.rs
@@ -37,6 +37,7 @@ use crate::config::{
     Config, PipelineAgentConfig, PipelineConfig, RouteConfig, TicketConfig, TicketSource,
     WorktreeConfig,
 };
+use crate::event::AgentState;
 
 /// Ticket body characters kept in a rendered prompt. A description can run
 /// to thousands of words; the prompt carries the shape of the task and the
@@ -665,12 +666,34 @@ fn render_agent(
 }
 
 /// A pane that already exists in the work window.
+///
+/// `state` is what makes a re-run a reconcile rather than a headcount. A
+/// pane proves someone was started there; it says nothing about whether
+/// that agent is working, idle, or stuck on a permission prompt nobody
+/// will ever answer. Those look identical from tmux and could not be
+/// further apart in what they need.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ExistingAgent {
     pub pane: String,
     pub program: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
+    /// From the daemon's registry. `None` means the daemon had nothing for
+    /// this pane — usually that it is not running.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<AgentState>,
+}
+
+/// Whether this agent is blocked on a person.
+///
+/// A prompt typed at an agent sitting on an approval dialog is swallowed
+/// by the dialog, so muxa must report it rather than talk over it.
+#[must_use]
+pub fn needs_a_human(state: Option<AgentState>) -> bool {
+    matches!(
+        state,
+        Some(AgentState::WaitingInput | AgentState::WaitingChoice | AgentState::Error)
+    )
 }
 
 /// What `muxa work up` intends to do to one pane.
@@ -686,7 +709,20 @@ pub enum PlanStep {
         prompt: String,
     },
     /// The alias has a live pane and nothing to say to it. Converged.
-    Keep { alias: String, pane: String },
+    Keep {
+        alias: String,
+        pane: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        state: Option<AgentState>,
+    },
+    /// The alias is blocked on a person — an approval prompt or an error.
+    /// Never prompted over: the dialog would eat the message, and the
+    /// operator would be left believing it was delivered.
+    Attention {
+        alias: String,
+        pane: String,
+        state: Option<AgentState>,
+    },
 }
 
 impl PlanStep {
@@ -694,7 +730,9 @@ impl PlanStep {
     pub fn alias(&self) -> &str {
         match self {
             Self::Launch(agent) => &agent.alias,
-            Self::Reprompt { alias, .. } | Self::Keep { alias, .. } => alias,
+            Self::Reprompt { alias, .. }
+            | Self::Keep { alias, .. }
+            | Self::Attention { alias, .. } => alias,
         }
     }
 }
@@ -728,9 +766,19 @@ impl Plan {
 
     /// True when every desired pane already exists and there is nothing to
     /// say to any of them.
+    /// Aliases blocked on a person. Converging is not possible until
+    /// somebody answers them, so they are counted separately.
+    #[must_use]
+    pub fn attention(&self) -> usize {
+        self.steps
+            .iter()
+            .filter(|step| matches!(step, PlanStep::Attention { .. }))
+            .count()
+    }
+
     #[must_use]
     pub fn converged(&self) -> bool {
-        self.launches() == 0 && self.reprompts() == 0
+        self.launches() == 0 && self.reprompts() == 0 && self.attention() == 0
     }
 }
 
@@ -754,6 +802,13 @@ pub fn plan(desired: &[DesiredAgent], existing: &[ExistingAgent], broadcast: Opt
             });
             match (live, broadcast) {
                 (None, _) => PlanStep::Launch(agent.clone()),
+                // Blocked on a person beats everything: do not type at it,
+                // and do not report it as converged either.
+                (Some(live), _) if needs_a_human(live.state) => PlanStep::Attention {
+                    alias: agent.alias.clone(),
+                    pane: live.pane.clone(),
+                    state: live.state,
+                },
                 (Some(live), Some(message)) => PlanStep::Reprompt {
                     alias: agent.alias.clone(),
                     pane: live.pane.clone(),
@@ -762,6 +817,7 @@ pub fn plan(desired: &[DesiredAgent], existing: &[ExistingAgent], broadcast: Opt
                 (Some(live), None) => PlanStep::Keep {
                     alias: agent.alias.clone(),
                     pane: live.pane.clone(),
+                    state: live.state,
                 },
             }
         })
@@ -1073,11 +1129,16 @@ program = 'claude'
     }
 
     fn existing(rows: &[(&str, Option<&str>)]) -> Vec<ExistingAgent> {
+        existing_in(rows, Some(AgentState::Working))
+    }
+
+    fn existing_in(rows: &[(&str, Option<&str>)], state: Option<AgentState>) -> Vec<ExistingAgent> {
         rows.iter()
             .map(|(pane, alias)| ExistingAgent {
                 pane: (*pane).to_string(),
                 program: "codex".into(),
                 alias: alias.map(str::to_string),
+                state,
             })
             .collect()
     }
@@ -1128,6 +1189,52 @@ program = 'claude'
             PlanStep::Reprompt { pane, prompt, .. }
                 if pane == "%1" && prompt == "rebase onto main first"
         ));
+    }
+
+    #[test]
+    fn an_agent_blocked_on_a_person_is_never_prompted_over() {
+        // A prompt typed at an approval dialog is eaten by the dialog, and
+        // the operator is left believing it was delivered.
+        for state in [
+            AgentState::WaitingInput,
+            AgentState::WaitingChoice,
+            AgentState::Error,
+        ] {
+            let plan = plan(
+                &desired(&["impl"]),
+                &existing_in(&[("%1", Some("impl"))], Some(state)),
+                Some("carry on"),
+            );
+            assert_eq!(plan.reprompts(), 0, "{state:?} must not be prompted");
+            assert_eq!(plan.attention(), 1, "{state:?}");
+            assert!(!plan.converged(), "{state:?} is not converged");
+        }
+    }
+
+    #[test]
+    fn a_working_agent_is_kept_and_a_broadcast_still_reaches_it() {
+        let working = existing_in(&[("%1", Some("impl"))], Some(AgentState::Working));
+        assert!(plan(&desired(&["impl"]), &working, None).converged());
+        assert_eq!(
+            plan(&desired(&["impl"]), &working, Some("go")).reprompts(),
+            1
+        );
+
+        // Idle is still staffed — it just has nothing to say for itself.
+        // Distinguishing it from Working is the operator's call, not a
+        // reason to relaunch.
+        let idle = existing_in(&[("%1", Some("impl"))], Some(AgentState::Idle));
+        assert!(plan(&desired(&["impl"]), &idle, None).converged());
+        assert_eq!(plan(&desired(&["impl"]), &idle, Some("go")).reprompts(), 1);
+    }
+
+    #[test]
+    fn an_unknown_state_is_treated_as_present_not_blocked() {
+        // The daemon may simply not have this pane; that is not a reason to
+        // claim a human is needed.
+        assert!(!needs_a_human(None));
+        assert!(!needs_a_human(Some(AgentState::Starting)));
+        assert!(!needs_a_human(Some(AgentState::Stopped)));
     }
 
     #[test]

--- a/crates/muxa/src/pipeline.rs
+++ b/crates/muxa/src/pipeline.rs
@@ -861,6 +861,64 @@ impl Plan {
     }
 }
 
+/// One row of a rendered pipeline graph: an agent, how deep its longest
+/// dependency chain runs, and what it is waiting on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GraphNode {
+    pub alias: String,
+    pub program: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// 0 for anything that can start immediately; otherwise one past the
+    /// deepest thing it waits on. Everything sharing a depth can run at the
+    /// same time, which is the fact a list of tables hides.
+    pub depth: usize,
+    pub after: Vec<String>,
+}
+
+/// Lay a pipeline out by dependency depth.
+///
+/// The TOML says which agents exist and, buried in an `after` key, which
+/// ones wait. It does not say what runs *together*, and that is the thing
+/// an operator actually wants to know before spending money on a run.
+/// Depth answers it: equal depth means parallel.
+///
+/// Assumes the edges are already validated — [`desired_agents`] refuses
+/// unknown aliases and cycles, so a node here always resolves.
+#[must_use]
+pub fn graph(agents: &[DesiredAgent]) -> Vec<GraphNode> {
+    let mut depths: BTreeMap<&str, usize> = BTreeMap::new();
+    // Repeated relaxation rather than a recursive walk: the set is tiny and
+    // this cannot blow the stack on a pathological config.
+    for _ in 0..agents.len() {
+        for agent in agents {
+            let depth = agent
+                .after
+                .iter()
+                .map(|dependency| depths.get(dependency.as_str()).map_or(0, |depth| depth + 1))
+                .max()
+                .unwrap_or(0);
+            depths.insert(agent.alias.as_str(), depth);
+        }
+    }
+    let mut nodes: Vec<GraphNode> = agents
+        .iter()
+        .map(|agent| GraphNode {
+            alias: agent.alias.clone(),
+            program: agent.program.clone(),
+            role: agent.role.clone(),
+            depth: depths.get(agent.alias.as_str()).copied().unwrap_or(0),
+            after: agent.after.clone(),
+        })
+        .collect();
+    nodes.sort_by(|left, right| {
+        left.depth
+            .cmp(&right.depth)
+            .then_with(|| left.alias.cmp(&right.alias))
+    });
+    nodes
+}
+
 /// Compare the pipeline's panes against the window's panes.
 ///
 /// `broadcast` is the "improve work already in flight" path: with it, every
@@ -1271,6 +1329,32 @@ program = 'claude'
             direction: None,
             after: after.iter().map(|a| (*a).to_string()).collect(),
         }
+    }
+
+    #[test]
+    fn depth_says_what_runs_together_which_the_toml_never_does() {
+        let agents = vec![
+            desired_after("impl", &[]),
+            desired_after("docs", &[]),
+            desired_after("review", &["impl"]),
+            desired_after("ship", &["review", "docs"]),
+        ];
+        let nodes = graph(&agents);
+        let depth = |alias: &str| {
+            nodes
+                .iter()
+                .find(|node| node.alias == alias)
+                .expect("node")
+                .depth
+        };
+        // impl and docs have nothing to wait for, so they run together.
+        assert_eq!(depth("impl"), 0);
+        assert_eq!(depth("docs"), 0);
+        assert_eq!(depth("review"), 1);
+        // ship waits on the *deepest* of its edges, not the first.
+        assert_eq!(depth("ship"), 2);
+        // Rendered shallowest-first so the reading order is the run order.
+        assert!(nodes.windows(2).all(|w| w[0].depth <= w[1].depth));
     }
 
     #[test]

--- a/crates/muxa/src/pipeline.rs
+++ b/crates/muxa/src/pipeline.rs
@@ -582,7 +582,7 @@ fn default_worktree_path(repo: &Path, work: &str) -> std::path::PathBuf {
 }
 
 /// One pane the pipeline wants, with every template already rendered.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
 pub struct DesiredAgent {
     pub alias: String,
     pub program: String,
@@ -595,7 +595,7 @@ pub struct DesiredAgent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub direction: Option<String>,
     /// Aliases that must report done before this one may start.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub after: Vec<String>,
 }
 

--- a/crates/muxa/src/pipeline_run.rs
+++ b/crates/muxa/src/pipeline_run.rs
@@ -1,0 +1,1335 @@
+//! Durable execution state for declarative Work pipelines.
+//!
+//! A pane is evidence that an agent process exists; it is not the pipeline
+//! state itself. This store keeps the desired graph and one generation-aware
+//! state per alias so completion survives pane and daemon restarts without a
+//! stale completion opening a new generation's dependency edges.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::{watch, Mutex};
+
+use crate::pipeline::DesiredAgent;
+use crate::work::WorkIdentity;
+
+pub const PIPELINE_RUN_SCHEMA_VERSION: u8 = 1;
+const CLAIM_LEASE_SECONDS: i64 = 15;
+
+#[cfg(unix)]
+const STORE_FILE_MODE: u32 = 0o600;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PipelineAliasStatus {
+    Pending,
+    Running,
+    Blocked,
+    Done,
+    Failed,
+}
+
+impl std::fmt::Display for PipelineAliasStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Blocked => "blocked",
+            Self::Done => "done",
+            Self::Failed => "failed",
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PipelineAliasState {
+    pub alias: String,
+    pub status: PipelineAliasStatus,
+    /// Generation in which this alias most recently changed state.
+    pub generation: u64,
+    /// Generation accepted by the atomic `done(alias, generation)` event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion_generation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pane: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Whether this alias still needs the reconciler to launch or re-prompt
+    /// it. Kept separate from the five public statuses so a gated pane can
+    /// truthfully remain `blocked` without losing the pending restart.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub reconcile_pending: bool,
+    /// Internal launch reservation. It deliberately does not add another
+    /// public status; an abandoned reservation becomes claimable again after
+    /// a short lease so daemon/CLI crashes cannot strand the Run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claim_started_at: Option<OffsetDateTime>,
+    pub updated_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PipelineRun {
+    pub identity: WorkIdentity,
+    pub pipeline: String,
+    pub desired: Vec<DesiredAgent>,
+    pub cwd: PathBuf,
+    pub generation: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_id: Option<String>,
+    pub aliases: BTreeMap<String, PipelineAliasState>,
+    pub updated_at: OffsetDateTime,
+}
+
+/// Prompt-free projection used by list/watch surfaces.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PipelineRunSummary {
+    pub pipeline: String,
+    pub generation: u64,
+    pub aliases: Vec<PipelineAliasSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PipelineAliasSummary {
+    pub alias: String,
+    pub status: PipelineAliasStatus,
+    pub generation: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion_generation: Option<u64>,
+}
+
+impl PipelineRun {
+    #[must_use]
+    pub fn desired_aliases(&self) -> Vec<String> {
+        self.desired
+            .iter()
+            .map(|agent| agent.alias.clone())
+            .collect()
+    }
+
+    #[must_use]
+    pub fn completion(&self) -> (usize, usize) {
+        (
+            self.aliases
+                .values()
+                .filter(|state| state.status == PipelineAliasStatus::Done)
+                .count(),
+            self.desired.len(),
+        )
+    }
+
+    #[must_use]
+    pub fn has_ready_alias(&self) -> bool {
+        let done: BTreeSet<&str> = self
+            .aliases
+            .values()
+            .filter(|state| state.status == PipelineAliasStatus::Done)
+            .map(|state| state.alias.as_str())
+            .collect();
+        let now = OffsetDateTime::now_utc();
+        self.desired.iter().any(|agent| {
+            self.aliases.get(&agent.alias).is_some_and(|state| {
+                claimable(state, now)
+                    && agent
+                        .after
+                        .iter()
+                        .all(|dependency| done.contains(dependency.as_str()))
+            })
+        })
+    }
+
+    #[must_use]
+    pub fn summary(&self) -> PipelineRunSummary {
+        PipelineRunSummary {
+            pipeline: self.pipeline.clone(),
+            generation: self.generation,
+            aliases: self
+                .desired
+                .iter()
+                .filter_map(|agent| self.aliases.get(&agent.alias))
+                .map(|state| PipelineAliasSummary {
+                    alias: state.alias.clone(),
+                    status: state.status,
+                    generation: state.generation,
+                    completion_generation: state.completion_generation,
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Live-pane evidence supplied during `work up` reconciliation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PipelineAliasObservation {
+    pub alias: String,
+    pub pane: String,
+    pub status: PipelineAliasStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PipelineRunRegistration {
+    pub identity: WorkIdentity,
+    pub pipeline: String,
+    pub desired: Vec<DesiredAgent>,
+    pub cwd: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_id: Option<String>,
+    #[serde(default)]
+    pub observed: Vec<PipelineAliasObservation>,
+    /// Explicitly restarted or re-prompted aliases. Their transitive
+    /// downstream closure loses completion in the new Run generation.
+    #[serde(default)]
+    pub invalidate: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PipelineClaim {
+    pub identity: WorkIdentity,
+    pub pipeline: String,
+    pub generation: u64,
+    pub cwd: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_id: Option<String>,
+    pub agent: DesiredAgent,
+    /// Existing pane to re-prompt after an invalidation. `None` means launch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pane: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PipelineRunError {
+    #[error("pipeline run {0} was not found")]
+    NotFound(String),
+    #[error("pipeline alias {alias:?} does not exist in run {run}")]
+    UnknownAlias { run: String, alias: String },
+    #[error(
+        "stale completion for {alias:?}: expected generation is {current}, event generation was {event}"
+    )]
+    StaleGeneration {
+        alias: String,
+        current: u64,
+        event: u64,
+    },
+    #[error("invalid pipeline run: {0}")]
+    Invalid(String),
+    #[error("pipeline Run store I/O: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PipelineRunFile {
+    version: u8,
+    runs: Vec<PipelineRun>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    path: Option<PathBuf>,
+    runs: BTreeMap<WorkIdentity, PipelineRun>,
+}
+
+#[derive(Debug)]
+pub struct PipelineRunStore {
+    inner: Mutex<Inner>,
+    revision: watch::Sender<u64>,
+}
+
+impl PipelineRunStore {
+    #[must_use]
+    pub fn in_memory() -> std::sync::Arc<Self> {
+        Self::from_runs(None, BTreeMap::new())
+    }
+
+    /// Load durable Runs. Missing state is a first start; malformed or
+    /// unsupported state is fatal so muxad never silently replaces known
+    /// completion with an empty scheduler.
+    pub fn load(path: Option<PathBuf>) -> Result<std::sync::Arc<Self>, PipelineRunError> {
+        let Some(path) = path else {
+            return Ok(Self::in_memory());
+        };
+        let bytes = match std::fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Self::from_runs(Some(path), BTreeMap::new()));
+            }
+            Err(error) => return Err(error.into()),
+        };
+        #[cfg(unix)]
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(STORE_FILE_MODE))?;
+        let file: PipelineRunFile = serde_json::from_slice(&bytes).map_err(|error| {
+            PipelineRunError::Invalid(format!("cannot parse {}: {error}", path.display()))
+        })?;
+        if file.version != PIPELINE_RUN_SCHEMA_VERSION {
+            return Err(PipelineRunError::Invalid(format!(
+                "unsupported schema version {} in {}; expected {}",
+                file.version,
+                path.display(),
+                PIPELINE_RUN_SCHEMA_VERSION
+            )));
+        }
+        let mut runs = BTreeMap::new();
+        for run in file.runs {
+            let identity = run.identity.clone();
+            if runs.insert(identity.clone(), run).is_some() {
+                return Err(PipelineRunError::Invalid(format!(
+                    "duplicate Run identity {} in {}",
+                    identity.key(),
+                    path.display()
+                )));
+            }
+        }
+        Ok(Self::from_runs(Some(path), runs))
+    }
+
+    fn from_runs(
+        path: Option<PathBuf>,
+        runs: BTreeMap<WorkIdentity, PipelineRun>,
+    ) -> std::sync::Arc<Self> {
+        let (revision, _) = watch::channel(0);
+        std::sync::Arc::new(Self {
+            inner: Mutex::new(Inner { path, runs }),
+            revision,
+        })
+    }
+
+    #[must_use]
+    pub fn subscribe(&self) -> watch::Receiver<u64> {
+        self.revision.subscribe()
+    }
+
+    pub async fn list(&self) -> Vec<PipelineRun> {
+        self.inner.lock().await.runs.values().cloned().collect()
+    }
+
+    pub async fn get(&self, identity: &WorkIdentity) -> Option<PipelineRun> {
+        self.inner.lock().await.runs.get(identity).cloned()
+    }
+
+    /// Register desired state and reconcile live-pane evidence in one durable
+    /// transaction. A graph change starts a fresh generation. Explicit
+    /// invalidation resets the named aliases and their downstream closure.
+    #[allow(clippy::too_many_lines)] // one lock/commit intentionally covers the full reconciliation transaction
+    pub async fn register(
+        &self,
+        registration: PipelineRunRegistration,
+    ) -> Result<PipelineRun, PipelineRunError> {
+        validate_registration(&registration)?;
+        let mut inner = self.inner.lock().await;
+        let previous = inner.runs.get(&registration.identity).cloned();
+        let now = OffsetDateTime::now_utc();
+        let mut run = previous.clone().unwrap_or_else(|| PipelineRun {
+            identity: registration.identity.clone(),
+            pipeline: registration.pipeline.clone(),
+            desired: registration.desired.clone(),
+            cwd: registration.cwd.clone(),
+            generation: 1,
+            window_id: registration.window_id.clone(),
+            aliases: registration
+                .desired
+                .iter()
+                .map(|agent| (agent.alias.clone(), pending_state(&agent.alias, 1, now)))
+                .collect(),
+            updated_at: now,
+        });
+
+        let topology_changed = run.pipeline != registration.pipeline
+            || run.cwd != registration.cwd
+            || !same_topology(&run.desired, &registration.desired);
+        let definition_changed = run.desired != registration.desired;
+        if topology_changed {
+            run.generation = run.generation.saturating_add(1);
+            run.aliases = registration
+                .desired
+                .iter()
+                .map(|agent| {
+                    (
+                        agent.alias.clone(),
+                        pending_state(&agent.alias, run.generation, now),
+                    )
+                })
+                .collect();
+        }
+        run.pipeline = registration.pipeline;
+        run.desired = registration.desired;
+        run.cwd = registration.cwd;
+        if registration.window_id.is_some() {
+            run.window_id = registration.window_id;
+        }
+
+        let observed_by_alias: BTreeMap<&str, &PipelineAliasObservation> = registration
+            .observed
+            .iter()
+            .map(|observation| (observation.alias.as_str(), observation))
+            .collect();
+        let vanished: Vec<String> = if topology_changed {
+            Vec::new()
+        } else {
+            run.aliases
+                .values()
+                .filter(|state| {
+                    state.status != PipelineAliasStatus::Done
+                        && state.pane.is_some()
+                        && !observed_by_alias.contains_key(state.alias.as_str())
+                })
+                .map(|state| state.alias.clone())
+                .collect()
+        };
+        let vanished_set: BTreeSet<String> = vanished.iter().cloned().collect();
+        let definition_roots = if definition_changed || topology_changed {
+            run.desired_aliases()
+        } else {
+            Vec::new()
+        };
+        let invalidated_roots: Vec<String> = registration
+            .invalidate
+            .into_iter()
+            .chain(definition_roots)
+            .chain(vanished)
+            .collect();
+        let invalidated = downstream_closure(&run.desired, &invalidated_roots);
+        if !invalidated.is_empty() && !topology_changed {
+            run.generation = run.generation.saturating_add(1);
+            for alias in &invalidated {
+                if let Some(state) = run.aliases.get_mut(alias) {
+                    state.status = PipelineAliasStatus::Pending;
+                    state.generation = run.generation;
+                    state.completion_generation = None;
+                    state.error = None;
+                    state.reconcile_pending = true;
+                    state.claim_started_at = None;
+                    state.updated_at = now;
+                    // Keep the pane as a re-prompt target. The downstream
+                    // agent is not considered running in the new generation
+                    // until its dependencies are complete and it is claimed.
+                    if vanished_set.contains(alias) {
+                        state.pane = None;
+                    }
+                }
+            }
+        }
+
+        for observation in registration.observed {
+            let Some(state) = run.aliases.get_mut(&observation.alias) else {
+                continue;
+            };
+            state.pane = Some(observation.pane);
+            // Done is explicit and generation-bound. Pane observation must
+            // never demote it; invalidation above is the only reset path.
+            if state.status != PipelineAliasStatus::Done {
+                if invalidated.contains(&observation.alias) {
+                    // A human block remains visible and must not be prompted
+                    // over. Once the daemon observes it running again,
+                    // `observe_pane` moves it back to ready/pending.
+                    if matches!(
+                        observation.status,
+                        PipelineAliasStatus::Blocked | PipelineAliasStatus::Failed
+                    ) {
+                        state.status = observation.status;
+                    }
+                } else {
+                    state.status = observation.status;
+                    state.generation = run.generation;
+                    state.reconcile_pending = false;
+                    state.error = None;
+                    state.claim_started_at = None;
+                }
+                state.updated_at = now;
+            }
+        }
+        run.updated_at = now;
+        persist_run(&mut inner, run.clone(), previous).await?;
+        self.bump_revision();
+        Ok(run)
+    }
+
+    /// Atomically accept one completion claim. The generation comparison and
+    /// state transition happen under the same store lock and disk commit.
+    pub async fn done(
+        &self,
+        identity: &WorkIdentity,
+        alias: &str,
+        generation: u64,
+    ) -> Result<PipelineRun, PipelineRunError> {
+        let mut inner = self.inner.lock().await;
+        let previous = inner
+            .runs
+            .get(identity)
+            .cloned()
+            .ok_or_else(|| PipelineRunError::NotFound(identity.key()))?;
+        let mut run = previous.clone();
+        let state = run
+            .aliases
+            .get_mut(alias)
+            .ok_or_else(|| PipelineRunError::UnknownAlias {
+                run: identity.key(),
+                alias: alias.to_string(),
+            })?;
+        // Run generation is a monotonic revision, but independent branches
+        // may still be working in an older generation. Validate the alias's
+        // expected generation so restarting one branch does not invalidate an
+        // unrelated branch's legitimate completion event.
+        if state.generation != generation {
+            return Err(PipelineRunError::StaleGeneration {
+                alias: alias.to_string(),
+                current: state.generation,
+                event: generation,
+            });
+        }
+        // A generation number alone is not proof that this alias was
+        // materialized. Accept completion only after an observed run or an
+        // active atomic claim; otherwise a caller could skip the scheduler
+        // and open downstream work directly.
+        if state.reconcile_pending && state.claim_started_at.is_none() {
+            return Err(PipelineRunError::Invalid(format!(
+                "alias {alias:?} has not started in generation {generation}"
+            )));
+        }
+        let now = OffsetDateTime::now_utc();
+        state.status = PipelineAliasStatus::Done;
+        state.generation = generation;
+        state.completion_generation = Some(generation);
+        state.error = None;
+        state.reconcile_pending = false;
+        state.claim_started_at = None;
+        state.updated_at = now;
+        run.updated_at = now;
+        persist_run(&mut inner, run.clone(), Some(previous)).await?;
+        self.bump_revision();
+        Ok(run)
+    }
+
+    /// Undo completion by starting a new generation and invalidating the
+    /// alias plus everything transitively downstream.
+    pub async fn invalidate(
+        &self,
+        identity: &WorkIdentity,
+        alias: &str,
+        generation: u64,
+    ) -> Result<PipelineRun, PipelineRunError> {
+        let mut inner = self.inner.lock().await;
+        let previous = inner
+            .runs
+            .get(identity)
+            .cloned()
+            .ok_or_else(|| PipelineRunError::NotFound(identity.key()))?;
+        if !previous.aliases.contains_key(alias) {
+            return Err(PipelineRunError::UnknownAlias {
+                run: identity.key(),
+                alias: alias.to_string(),
+            });
+        }
+        let expected = previous.aliases[alias].generation;
+        if expected != generation {
+            return Err(PipelineRunError::StaleGeneration {
+                alias: alias.to_string(),
+                current: expected,
+                event: generation,
+            });
+        }
+        let mut run = previous.clone();
+        run.generation = run.generation.saturating_add(1);
+        let now = OffsetDateTime::now_utc();
+        for affected in downstream_closure(&run.desired, &[alias.to_string()]) {
+            if let Some(state) = run.aliases.get_mut(&affected) {
+                state.status = PipelineAliasStatus::Pending;
+                state.generation = run.generation;
+                state.completion_generation = None;
+                state.error = None;
+                state.reconcile_pending = true;
+                state.claim_started_at = None;
+                state.updated_at = now;
+            }
+        }
+        run.updated_at = now;
+        persist_run(&mut inner, run.clone(), Some(previous)).await?;
+        self.bump_revision();
+        Ok(run)
+    }
+
+    /// Claim every dependency-ready pending alias for one Run. Claiming and
+    /// changing to `running` are atomic, so concurrent CLI/daemon reconcilers
+    /// cannot launch the same alias twice.
+    pub async fn claim_ready(
+        &self,
+        identity: &WorkIdentity,
+        generation: u64,
+    ) -> Result<Vec<PipelineClaim>, PipelineRunError> {
+        let mut inner = self.inner.lock().await;
+        let previous = inner
+            .runs
+            .get(identity)
+            .cloned()
+            .ok_or_else(|| PipelineRunError::NotFound(identity.key()))?;
+        if previous.generation != generation {
+            return Err(PipelineRunError::StaleGeneration {
+                alias: "reconcile".to_string(),
+                current: previous.generation,
+                event: generation,
+            });
+        }
+        let done: BTreeSet<&str> = previous
+            .aliases
+            .values()
+            .filter(|state| state.status == PipelineAliasStatus::Done)
+            .map(|state| state.alias.as_str())
+            .collect();
+        let now = OffsetDateTime::now_utc();
+        let ready: Vec<DesiredAgent> = previous
+            .desired
+            .iter()
+            .filter(|agent| {
+                previous.aliases.get(&agent.alias).is_some_and(|state| {
+                    claimable(state, now)
+                        && agent
+                            .after
+                            .iter()
+                            .all(|dependency| done.contains(dependency.as_str()))
+                })
+            })
+            .cloned()
+            .collect();
+        if ready.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut run = previous.clone();
+        let mut claims = Vec::with_capacity(ready.len());
+        for agent in ready {
+            let state = run.aliases.get_mut(&agent.alias).expect("validated alias");
+            state.status = PipelineAliasStatus::Running;
+            state.generation = generation;
+            state.error = None;
+            state.reconcile_pending = true;
+            state.claim_started_at = Some(now);
+            state.updated_at = now;
+            claims.push(PipelineClaim {
+                identity: run.identity.clone(),
+                pipeline: run.pipeline.clone(),
+                generation,
+                cwd: run.cwd.clone(),
+                window_id: run.window_id.clone(),
+                agent,
+                pane: state.pane.clone(),
+            });
+        }
+        run.updated_at = now;
+        persist_run(&mut inner, run, Some(previous)).await?;
+        self.bump_revision();
+        Ok(claims)
+    }
+
+    #[allow(clippy::too_many_arguments)] // wire transition fields stay explicit at the atomic store boundary
+    pub async fn report(
+        &self,
+        identity: &WorkIdentity,
+        alias: &str,
+        generation: u64,
+        status: PipelineAliasStatus,
+        pane: Option<String>,
+        error: Option<String>,
+        window_id: Option<String>,
+    ) -> Result<PipelineRun, PipelineRunError> {
+        if status == PipelineAliasStatus::Done || status == PipelineAliasStatus::Pending {
+            return Err(PipelineRunError::Invalid(
+                "report accepts running, blocked, or failed; use done/invalidate for other transitions"
+                    .to_string(),
+            ));
+        }
+        let mut inner = self.inner.lock().await;
+        let previous = inner
+            .runs
+            .get(identity)
+            .cloned()
+            .ok_or_else(|| PipelineRunError::NotFound(identity.key()))?;
+        let mut run = previous.clone();
+        let state = run
+            .aliases
+            .get_mut(alias)
+            .ok_or_else(|| PipelineRunError::UnknownAlias {
+                run: identity.key(),
+                alias: alias.to_string(),
+            })?;
+        if state.generation != generation {
+            return Err(PipelineRunError::StaleGeneration {
+                alias: alias.to_string(),
+                current: state.generation,
+                event: generation,
+            });
+        }
+        let now = OffsetDateTime::now_utc();
+        let preserve_human_gate = status == PipelineAliasStatus::Running
+            && state.reconcile_pending
+            && matches!(
+                state.status,
+                PipelineAliasStatus::Blocked | PipelineAliasStatus::Failed
+            );
+        if !preserve_human_gate {
+            state.status = status;
+            state.error = error;
+            state.reconcile_pending = false;
+        }
+        state.generation = generation;
+        if pane.is_some() {
+            state.pane = pane;
+        }
+        state.claim_started_at = None;
+        state.updated_at = now;
+        if window_id.is_some() {
+            run.window_id = window_id;
+        }
+        run.updated_at = now;
+        persist_run(&mut inner, run.clone(), Some(previous)).await?;
+        self.bump_revision();
+        Ok(run)
+    }
+
+    /// Project an authoritative daemon agent transition onto the alias bound
+    /// to `pane`. Explicit completion always wins: an idle/stopped pane must
+    /// never demote `done`, because only `done(alias, generation)` can make or
+    /// revoke that claim.
+    pub async fn observe_pane(
+        &self,
+        pane: &str,
+        status: PipelineAliasStatus,
+    ) -> Result<Option<PipelineRun>, PipelineRunError> {
+        if matches!(
+            status,
+            PipelineAliasStatus::Pending | PipelineAliasStatus::Done
+        ) {
+            return Err(PipelineRunError::Invalid(
+                "pane observation accepts running, blocked, or failed".to_string(),
+            ));
+        }
+        let mut inner = self.inner.lock().await;
+        let Some(identity) = inner
+            .runs
+            .iter()
+            .filter(|(_, run)| {
+                run.aliases
+                    .values()
+                    .any(|state| state.pane.as_deref() == Some(pane))
+            })
+            .max_by_key(|(_, run)| run.updated_at)
+            .map(|(identity, _)| identity.clone())
+        else {
+            return Ok(None);
+        };
+        let previous = inner.runs.get(&identity).cloned().expect("identity found");
+        let mut run = previous.clone();
+        let state = run
+            .aliases
+            .values_mut()
+            .find(|state| state.pane.as_deref() == Some(pane))
+            .expect("pane found");
+        if state.status == PipelineAliasStatus::Done {
+            return Ok(Some(run));
+        }
+        if state.reconcile_pending && state.claim_started_at.is_none() {
+            let next = match status {
+                PipelineAliasStatus::Running => PipelineAliasStatus::Pending,
+                PipelineAliasStatus::Blocked => PipelineAliasStatus::Blocked,
+                PipelineAliasStatus::Failed => PipelineAliasStatus::Failed,
+                PipelineAliasStatus::Pending | PipelineAliasStatus::Done => unreachable!(),
+            };
+            if state.status == next {
+                return Ok(Some(run));
+            }
+            let now = OffsetDateTime::now_utc();
+            state.status = next;
+            state.error = (next == PipelineAliasStatus::Failed)
+                .then(|| "agent entered a failed/stopped state".to_string());
+            state.updated_at = now;
+            run.updated_at = now;
+            persist_run(&mut inner, run.clone(), Some(previous)).await?;
+            self.bump_revision();
+            return Ok(Some(run));
+        }
+        let materialized_claim = state.claim_started_at.is_some();
+        if state.status == status && !materialized_claim {
+            return Ok(Some(run));
+        }
+        let now = OffsetDateTime::now_utc();
+        state.status = status;
+        state.reconcile_pending = state.reconcile_pending
+            && matches!(
+                status,
+                PipelineAliasStatus::Blocked | PipelineAliasStatus::Failed
+            );
+        state.claim_started_at = None;
+        state.error = (status == PipelineAliasStatus::Failed)
+            .then(|| "agent entered a failed/stopped state".to_string());
+        state.updated_at = now;
+        run.updated_at = now;
+        persist_run(&mut inner, run.clone(), Some(previous)).await?;
+        self.bump_revision();
+        Ok(Some(run))
+    }
+
+    fn bump_revision(&self) {
+        let next = self.revision.borrow().saturating_add(1);
+        self.revision.send_replace(next);
+    }
+}
+
+fn validate_registration(registration: &PipelineRunRegistration) -> Result<(), PipelineRunError> {
+    if registration.identity.workspace_id.trim().is_empty()
+        || registration.identity.work_id.trim().is_empty()
+        || registration.pipeline.trim().is_empty()
+        || registration.desired.is_empty()
+    {
+        return Err(PipelineRunError::Invalid(
+            "workspace, Work, pipeline, and at least one desired alias are required".to_string(),
+        ));
+    }
+    let aliases: BTreeSet<&str> = registration
+        .desired
+        .iter()
+        .map(|agent| agent.alias.as_str())
+        .collect();
+    if aliases.len() != registration.desired.len() {
+        return Err(PipelineRunError::Invalid(
+            "desired aliases must be unique".to_string(),
+        ));
+    }
+    if aliases.iter().any(|alias| alias.trim().is_empty()) {
+        return Err(PipelineRunError::Invalid(
+            "desired aliases cannot be empty".to_string(),
+        ));
+    }
+    for agent in &registration.desired {
+        if let Some(dependency) = agent
+            .after
+            .iter()
+            .find(|dependency| !aliases.contains(dependency.as_str()))
+        {
+            return Err(PipelineRunError::Invalid(format!(
+                "alias {:?} depends on unknown alias {dependency:?}",
+                agent.alias
+            )));
+        }
+    }
+    let mut settled = BTreeSet::new();
+    for _ in 0..registration.desired.len() {
+        let before = settled.len();
+        for agent in &registration.desired {
+            if agent
+                .after
+                .iter()
+                .all(|dependency| settled.contains(dependency))
+            {
+                settled.insert(agent.alias.clone());
+            }
+        }
+        if settled.len() == registration.desired.len() {
+            break;
+        }
+        if settled.len() == before {
+            return Err(PipelineRunError::Invalid(
+                "pipeline dependencies contain a cycle".to_string(),
+            ));
+        }
+    }
+    let mut observed = BTreeSet::new();
+    for observation in &registration.observed {
+        if !aliases.contains(observation.alias.as_str()) {
+            continue;
+        }
+        if !observed.insert(observation.alias.as_str()) {
+            return Err(PipelineRunError::Invalid(format!(
+                "alias {:?} has more than one live-pane observation",
+                observation.alias
+            )));
+        }
+        if matches!(
+            observation.status,
+            PipelineAliasStatus::Pending | PipelineAliasStatus::Done
+        ) {
+            return Err(PipelineRunError::Invalid(format!(
+                "alias {:?} has an invalid observed status {}",
+                observation.alias, observation.status
+            )));
+        }
+    }
+    if let Some(unknown) = registration
+        .invalidate
+        .iter()
+        .find(|alias| !aliases.contains(alias.as_str()))
+    {
+        return Err(PipelineRunError::Invalid(format!(
+            "cannot invalidate unknown alias {unknown:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn pending_state(alias: &str, generation: u64, now: OffsetDateTime) -> PipelineAliasState {
+    PipelineAliasState {
+        alias: alias.to_string(),
+        status: PipelineAliasStatus::Pending,
+        generation,
+        completion_generation: None,
+        pane: None,
+        error: None,
+        reconcile_pending: true,
+        claim_started_at: None,
+        updated_at: now,
+    }
+}
+
+fn claimable(state: &PipelineAliasState, now: OffsetDateTime) -> bool {
+    state.reconcile_pending
+        && (state.status == PipelineAliasStatus::Pending
+            || (state.status == PipelineAliasStatus::Running
+                && state
+                    .claim_started_at
+                    .is_some_and(|started| (now - started).whole_seconds() >= CLAIM_LEASE_SECONDS)))
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)] // serde skip_serializing_if requires fn(&T) -> bool
+const fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+fn same_topology(left: &[DesiredAgent], right: &[DesiredAgent]) -> bool {
+    left.len() == right.len()
+        && left.iter().zip(right).all(|(left, right)| {
+            left.alias == right.alias
+                && left.program == right.program
+                && left.role == right.role
+                && left.task == right.task
+                && left.direction == right.direction
+                && left.after == right.after
+        })
+}
+
+fn downstream_closure(desired: &[DesiredAgent], roots: &[String]) -> BTreeSet<String> {
+    let mut affected: BTreeSet<String> = roots.iter().cloned().collect();
+    let mut queue: VecDeque<String> = roots.iter().cloned().collect();
+    while let Some(done) = queue.pop_front() {
+        for agent in desired
+            .iter()
+            .filter(|agent| agent.after.iter().any(|dependency| dependency == &done))
+        {
+            if affected.insert(agent.alias.clone()) {
+                queue.push_back(agent.alias.clone());
+            }
+        }
+    }
+    affected
+}
+
+async fn persist_run(
+    inner: &mut Inner,
+    run: PipelineRun,
+    previous: Option<PipelineRun>,
+) -> Result<(), PipelineRunError> {
+    let identity = run.identity.clone();
+    inner.runs.insert(identity.clone(), run);
+    let Some(path) = inner.path.as_ref() else {
+        return Ok(());
+    };
+    let file = PipelineRunFile {
+        version: PIPELINE_RUN_SCHEMA_VERSION,
+        runs: inner.runs.values().cloned().collect(),
+    };
+    let body = serde_json::to_vec_pretty(&file)
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
+    if let Err(error) = atomic_save(path, &body).await {
+        if let Some(previous) = previous {
+            inner.runs.insert(identity, previous);
+        } else {
+            inner.runs.remove(&identity);
+        }
+        return Err(error.into());
+    }
+    Ok(())
+}
+
+async fn atomic_save(path: &Path, body: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let tmp = path.with_extension(format!("tmp-{}", uuid::Uuid::new_v4().simple()));
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        options.mode(STORE_FILE_MODE);
+    }
+    let mut file = options.open(&tmp).await?;
+    let result = async {
+        file.write_all(body).await?;
+        file.sync_all().await?;
+        drop(file);
+        tokio::fs::rename(&tmp, path).await
+    }
+    .await;
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&tmp).await;
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent(alias: &str, after: &[&str]) -> DesiredAgent {
+        DesiredAgent {
+            alias: alias.to_string(),
+            program: "codex".to_string(),
+            role: None,
+            task: None,
+            prompt: Some(format!("do {alias}")),
+            direction: None,
+            after: after.iter().map(|value| (*value).to_string()).collect(),
+        }
+    }
+
+    fn registration(invalidate: Vec<String>) -> PipelineRunRegistration {
+        PipelineRunRegistration {
+            identity: WorkIdentity::new("ws", "WORK-1"),
+            pipeline: "chain".to_string(),
+            desired: vec![
+                agent("plan", &[]),
+                agent("impl", &["plan"]),
+                agent("review", &["impl"]),
+            ],
+            cwd: PathBuf::from("/tmp/work"),
+            window_id: Some("@1".to_string()),
+            observed: Vec::new(),
+            invalidate,
+        }
+    }
+
+    #[tokio::test]
+    async fn done_opens_only_the_immediate_ready_edge() {
+        let store = PipelineRunStore::in_memory();
+        let run = store.register(registration(Vec::new())).await.unwrap();
+        let claims = store
+            .claim_ready(&run.identity, run.generation)
+            .await
+            .unwrap();
+        assert_eq!(
+            claims
+                .iter()
+                .map(|claim| claim.agent.alias.as_str())
+                .collect::<Vec<_>>(),
+            vec!["plan"]
+        );
+        store
+            .done(&run.identity, "plan", run.generation)
+            .await
+            .unwrap();
+        let claims = store
+            .claim_ready(&run.identity, run.generation)
+            .await
+            .unwrap();
+        assert_eq!(
+            claims
+                .iter()
+                .map(|claim| claim.agent.alias.as_str())
+                .collect::<Vec<_>>(),
+            vec!["impl"]
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_done_cannot_open_a_new_generation() {
+        let store = PipelineRunStore::in_memory();
+        let run = store.register(registration(Vec::new())).await.unwrap();
+        store
+            .claim_ready(&run.identity, run.generation)
+            .await
+            .unwrap();
+        store
+            .done(&run.identity, "plan", run.generation)
+            .await
+            .unwrap();
+        let next = store
+            .register(registration(vec!["plan".to_string()]))
+            .await
+            .unwrap();
+        assert_eq!(next.generation, run.generation + 1);
+        let error = store
+            .done(&run.identity, "plan", run.generation)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, PipelineRunError::StaleGeneration { .. }));
+        assert_eq!(next.aliases["plan"].status, PipelineAliasStatus::Pending);
+        assert_eq!(next.aliases["impl"].status, PipelineAliasStatus::Pending);
+        assert_eq!(next.aliases["review"].status, PipelineAliasStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn persistence_survives_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pipeline-runs.json");
+        let store = PipelineRunStore::load(Some(path.clone())).unwrap();
+        let run = store.register(registration(Vec::new())).await.unwrap();
+        store
+            .claim_ready(&run.identity, run.generation)
+            .await
+            .unwrap();
+        store
+            .done(&run.identity, "plan", run.generation)
+            .await
+            .unwrap();
+        drop(store);
+        let restored = PipelineRunStore::load(Some(path)).unwrap();
+        let run = restored
+            .get(&WorkIdentity::new("ws", "WORK-1"))
+            .await
+            .unwrap();
+        assert_eq!(run.pipeline, "chain");
+        assert_eq!(run.desired_aliases(), vec!["plan", "impl", "review"]);
+        assert_eq!(run.aliases["plan"].completion_generation, Some(1));
+    }
+
+    #[tokio::test]
+    async fn concurrent_done_events_do_not_lose_each_other() {
+        let store = PipelineRunStore::in_memory();
+        let mut registration = registration(Vec::new());
+        registration.desired = vec![agent("left", &[]), agent("right", &[])];
+        let run = store.register(registration).await.unwrap();
+        store
+            .claim_ready(&run.identity, run.generation)
+            .await
+            .unwrap();
+        let (left, right) = tokio::join!(
+            store.done(&run.identity, "left", run.generation),
+            store.done(&run.identity, "right", run.generation),
+        );
+        left.unwrap();
+        right.unwrap();
+        let final_run = store.get(&run.identity).await.unwrap();
+        assert_eq!(final_run.completion(), (2, 2));
+        assert_eq!(
+            final_run.aliases["left"].completion_generation,
+            Some(run.generation)
+        );
+        assert_eq!(
+            final_run.aliases["right"].completion_generation,
+            Some(run.generation)
+        );
+    }
+
+    #[tokio::test]
+    async fn invalidation_resets_only_the_alias_and_downstream_closure() {
+        let store = PipelineRunStore::in_memory();
+        let mut registration = registration(Vec::new());
+        registration.desired.push(agent("docs", &[]));
+        let run = store.register(registration).await.unwrap();
+        let roots = store
+            .claim_ready(&run.identity, run.generation)
+            .await
+            .unwrap();
+        assert_eq!(roots.len(), 2);
+        for alias in ["plan", "docs"] {
+            store
+                .done(&run.identity, alias, run.generation)
+                .await
+                .unwrap();
+        }
+        let impl_claim = store
+            .claim_ready(&run.identity, run.generation)
+            .await
+            .unwrap();
+        assert_eq!(impl_claim[0].agent.alias, "impl");
+        store
+            .done(&run.identity, "impl", run.generation)
+            .await
+            .unwrap();
+        let review_claim = store
+            .claim_ready(&run.identity, run.generation)
+            .await
+            .unwrap();
+        assert_eq!(review_claim[0].agent.alias, "review");
+        store
+            .done(&run.identity, "review", run.generation)
+            .await
+            .unwrap();
+        let next = store
+            .invalidate(&run.identity, "impl", run.generation)
+            .await
+            .unwrap();
+        assert_eq!(next.generation, run.generation + 1);
+        assert_eq!(next.aliases["plan"].status, PipelineAliasStatus::Done);
+        assert_eq!(next.aliases["docs"].status, PipelineAliasStatus::Done);
+        assert_eq!(next.aliases["impl"].status, PipelineAliasStatus::Pending);
+        assert_eq!(next.aliases["review"].status, PipelineAliasStatus::Pending);
+        assert_eq!(next.aliases["impl"].completion_generation, None);
+        assert_eq!(next.aliases["review"].completion_generation, None);
+    }
+
+    #[tokio::test]
+    async fn changed_prompt_reprompts_existing_alias_in_a_new_generation() {
+        let store = PipelineRunStore::in_memory();
+        let mut initial = registration(Vec::new());
+        initial.desired = vec![agent("impl", &[])];
+        initial.observed = vec![PipelineAliasObservation {
+            alias: "impl".to_string(),
+            pane: "%1".to_string(),
+            status: PipelineAliasStatus::Running,
+        }];
+        let first = store.register(initial.clone()).await.unwrap();
+        store
+            .done(&first.identity, "impl", first.generation)
+            .await
+            .unwrap();
+        initial.desired[0].prompt = Some("do impl again".to_string());
+        let next = store.register(initial).await.unwrap();
+        assert_eq!(next.generation, first.generation + 1);
+        assert_eq!(next.aliases["impl"].status, PipelineAliasStatus::Pending);
+        let claims = store
+            .claim_ready(&next.identity, next.generation)
+            .await
+            .unwrap();
+        assert_eq!(claims.len(), 1);
+        assert_eq!(claims[0].pane.as_deref(), Some("%1"));
+        assert_eq!(claims[0].agent.prompt.as_deref(), Some("do impl again"));
+    }
+
+    #[tokio::test]
+    async fn unrelated_branch_can_finish_after_another_branch_restarts() {
+        let store = PipelineRunStore::in_memory();
+        let mut registration = registration(Vec::new());
+        registration.desired = vec![agent("left", &[]), agent("right", &[])];
+        let first = store.register(registration).await.unwrap();
+        let claims = store
+            .claim_ready(&first.identity, first.generation)
+            .await
+            .unwrap();
+        assert_eq!(claims.len(), 2);
+        let next = store
+            .invalidate(&first.identity, "left", first.generation)
+            .await
+            .unwrap();
+        assert_eq!(next.aliases["left"].generation, next.generation);
+        assert_eq!(next.aliases["right"].generation, first.generation);
+        let stale = store
+            .invalidate(&first.identity, "left", first.generation)
+            .await
+            .unwrap_err();
+        assert!(matches!(stale, PipelineRunError::StaleGeneration { .. }));
+
+        store
+            .report(
+                &first.identity,
+                "right",
+                first.generation,
+                PipelineAliasStatus::Running,
+                Some("%2".to_string()),
+                None,
+                Some("@1".to_string()),
+            )
+            .await
+            .unwrap();
+        let completed = store
+            .done(&first.identity, "right", first.generation)
+            .await
+            .unwrap();
+        assert_eq!(completed.aliases["right"].status, PipelineAliasStatus::Done);
+        assert_eq!(
+            completed.aliases["right"].completion_generation,
+            Some(first.generation)
+        );
+        let restarted_right = store
+            .invalidate(&first.identity, "right", first.generation)
+            .await
+            .unwrap();
+        assert_eq!(
+            restarted_right.aliases["right"].generation,
+            restarted_right.generation
+        );
+    }
+
+    #[tokio::test]
+    async fn pane_observation_updates_status_but_never_demotes_done() {
+        let store = PipelineRunStore::in_memory();
+        let mut registration = registration(Vec::new());
+        registration.desired = vec![agent("impl", &[])];
+        registration.observed = vec![PipelineAliasObservation {
+            alias: "impl".to_string(),
+            pane: "%1".to_string(),
+            status: PipelineAliasStatus::Running,
+        }];
+        let run = store.register(registration).await.unwrap();
+        let blocked = store
+            .observe_pane("%1", PipelineAliasStatus::Blocked)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(blocked.aliases["impl"].status, PipelineAliasStatus::Blocked);
+        store
+            .done(&run.identity, "impl", run.generation)
+            .await
+            .unwrap();
+        let stopped = store
+            .observe_pane("%1", PipelineAliasStatus::Failed)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stopped.aliases["impl"].status, PipelineAliasStatus::Done);
+    }
+
+    #[tokio::test]
+    async fn invalidated_blocked_pane_waits_for_the_human_before_reprompt() {
+        let store = PipelineRunStore::in_memory();
+        let mut registration = registration(Vec::new());
+        registration.desired = vec![agent("impl", &[])];
+        registration.observed = vec![PipelineAliasObservation {
+            alias: "impl".to_string(),
+            pane: "%1".to_string(),
+            status: PipelineAliasStatus::Blocked,
+        }];
+        store.register(registration.clone()).await.unwrap();
+        registration.invalidate = vec!["impl".to_string()];
+        let blocked = store.register(registration).await.unwrap();
+        assert_eq!(blocked.aliases["impl"].status, PipelineAliasStatus::Blocked);
+        assert!(!blocked.has_ready_alias());
+
+        let ready = store
+            .observe_pane("%1", PipelineAliasStatus::Running)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(ready.aliases["impl"].status, PipelineAliasStatus::Pending);
+        assert!(ready.has_ready_alias());
+    }
+
+    #[tokio::test]
+    async fn current_generation_cannot_complete_an_alias_that_never_started() {
+        let store = PipelineRunStore::in_memory();
+        let run = store.register(registration(Vec::new())).await.unwrap();
+
+        let error = store
+            .done(&run.identity, "plan", run.generation)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, PipelineRunError::Invalid(_)));
+        let unchanged = store.get(&run.identity).await.unwrap();
+        assert_eq!(
+            unchanged.aliases["plan"].status,
+            PipelineAliasStatus::Pending
+        );
+        assert_eq!(unchanged.aliases["plan"].completion_generation, None);
+    }
+
+    #[test]
+    fn malformed_durable_state_fails_loudly() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pipeline-runs.json");
+        std::fs::write(&path, b"not json").unwrap();
+
+        let error = PipelineRunStore::load(Some(path)).unwrap_err();
+
+        assert!(matches!(error, PipelineRunError::Invalid(_)));
+    }
+}

--- a/crates/muxa/src/reconcile.rs
+++ b/crates/muxa/src/reconcile.rs
@@ -701,6 +701,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/reconcile.rs
+++ b/crates/muxa/src/reconcile.rs
@@ -699,6 +699,8 @@ mod tests {
 
     fn pane(id: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/screen.rs
+++ b/crates/muxa/src/screen.rs
@@ -172,6 +172,17 @@ impl ManifestSet {
         self.manifests.len()
     }
 
+    /// The manifest whose `name` matches, for callers that know *which* agent
+    /// occupies a pane rather than only what its foreground command is called.
+    /// An npm-installed codex reports `node`, so the command is the weaker of
+    /// the two keys whenever the registry has an answer.
+    #[must_use]
+    pub fn manifest_for_name(&self, name: &str) -> Option<&AgentManifest> {
+        self.manifests
+            .iter()
+            .find(|manifest| manifest.name.eq_ignore_ascii_case(name))
+    }
+
     /// Names of the loaded manifests, for startup logging.
     pub fn names(&self) -> impl Iterator<Item = &str> {
         self.manifests.iter().map(|m| m.name.as_str())

--- a/crates/muxa/src/screen.rs
+++ b/crates/muxa/src/screen.rs
@@ -337,7 +337,18 @@ fn load_user_overrides(dir: &std::path::Path, manifests: &mut Vec<AgentManifest>
 #[must_use]
 pub fn prepare_capture(raw: &str, max_lines: usize) -> String {
     let stripped = strip_ansi(raw);
-    let lines: Vec<&str> = stripped.lines().collect();
+    let mut lines: Vec<&str> = stripped.lines().collect();
+    // tmux pads a capture out to the full pane height, so a screen that paints
+    // at the TOP of an otherwise empty display — codex's startup gate is the
+    // motivating case — arrives as a few lines of content followed by dozens of
+    // blank rows. Slicing the tail verbatim would then keep only the padding
+    // and classify the pane as unknown. Trailing blanks carry no signal for any
+    // rule, so dropping them first costs nothing and makes the tail mean "the
+    // last `max_lines` lines that exist" for scrolling transcripts and
+    // top-anchored screens alike.
+    while lines.last().is_some_and(|line| line.trim().is_empty()) {
+        lines.pop();
+    }
     let start = lines.len().saturating_sub(max_lines);
     lines[start..].join("\n")
 }
@@ -359,6 +370,54 @@ fn strip_ansi(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// Verbatim from a real `tmux capture-pane` of codex's startup gate on a
+    /// 50-row pane: nine lines of content, then padding to the pane height.
+    /// The gate is the one screen codex's hooks structurally cannot report, so
+    /// if this capture does not classify, nothing reports it at all.
+    #[test]
+    fn codex_startup_gate_survives_tail_slicing() {
+        let gate = "> You are in /tmp/gate-probe\n\
+                    \n\
+                    \x20 Do you trust the contents of this directory?\n\
+                    \x20 the directory allows project-local config to load.\n\
+                    \n\
+                    \u{203a} 1. Yes, continue\n\
+                    \x20 2. No, quit\n\
+                    \n\
+                    \x20 Press enter to continue\n";
+        let raw = format!("{gate}{}", "\n".repeat(54));
+
+        let prepared = prepare_capture(&raw, 40);
+        assert!(
+            prepared.contains("1. Yes, continue"),
+            "tail slicing must not discard a top-anchored screen; got {prepared:?}",
+        );
+
+        let set = load_manifests();
+        let codex = set
+            .manifest_for_name("codex")
+            .expect("bundled codex manifest");
+        assert_eq!(
+            codex.classify(&prepared),
+            Some(ScreenState::Blocked),
+            "a pane sitting on the trust gate is blocked on the operator",
+        );
+    }
+
+    /// The tail must still be a tail: a transcript longer than `max_lines`
+    /// keeps its END, which is where a scrolling agent's current state lives.
+    #[test]
+    fn prepare_capture_still_keeps_the_end_of_a_long_transcript() {
+        use std::fmt::Write as _;
+        let raw = (0..100).fold(String::new(), |mut acc, i| {
+            let _ = writeln!(acc, "line {i}");
+            acc
+        });
+        let prepared = prepare_capture(&raw, 10);
+        assert!(prepared.starts_with("line 90"));
+        assert!(prepared.ends_with("line 99"));
+    }
     use super::*;
 
     fn cursor() -> AgentManifest {

--- a/crates/muxa/src/screen.rs
+++ b/crates/muxa/src/screen.rs
@@ -222,9 +222,10 @@ fn command_basename(cmd: &str) -> String {
 /// The bundled manifest sources, shipped in the binary via `include_str!`.
 /// These are muxa-authored and MUST parse — a parse failure is a build-time
 /// bug caught by [`tests::every_bundled_manifest_parses`].
-fn bundled_sources() -> [(&'static str, &'static str); 6] {
+fn bundled_sources() -> [(&'static str, &'static str); 7] {
     [
         ("agy", include_str!("screen/agents/agy.toml")),
+        ("codex", include_str!("screen/agents/codex.toml")),
         ("cursor", include_str!("screen/agents/cursor.toml")),
         ("amp", include_str!("screen/agents/amp.toml")),
         ("copilot", include_str!("screen/agents/copilot.toml")),
@@ -462,7 +463,7 @@ idle = ['^> $']
     #[test]
     fn every_bundled_manifest_parses() {
         let set = bundled_manifests();
-        assert_eq!(set.len(), 6);
+        assert_eq!(set.len(), bundled_sources().len());
         for m in &set {
             assert!(!m.name.is_empty());
         }
@@ -549,6 +550,33 @@ idle = ['^> $']
             m.classify("Allow access to this file?\n> Yes, allow access\n  No, deny access"),
             Some(ScreenState::Blocked),
         );
+        // Codex's startup gate, captured verbatim from a live pane. Note the
+        // cursor glyph: codex renders U+203A, and matching only ASCII `>` is
+        // exactly why muxa read a blocked agent as idle.
+        let codex = bundled_manifests()
+            .into_iter()
+            .find(|m| m.name == "codex")
+            .expect("codex manifest is bundled");
+        assert_eq!(
+            codex.classify(
+                "policies to load.\n› 1. Yes, continue\n  2. No, quit\n  Press enter to continue"
+            ),
+            Some(ScreenState::Blocked),
+            "codex startup gate must read as blocked",
+        );
+        // The same widget with an ASCII cursor still matches.
+        assert_eq!(
+            codex.classify("> 1. Yes, proceed\n  2. No"),
+            Some(ScreenState::Blocked),
+        );
+        // And ordinary output must not.
+        assert_eq!(
+            codex.classify("Steps:\n1. Yes it compiles\n2. No warnings remain"),
+            None,
+            "a plain numbered list is not a selection widget",
+        );
+        assert_eq!(codex.classify("› "), Some(ScreenState::Idle));
+
         // The folder-trust gate blocks the very first prompt of a session.
         assert_eq!(
             m.classify(

--- a/crates/muxa/src/screen/agents/codex.toml
+++ b/crates/muxa/src/screen/agents/codex.toml
@@ -1,0 +1,43 @@
+# Bundled screen-detection manifest — OpenAI Codex CLI (`codex`).
+#
+# muxa ships hooks for codex and they win everywhere except one window: the
+# startup gate. Codex asks about policies/trust *before* the session exists,
+# so no hook has been created yet and none can fire. A pane sitting on that
+# question therefore reads as `idle` — indistinguishable from an agent that
+# finished its turn — until something looks at the screen.
+#
+# The `blocked` rules below exist for that window. They were derived from a
+# REAL captured pane:
+#
+#     › 1. Yes, continue
+#       2. No, quit
+#       Press enter to continue
+#
+# Note the cursor marker: codex renders U+203A (`›`), not ASCII `>`. Matching
+# only `>` is why this gate went undetected. See docs/SCREEN_DETECTION.md.
+# Override at $XDG_CONFIG_HOME/muxa/agents/codex.toml.
+
+[agent]
+name = "codex"
+command = ["codex"]
+
+[rules]
+blocked = [
+    # The highlighted row of a numbered selection widget. Anchored to a
+    # cursor marker AND the number, so ordinary prose and plain numbered
+    # lists can never match. `[>›❯]` covers ASCII and the two angle glyphs
+    # TUIs actually render.
+    '(?m)^\s*[>›❯]\s*\d+\.\s+(?i:Yes|No)\b',
+    # The startup gate's own footer, constant across its variants.
+    '(?i)Press enter to continue',
+    # Approval prompts that render a yes/no pair without numbering.
+    '(?m)^\s*[>›❯]\s*(?i:Yes|No),\s',
+]
+working = [
+    # Codex prints an elapsed-time working line while a turn runs.
+    '(?m)^\s*(?i:Esc to interrupt)\b',
+]
+idle = [
+    # The bare composer prompt, nothing pending.
+    '(?m)^\s*[>›❯]\s*$',
+]

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -2561,6 +2561,7 @@ mod tests {
         let pane = PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: "%1".into(),
             session_id: String::new(),
@@ -4353,6 +4354,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -2559,6 +2559,8 @@ mod tests {
             .await
             .unwrap();
         let pane = PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: "%1".into(),
             session_id: String::new(),
@@ -4349,6 +4351,8 @@ mod tests {
 
     fn pane(id: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -506,6 +506,12 @@ pub struct PaneInfo {
     /// `@muxa_agent_alias` — the pipeline-local name for this pane (`impl`,
     /// `review`). Same provenance and caveats as [`Self::agent_role`].
     pub agent_alias: Option<String>,
+    /// `@muxa_work_done` — the aliases that have reported finishing on this
+    /// pane's *work*. A window option, so every pane of one work carries the
+    /// same list; it rides along here so a reader that already has the panes
+    /// can tell a converged pipeline from a stalled one without a second
+    /// tmux round trip.
+    pub work_done: Vec<String>,
 }
 
 /// The short display name for a tmux socket path: its file basename
@@ -566,7 +572,7 @@ pub struct ClientInfo {
 /// `tmux -F` format string for `list-panes`. Tab-separated columns parsed
 /// in `parse_pane_lines`. Kept `pub(crate)` so [`scanner`] can reuse it.
 pub(crate) const PANE_FMT: &str =
-    "#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_tty}\t#{pane_current_command}\t#{pane_title}\t#{pane_pid}\t#{pane_current_path}\t#{session_id}\t#{window_id}\t#{window_name}\t#{@muxa_workspace_id}\t#{@muxa_workspace_cwd}\t#{@muxa_managed_workspace}\t#{@muxa_work_id}\t#{@muxa_work_cwd}\t#{@muxa_managed_work}\t#{@muxa_agent}\t#{@muxa_agent_role}\t#{@muxa_agent_task}\t#{@muxa_managed_agent}\t#{@muxa_agent_workspace_id}\t#{@muxa_agent_work_id}\t#{@muxa_external_source}\t#{@muxa_external_scope}\t#{@muxa_external_stable_id}\t#{@muxa_external_key}\t#{@muxa_external_title}\t#{@muxa_external_url}\t#{@muxa_external_status}\t#{@muxa_agent_alias}";
+    "#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_tty}\t#{pane_current_command}\t#{pane_title}\t#{pane_pid}\t#{pane_current_path}\t#{session_id}\t#{window_id}\t#{window_name}\t#{@muxa_workspace_id}\t#{@muxa_workspace_cwd}\t#{@muxa_managed_workspace}\t#{@muxa_work_id}\t#{@muxa_work_cwd}\t#{@muxa_managed_work}\t#{@muxa_agent}\t#{@muxa_agent_role}\t#{@muxa_agent_task}\t#{@muxa_managed_agent}\t#{@muxa_agent_workspace_id}\t#{@muxa_agent_work_id}\t#{@muxa_external_source}\t#{@muxa_external_scope}\t#{@muxa_external_stable_id}\t#{@muxa_external_key}\t#{@muxa_external_title}\t#{@muxa_external_url}\t#{@muxa_external_status}\t#{@muxa_agent_alias}\t#{@muxa_work_done}";
 
 pub(crate) const SESSION_FMT: &str = "#{session_id}\t#{session_name}\t#{session_attached}";
 pub(crate) const CLIENT_FMT: &str =
@@ -616,6 +622,15 @@ pub(crate) fn parse_pane_lines_for_socket(stdout: &str, socket: Option<&str>) ->
             socket: socket.map(Into::into),
             agent_role: non_empty(cols.get(19)),
             agent_alias: non_empty(cols.get(31)),
+            work_done: non_empty(cols.get(32))
+                .map(|raw| {
+                    raw.split(',')
+                        .map(str::trim)
+                        .filter(|alias| !alias.is_empty())
+                        .map(str::to_ascii_lowercase)
+                        .collect()
+                })
+                .unwrap_or_default(),
         });
     }
     panes

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -497,6 +497,15 @@ pub struct PaneInfo {
     /// use this to disambiguate. `None` when the backend cannot name one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub socket: Option<String>,
+    /// `@muxa_agent_role` — the role a muxa-managed launch stamped on this
+    /// pane (`implementer`, `reviewer`, ...). Declared by the launcher, not
+    /// self-registered by the agent, so it survives the window before the
+    /// agent's first hook and lets `role:` routing resolve a pipeline peer.
+    /// `None` for unmanaged panes and non-tmux backends.
+    pub agent_role: Option<String>,
+    /// `@muxa_agent_alias` — the pipeline-local name for this pane (`impl`,
+    /// `review`). Same provenance and caveats as [`Self::agent_role`].
+    pub agent_alias: Option<String>,
 }
 
 /// The short display name for a tmux socket path: its file basename
@@ -557,7 +566,7 @@ pub struct ClientInfo {
 /// `tmux -F` format string for `list-panes`. Tab-separated columns parsed
 /// in `parse_pane_lines`. Kept `pub(crate)` so [`scanner`] can reuse it.
 pub(crate) const PANE_FMT: &str =
-    "#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_tty}\t#{pane_current_command}\t#{pane_title}\t#{pane_pid}\t#{pane_current_path}\t#{session_id}\t#{window_id}\t#{window_name}\t#{@muxa_workspace_id}\t#{@muxa_workspace_cwd}\t#{@muxa_managed_workspace}\t#{@muxa_work_id}\t#{@muxa_work_cwd}\t#{@muxa_managed_work}\t#{@muxa_agent}\t#{@muxa_agent_role}\t#{@muxa_agent_task}\t#{@muxa_managed_agent}\t#{@muxa_agent_workspace_id}\t#{@muxa_agent_work_id}\t#{@muxa_external_source}\t#{@muxa_external_scope}\t#{@muxa_external_stable_id}\t#{@muxa_external_key}\t#{@muxa_external_title}\t#{@muxa_external_url}\t#{@muxa_external_status}";
+    "#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_tty}\t#{pane_current_command}\t#{pane_title}\t#{pane_pid}\t#{pane_current_path}\t#{session_id}\t#{window_id}\t#{window_name}\t#{@muxa_workspace_id}\t#{@muxa_workspace_cwd}\t#{@muxa_managed_workspace}\t#{@muxa_work_id}\t#{@muxa_work_cwd}\t#{@muxa_managed_work}\t#{@muxa_agent}\t#{@muxa_agent_role}\t#{@muxa_agent_task}\t#{@muxa_managed_agent}\t#{@muxa_agent_workspace_id}\t#{@muxa_agent_work_id}\t#{@muxa_external_source}\t#{@muxa_external_scope}\t#{@muxa_external_stable_id}\t#{@muxa_external_key}\t#{@muxa_external_title}\t#{@muxa_external_url}\t#{@muxa_external_status}\t#{@muxa_agent_alias}";
 
 pub(crate) const SESSION_FMT: &str = "#{session_id}\t#{session_name}\t#{session_attached}";
 pub(crate) const CLIENT_FMT: &str =
@@ -575,6 +584,14 @@ pub(crate) fn parse_pane_lines(stdout: &str) -> Vec<PaneInfo> {
 
 /// `parse_pane_lines` with the originating server's socket short name
 /// stamped on every row (see [`PaneInfo::socket`]).
+/// A tmux format column that was never set comes back as the empty string,
+/// which is absence, not a value.
+fn non_empty(col: Option<&&str>) -> Option<String> {
+    col.map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
 pub(crate) fn parse_pane_lines_for_socket(stdout: &str, socket: Option<&str>) -> Vec<PaneInfo> {
     let mut panes = Vec::new();
     for line in stdout.lines() {
@@ -597,6 +614,8 @@ pub(crate) fn parse_pane_lines_for_socket(stdout: &str, socket: Option<&str>) ->
             pane_pid,
             current_path: cols.get(8).map(|s| (*s).to_string()).unwrap_or_default(),
             socket: socket.map(Into::into),
+            agent_role: non_empty(cols.get(19)),
+            agent_alias: non_empty(cols.get(31)),
         });
     }
     panes
@@ -1196,6 +1215,43 @@ mod tests {
         assert_eq!(panes[0].session_id, "$3");
         assert_eq!(panes[0].window_id, "@7");
         assert_eq!(panes[0].window_name, "auth-refactor");
+    }
+
+    /// `PANE_FMT` asked tmux for `@muxa_agent_role` long before anything kept
+    /// it, so `role:` routing had nothing to match and pipeline peers were
+    /// unaddressable. Both columns are now retained.
+    #[test]
+    fn parses_managed_agent_role_and_alias() {
+        let mut cols = vec!["%10", "main", "0", "0", "/dev/pts/0", "codex", "title"];
+        cols.resize(19, "");
+        cols.push("reviewer"); // 19: @muxa_agent_role
+        cols.resize(31, "");
+        cols.push("review"); // 31: @muxa_agent_alias
+        let panes = parse_pane_lines(&format!("{}\n", cols.join("\t")));
+        assert_eq!(panes[0].agent_role.as_deref(), Some("reviewer"));
+        assert_eq!(panes[0].agent_alias.as_deref(), Some("review"));
+    }
+
+    /// An unmanaged pane leaves both options unset, and tmux renders unset as
+    /// the empty string — which is absence, not a role named "".
+    #[test]
+    fn unset_role_and_alias_columns_are_absent_not_empty() {
+        let stdout = "%10\tmain\t0\t0\t/dev/pts/0\tclaude\ttitle\n";
+        let panes = parse_pane_lines(stdout);
+        assert_eq!(panes[0].agent_role, None);
+        assert_eq!(panes[0].agent_alias, None);
+
+        let padded = format!(
+            "{}\n",
+            ["%11", "main", "0", "0", "/dev/pts/0", "claude", "t"]
+                .into_iter()
+                .chain(std::iter::repeat_n("", 26))
+                .collect::<Vec<_>>()
+                .join("\t")
+        );
+        let panes = parse_pane_lines(&padded);
+        assert_eq!(panes[0].agent_role, None);
+        assert_eq!(panes[0].agent_alias, None);
     }
 
     #[test]

--- a/crates/muxa/src/tmux/scanner.rs
+++ b/crates/muxa/src/tmux/scanner.rs
@@ -582,6 +582,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/tmux/scanner.rs
+++ b/crates/muxa/src/tmux/scanner.rs
@@ -580,6 +580,8 @@ mod tests {
     use std::sync::Arc;
     fn fake_pane(id: &str, session: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/topology.rs
+++ b/crates/muxa/src/topology.rs
@@ -227,6 +227,11 @@ pub struct WindowNode {
     /// list, dashboard — reads the same number instead of each deriving it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completion: Option<WorkCompletion>,
+    /// Durable daemon-owned pipeline state, when this window is bound to a
+    /// declarative Work Run. Unlike `panes`, this includes aliases that have
+    /// not launched yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pipeline_run: Option<crate::pipeline_run::PipelineRunSummary>,
 }
 
 /// `done` of `total` pipeline agents have reported `muxa work done`.
@@ -571,6 +576,7 @@ impl WindowBuilder {
             states,
             panes: self.panes,
             completion,
+            pipeline_run: None,
         }
     }
 }

--- a/crates/muxa/src/topology.rs
+++ b/crates/muxa/src/topology.rs
@@ -636,6 +636,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             pane_id: "%1".into(),
             session_id: "$1".into(),
             session: session_name.into(),

--- a/crates/muxa/src/topology.rs
+++ b/crates/muxa/src/topology.rs
@@ -634,6 +634,8 @@ mod tests {
 
     fn pane(socket: &str, session_name: &str, window_name: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             pane_id: "%1".into(),
             session_id: "$1".into(),
             session: session_name.into(),

--- a/crates/muxa/src/topology.rs
+++ b/crates/muxa/src/topology.rs
@@ -200,6 +200,11 @@ pub struct PaneNode {
     /// `TopologySnapshot::unassigned_agents` rather than being silently lost.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub agent: Option<Agent>,
+    /// Pipeline alias the launcher stamped on this pane, when it has one.
+    /// Present on the node because completion is counted over aliases, and a
+    /// hand-split pane has none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_alias: Option<String>,
 }
 
 impl PaneNode {
@@ -217,6 +222,25 @@ pub struct WindowNode {
     pub cwd: Option<String>,
     pub states: StateDistribution,
     pub panes: Vec<PaneNode>,
+    /// How far this window's pipeline has reported, or `None` when the window
+    /// is not a pipeline. Computed here so every surface — TUI tree, flat
+    /// list, dashboard — reads the same number instead of each deriving it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion: Option<WorkCompletion>,
+}
+
+/// `done` of `total` pipeline agents have reported `muxa work done`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkCompletion {
+    pub done: usize,
+    pub total: usize,
+}
+
+impl WorkCompletion {
+    #[must_use]
+    pub fn is_complete(self) -> bool {
+        self.done == self.total
+    }
 }
 
 impl WindowNode {
@@ -409,7 +433,11 @@ impl TopologySnapshot {
                     },
                     index: pane.window_index.clone(),
                     panes: Vec::new(),
+                    done: Vec::new(),
                 });
+            if window.done.is_empty() {
+                window.done.clone_from(&pane.work_done);
+            }
             window.panes.push(PaneNode {
                 key: pane_key,
                 index: pane.pane_index,
@@ -419,6 +447,7 @@ impl TopologySnapshot {
                 cwd: pane.current_path,
                 pane_pid: pane.pane_pid,
                 agent,
+                agent_alias: pane.agent_alias,
             });
         }
 
@@ -511,6 +540,9 @@ struct WindowBuilder {
     name: String,
     index: String,
     panes: Vec<PaneNode>,
+    /// Aliases this window has recorded as finished, from `@muxa_work_done`.
+    /// A window option, so whichever pane is seen first supplies it.
+    done: Vec<String>,
 }
 
 impl WindowBuilder {
@@ -525,6 +557,12 @@ impl WindowBuilder {
         for agent in self.panes.iter().filter_map(|pane| pane.agent.as_ref()) {
             states.add(agent.state);
         }
+        let completion = work_completion(
+            self.panes
+                .iter()
+                .filter_map(|pane| pane.agent_alias.as_deref()),
+            &self.done,
+        );
         WindowNode {
             key: self.key,
             name: self.name,
@@ -532,8 +570,36 @@ impl WindowBuilder {
             cwd,
             states,
             panes: self.panes,
+            completion,
         }
     }
+}
+
+/// Completion over the *aliased* panes only.
+///
+/// `@muxa_work_done` records aliases, so a pane the operator split by hand can
+/// never appear in it; counting it would show a converged pair as 2/3 forever.
+/// A window with no aliases was never a pipeline and gets `None` rather than
+/// `0/1`, which would libel an agent nobody asked to report.
+pub fn work_completion<'a>(
+    aliases: impl IntoIterator<Item = &'a str>,
+    done: &[String],
+) -> Option<WorkCompletion> {
+    let aliases: Vec<&str> = aliases.into_iter().collect();
+    if aliases.is_empty() {
+        return None;
+    }
+    let reported = aliases
+        .iter()
+        .filter(|alias| {
+            done.iter()
+                .any(|reported| reported.eq_ignore_ascii_case(alias))
+        })
+        .count();
+    Some(WorkCompletion {
+        done: reported,
+        total: aliases.len(),
+    })
 }
 
 fn numeric_index(value: &str) -> u64 {

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -1871,6 +1871,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             pane_id: pane_id.into(),
             session_id: "$1".into(),
             session: "collaboration".into(),

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -23,6 +23,7 @@ use muxa::dashboard::{DashboardConfig, DashboardOverrides};
 use muxa::history::{HistoryOptions, PaneSessionCache, PromptHistory};
 use muxa::ipc::{harden_permissions, Client, RestartController, Server};
 use muxa::notify::Notifier;
+use muxa::pipeline_run::PipelineRunStore;
 use muxa::reconcile::Reconciler;
 use muxa::sinks::{webhook as webhook_sink, OhMyPromptSink, WebhookSink};
 use muxa::snapshot::{self, Snapshotter, SnapshotterOptions};
@@ -166,6 +167,8 @@ async fn main() -> Result<()> {
     let collaboration = build_collaboration(&cfg).await;
     let collaboration_audit = build_collaboration_audit(&cfg);
     let ask = build_ask(&cfg).await;
+    let pipeline_runs = PipelineRunStore::load(paths::default_pipeline_run_file())
+        .context("loading durable pipeline Runs")?;
 
     // The set of backends this daemon observes simultaneously — tmux + herdr
     // during a migration (see `docs/MULTI_HOST.md`). Resolution honors
@@ -267,6 +270,8 @@ async fn main() -> Result<()> {
         backends.clone(),
         &shutdown_tx,
     );
+    let pipeline_state_handle =
+        spawn_pipeline_state_task(pipeline_runs.clone(), store.clone(), &shutdown_tx);
 
     // The snapshotter listens on its own dedicated channel rather than
     // the main shutdown broadcast: it has to be the last thing to die
@@ -375,6 +380,7 @@ async fn main() -> Result<()> {
         .with_collaboration_audit(collaboration_audit)
         .with_ask(ask)
         .with_fleet(fleet_runtime)
+        .with_pipeline_runs(pipeline_runs.clone())
         .with_restart_controller(Arc::clone(&restart));
     let handle = tokio::spawn(server.run(shutdown_tx.subscribe()));
 
@@ -391,6 +397,12 @@ async fn main() -> Result<()> {
         }
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
+    // Subscribe only after the socket is accepting connections: the worker
+    // delegates physical launch to the sibling `muxa` CLI over this IPC path.
+    // Its initial authoritative scan still catches completions committed
+    // between server start and subscription.
+    let pipeline_reconciler_handle =
+        spawn_pipeline_reconciler_task(pipeline_runs, socket.clone(), &shutdown_tx);
 
     // Self-heal: if a tmux server is already running, inject our socket
     // path into its environment so that every pane — including any that
@@ -427,6 +439,8 @@ async fn main() -> Result<()> {
     await_shutdown_task("history compaction", history_compaction_handle).await;
     await_shutdown_task("activity compaction", activity_compaction_handle).await;
     await_shutdown_task("collaboration waker", collaboration_waker_handle).await;
+    await_shutdown_task("pipeline reconciler", Some(pipeline_reconciler_handle)).await;
+    await_shutdown_task("pipeline state projection", Some(pipeline_state_handle)).await;
     await_shutdown_task("fleet manager", Some(fleet_handle)).await;
 
     let _ = activity_transition_shutdown_tx.send(());
@@ -576,6 +590,136 @@ fn build_collaboration_audit(cfg: &Config) -> Arc<CollaborationAuditLog> {
         }
     }
     CollaborationAuditLog::in_memory()
+}
+
+/// Completion changes wake a daemon-owned reconciliation loop. The worker
+/// deliberately invokes the installed `muxa` binary instead of duplicating
+/// its allowlisted agent-launch policy inside muxad; the CLI atomically claims
+/// ready aliases over IPC before touching tmux, so a user-triggered `work up`
+/// racing this worker cannot launch a duplicate.
+fn spawn_pipeline_reconciler_task(
+    pipeline_runs: Arc<PipelineRunStore>,
+    socket: PathBuf,
+    shutdown_tx: &broadcast::Sender<()>,
+) -> tokio::task::JoinHandle<()> {
+    let mut changes = pipeline_runs.subscribe();
+    let mut shutdown = shutdown_tx.subscribe();
+    tokio::spawn(async move {
+        let mut safety_scan = tokio::time::interval(std::time::Duration::from_secs(30));
+        safety_scan.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            let ready = pipeline_runs
+                .list()
+                .await
+                .iter()
+                .any(muxa::pipeline_run::PipelineRun::has_ready_alias);
+            if ready {
+                run_pipeline_reconciler(&socket).await;
+            }
+            tokio::select! {
+                revision = changes.changed() => {
+                    if revision.is_err() {
+                        break;
+                    }
+                }
+                _ = safety_scan.tick() => {}
+                _ = shutdown.recv() => break,
+            }
+        }
+    })
+}
+
+fn spawn_pipeline_state_task(
+    pipeline_runs: Arc<PipelineRunStore>,
+    store: muxa::SharedStore,
+    shutdown_tx: &broadcast::Sender<()>,
+) -> tokio::task::JoinHandle<()> {
+    let mut transitions = store.subscribe();
+    let mut shutdown = shutdown_tx.subscribe();
+    tokio::spawn(async move {
+        // Rehydrate the projection immediately. This covers agent state loaded
+        // from state.json before the subscriber was installed.
+        for agent in store.snapshot().await {
+            if let Some(pane) = agent.pane.as_deref() {
+                observe_pipeline_agent(&pipeline_runs, pane, agent.state).await;
+            }
+        }
+        loop {
+            tokio::select! {
+                transition = transitions.recv() => match transition {
+                    Ok(transition) => {
+                        if let Some(pane) = transition.agent.pane.as_deref() {
+                            observe_pipeline_agent(&pipeline_runs, pane, transition.to).await;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        for agent in store.snapshot().await {
+                            if let Some(pane) = agent.pane.as_deref() {
+                                observe_pipeline_agent(&pipeline_runs, pane, agent.state).await;
+                            }
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                },
+                _ = shutdown.recv() => break,
+            }
+        }
+    })
+}
+
+async fn observe_pipeline_agent(
+    pipeline_runs: &PipelineRunStore,
+    pane: &str,
+    state: muxa::AgentState,
+) {
+    let status = match state {
+        muxa::AgentState::WaitingInput | muxa::AgentState::WaitingChoice => {
+            muxa::pipeline_run::PipelineAliasStatus::Blocked
+        }
+        muxa::AgentState::Error | muxa::AgentState::Stopped => {
+            muxa::pipeline_run::PipelineAliasStatus::Failed
+        }
+        muxa::AgentState::Starting | muxa::AgentState::Working | muxa::AgentState::Idle => {
+            muxa::pipeline_run::PipelineAliasStatus::Running
+        }
+    };
+    if let Err(error) = pipeline_runs.observe_pane(pane, status).await {
+        tracing::warn!(pane, %error, "could not project agent state into pipeline Run");
+    }
+}
+
+async fn run_pipeline_reconciler(socket: &Path) {
+    let program = std::env::var_os("MUXA_PIPELINE_CLI").map_or_else(
+        || {
+            std::env::current_exe()
+                .ok()
+                .map(|path| path.with_file_name("muxa"))
+                .filter(|path| path.exists())
+                .unwrap_or_else(|| PathBuf::from("muxa"))
+        },
+        PathBuf::from,
+    );
+    match tokio::process::Command::new(&program)
+        .args(["work", "reconcile", "--all"])
+        .env("MUXA_SOCKET", socket)
+        .output()
+        .await
+    {
+        Ok(output) if output.status.success() => {
+            tracing::debug!(program = %program.display(), "pipeline reconcile completed");
+        }
+        Ok(output) => {
+            tracing::warn!(
+                program = %program.display(),
+                status = %output.status,
+                stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+                "pipeline reconcile command failed",
+            );
+        }
+        Err(error) => {
+            tracing::warn!(program = %program.display(), %error, "could not start pipeline reconciler");
+        }
+    }
 }
 
 fn spawn_collaboration_waker_task(

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -1869,6 +1869,8 @@ mod tests {
 
     fn collaboration_pane(pane_id: &str, pane_index: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             pane_id: pane_id.into(),
             session_id: "$1".into(),
             session: "collaboration".into(),

--- a/crates/muxad/src/screen_detect.rs
+++ b/crates/muxad/src/screen_detect.rs
@@ -441,6 +441,7 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
+            work_done: Vec::new(),
             socket: Some("default".into()),
             pane_id: pane_id.into(),
             session_id: String::new(),

--- a/crates/muxad/src/screen_detect.rs
+++ b/crates/muxad/src/screen_detect.rs
@@ -186,11 +186,23 @@ impl ScreenDetector {
             .collect();
 
         let backends = self.backends.clone();
-        let panes: Vec<(usize, PaneInfo)> = spawn_blocking(move || {
+        // `discover_from_panes` walks the process tree for wrapper panes, which
+        // is the only way to identify an agent that has NO registry row yet —
+        // exactly the startup gate, since the row is minted by the first hook
+        // and the gate paints before any hook exists. Blocking (/proc), so it
+        // rides along inside the same `spawn_blocking` as `list_panes`.
+        let panes: Vec<(usize, PaneInfo, Option<AgentKind>)> = spawn_blocking(move || {
             let mut out = Vec::new();
             for (i, backend) in backends.iter().enumerate() {
-                for pane in backend.list_panes() {
-                    out.push((i, pane));
+                let listed = backend.list_panes();
+                let discovered: HashMap<String, AgentKind> =
+                    muxa::discovery::discover_from_panes(&listed)
+                        .into_iter()
+                        .map(|d| (d.pane.pane_id, d.kind))
+                        .collect();
+                for pane in listed {
+                    let kind = discovered.get(&pane.pane_id).copied();
+                    out.push((i, pane, kind));
                 }
             }
             out
@@ -200,7 +212,7 @@ impl ScreenDetector {
 
         panes
             .into_iter()
-            .filter_map(|(i, p)| {
+            .filter_map(|(i, p, discovered)| {
                 let direct = self.manifests.manifest_for_command(&p.current_command);
                 // The registry knows which agent muxa put on the pane; the
                 // foreground command only knows which process is in front, and
@@ -209,15 +221,14 @@ impl ScreenDetector {
                 // agent host. A pane that fell back to a shell has lost its
                 // agent, and must drop out of candidacy even though a row may
                 // still (briefly) point at it.
-                let by_kind = (direct.is_some()
+                let registry = (direct.is_some()
                     || muxa::discovery::is_wrapper_command(&p.current_command))
-                .then(|| {
-                    by_pane
-                        .get(&p.pane_id)
-                        .and_then(|kind| kind.screen_manifest_name())
-                })
-                .flatten()
-                .and_then(|name| self.manifests.manifest_for_name(name));
+                .then(|| by_pane.get(&p.pane_id).copied())
+                .flatten();
+                let by_kind = registry
+                    .or(discovered)
+                    .and_then(AgentKind::screen_manifest_name)
+                    .and_then(|name| self.manifests.manifest_for_name(name));
                 by_kind.or(direct).map(|m| (i, p, m.clone()))
             })
             .collect()

--- a/crates/muxad/src/screen_detect.rs
+++ b/crates/muxad/src/screen_detect.rs
@@ -170,6 +170,21 @@ impl ScreenDetector {
     /// not re-resolve it. The `list_panes` calls (blocking tmux shell-outs) run
     /// inside one `spawn_blocking`.
     async fn gather_candidates(&self) -> Vec<(usize, PaneInfo, AgentManifest)> {
+        // What the registry believes occupies each pane, built once per tick.
+        // This is the stronger of the two selectors: an npm-installed codex
+        // reports `node` as its foreground command, which names no manifest,
+        // so command-only selection skipped those panes entirely and their
+        // startup gate was never seen. Stopped rows are tombstones, not
+        // occupants.
+        let by_pane: HashMap<String, AgentKind> = self
+            .store
+            .snapshot()
+            .await
+            .into_iter()
+            .filter(|a| a.state != muxa::AgentState::Stopped)
+            .filter_map(|a| a.pane.clone().map(|pane| (pane, a.kind)))
+            .collect();
+
         let backends = self.backends.clone();
         let panes: Vec<(usize, PaneInfo)> = spawn_blocking(move || {
             let mut out = Vec::new();
@@ -186,9 +201,24 @@ impl ScreenDetector {
         panes
             .into_iter()
             .filter_map(|(i, p)| {
-                self.manifests
-                    .manifest_for_command(&p.current_command)
-                    .map(|m| (i, p, m.clone()))
+                let direct = self.manifests.manifest_for_command(&p.current_command);
+                // The registry knows which agent muxa put on the pane; the
+                // foreground command only knows which process is in front, and
+                // for an npm install that is the `node` shim. So prefer the
+                // registry — but only while the command still looks like an
+                // agent host. A pane that fell back to a shell has lost its
+                // agent, and must drop out of candidacy even though a row may
+                // still (briefly) point at it.
+                let by_kind = (direct.is_some()
+                    || muxa::discovery::is_wrapper_command(&p.current_command))
+                .then(|| {
+                    by_pane
+                        .get(&p.pane_id)
+                        .and_then(|kind| kind.screen_manifest_name())
+                })
+                .flatten()
+                .and_then(|name| self.manifests.manifest_for_name(name));
+                by_kind.or(direct).map(|m| (i, p, m.clone()))
             })
             .collect()
     }
@@ -207,7 +237,7 @@ impl ScreenDetector {
         let pane_id = pane.pane_id.clone();
 
         let occupants = self.store.by_pane(&pane_id).await;
-        let ownership = synthetic::pane_ownership(&occupants);
+        let ownership = synthetic::pane_ownership(&occupants, OffsetDateTime::now_utc());
         if matches!(ownership, synthetic::PaneOwnership::Hooked) {
             // Hook-authoritative: a live real row owns the pane and its hooks
             // report every state — don't even capture. Forget any tracking so
@@ -452,6 +482,62 @@ mod tests {
             "only the capture-capable tmux backend remains"
         );
         assert_eq!(out[0].kind(), HostKind::Tmux);
+    }
+
+    /// The regression this pairs with the `STARTUP_ATTENTION_WINDOW` carve-out:
+    /// an npm-installed codex runs as `node`, so command-based manifest
+    /// selection never even considered the pane, and its startup gate — the one
+    /// screen codex's own hooks structurally cannot report, because it paints
+    /// before the session exists — showed up in muxa as a plain `idle` agent.
+    ///
+    /// Both halves have to hold for this to pass: the kind must select the
+    /// manifest, and the fresh hooked row must still be refinable.
+    #[tokio::test]
+    async fn codex_startup_gate_is_detected_on_a_pane_running_as_node() {
+        let captures = Arc::new(Mutex::new(HashMap::new()));
+        captures.lock().unwrap().insert(
+            "%1".into(),
+            "  Do you trust this folder?\n› 1. Yes, continue\n  2. No, quit\n".into(),
+        );
+        // `node`, not `codex` — exactly what an npm install reports.
+        let backend: SharedBackend = Arc::new(FakeBackend::tmux(
+            vec![pane("%1", "node")],
+            captures.clone(),
+        ));
+        let store = Store::shared();
+
+        // A live codex row muxa just launched: Idle, because no hook has fired.
+        let launched_at = OffsetDateTime::now_utc();
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    kind: AgentKind::Codex,
+                    session_id: "sess-1".into(),
+                    surface: None,
+                    pane: Some("%1".into()),
+                    tmux_socket: None,
+                    cwd: None,
+                },
+                at: launched_at,
+            })
+            .await;
+        assert_eq!(store.by_pane("%1").await[0].state, AgentState::Idle);
+
+        let mut det = detector(vec![backend], store.clone());
+        assert_eq!(det.run_tick().await, 1, "the gate must be detected");
+
+        let rows = store.by_pane("%1").await;
+        assert_eq!(rows.len(), 1, "refinement targets the REAL row, adds none");
+        assert_eq!(rows[0].kind, AgentKind::Codex);
+        assert_eq!(
+            rows[0].state,
+            AgentState::WaitingInput,
+            "a pane sitting on the trust gate is waiting on the operator",
+        );
+        assert!(
+            !det.tracked.contains("%1"),
+            "a real row is not ours to stop-sweep",
+        );
     }
 
     #[tokio::test]

--- a/crates/muxad/src/screen_detect.rs
+++ b/crates/muxad/src/screen_detect.rs
@@ -439,6 +439,8 @@ mod tests {
 
     fn pane(pane_id: &str, command: &str) -> PaneInfo {
         PaneInfo {
+            agent_role: None,
+            agent_alias: None,
             socket: Some("default".into()),
             pane_id: pane_id.into(),
             session_id: String::new(),

--- a/crates/muxad/src/synthetic.rs
+++ b/crates/muxad/src/synthetic.rs
@@ -32,7 +32,7 @@
 use muxa::event::{AgentEvent, AgentId, NotificationLevel};
 use muxa::state::{Agent, SYNTHETIC_SESSION_PREFIX};
 use muxa::{AgentState, SharedStore};
-use time::OffsetDateTime;
+use time::{Duration, OffsetDateTime};
 
 /// The three states screen inference can distinguish. Both synthetic producers
 /// map their host-specific signal onto this before building events.
@@ -77,17 +77,44 @@ pub enum PaneOwnership {
     AttentionBlind { id: AgentId, state: AgentState },
 }
 
+/// How long after launch a hook-reporting row still accepts screen-sourced
+/// attention refinement.
+///
+/// A hooked agent's hooks are authoritative — but only once they exist. Codex
+/// asks its trust/policy question *before* creating the session that owns the
+/// hooks, so during that gate no hook can fire and the row sits at whatever
+/// state muxa launched it in. Treating the pane as fully `Hooked` from second
+/// zero means nothing ever looks at the screen and the gate reads as `idle`.
+///
+/// Inside this window the row is merely [`PaneOwnership::AttentionBlind`], so
+/// [`attention_refinement_events`] may promote it to waiting (and only that —
+/// `Working` still contributes nothing, so a healthy agent's hooks are never
+/// raced). The window is generous relative to what it covers: the gate paints
+/// within a second of launch, so anything that has not shown one by then never
+/// will.
+pub const STARTUP_ATTENTION_WINDOW: Duration = Duration::minutes(5);
+
+/// Is this row still inside the post-launch window where its hooks may not
+/// exist yet? Only `Idle` qualifies: any other state is itself proof that
+/// something already reported, and a row muxa launched starts out `Idle`.
+fn in_startup_window(owner: &Agent, now: OffsetDateTime) -> bool {
+    owner.state == AgentState::Idle && now - owner.started_at < STARTUP_ATTENTION_WINDOW
+}
+
 /// Classify `occupants` (as returned by `Store::by_pane`) into the update the
 /// producer is allowed to make.
 ///
 /// The first authoritative occupant wins; in practice there is at most one,
 /// because `Store::apply` evicts synthetic rows from a pane a real row claims.
+///
+/// `now` exists for the [`STARTUP_ATTENTION_WINDOW`] carve-out described on
+/// that constant.
 #[must_use]
-pub fn pane_ownership(occupants: &[Agent]) -> PaneOwnership {
+pub fn pane_ownership(occupants: &[Agent], now: OffsetDateTime) -> PaneOwnership {
     let Some(owner) = occupants.iter().find(|a| occupant_is_authoritative(a)) else {
         return PaneOwnership::Free;
     };
-    if owner.kind.hooks_report_attention() {
+    if owner.kind.hooks_report_attention() && !in_startup_window(owner, now) {
         return PaneOwnership::Hooked;
     }
     PaneOwnership::AttentionBlind {
@@ -279,6 +306,9 @@ mod tests {
     use super::*;
 
     const AT: OffsetDateTime = datetime!(2026-07-20 12:00:00 UTC);
+    /// Past [`STARTUP_ATTENTION_WINDOW`] from `AT` — steady state, where a
+    /// hook-reporting row is fully hook-authoritative.
+    const LATER: OffsetDateTime = datetime!(2026-07-20 13:00:00 UTC);
 
     fn id(pane: &str) -> AgentId {
         AgentId {
@@ -389,17 +419,17 @@ mod tests {
 
     #[test]
     fn pane_ownership_free_when_no_live_real_row() {
-        assert!(matches!(pane_ownership(&[]), PaneOwnership::Free));
+        assert!(matches!(pane_ownership(&[], AT), PaneOwnership::Free));
         // A synthetic row does not own the pane...
         let synth = row(
             AgentKind::Unknown,
             &format!("{SYNTHETIC_SESSION_PREFIX}%1"),
             AgentState::Working,
         );
-        assert!(matches!(pane_ownership(&[synth]), PaneOwnership::Free));
+        assert!(matches!(pane_ownership(&[synth], AT), PaneOwnership::Free));
         // ...and neither does a stopped real one.
         let dead = row(AgentKind::ClaudeCode, "real", AgentState::Stopped);
-        assert!(matches!(pane_ownership(&[dead]), PaneOwnership::Free));
+        assert!(matches!(pane_ownership(&[dead], AT), PaneOwnership::Free));
     }
 
     /// Every agent whose hooks can report a permission prompt keeps screen
@@ -414,7 +444,7 @@ mod tests {
         ] {
             let owner = row(kind, "real", AgentState::Working);
             assert!(
-                matches!(pane_ownership(&[owner]), PaneOwnership::Hooked),
+                matches!(pane_ownership(&[owner], LATER), PaneOwnership::Hooked),
                 "{kind} hooks report attention, so nothing may refine it",
             );
         }
@@ -427,7 +457,7 @@ mod tests {
     #[test]
     fn pane_ownership_attention_blind_for_antigravity() {
         let owner = row(AgentKind::Antigravity, "conv-1", AgentState::Working);
-        match pane_ownership(&[owner]) {
+        match pane_ownership(&[owner], LATER) {
             PaneOwnership::AttentionBlind { id, state } => {
                 assert_eq!(id.session_id, "conv-1");
                 assert_eq!(id.kind, AgentKind::Antigravity);
@@ -436,6 +466,65 @@ mod tests {
             }
             other => panic!("expected AttentionBlind, got {other:?}"),
         }
+    }
+
+    /// The gap this carve-out exists for: codex's trust gate paints before the
+    /// session (and therefore the hooks) exist, so a freshly launched, still
+    /// `Idle` row must stay refinable even though codex hooks normally report
+    /// attention.
+    #[test]
+    fn pane_ownership_refinable_inside_the_startup_window() {
+        let owner = row(AgentKind::Codex, "real", AgentState::Idle);
+        let just_after = AT + Duration::seconds(3);
+        match pane_ownership(&[owner], just_after) {
+            PaneOwnership::AttentionBlind { id, state } => {
+                assert_eq!(id.kind, AgentKind::Codex);
+                assert_eq!(state, AgentState::Idle);
+            }
+            other => panic!("a just-launched codex row must be refinable, got {other:?}"),
+        }
+    }
+
+    /// ...and the carve-out is bounded on both axes: it closes once the window
+    /// elapses, and it never applies to a row that already reported a state,
+    /// since that state is itself proof the hooks are alive.
+    #[test]
+    fn startup_carve_out_is_bounded_by_time_and_by_state() {
+        let stale = row(AgentKind::Codex, "real", AgentState::Idle);
+        assert!(
+            matches!(
+                pane_ownership(&[stale], AT + STARTUP_ATTENTION_WINDOW),
+                PaneOwnership::Hooked
+            ),
+            "the window must close, or screen inference races hooks forever",
+        );
+
+        let reported = row(AgentKind::Codex, "real", AgentState::Working);
+        assert!(
+            matches!(
+                pane_ownership(&[reported], AT + Duration::seconds(3)),
+                PaneOwnership::Hooked
+            ),
+            "a row that already left Idle has live hooks; stay out of its way",
+        );
+    }
+
+    /// The registry names the agent on a pane; `pane_current_command` only
+    /// names the process. For an npm-installed codex those disagree (`node`),
+    /// which is why manifest selection consults the kind first.
+    #[test]
+    fn codex_kind_names_its_manifest() {
+        assert_eq!(AgentKind::Codex.screen_manifest_name(), Some("codex"));
+        assert_eq!(AgentKind::Antigravity.screen_manifest_name(), Some("agy"));
+        // Kinds whose hooks fully cover attention ship no manifest.
+        assert_eq!(AgentKind::ClaudeCode.screen_manifest_name(), None);
+
+        let set = muxa::screen::load_manifests();
+        assert!(
+            set.manifest_for_name("codex").is_some(),
+            "every name screen_manifest_name returns must resolve",
+        );
+        assert!(set.manifest_for_name("agy").is_some());
     }
 
     fn refine(owner_state: AgentState, observed: SyntheticState) -> Vec<AgentEvent> {
@@ -588,7 +677,9 @@ mod tests {
         assert_eq!(store.by_pane("%1").await[0].state, AgentState::Working);
 
         let occupants = store.by_pane("%1").await;
-        let PaneOwnership::AttentionBlind { id, state } = pane_ownership(&occupants) else {
+        let PaneOwnership::AttentionBlind { id, state } =
+            pane_ownership(&occupants, OffsetDateTime::now_utc())
+        else {
             panic!("an agy row must be attention-blind");
         };
         for ev in attention_refinement_events(id, state, SyntheticState::Blocked, "agy", None, AT) {

--- a/docs/PIPELINE.ko.md
+++ b/docs/PIPELINE.ko.md
@@ -42,6 +42,11 @@ muxa는 headless agent 한 턴으로 그 문장을 TOML로 바꾸고, **위임�
 건드리는 건 `[ticket]`·`[[route]]`·`[pipeline.*]` 셋뿐입니다. `toml_edit`으로 다시
 쓰므로 주석과 나머지 섹션은 그대로 살아남습니다.
 
+여기의 모든 경로는 **headless agent 턴 하나를 쓰고, 그 비용은 계정에 과금됩니다.**
+muxa는 실행 전에 무엇을 호출하는지 먼저 알리고, `--dry-run`은 파일 쓰기만
+건너뜁니다 — 턴은 그대로 돌고 그대로 과금됩니다. 비대화형 호출은 `--yes`로
+그 지출을 확인해야 합니다.
+
 ```console
 muxa work init                                # 대화형으로 묻기
 muxa work init --describe "..."               # 비대화형

--- a/docs/PIPELINE.ko.md
+++ b/docs/PIPELINE.ko.md
@@ -20,6 +20,38 @@ work auth-cleanup is in workspace callabo via pipeline triad
 Workspace를, window는 현재 Run을, pane은 agent session을 바인딩합니다.
 ([WORK_MODEL.md](WORK_MODEL.md))
 
+## 설정부터
+
+`[ticket]`·`[[route]]`·`[pipeline.*]`는 muxa가 요구하는 가장 구조적인 설정이고
+가장 짐작하기 어렵습니다 — 중첩 테이블, 순서 있는 route 배열, 정규식, 플레이스홀더
+템플릿. 그래서 이 문서를 보며 손으로 쓰지 않아도 됩니다.
+
+```console
+$ muxa work init
+◇  Describe the work pipeline you want
+│  cal-* 티켓은 codex 기획, codex 구현, claude 리뷰로
+```
+
+muxa는 headless agent 한 턴으로 그 문장을 TOML로 바꾸고, **위임하지 않는 부분**을
+합니다 — 결과를 파싱하고, 정규식을 전부 컴파일하고, route가 지목한 pipeline이
+존재하는지와 나열된 agent가 실제로 뜰 수 있는지 확인하고, 무엇이 바뀔지 출력한
+뒤 확인을 받고서야 씁니다. 모델이 없는 키를 만들거나 `vim`을 agent라고 하면 이유를
+대고 거부하며 config는 그대로 둡니다. `Config`는 unknown field를 거부하므로,
+오타가 디스크에 쓰이면 다음 데몬 시작이 죽습니다.
+
+건드리는 건 `[ticket]`·`[[route]]`·`[pipeline.*]` 셋뿐입니다. `toml_edit`으로 다시
+쓰므로 주석과 나머지 섹션은 그대로 살아남습니다.
+
+```console
+muxa work init                                # 대화형으로 묻기
+muxa work init --describe "..."               # 비대화형
+muxa work init --dry-run                      # 제안만 보고 안 씀
+muxa work init --agent codex                  # 다른 resolver 사용
+```
+
+손으로 쓰는 게 편하시면 주석 달린 레퍼런스가
+[`config.example.toml`](../config.example.toml)에 있고, 아래가 각 부분의 설명입니다.
+
 ## 구조
 
 ```
@@ -235,6 +267,7 @@ prompt는 일의 모양과 URL을 나르고, 나머지는 agent가 직접 읽으
 ## 명령 정리
 
 ```console
+muxa work init                       # 말로 설명해 설정 쓰기
 muxa work up <work> --external <id>  # 외부 이슈 연결 → routing → 없는 것만 생성
 muxa work up <id>                    # 호환 경로: <id>를 외부 이슈로도 조회
 muxa work up <id> --dry-run          # 계획만 출력, tmux는 건드리지 않음

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -47,6 +47,11 @@ Only `[ticket]`, `[[route]]`, and `[pipeline.*]` are touched. The file is
 rewritten through `toml_edit`, so your comments and every other section
 survive verbatim.
 
+Every path here spends **one headless agent turn, billed to your agent
+account**. muxa says what it is about to run before it runs it, and
+`--dry-run` skips only the file write — the turn still happens and still
+bills. Non-interactive callers must pass `--yes` to confirm the spend.
+
 ```console
 muxa work init                                # ask interactively
 muxa work init --describe "..."               # non-interactive

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -21,6 +21,43 @@ Under the hood, Workspace and Work are durable logical objects. A tmux session
 binds a Workspace, a window binds the current Run, and a pane binds an agent
 session (see [WORK_MODEL.md](WORK_MODEL.md)).
 
+## Getting set up
+
+`[ticket]`, `[[route]]`, and `[pipeline.*]` are the most structured
+configuration muxa asks for and the least guessable — nested tables, an
+ordered array of routes, regexes, placeholder templates. So you do not have
+to write them from this document:
+
+```console
+$ muxa work init
+◇  Describe the work pipeline you want
+│  cal-* tickets: codex planner, codex implementer, claude reviewer
+```
+
+muxa spends one headless agent turn turning that sentence into TOML, then
+does the part it does *not* delegate: parse the result, compile every
+regex, check that every pipeline a route names exists and that every agent
+it lists could actually launch, print what it would change, and only write
+after you confirm. A model that invents a key or names `vim` as an agent is
+refused with the reason, and your config is left untouched — `Config`
+denies unknown fields, so a typo written to disk would take the daemon down
+at its next start.
+
+Only `[ticket]`, `[[route]]`, and `[pipeline.*]` are touched. The file is
+rewritten through `toml_edit`, so your comments and every other section
+survive verbatim.
+
+```console
+muxa work init                                # ask interactively
+muxa work init --describe "..."               # non-interactive
+muxa work init --dry-run                      # show the proposal, write nothing
+muxa work init --agent codex                  # use a different resolver
+```
+
+Prefer to write it by hand? The annotated reference is in
+[`config.example.toml`](../config.example.toml), and everything below
+explains what each part does.
+
 ## The shape
 
 ```
@@ -270,6 +307,7 @@ So an agent's launch prompt is three layers, outermost first:
 ## Command reference
 
 ```console
+muxa work init                       # write the config by describing it
 muxa work up <work> --external <id>  # link issue, route, create what is missing
 muxa work up <id>                    # compatibility: also look up <id> as an issue
 muxa work up <id> --dry-run          # print the plan, touch nothing


### PR DESCRIPTION
Turns `muxa work up` into a pipeline that can actually finish: agents wait on
each other, hand off through commits, and — the part that was missing — say so
where an operator can see it.

## Why

A run of the pair pipeline (implementer → reviewer) produced a good review that
then sat unnoticed for two hours. Nothing was broken in a way that showed up:
the review completed, both panes went idle, and `muxa work up` rendered exactly
what it renders for a pipeline that stalled. Several separate defects fed into
that, and each is a commit here.

## What it adds

**Edges.** `after = ['impl']` holds an agent until its upstream reports
`muxa work done`, so a reviewer never reads a tree that is still moving. The
graph is cycle-checked and drawn in the plan output, because the TOML cannot be
read as one.

**Spend confirmation.** A ticket lookup costs a headless turn. `work up` now
names what it will call and waits for a yes before spending, `--dry-run`
included — a dry run that writes config still bills on the next real run.

**`muxa work init`.** Describes a pipeline in your own words and has an agent
write the `[ticket]`/`[[route]]`/`[pipeline.*]` config, with a drift test that
fails if a config field is missing from the schema the agent is handed.

**Completion, everywhere.** `work list` renders as a table with a `DONE`
column; `watch` shows the ratio on the work row and names panes by their
pipeline alias (`impl`, `review`) rather than by CLI, which stops
distinguishing anything when one work runs two claudes. `w` opens a composer
and hands you to a window running `muxa work up`, so the confirmation flow
stays in one place rather than being rebuilt inside a TUI.

## Detection fixes

Codex's trust gate paints before the session that owns its hooks exists, so no
hook can report it. Four separate things had to be true for muxa to see it, and
none were: the manifest was selected by `pane_current_command` (an npm codex is
`node`), a hook-owned pane skipped capture entirely, a pane with no registry row
could not be identified at all, and `prepare_capture` sliced the tail of a
50-row pane whose only content was in the first nine lines.

`role:` routing was also silently dropping messages. `work up` stamps
`@muxa_agent_role` on every pane it launches, but the collaboration room only
knew about identities an agent registered for itself — which a pipeline agent
never does. `PANE_FMT` had been fetching that option all along and the parser
threw it away.

## Verification

Ran end to end against a real Linear ticket, from an empty workspace: `w` →
spend gate → `callabo-set ws create` → implementer commits and reports →
reviewer launches on the fixed commit → findings handed over → applied and
committed → re-review returns `converged` → both report done → `2/2`.

The first such run needed three manual rescues. The last one needed none.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -D
warnings`, and 1579 tests pass on this branch rebased onto main.

One commit from the branch was dropped as empty during that rebase — `prepare`
support landed independently via #82, identically enough that git found nothing
left to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
