### PR TITLE
fix: restore wire compatibility for the new pane fields

### DIFF
--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -5838,6 +5838,14 @@ mod work_up_key_tests {
         );
     }
 
+    /// Outside tmux the window would be created somewhere the operator is not
+    /// looking, and the run would sit on a confirmation prompt nobody sees.
+    #[test]
+    fn outside_tmux_it_refuses_and_names_the_command() {
+        let error = open_work_up_window("cal-7229", false).expect_err("must refuse");
+        assert!(error.contains("muxa work up CAL-7229"), "{error}");
+    }
+
     /// The window has to outlive the command, or the plan `work up` prints
     /// scrolls past before it can be read.
     #[test]
@@ -7190,7 +7198,8 @@ pub async fn run(
                 }
                 Action::SubmitWorkUp => {
                     if let Some(work) = app.work_composer.take() {
-                        match open_work_up_window(&work.input) {
+                        let in_tmux = std::env::var_os("TMUX").is_some();
+                        match open_work_up_window(&work.input, in_tmux) {
                             Ok(id) => app.set_hint(
                                 format!("work up {id} — confirm in the new window"),
                                 HintLevel::Ok,
@@ -9146,8 +9155,18 @@ fn handle_command_event(code: KeyCode, modifiers: KeyModifiers, app: &mut App) -
 /// places where muxa decides whether it may spend the operator's money, and
 /// the second one would be the one nobody reviewed. So the TUI's job ends at
 /// putting the operator in front of the real thing.
-fn open_work_up_window(raw: &str) -> std::result::Result<String, String> {
+fn open_work_up_window(raw: &str, in_tmux: bool) -> std::result::Result<String, String> {
     let work = crate::tmux_work::normalize_work_id(raw).map_err(|error| error.to_string())?;
+    // Outside tmux, `new-window` still succeeds — it lands in whichever session
+    // the server saw last, which is not one the operator is looking at. They
+    // would be told to confirm in a window they cannot find, and the run would
+    // hang on a prompt nobody sees. Refusing and naming the command is the
+    // honest outcome.
+    if !in_tmux {
+        return Err(format!(
+            "not inside tmux; run `muxa work up {work}` from a shell instead"
+        ));
+    }
     let exe = std::env::current_exe()
         .map_err(|error| format!("locate the muxa binary: {error}"))?
         .display()

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -502,15 +502,18 @@ pub struct PaneInfo {
     /// self-registered by the agent, so it survives the window before the
     /// agent's first hook and lets `role:` routing resolve a pipeline peer.
     /// `None` for unmanaged panes and non-tmux backends.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_role: Option<String>,
     /// `@muxa_agent_alias` — the pipeline-local name for this pane (`impl`,
     /// `review`). Same provenance and caveats as [`Self::agent_role`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_alias: Option<String>,
     /// `@muxa_work_done` — the aliases that have reported finishing on this
     /// pane's *work*. A window option, so every pane of one work carries the
     /// same list; it rides along here so a reader that already has the panes
     /// can tell a converged pipeline from a stalled one without a second
     /// tmux round trip.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub work_done: Vec<String>,
 }
 
@@ -1235,6 +1238,51 @@ mod tests {
     /// `PANE_FMT` asked tmux for `@muxa_agent_role` long before anything kept
     /// it, so `role:` routing had nothing to match and pipeline peers were
     /// unaddressable. Both columns are now retained.
+    /// These three fields are additive on the wire, and `PaneInfo` crosses it:
+    /// pane snapshots go CLI → daemon over IPC and host → host over the fleet
+    /// relay. A peer built before they existed sends a payload without them,
+    /// and without `serde(default)` the newer side rejects the whole snapshot
+    /// — which is exactly the version skew an upgrade creates.
+    #[test]
+    fn a_snapshot_from_a_peer_without_the_pipeline_fields_still_loads() {
+        let json = r#"{"pane_id":"%1","session":"s","window_index":"0",
+            "pane_index":"0","tty":"","current_command":"claude","title":"",
+            "pane_pid":0}"#;
+        let pane: PaneInfo = serde_json::from_str(json).expect("older peer payload");
+        assert_eq!(pane.pane_id, "%1");
+        assert_eq!(pane.agent_role, None);
+        assert_eq!(pane.agent_alias, None);
+        assert!(pane.work_done.is_empty());
+    }
+
+    /// And the reverse: an unaliased pane must not grow the payload it sends
+    /// to an older peer with keys that peer has no field for.
+    #[test]
+    fn an_unaliased_pane_serializes_without_the_new_keys() {
+        let pane = PaneInfo {
+            agent_role: None,
+            agent_alias: None,
+            work_done: Vec::new(),
+            pane_id: "%1".into(),
+            session_id: String::new(),
+            session: "s".into(),
+            window_id: String::new(),
+            window_name: String::new(),
+            window_index: "0".into(),
+            pane_index: "0".into(),
+            tty: String::new(),
+            current_command: "claude".into(),
+            title: String::new(),
+            pane_pid: 0,
+            current_path: String::new(),
+            socket: None,
+        };
+        let json = serde_json::to_string(&pane).expect("serialize");
+        assert!(!json.contains("agent_role"), "{json}");
+        assert!(!json.contains("agent_alias"), "{json}");
+        assert!(!json.contains("work_done"), "{json}");
+    }
+
     #[test]
     fn parses_managed_agent_role_and_alias() {
         let mut cols = vec!["%10", "main", "0", "0", "/dev/pts/0", "codex", "title"];

--- a/docs/PIPELINE.ko.md
+++ b/docs/PIPELINE.ko.md
@@ -320,10 +320,20 @@ blocked와 attention은 별도 signal로 남습니다.
 
 ```console
 $ muxa work list
-auth-cleanup  workspace=callabo  session=callabo  window=@7  agents=3  cwd=…  stage=review
+┌────────────────────────────────────────────────────────────────────────┐
+│ WORK           WORKSPACE   AGENTS          DONE   STAGE    CWD         │
+╞════════════════════════════════════════════════════════════════════════╡
+│ auth-cleanup   callabo     impl · review    1/2   review   ~/work/auth │
+└────────────────────────────────────────────────────────────────────────┘
 ```
 
-`stage=auto`는 아무것도 출력하지 않습니다. auto는 "아무도 말한 적 없음"이라,
+`DONE`은 pipeline이 이름 붙인 agent 중 `muxa work done`을 보고한 수입니다.
+수렴한 실행과 정체한 실행을 가르는 값입니다 — 둘 다 모든 pane이 idle이기
+때문입니다. pipeline alias가 없는 window는 `0/1`이 아니라 `-`입니다.
+거기서는 아무도 보고를 요구받지 않았습니다.
+
+`STAGE` 칼럼은 stage가 붙은 work가 있을 때만 나타납니다. auto는 "아무도 말한
+적 없음"이라,
 항상 붙어 있는 칼럼보다 할 말이 있을 때만 나타나는 칼럼이 더 많은 걸 말합니다.
 CLI는 그 저장소를 읽기만 하고, 쓰기는 daemon이 소유합니다.
 [DASHBOARD.md](DASHBOARD.md) 참고.

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -364,10 +364,20 @@ attention remain signals:
 
 ```console
 $ muxa work list
-auth-cleanup  workspace=callabo  session=callabo  window=@7  agents=3  cwd=…  stage=review
+┌────────────────────────────────────────────────────────────────────────┐
+│ WORK           WORKSPACE   AGENTS          DONE   STAGE    CWD         │
+╞════════════════════════════════════════════════════════════════════════╡
+│ auth-cleanup   callabo     impl · review    1/2   review   ~/work/auth │
+└────────────────────────────────────────────────────────────────────────┘
 ```
 
-`stage=auto` prints nothing — auto means nobody has said anything, and a
+`DONE` counts the agents that reported `muxa work done` against the ones
+the pipeline named. It is the difference between a run that converged and
+one that stalled — both leave every pane idle. A window with no pipeline
+aliases shows `-` rather than `0/1`: nothing there was asked to report.
+
+The `STAGE` column appears only when something is staged — `auto` means
+nobody has said anything, and a
 column that is always there says less than one that appears when it has
 something to report. The CLI only ever reads that store; the daemon owns
 writing it. See [DASHBOARD.md](DASHBOARD.md).

--- a/docs/WATCH.ko.md
+++ b/docs/WATCH.ko.md
@@ -36,6 +36,7 @@ child pane은 agent session을 바인딩합니다. `view = "pane"`은 pane별로
 | `Ctrl-U` / `Ctrl-D`, `PageUp` / `PageDown` | 탐색 중 반 페이지 / 한 페이지 이동. |
 | `Enter` | 선택한 pane에 바로 attach. |
 | `n` | workspace session과 work window를 생성/재사용하고 agent pane 추가. |
+| `w` | pipeline 실행: work id를 입력하면 `muxa work up`을 실행하는 window로 넘어갑니다. |
 | `\|` | list/inspector 분할 순환: 50/50 → 70/30 → 30/70. |
 | `a` / `A` | 설정한 agent에게 headless 질의 / 답변 이력 보기. |
 | `m` / `M` | 선택한 agent에게 request 보내기 / incoming·sent mailbox 열기. |

--- a/docs/WATCH.md
+++ b/docs/WATCH.md
@@ -57,6 +57,7 @@ children keep their aggregate state markers.
 | `Ctrl-U` / `Ctrl-D`, `PageUp` / `PageDown` | Move half / full pages while browsing. |
 | `Enter` | Attach to the selected pane. |
 | `n` | Create/reuse a workspace session and work window, then add an agent pane. |
+| `w` | Run a pipeline: type a work id and hand off to a window running `muxa work up`. |
 | `\|` | Cycle the list/inspector split: 50/50 → 70/30 → 30/70. |
 | `a` / `A` | Ask the configured agent a headless question / browse the answers. |
 | `m` / `M` | Message the selected agent / open incoming/sent mailbox. |


### PR DESCRIPTION
Three fixes from self-reviewing #83. They were pushed to that branch about a
minute after it merged, so they missed the train — the first one is a live bug
on `main` right now.

**`PaneInfo` is missing `serde(default)` on three fields.** Every other
additive field on that struct carries one and says why; #83 added
`agent_role`, `agent_alias` and `work_done` without. `PaneInfo` crosses the
wire — pane snapshots go CLI → daemon over IPC and host → host over the fleet
relay — so a peer built before those fields existed sends a payload the newer
side rejects outright:

```
Error("missing field `work_done`")
```

That is exactly the version skew an upgrade creates. #83 was developed against
mismatched binaries twice without hitting it, only because the skew ran the
other way: the older side ignores keys it does not know, the newer side
refuses a payload missing a field it requires. Both directions are pinned by
tests now.

**`w` lied when watch ran outside tmux.** `new-window` still succeeds there —
it lands in whichever session the server saw last — so the operator was told
to confirm in a window they could not find while the run sat on a prompt
nobody saw. It refuses now and names the command to run instead.

**Docs described the old surfaces.** `WATCH.md` had no `w`, and `PIPELINE.md`
still showed `work list` as key=value lines with a `stage=` suffix that no
longer exists. Updated both, and their Korean counterparts.

---

One thing this PR does **not** touch, for a reviewer to weigh in on: since
#82's pipeline run store landed, nothing writes `@muxa_work_done` any more.
`PaneInfo::work_done`, its `PANE_FMT` column, `WorkInfo::done` and
`topology::work_completion`'s `done` argument are now read-only paths over an
option with no writer. Every live caller already prefers the durable run —
`work_up` falls back to it only when no run is registered, `work_list_table`
and the watch tree both override it — so the value is always empty and the
fallback is a correct default. It is dead weight rather than a bug, and it
sits in the module #82 is actively evolving, so removing it belongs to
whoever owns that rewrite rather than to this PR. The comments that still
claim "the completion set lives on the work window" should go with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
