### PR TITLE
feat(collaboration): deliver full wake payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ One-time setup: add the following to `~/.config/muxa/config.toml`, restart
 [collaboration]
 enabled = true
 wake = "idle_only"
+# Optional: claim and deliver request bodies directly to idle agent prompts.
+wake_payload = "full"
 ```
 
 Register the MCP server once for both agent hosts, then restart agents that

--- a/crates/muxa-cli/src/dashboard_tui.rs
+++ b/crates/muxa-cli/src/dashboard_tui.rs
@@ -5263,6 +5263,7 @@ mod tests {
             status,
             created_at: now,
             claimed_at: (status == RequestStatus::Claimed).then_some(now),
+            wake_delivery: None,
             notified_at: None,
             reply_notified_at: None,
             reply_read_at: None,

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -16973,6 +16973,7 @@ mod tests {
             status,
             created_at: now,
             claimed_at: (status == RequestStatus::Claimed).then_some(now),
+            wake_delivery: None,
             notified_at: None,
             reply_notified_at: None,
             reply_read_at: None,

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -361,6 +361,16 @@ pub enum RequestStatus {
     Cancelled,
 }
 
+/// Durable recovery state for a request body being delivered directly into
+/// an idle agent prompt. This is normally absent: it exists only between the
+/// automatic claim and successful prompt submission.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WakeDeliveryState {
+    Prepared,
+    PromptWritten,
+}
+
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RequestMailbox {
@@ -422,6 +432,8 @@ pub struct CollaborationRequest {
         with = "time::serde::rfc3339::option"
     )]
     pub claimed_at: Option<OffsetDateTime>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wake_delivery: Option<WakeDeliveryState>,
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -738,6 +750,7 @@ impl CollaborationStore {
             status: RequestStatus::Queued,
             created_at: now,
             claimed_at: None,
+            wake_delivery: None,
             notified_at: None,
             reply_notified_at: None,
             reply_read_at: None,
@@ -782,6 +795,15 @@ impl CollaborationStore {
                         };
                         request.claimed_at = Some(now);
                         changed = true;
+                    } else if request.wake_delivery.take().is_some() {
+                        // A direct wake was prepared but the recipient pulled
+                        // its inbox first. Manual retrieval wins and suppresses
+                        // any recovery injection from the daemon.
+                        request.notified_at.get_or_insert(now);
+                        if !request.expects_reply {
+                            request.status = RequestStatus::Completed;
+                        }
+                        changed = true;
                     }
                     inbox.push(request.clone());
                 }
@@ -796,6 +818,73 @@ impl CollaborationStore {
             self.publish_change();
         }
         Ok(inbox)
+    }
+
+    /// Atomically reserve one queued request for direct prompt delivery.
+    /// Claiming before the terminal side effect closes the sender-cancel race:
+    /// once a body may reach the agent, the request can no longer be cancelled.
+    pub async fn prepare_direct_wake(
+        &self,
+        caller: &Participant,
+        request_id: &str,
+    ) -> Result<Option<CollaborationRequest>, CollaborationError> {
+        self.ensure_enabled()?;
+        let _transaction = self.transaction_lock.lock().await;
+        let previous = self.requests.read().await.clone();
+        let prepared = {
+            let mut requests = self.requests.write().await;
+            let Some(request) = requests.get_mut(request_id) else {
+                return Err(CollaborationError::NotFound(request_id.to_string()));
+            };
+            if !request.to.same_endpoint(caller) {
+                return Err(CollaborationError::NotParticipant(request_id.to_string()));
+            }
+            if request.status != RequestStatus::Queued || request.notified_at.is_some() {
+                None
+            } else {
+                request.status = RequestStatus::Claimed;
+                request.claimed_at = Some(OffsetDateTime::now_utc());
+                request.wake_delivery = Some(WakeDeliveryState::Prepared);
+                Some(request.clone())
+            }
+        };
+        if prepared.is_some() {
+            if let Err(error) = self.persist_current().await {
+                *self.requests.write().await = previous;
+                return Err(error);
+            }
+            self.publish_change();
+        }
+        Ok(prepared)
+    }
+
+    /// Record that the direct prompt text reached the pane. Submission is a
+    /// separate keystroke, so a daemon restart can retry only Enter rather
+    /// than injecting the request body a second time.
+    pub async fn mark_wake_prompt_written(
+        &self,
+        request_id: &str,
+    ) -> Result<(), CollaborationError> {
+        let _transaction = self.transaction_lock.lock().await;
+        let changed = {
+            let mut requests = self.requests.write().await;
+            requests.get_mut(request_id).is_some_and(|request| {
+                if request.wake_delivery == Some(WakeDeliveryState::Prepared) {
+                    request.wake_delivery = Some(WakeDeliveryState::PromptWritten);
+                    true
+                } else {
+                    false
+                }
+            })
+        };
+        if changed {
+            // The text side effect cannot be rolled back. Retain the in-memory
+            // phase even if persistence fails, matching notification markers.
+            let result = self.persist_current().await;
+            self.publish_change();
+            result?;
+        }
+        Ok(())
     }
 
     pub async fn reply(
@@ -976,13 +1065,19 @@ impl CollaborationStore {
 
     pub async fn pending_unnotified(&self) -> Vec<CollaborationRequest> {
         let _transaction = self.transaction_lock.lock().await;
-        self.requests
+        let mut requests: Vec<_> = self
+            .requests
             .read()
             .await
             .values()
-            .filter(|r| r.status == RequestStatus::Queued && r.notified_at.is_none())
+            .filter(|request| {
+                request.notified_at.is_none()
+                    && (request.status == RequestStatus::Queued || request.wake_delivery.is_some())
+            })
             .cloned()
-            .collect()
+            .collect();
+        requests.sort_by_key(|request| request.created_at);
+        requests
     }
 
     /// Replies still owed a wake to their sender.
@@ -993,7 +1088,8 @@ impl CollaborationStore {
     /// is delivered by being readable in the recipient's mailbox.
     pub async fn pending_reply_unnotified(&self) -> Vec<CollaborationRequest> {
         let _transaction = self.transaction_lock.lock().await;
-        self.requests
+        let mut requests: Vec<_> = self
+            .requests
             .read()
             .await
             .values()
@@ -1004,7 +1100,9 @@ impl CollaborationStore {
                     && !request.from.console
             })
             .cloned()
-            .collect()
+            .collect();
+        requests.sort_by_key(|request| request.created_at);
+        requests
     }
 
     pub async fn mark_notified(&self, request_id: &str) -> Result<(), CollaborationError> {
@@ -1012,8 +1110,14 @@ impl CollaborationStore {
         let changed = {
             let mut requests = self.requests.write().await;
             requests.get_mut(request_id).is_some_and(|request| {
-                if request.status == RequestStatus::Queued && request.notified_at.is_none() {
+                if request.notified_at.is_none()
+                    && (request.status == RequestStatus::Queued || request.wake_delivery.is_some())
+                {
                     request.notified_at = Some(OffsetDateTime::now_utc());
+                    request.wake_delivery = None;
+                    if !request.expects_reply && request.status == RequestStatus::Claimed {
+                        request.status = RequestStatus::Completed;
+                    }
                     true
                 } else {
                     false
@@ -1062,7 +1166,10 @@ impl CollaborationStore {
             .read()
             .await
             .values()
-            .filter(|r| r.status == RequestStatus::Queued && r.to.same_endpoint(participant))
+            .filter(|request| {
+                request.to.same_endpoint(participant)
+                    && (request.status == RequestStatus::Queued || request.wake_delivery.is_some())
+            })
             .count()
     }
 
@@ -1757,6 +1864,163 @@ mod tests {
         );
         assert_eq!(mailbox.unread_reply_count(&sender).await, 0);
         assert!(mailbox.pending_reply_unnotified().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn direct_wake_claims_before_delivery_and_tracks_submission_phase() {
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let sender = participant("%1", "sender");
+        let recipient = participant("%2", "recipient");
+        let request = mailbox
+            .create(
+                sender.clone(),
+                recipient.clone(),
+                NewRequest {
+                    kind: RequestKind::Task,
+                    body: "apply the scoped change".into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::Execute,
+                    paths: vec!["src/auth.rs".into()],
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let prepared = mailbox
+            .prepare_direct_wake(&recipient, &request.id)
+            .await
+            .unwrap()
+            .expect("queued request should be reserved");
+        assert_eq!(prepared.status, RequestStatus::Claimed);
+        assert_eq!(prepared.wake_delivery, Some(WakeDeliveryState::Prepared));
+        assert!(matches!(
+            mailbox.cancel_for(&sender, &request.id).await,
+            Err(CollaborationError::AlreadyClaimed(_))
+        ));
+        assert_eq!(mailbox.pending_unnotified().await.len(), 1);
+
+        mailbox.mark_wake_prompt_written(&request.id).await.unwrap();
+        assert_eq!(
+            mailbox.pending_unnotified().await[0].wake_delivery,
+            Some(WakeDeliveryState::PromptWritten)
+        );
+
+        mailbox.mark_notified(&request.id).await.unwrap();
+        assert!(mailbox.pending_unnotified().await.is_empty());
+        let delivered = mailbox.get_for(&recipient, &request.id).await.unwrap();
+        assert_eq!(delivered.status, RequestStatus::Claimed);
+        assert_eq!(delivered.wake_delivery, None);
+        assert!(delivered.notified_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn inbox_pull_supersedes_prepared_direct_wake() {
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let recipient = participant("%2", "recipient");
+        let request = mailbox
+            .create(
+                participant("%1", "sender"),
+                recipient.clone(),
+                NewRequest {
+                    kind: RequestKind::Notice,
+                    body: "deployment finished".into(),
+                    expects_reply: false,
+                    work_mode: WorkMode::ReadOnly,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+        mailbox
+            .prepare_direct_wake(&recipient, &request.id)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let inbox = mailbox.claim_for(&recipient).await.unwrap();
+        assert_eq!(inbox.len(), 1);
+        assert_eq!(inbox[0].body, "deployment finished");
+        assert_eq!(inbox[0].status, RequestStatus::Completed);
+        assert_eq!(inbox[0].wake_delivery, None);
+        assert!(inbox[0].notified_at.is_some());
+        assert!(mailbox.pending_unnotified().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn direct_wake_recovery_phase_survives_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        let options = CollaborationOptions {
+            path: Some(dir.path().join("collaboration.json")),
+            ..CollaborationOptions::default()
+        };
+        let recipient = participant("%2", "recipient");
+        let mailbox = CollaborationStore::load(options.clone()).await.unwrap();
+        let request = mailbox
+            .create(
+                participant("%1", "sender"),
+                recipient.clone(),
+                NewRequest {
+                    kind: RequestKind::Task,
+                    body: "survive a daemon restart".into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::Execute,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+        mailbox
+            .prepare_direct_wake(&recipient, &request.id)
+            .await
+            .unwrap()
+            .unwrap();
+        mailbox.mark_wake_prompt_written(&request.id).await.unwrap();
+        drop(mailbox);
+
+        let reloaded = CollaborationStore::load(options).await.unwrap();
+        let pending = reloaded.pending_unnotified().await;
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].status, RequestStatus::Claimed);
+        assert_eq!(
+            pending[0].wake_delivery,
+            Some(WakeDeliveryState::PromptWritten)
+        );
+    }
+
+    #[tokio::test]
+    async fn delivered_direct_notice_completes_without_a_reply() {
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let recipient = participant("%2", "recipient");
+        let request = mailbox
+            .create(
+                participant("%1", "sender"),
+                recipient.clone(),
+                NewRequest {
+                    kind: RequestKind::Notice,
+                    body: "build completed".into(),
+                    expects_reply: false,
+                    work_mode: WorkMode::ReadOnly,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+        mailbox
+            .prepare_direct_wake(&recipient, &request.id)
+            .await
+            .unwrap()
+            .unwrap();
+        mailbox.mark_wake_prompt_written(&request.id).await.unwrap();
+        mailbox.mark_notified(&request.id).await.unwrap();
+
+        let delivered = mailbox.get_for(&recipient, &request.id).await.unwrap();
+        assert_eq!(delivered.status, RequestStatus::Completed);
+        assert!(delivered.reply.is_none());
+        assert!(mailbox.pending_unnotified().await.is_empty());
     }
 
     #[tokio::test]

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -480,8 +480,8 @@ pub struct PipelineAgentConfig {
 }
 
 /// `[collaboration]` config — same-window durable agent request/reply.
-/// Disabled by default because idle wake-up injects a short prompt into a
-/// peer pane. Enabling it is an explicit grant for local peer coordination.
+/// Disabled by default because idle wake-up injects a prompt into a peer pane.
+/// Enabling it is an explicit grant for local peer coordination.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct CollaborationConfig {
@@ -492,6 +492,10 @@ pub struct CollaborationConfig {
     /// `never` keeps delivery pull-only; `idle_only` wakes hook-authoritative
     /// agents only at their top-level idle prompt.
     pub wake: CollaborationWake,
+    /// `notice` injects only a mailbox notification. `full` atomically claims
+    /// each request and injects its metadata and body into the recipient's
+    /// prompt, avoiding a separate inbox tool round.
+    pub wake_payload: CollaborationWakePayload,
     /// How far an explicit `pane:%N` target may reach. `window` (default)
     /// keeps requests inside the sender's tmux window — co-locating agents
     /// in a window is the consent to let them talk. `host` lets a request
@@ -510,6 +514,7 @@ impl Default for CollaborationConfig {
             enabled: false,
             path: None,
             wake: CollaborationWake::IdleOnly,
+            wake_payload: CollaborationWakePayload::Notice,
             scope: CollaborationScope::default(),
             max_message_bytes: default_collaboration_max_message_bytes(),
         }
@@ -530,6 +535,14 @@ pub enum CollaborationWake {
     Never,
     #[default]
     IdleOnly,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CollaborationWakePayload {
+    #[default]
+    Notice,
+    Full,
 }
 
 fn default_collaboration_max_message_bytes() -> usize {
@@ -1980,12 +1993,22 @@ agent-review = "create a codex pane and pass our changes for review"
     fn collaboration_is_opt_in_and_parses_wake_policy() {
         assert!(!Config::default().collaboration.enabled);
         let cfg: Config = toml::from_str(
-            "[collaboration]\nenabled = true\nwake = \"never\"\nmax_message_bytes = 4096\n",
+            "[collaboration]\nenabled = true\nwake = \"never\"\nwake_payload = \"full\"\nmax_message_bytes = 4096\n",
         )
         .unwrap();
         assert!(cfg.collaboration.enabled);
         assert_eq!(cfg.collaboration.wake, CollaborationWake::Never);
+        assert_eq!(
+            cfg.collaboration.wake_payload,
+            CollaborationWakePayload::Full
+        );
         assert_eq!(cfg.collaboration.max_message_bytes, 4096);
+
+        let defaults: Config = toml::from_str("[collaboration]\nenabled = true\n").unwrap();
+        assert_eq!(
+            defaults.collaboration.wake_payload,
+            CollaborationWakePayload::Notice
+        );
     }
 
     #[test]

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -14,10 +14,10 @@ use muxa::activity::{
 use muxa::ask::{AskOptions, AskStore};
 use muxa::collaboration::{
     CollaborationClientKind, CollaborationOptions, CollaborationOriginMatch, CollaborationRequest,
-    CollaborationStore,
+    CollaborationStore, WakeDeliveryState,
 };
 use muxa::collaboration_audit::CollaborationAuditLog;
-use muxa::config::CollaborationWake;
+use muxa::config::{CollaborationWake, CollaborationWakePayload};
 use muxa::config::{DashboardAuthMode, NotifierBackend};
 use muxa::dashboard::{DashboardConfig, DashboardOverrides};
 use muxa::history::{HistoryOptions, PaneSessionCache, PromptHistory};
@@ -29,7 +29,7 @@ use muxa::sinks::{webhook as webhook_sink, OhMyPromptSink, WebhookSink};
 use muxa::snapshot::{self, Snapshotter, SnapshotterOptions};
 use muxa::tmux::scanner::PaneCache;
 use muxa::{discovery, paths, Config, Store};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -564,6 +564,7 @@ async fn build_collaboration(cfg: &Config) -> Arc<CollaborationStore> {
                 tracing::info!(
                     path = ?options.path,
                     wake = ?cfg.collaboration.wake,
+                    wake_payload = ?cfg.collaboration.wake_payload,
                     "agent collaboration enabled",
                 );
             }
@@ -738,8 +739,17 @@ fn spawn_collaboration_waker_task(
     // by that scan or by an already-pending signal.
     let mut mailbox_changes = collaboration.subscribe();
     let mut agent_transitions = store.subscribe();
+    let wake_payload = cfg.collaboration.wake_payload;
     Some(tokio::spawn(async move {
-        wake_idle_collaboration_peers(&collaboration, &store, &backends).await;
+        let mut wake_inflight = HashSet::new();
+        wake_idle_collaboration_peers_with_inflight(
+            &collaboration,
+            &store,
+            &backends,
+            wake_payload,
+            &mut wake_inflight,
+        )
+        .await;
         let mut reconcile = tokio::time::interval(std::time::Duration::from_secs(
             COLLABORATION_WAKE_RECONCILE_SECONDS,
         ));
@@ -754,29 +764,93 @@ fn spawn_collaboration_waker_task(
                     true
                 }
                 transition = agent_transitions.recv() => match transition {
-                    Ok(transition) => transition.to == muxa::AgentState::Idle,
+                    Ok(transition) => {
+                        let should_scan = transition.to == muxa::AgentState::Idle;
+                        if matches!(
+                            transition.to,
+                            muxa::AgentState::Idle
+                                | muxa::AgentState::Stopped
+                                | muxa::AgentState::Error
+                        ) {
+                            if let Some(key) = collaboration_wake_key_for_agent(&transition.agent) {
+                                wake_inflight.remove(&key);
+                            }
+                        }
+                        should_scan
+                    }
                     // A lag means the exact transition to Idle may have been
                     // dropped. Re-read the authoritative state immediately.
                     Err(broadcast::error::RecvError::Lagged(dropped)) => {
                         tracing::debug!(dropped, "collaboration waker transition stream lagged");
+                        wake_inflight.clear();
                         true
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
                 },
-                _ = reconcile.tick() => true,
+                _ = reconcile.tick() => {
+                    // A successfully submitted prompt should produce a hook
+                    // transition. The periodic reset is the bounded recovery
+                    // path if that event was lost; the authoritative state
+                    // snapshot below still refuses non-idle recipients.
+                    wake_inflight.clear();
+                    true
+                },
                 _ = shutdown_rx.recv() => break,
             };
             if should_scan {
-                wake_idle_collaboration_peers(&collaboration, &store, &backends).await;
+                wake_idle_collaboration_peers_with_inflight(
+                    &collaboration,
+                    &store,
+                    &backends,
+                    wake_payload,
+                    &mut wake_inflight,
+                )
+                .await;
             }
         }
     }))
 }
 
+#[cfg(test)]
 async fn wake_idle_collaboration_peers(
     collaboration: &CollaborationStore,
     store: &muxa::SharedStore,
     backends: &[muxa::SharedBackend],
+) {
+    let mut wake_inflight = HashSet::new();
+    wake_idle_collaboration_peers_with_inflight(
+        collaboration,
+        store,
+        backends,
+        CollaborationWakePayload::Notice,
+        &mut wake_inflight,
+    )
+    .await;
+}
+
+#[cfg(test)]
+async fn wake_idle_collaboration_peers_with_full_payload(
+    collaboration: &CollaborationStore,
+    store: &muxa::SharedStore,
+    backends: &[muxa::SharedBackend],
+) {
+    let mut wake_inflight = HashSet::new();
+    wake_idle_collaboration_peers_with_inflight(
+        collaboration,
+        store,
+        backends,
+        CollaborationWakePayload::Full,
+        &mut wake_inflight,
+    )
+    .await;
+}
+
+async fn wake_idle_collaboration_peers_with_inflight(
+    collaboration: &CollaborationStore,
+    store: &muxa::SharedStore,
+    backends: &[muxa::SharedBackend],
+    wake_payload: CollaborationWakePayload,
+    wake_inflight: &mut HashSet<(String, Option<String>, String)>,
 ) {
     let requests = collaboration.pending_unnotified().await;
     let replies = collaboration.pending_reply_unnotified().await;
@@ -800,6 +874,26 @@ async fn wake_idle_collaboration_peers(
         let Some(recipient) = idle_collaboration_participant(&participants, &request.to) else {
             continue;
         };
+        let wake_key = collaboration_wake_key(recipient);
+        if wake_inflight.contains(&wake_key) {
+            continue;
+        }
+        if wake_payload == CollaborationWakePayload::Full
+            && direct_wake_body_is_terminal_safe(&request.body)
+        {
+            if deliver_full_collaboration_request(collaboration, recipient, &request, backends)
+                .await
+            {
+                wake_inflight.insert(wake_key);
+            }
+            continue;
+        }
+        if wake_payload == CollaborationWakePayload::Full {
+            tracing::debug!(
+                request_id = request.id,
+                "direct wake body contains terminal control characters; using mailbox notice",
+            );
+        }
         let prompt = format!(
             "[muxa:{}] New {:?} request {}. Claim/read it with muxa_inbox (MCP) or `muxa msg inbox --json`; honor kind/work_mode/paths, then respond with muxa_reply or `muxa msg reply`.",
             request.id,
@@ -807,6 +901,9 @@ async fn wake_idle_collaboration_peers(
             collaboration_request_source(&request),
         );
         let (sent, submitted) = send_collaboration_wake(recipient, &prompt, backends).await;
+        if submitted {
+            wake_inflight.insert(wake_key);
+        }
         if sent {
             if let Err(error) = collaboration.mark_notified(&request.id).await {
                 tracing::warn!(request_id = request.id, %error, "failed to persist wake marker");
@@ -824,6 +921,10 @@ async fn wake_idle_collaboration_peers(
         let Some(sender) = idle_collaboration_participant(&participants, &request.from) else {
             continue;
         };
+        let wake_key = collaboration_wake_key(sender);
+        if wake_inflight.contains(&wake_key) {
+            continue;
+        }
         let prompt = format!(
             "[muxa:{}] {:?} reply from {} is ready. Read it with muxa_wait_reply (MCP) or `muxa msg wait {}`.",
             request.id,
@@ -832,6 +933,9 @@ async fn wake_idle_collaboration_peers(
             request.id,
         );
         let (sent, submitted) = send_collaboration_wake(sender, &prompt, backends).await;
+        if submitted {
+            wake_inflight.insert(wake_key);
+        }
         if sent {
             if let Err(error) = collaboration.mark_reply_notified(&request.id).await {
                 tracing::warn!(
@@ -848,6 +952,146 @@ async fn wake_idle_collaboration_peers(
             );
         }
     }
+}
+
+async fn deliver_full_collaboration_request(
+    collaboration: &CollaborationStore,
+    recipient: &muxa::collaboration::Participant,
+    pending: &CollaborationRequest,
+    backends: &[muxa::SharedBackend],
+) -> bool {
+    let (request, newly_prepared) = if pending.status == muxa::collaboration::RequestStatus::Queued
+    {
+        match collaboration
+            .prepare_direct_wake(recipient, &pending.id)
+            .await
+        {
+            Ok(Some(request)) => (request, true),
+            Ok(None) => return false,
+            Err(error) => {
+                tracing::warn!(
+                    request_id = pending.id,
+                    %error,
+                    "failed to reserve direct collaboration wake",
+                );
+                return false;
+            }
+        }
+    } else {
+        (pending.clone(), false)
+    };
+
+    match request.wake_delivery {
+        Some(WakeDeliveryState::Prepared) => {
+            let prompt = if newly_prepared {
+                full_collaboration_request_prompt(&request)
+            } else {
+                interrupted_collaboration_request_prompt(&request)
+            };
+            if !send_collaboration_text(recipient, &prompt, backends).await {
+                return false;
+            }
+            if let Err(error) = collaboration.mark_wake_prompt_written(&request.id).await {
+                tracing::warn!(
+                    request_id = request.id,
+                    %error,
+                    "failed to persist direct wake prompt phase",
+                );
+            }
+            tokio::time::sleep(muxa::backend::PROMPT_SUBMIT_GRACE).await;
+            submit_direct_collaboration_prompt(collaboration, recipient, &request.id, backends)
+                .await
+        }
+        Some(WakeDeliveryState::PromptWritten) => {
+            // The body or recovery notice is already in the input buffer.
+            // Retrying only Enter avoids executing the request twice.
+            submit_direct_collaboration_prompt(collaboration, recipient, &request.id, backends)
+                .await
+        }
+        None => false,
+    }
+}
+
+async fn submit_direct_collaboration_prompt(
+    collaboration: &CollaborationStore,
+    recipient: &muxa::collaboration::Participant,
+    request_id: &str,
+    backends: &[muxa::SharedBackend],
+) -> bool {
+    if !send_collaboration_text(recipient, "\r", backends).await {
+        return false;
+    }
+    mark_collaboration_request_notified(collaboration, request_id).await;
+    true
+}
+
+async fn mark_collaboration_request_notified(collaboration: &CollaborationStore, request_id: &str) {
+    if let Err(error) = collaboration.mark_notified(request_id).await {
+        tracing::warn!(request_id, %error, "failed to persist wake marker");
+    }
+}
+
+fn full_collaboration_request_prompt(request: &CollaborationRequest) -> String {
+    let paths = serde_json::to_string(&request.paths).unwrap_or_else(|_| "[]".into());
+    let air_artifacts = if request.air_artifacts.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "\nair_artifacts: {}",
+            serde_json::to_string(&request.air_artifacts).unwrap_or_else(|_| "[]".into())
+        )
+    };
+    let reply = if request.expects_reply {
+        format!(
+            "When finished, respond with muxa_reply for request {} or `muxa msg reply {0} <body>`.",
+            request.id
+        )
+    } else {
+        "No reply is expected; do not send an acknowledgement solely for this delivery.".into()
+    };
+    format!(
+        "[muxa:{}] New {} request {}. This request is already claimed; do not call muxa_inbox for it.\nkind: {}\nwork_mode: {}\npaths: {}{}\nexpects_reply: {}\n{}\n\n--- request body ({} bytes) ---\n{}\n--- end request body ---",
+        request.id,
+        collaboration_request_kind(request.kind),
+        collaboration_request_source(request),
+        collaboration_request_kind(request.kind),
+        collaboration_work_mode(request.work_mode),
+        paths,
+        air_artifacts,
+        request.expects_reply,
+        reply,
+        request.body.len(),
+        request.body,
+    )
+}
+
+fn interrupted_collaboration_request_prompt(request: &CollaborationRequest) -> String {
+    format!(
+        "[muxa:{}] Direct {} request delivery was interrupted after it was claimed. Read it with muxa_inbox (MCP) or `muxa msg inbox --json`; honor kind/work_mode/paths, then respond as requested.",
+        request.id,
+        collaboration_request_kind(request.kind),
+    )
+}
+
+fn collaboration_request_kind(kind: muxa::collaboration::RequestKind) -> &'static str {
+    match kind {
+        muxa::collaboration::RequestKind::Question => "question",
+        muxa::collaboration::RequestKind::Review => "review",
+        muxa::collaboration::RequestKind::Task => "task",
+        muxa::collaboration::RequestKind::Notice => "notice",
+    }
+}
+
+fn collaboration_work_mode(mode: muxa::collaboration::WorkMode) -> &'static str {
+    match mode {
+        muxa::collaboration::WorkMode::ReadOnly => "read_only",
+        muxa::collaboration::WorkMode::Execute => "execute",
+    }
+}
+
+fn direct_wake_body_is_terminal_safe(body: &str) -> bool {
+    body.chars()
+        .all(|character| matches!(character, '\n' | '\t') || !character.is_control())
 }
 
 fn collaboration_request_source(request: &CollaborationRequest) -> String {
@@ -891,36 +1135,62 @@ fn idle_collaboration_participant<'a>(
     })
 }
 
+fn collaboration_wake_key(
+    participant: &muxa::collaboration::Participant,
+) -> (String, Option<String>, String) {
+    (
+        participant.pane.clone(),
+        participant.socket.clone(),
+        participant.agent_session_id.clone(),
+    )
+}
+
+fn collaboration_wake_key_for_agent(
+    agent: &muxa::Agent,
+) -> Option<(String, Option<String>, String)> {
+    Some((
+        agent.pane.clone()?,
+        agent.tmux_socket.clone(),
+        agent.session_id.clone(),
+    ))
+}
+
 async fn send_collaboration_wake(
     participant: &muxa::collaboration::Participant,
     prompt: &str,
     backends: &[muxa::SharedBackend],
 ) -> (bool, bool) {
+    let sent = send_collaboration_text(participant, prompt, backends).await;
+    let submitted = if sent {
+        tokio::time::sleep(muxa::backend::PROMPT_SUBMIT_GRACE).await;
+        send_collaboration_text(participant, "\r", backends).await
+    } else {
+        false
+    };
+    (sent, submitted)
+}
+
+async fn send_collaboration_text(
+    participant: &muxa::collaboration::Participant,
+    text: &str,
+    backends: &[muxa::SharedBackend],
+) -> bool {
     let Some(kind) = muxa::backend::pane_id_host_kind(&participant.pane) else {
-        return (false, false);
+        return false;
     };
     let Some(backend) = backends
         .iter()
         .find(|backend| backend.kind() == kind && backend.caps().send_text)
         .cloned()
     else {
-        return (false, false);
+        return false;
     };
     let pane = participant.pane.clone();
     let socket = participant.socket.clone();
-    let prompt = prompt.to_string();
-    tokio::task::spawn_blocking(move || {
-        let sent = backend.send_text_on(socket.as_deref(), &pane, &prompt);
-        let submitted = if sent {
-            std::thread::sleep(muxa::backend::PROMPT_SUBMIT_GRACE);
-            backend.send_text_on(socket.as_deref(), &pane, "\r")
-        } else {
-            false
-        };
-        (sent, submitted)
-    })
-    .await
-    .unwrap_or((false, false))
+    let text = text.to_string();
+    tokio::task::spawn_blocking(move || backend.send_text_on(socket.as_deref(), &pane, &text))
+        .await
+        .unwrap_or(false)
 }
 
 /// Spawn the GC task: evicts long-stopped agents on a periodic timer.
@@ -2119,6 +2389,274 @@ mod tests {
 
         shutdown_tx.send(()).unwrap();
         waker.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn full_wake_claims_and_injects_the_structured_request_body() {
+        let store = muxa::Store::shared();
+        add_agent(&store, "%1", "sender", AgentKind::Codex).await;
+        add_agent(&store, "%2", "recipient", AgentKind::ClaudeCode).await;
+        let panes = vec![collaboration_pane("%1", "0"), collaboration_pane("%2", "1")];
+        let participants = muxa::collaboration::participants_from(&store.snapshot().await, &panes);
+        let sender = participants
+            .iter()
+            .find(|participant| participant.pane == "%1")
+            .unwrap()
+            .clone();
+        let recipient = participants
+            .iter()
+            .find(|participant| participant.pane == "%2")
+            .unwrap()
+            .clone();
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let request = mailbox
+            .create(
+                sender.clone(),
+                recipient.clone(),
+                NewRequest {
+                    kind: RequestKind::Task,
+                    body: "change only the authorized file".into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::Execute,
+                    paths: vec!["src/auth.rs".into()],
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+        let sends = Arc::new(Mutex::new(Vec::new()));
+        let backend: muxa::SharedBackend = Arc::new(CollaborationWakeBackend {
+            panes,
+            sends: sends.clone(),
+        });
+
+        wake_idle_collaboration_peers_with_full_payload(&mailbox, &store, &[backend]).await;
+
+        {
+            let delivered = sends.lock().unwrap();
+            assert_eq!(delivered.len(), 2);
+            assert_eq!(delivered[0].0, "%2");
+            assert!(delivered[0].1.contains(&request.id));
+            assert!(delivered[0].1.contains("kind: task"));
+            assert!(delivered[0].1.contains("work_mode: execute"));
+            assert!(delivered[0].1.contains("paths: [\"src/auth.rs\"]"));
+            assert!(delivered[0].1.contains("change only the authorized file"));
+            assert!(delivered[0].1.contains("already claimed"));
+            assert!(!delivered[0].1.contains("Read it with muxa_inbox"));
+            assert_eq!(delivered[1], ("%2".into(), "\r".into()));
+        }
+
+        let stored = mailbox.get_for(&recipient, &request.id).await.unwrap();
+        assert_eq!(stored.status, RequestStatus::Claimed);
+        assert!(stored.claimed_at.is_some());
+        assert!(stored.notified_at.is_some());
+        assert_eq!(stored.wake_delivery, None);
+        assert!(mailbox.pending_unnotified().await.is_empty());
+
+        sends.lock().unwrap().clear();
+        let unsafe_request = mailbox
+            .create(
+                sender,
+                recipient.clone(),
+                NewRequest {
+                    kind: RequestKind::Task,
+                    body: "unsafe\u{1b}[201~\rsubmit".into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::Execute,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+        let backend: muxa::SharedBackend = Arc::new(CollaborationWakeBackend {
+            panes: vec![collaboration_pane("%1", "0"), collaboration_pane("%2", "1")],
+            sends: sends.clone(),
+        });
+        wake_idle_collaboration_peers_with_full_payload(&mailbox, &store, &[backend]).await;
+        {
+            let delivered = sends.lock().unwrap();
+            assert_eq!(delivered.len(), 2);
+            assert!(delivered[0].1.contains("muxa_inbox"));
+            assert!(!delivered[0].1.contains(&unsafe_request.body));
+        }
+        let stored = mailbox
+            .get_for(&recipient, &unsafe_request.id)
+            .await
+            .unwrap();
+        assert_eq!(stored.status, RequestStatus::Queued);
+        assert!(stored.notified_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn full_wake_submits_only_one_request_per_idle_generation() {
+        let store = muxa::Store::shared();
+        add_agent(&store, "%1", "sender", AgentKind::Codex).await;
+        add_agent(&store, "%2", "recipient", AgentKind::ClaudeCode).await;
+        let panes = vec![collaboration_pane("%1", "0"), collaboration_pane("%2", "1")];
+        let participants = muxa::collaboration::participants_from(&store.snapshot().await, &panes);
+        let sender = participants
+            .iter()
+            .find(|participant| participant.pane == "%1")
+            .unwrap()
+            .clone();
+        let recipient = participants
+            .iter()
+            .find(|participant| participant.pane == "%2")
+            .unwrap()
+            .clone();
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        for body in ["first body", "second body"] {
+            mailbox
+                .create(
+                    sender.clone(),
+                    recipient.clone(),
+                    NewRequest {
+                        kind: RequestKind::Task,
+                        body: body.into(),
+                        expects_reply: true,
+                        work_mode: WorkMode::Execute,
+                        paths: Vec::new(),
+                        air_artifacts: Vec::new(),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        let sends = Arc::new(Mutex::new(Vec::new()));
+        let backend: muxa::SharedBackend = Arc::new(CollaborationWakeBackend {
+            panes,
+            sends: sends.clone(),
+        });
+        let mut wake_inflight = HashSet::new();
+
+        wake_idle_collaboration_peers_with_inflight(
+            &mailbox,
+            &store,
+            std::slice::from_ref(&backend),
+            CollaborationWakePayload::Full,
+            &mut wake_inflight,
+        )
+        .await;
+        assert_eq!(sends.lock().unwrap().len(), 2);
+        assert_eq!(mailbox.pending_unnotified().await.len(), 1);
+
+        // Mailbox revisions emitted by the first delivery can rescan while
+        // the state hook still says Idle. The generation gate must suppress
+        // a second prompt until a later Idle transition clears it.
+        wake_idle_collaboration_peers_with_inflight(
+            &mailbox,
+            &store,
+            std::slice::from_ref(&backend),
+            CollaborationWakePayload::Full,
+            &mut wake_inflight,
+        )
+        .await;
+        assert_eq!(sends.lock().unwrap().len(), 2);
+        assert_eq!(mailbox.pending_unnotified().await.len(), 1);
+
+        wake_inflight.clear();
+        wake_idle_collaboration_peers_with_inflight(
+            &mailbox,
+            &store,
+            &[backend],
+            CollaborationWakePayload::Full,
+            &mut wake_inflight,
+        )
+        .await;
+        assert_eq!(sends.lock().unwrap().len(), 4);
+        assert!(mailbox.pending_unnotified().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn full_wake_recovers_without_reinjecting_the_request_body() {
+        let store = muxa::Store::shared();
+        add_agent(&store, "%1", "sender", AgentKind::Codex).await;
+        add_agent(&store, "%2", "recipient", AgentKind::ClaudeCode).await;
+        let panes = vec![collaboration_pane("%1", "0"), collaboration_pane("%2", "1")];
+        let participants = muxa::collaboration::participants_from(&store.snapshot().await, &panes);
+        let sender = participants
+            .iter()
+            .find(|participant| participant.pane == "%1")
+            .unwrap()
+            .clone();
+        let recipient = participants
+            .iter()
+            .find(|participant| participant.pane == "%2")
+            .unwrap()
+            .clone();
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let request = mailbox
+            .create(
+                sender.clone(),
+                recipient.clone(),
+                NewRequest {
+                    kind: RequestKind::Task,
+                    body: "do not inject this twice".into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::Execute,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+        mailbox
+            .prepare_direct_wake(&recipient, &request.id)
+            .await
+            .unwrap()
+            .unwrap();
+        let sends = Arc::new(Mutex::new(Vec::new()));
+        let backend: muxa::SharedBackend = Arc::new(CollaborationWakeBackend {
+            panes: panes.clone(),
+            sends: sends.clone(),
+        });
+
+        wake_idle_collaboration_peers_with_full_payload(
+            &mailbox,
+            &store,
+            std::slice::from_ref(&backend),
+        )
+        .await;
+        {
+            let delivered = sends.lock().unwrap();
+            assert_eq!(delivered.len(), 2);
+            assert!(delivered[0].1.contains("delivery was interrupted"));
+            assert!(delivered[0].1.contains("muxa_inbox"));
+            assert!(!delivered[0].1.contains("do not inject this twice"));
+            assert_eq!(delivered[1], ("%2".into(), "\r".into()));
+        }
+        assert!(mailbox.pending_unnotified().await.is_empty());
+
+        let second = mailbox
+            .create(
+                sender,
+                recipient.clone(),
+                NewRequest {
+                    kind: RequestKind::Task,
+                    body: "the prompt text is already buffered".into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::Execute,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+        mailbox
+            .prepare_direct_wake(&recipient, &second.id)
+            .await
+            .unwrap()
+            .unwrap();
+        mailbox.mark_wake_prompt_written(&second.id).await.unwrap();
+        sends.lock().unwrap().clear();
+
+        wake_idle_collaboration_peers_with_full_payload(&mailbox, &store, &[backend]).await;
+        assert_eq!(
+            sends.lock().unwrap().as_slice(),
+            &[("%2".into(), "\r".into())]
+        );
+        assert!(mailbox.pending_unnotified().await.is_empty());
     }
 
     #[tokio::test]

--- a/docs/COLLABORATION.ko.md
+++ b/docs/COLLABORATION.ko.md
@@ -64,6 +64,8 @@ muxa init --component collaboration
 [collaboration]
 enabled = true
 wake = "idle_only"
+# 선택 사항: 기본값 "notice", 원문 직접 전달은 "full"
+wake_payload = "notice"
 ```
 
 이미 있는 `wake` 값은 덮어쓰지 않습니다. `never`는 "mailbox는 쓰되 내 pane은
@@ -263,6 +265,13 @@ Agent A: wait 중이 아니고 Idle이면 짧은 reply wake prompt 수신
 Agent A: muxa_wait_reply(request_id="req_...")
 ```
 
+`wake_payload = "full"`이면 Agent B의 두 단계는 다음처럼 바뀝니다.
+
+```text
+Agent B: idle 상태에서 metadata와 원문이 포함된 claimed request prompt 수신
+Agent B: inbox 호출 없이 작업 후 muxa_reply(request_id="req_...", ...)
+```
+
 ## Reviewer와 subagent로 활용하기
 
 agent가 상당한 작업을 시작할 때 권장 순서는 다음과 같습니다.
@@ -304,8 +313,7 @@ prompt/message/path/provider 식별자를 넣어서는 안 됩니다.
 
 메시지와 응답 본문은 `$XDG_DATA_HOME/muxa/collaboration.json`에 먼저
 저장됩니다. `idle_only` wake는 새 요청뿐 아니라 아직 발신자가 읽지 않은 terminal
-응답에도 적용됩니다. 다음 조건을 모두 만족할 때만 짧은 notification prompt를
-pane에 넣으며 본문은 terminal에 주입하지 않습니다.
+응답에도 적용됩니다. 다음 조건을 모두 만족할 때만 pane에 입력합니다.
 
 - hook 기반의 실제 agent session
 - state가 `Idle`
@@ -317,8 +325,23 @@ pane에 넣으며 본문은 terminal에 주입하지 않습니다.
 participant나 자동 wake 대상이 아닙니다. `wake = "never"`로 설정하면 mailbox는
 유지하면서 모든 입력 주입을 끌 수 있습니다.
 
-요청을 `muxa_inbox`로 읽는 순간 원자적으로 claim합니다. wake prompt가 중복돼도
-동일 request id의 작업을 새 요청으로 만들지 않습니다.
+기본값인 `wake_payload = "notice"`는 짧은 mailbox 알림만 넣고 본문을 terminal에
+주입하지 않습니다. 요청을 `muxa_inbox`로 읽는 순간 원자적으로 claim합니다.
+
+`wake_payload = "full"`은 terminal에 입력하기 전에 queued request 하나를
+원자적으로 claim하고, request id/source/kind/work mode/paths/AIR reference와 원문을
+구조화된 prompt로 직접 전달합니다. 이 request에는 inbox를 다시 호출할 필요가 없어
+tool round와 전체 JSON envelope를 줄입니다. idle generation 하나에는 원문 하나만
+제출하고, 실제 Idle transition이 온 뒤 다음 요청을 전달합니다. reply 본문은 이
+모드에서도 항상 mailbox에만 둡니다.
+
+`full`은 요청 본문을 terminal과 agent prompt history에도 남기므로 민감한 본문을
+mailbox에만 두려면 `notice`를 사용하세요. terminal 제어문자가 포함된 본문은
+변형하거나 위험하게 paste하지 않고 자동으로 `notice` 경로를 사용합니다. muxad는
+prompt text 기록과 별도 Enter 제출 단계를 durable state로 구분합니다. 중단 후
+text가 이미 기록된 것이 확실하면 Enter만 재시도하고, 기록 여부가 불확실하면 원문을
+다시 넣는 대신 짧은 inbox 복구 알림을 보냅니다. agent가 먼저 inbox를 읽으면 이
+자동 복구는 취소됩니다.
 
 모든 collaboration IPC 호출(context, identity, send, inbox, list, reply, get, wait,
 cancel)은 `$XDG_DATA_HOME/muxa/collaboration-audit.ndjson`에도 append-only로

--- a/docs/COLLABORATION.md
+++ b/docs/COLLABORATION.md
@@ -69,6 +69,8 @@ collaboration --uninstall` removes it). Hand-editing works just as well:
 [collaboration]
 enabled = true
 wake = "idle_only" # or "never" for pull-only delivery
+# Optional: "notice" (default) or "full" for direct request delivery.
+wake_payload = "notice"
 ```
 
 An existing `wake` is never overwritten — a deliberate `never` means "give me
@@ -265,12 +267,31 @@ session snapshot.
 ## Wake-up safety
 
 The mailbox is persisted to `$XDG_DATA_HOME/muxa/collaboration.json` before
-delivery. With `idle_only`, muxad injects a short notification for new requests
-and terminal replies, and only when the exact hook-authoritative participant
-is `Idle`. Message bodies never enter the terminal. It never injects into
-`Working`, `WaitingInput`, `WaitingChoice`, or `Error` panes. Synthetic
-screen-detected agents have no stable session identity, so they are not room
-participants or auto-wake targets.
+delivery. With `idle_only`, muxad injects only when the exact
+hook-authoritative participant is `Idle`. It never injects into `Working`,
+`WaitingInput`, `WaitingChoice`, or `Error` panes. Synthetic screen-detected
+agents have no stable session identity, so they are not room participants or
+auto-wake targets.
+
+`wake_payload = "notice"` is the default. It injects a short mailbox prompt;
+the recipient calls `muxa_inbox`, which atomically claims and returns the body.
+`wake_payload = "full"` instead claims one queued request before any terminal
+side effect, then injects a structured envelope containing request id, source,
+kind, work mode, paths, AIR references, and the original body. The recipient
+must not call inbox for that request, so one tool round and its JSON envelope
+are removed. Only one direct request is submitted per idle agent generation;
+the next waits for a real Idle transition. Terminal reply bodies always remain
+in the mailbox in both modes.
+
+Direct delivery deliberately makes the request body part of terminal and
+agent prompt history. Use `notice` for secrets that should remain only in the
+private mailbox. A body containing terminal control characters automatically
+falls back to `notice` rather than being transformed or pasted unsafely.
+Direct delivery records whether prompt text was written
+before the separate Enter keystroke. After interruption, muxad retries only
+Enter when text is known to be buffered; if writing was uncertain, it falls
+back to a short inbox recovery notice instead of injecting the body twice. A
+manual inbox read supersedes either recovery path.
 
 Reading a terminal result through `muxa_wait_reply` acknowledges it and
 prevents a later reply wake. Room context reports incoming unread requests and

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -88,6 +88,7 @@ sandbox/자동 검토를 유지한 채 workspace 편집을 허용하고, `defaul
 [collaboration]
 enabled = true
 wake = "idle_only" # idle_only | never
+wake_payload = "notice" # notice | full
 scope = "window"   # window | host
 max_message_bytes = 16384
 ```
@@ -95,8 +96,11 @@ max_message_bytes = 16384
 같은 stable tmux window에 있는 agent 사이의 durable request/reply 기능입니다.
 optional `path` 기본값은 `$XDG_DATA_HOME/muxa/collaboration.json`이며 mailbox와
 exact-session alias/role을 함께 저장합니다.
-`idle_only`는 hook 기반 top-level agent가 Idle일 때만 짧은 request/reply
-notification을 입력하며 본문은 mailbox에 둡니다.
+`idle_only`는 hook 기반 top-level agent가 Idle일 때만 입력합니다.
+기본값인 `wake_payload = "notice"`는 요청 본문을 mailbox에 두고, `full`은 idle
+generation마다 요청 하나를 원자적으로 claim한 뒤 구조화된 metadata와 본문을 직접
+입력하여 별도 inbox tool round를 없앱니다. reply wake는 두 모드 모두 본문 없는
+알림입니다.
 `scope = "host"`이면 watch에서 다른 tmux window나 session의 선택된 tracked
 agent를 정확한 pane id로 지정할 수 있습니다.
 [COLLABORATION.ko.md](COLLABORATION.ko.md)를 참고하세요.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -91,6 +91,7 @@ wall-clock safety limit, not an inactivity detector.
 [collaboration]
 enabled = true
 wake = "idle_only" # idle_only | never
+wake_payload = "notice" # notice | full
 scope = "window"   # window | host
 max_message_bytes = 16384
 ```
@@ -98,8 +99,11 @@ max_message_bytes = 16384
 Opt-in durable request/reply between agents in the same stable tmux window.
 The optional `path` defaults to `$XDG_DATA_HOME/muxa/collaboration.json` and
 stores both mailbox state and exact-session aliases/roles.
-`idle_only` injects short request/reply notifications only at a
-hook-authoritative top-level Idle prompt; message bodies stay in the mailbox.
+`idle_only` injects only at a hook-authoritative top-level Idle prompt.
+`wake_payload = "notice"` (the default) keeps request bodies in the mailbox;
+`full` atomically claims one request per idle generation and injects its
+structured metadata and body, avoiding a separate inbox tool round. Reply
+wakes remain body-free notifications in both modes.
 `scope = "host"` lets watch address the selected tracked agent in another
 tmux window or session by its exact pane id.
 See [COLLABORATION.md](COLLABORATION.md).

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -295,8 +295,10 @@ aliases.
 The collaboration tools are higher-level than `muxa_send_prompt`: muxad pins
 each request to the target's current agent session, persists it before wake-up,
 and restricts routing to the caller's stable tmux window. Request and reply
-wake prompts contain no message body and are sent only to idle agents. Enable
-the tools with `[collaboration] enabled = true`; see
+wake prompts are sent only to idle agents. Request bodies stay out of the
+terminal by default; opt-in `wake_payload = "full"` atomically claims and
+delivers one structured request body per idle generation. Reply wakes remain
+body-free. Enable the tools with `[collaboration] enabled = true`; see
 `docs/COLLABORATION.ko.md`.
 
 For rooms with several agents, call `muxa_set_identity` once per agent and

--- a/docs/demo-setup.sh
+++ b/docs/demo-setup.sh
@@ -178,7 +178,7 @@ seed_ask_history() {
     {
       "id": "ask-0001",
       "prompt": "what is the difference between wake = 'never' and wake = 'idle_only'?",
-      "answer": "\`never\` is pull-only: a request lands in the recipient's mailbox and\nsits there until that agent calls muxa_inbox of its own accord. Nothing\nis ever written into its pane.\n\n\`idle_only\` adds one narrow push: when the recipient is idle at its\ntop-level prompt — not mid-turn, not mid-tool-call — muxad injects a\nshort wake line telling it to check the mailbox.\n\nThe restriction is the whole design. Waking a working agent would\ninterleave text into whatever it was composing.",
+      "answer": "\`never\` is pull-only: a request lands in the recipient's mailbox and\nsits there until that agent calls muxa_inbox of its own accord. Nothing\nis ever written into its pane.\n\n\`idle_only\` adds one narrow push only at the recipient's top-level Idle\nprompt — not mid-turn or mid-tool-call. Its default \`wake_payload =\nnotice\` injects a short mailbox line; opt-in \`full\` atomically claims\nand injects one structured request body per idle generation. Reply bodies\nalways stay in the mailbox.\n\nThe Idle restriction prevents incoming text from interleaving with work\nthe agent is already composing.",
       "status": "answered",
       "agent": "claude",
       "agent_session_id": "demo-thread-claude",


### PR DESCRIPTION
## Summary

- add opt-in `wake_payload = "full"` delivery while preserving `notice` as the default
- atomically claim and inject structured request metadata and the original body into one idle agent prompt
- persist delivery phases for restart recovery, serialize one request per idle generation, and fall back to inbox notices for unsafe control characters
- document token, privacy, and recovery tradeoffs in English and Korean

## Validation

- `cargo test --workspace` (1600 passed, 1 ignored)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
