### PR TITLE
fix(work): source completion only from the durable Run

### DIFF
--- a/crates/muxa-cli/src/attend.rs
+++ b/crates/muxa-cli/src/attend.rs
@@ -387,7 +387,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa-cli/src/dashboard_tui.rs
+++ b/crates/muxa-cli/src/dashboard_tui.rs
@@ -5185,7 +5185,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: pane_id.to_string(),
             session_id: String::new(),

--- a/crates/muxa-cli/src/fleet_watch.rs
+++ b/crates/muxa-cli/src/fleet_watch.rs
@@ -4117,7 +4117,6 @@ mod tests {
                 panes: vec![PaneInfo {
                     agent_role: None,
                     agent_alias: None,
-                    work_done: Vec::new(),
                     pane_id: "%1".into(),
                     session_id: "$1".into(),
                     session: "work".into(),

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -2654,7 +2654,6 @@ mod tests {
         muxa::tmux::PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -2643,7 +2643,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             pane_id: pane_id.into(),
             session_id: "$1".into(),
             session: "registration".into(),

--- a/crates/muxa-cli/src/tmux_work.rs
+++ b/crates/muxa-cli/src/tmux_work.rs
@@ -49,7 +49,7 @@ const EXTERNAL_URL_OPTION: &str = "@muxa_external_url";
 const EXTERNAL_STATUS_OPTION: &str = "@muxa_external_status";
 
 const SESSION_FORMAT: &str = "#{session_name}\t#{session_id}\t#{@muxa_workspace_id}\t#{@muxa_workspace_cwd}\t#{@muxa_managed_workspace}\t#{session_attached}\t#{session_windows}";
-const WINDOW_FORMAT: &str = "#{session_name}\t#{session_id}\t#{window_id}\t#{window_index}\t#{window_name}\t#{@muxa_work_id}\t#{@muxa_work_cwd}\t#{@muxa_managed_work}\t#{@muxa_external_source}\t#{@muxa_external_scope}\t#{@muxa_external_stable_id}\t#{@muxa_external_key}\t#{@muxa_external_title}\t#{@muxa_external_url}\t#{@muxa_external_status}\t#{@muxa_work_done}";
+const WINDOW_FORMAT: &str = "#{session_name}\t#{session_id}\t#{window_id}\t#{window_index}\t#{window_name}\t#{@muxa_work_id}\t#{@muxa_work_cwd}\t#{@muxa_managed_work}\t#{@muxa_external_source}\t#{@muxa_external_scope}\t#{@muxa_external_stable_id}\t#{@muxa_external_key}\t#{@muxa_external_title}\t#{@muxa_external_url}\t#{@muxa_external_status}";
 const PANE_FORMAT: &str = "#{session_name}\t#{window_id}\t#{pane_id}\t#{@muxa_agent}\t#{@muxa_agent_role}\t#{@muxa_agent_task}\t#{pane_current_command}\t#{pane_current_path}\t#{@muxa_managed_agent}\t#{@muxa_agent_workspace_id}\t#{@muxa_agent_work_id}\t#{@muxa_agent_alias}";
 const WINDOW_IDENTITY_FORMAT: &str =
     "#{window_id}\t#{session_id}\t#{session_name}\t#{window_name}\t#{automatic-rename}";
@@ -82,9 +82,6 @@ pub struct WorkInfo {
     pub cwd: PathBuf,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_item: Option<Box<ExternalItemInfo>>,
-    /// Pipeline aliases that reported finishing, in the order recorded.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub done: Vec<String>,
     pub agents: Vec<ManagedAgentPane>,
 }
 
@@ -544,10 +541,7 @@ fn work_list_table(
         let run = runs.iter().find(|run| {
             run.identity.workspace_id == work.workspace && run.identity.work_id == work.work
         });
-        let (done, total) = run.map_or_else(
-            || done_ratio(work),
-            muxa::pipeline_run::PipelineRun::completion,
-        );
+        let completion = run.map(muxa::pipeline_run::PipelineRun::completion);
         let mut row = vec![
             theme.cell(&work.work, TableTone::Accent),
             theme.cell(&work.workspace, TableTone::Dim),
@@ -559,14 +553,14 @@ fn work_list_table(
                 run.map_or_else(|| agent_summary(work), pipeline_alias_summary),
                 TableTone::Tmux,
             ),
-            match total {
-                // Not a pipeline: nothing ever reports, so a ratio would
-                // read as "0 of 1 finished" for work that is simply running.
-                0 => theme.right_cell("-", TableTone::Dim),
-                total if done == total => {
+            match completion {
+                // No Run, or a Run that named no agents: nothing here was ever
+                // asked to report, and `0/N` would say the opposite.
+                None | Some((_, 0)) => theme.right_cell("-", TableTone::Dim),
+                Some((done, total)) if done == total => {
                     theme.right_cell(format!("{done}/{total}"), TableTone::Good)
                 }
-                total => theme.right_cell(format!("{done}/{total}"), TableTone::Warn),
+                Some((done, total)) => theme.right_cell(format!("{done}/{total}"), TableTone::Warn),
             },
         ];
         if show_stage {
@@ -611,28 +605,6 @@ fn pipeline_alias_summary(run: &muxa::pipeline_run::PipelineRun) -> String {
         })
         .collect::<Vec<_>>()
         .join(" \u{b7} ")
-}
-
-/// How many of this work's pipeline agents have reported finishing.
-///
-/// Counted over *aliased* panes only: `done` records aliases, so a pane the
-/// operator opened by hand could never be in it and must not inflate the
-/// denominator.
-fn done_ratio(work: &WorkInfo) -> (usize, usize) {
-    let aliases: Vec<&str> = work
-        .agents
-        .iter()
-        .filter_map(|agent| agent.alias.as_deref())
-        .collect();
-    let done = aliases
-        .iter()
-        .filter(|alias| {
-            work.done
-                .iter()
-                .any(|reported| reported.eq_ignore_ascii_case(alias))
-        })
-        .count();
-    (done, aliases.len())
 }
 
 /// Who is in the window: pipeline aliases when it has them, otherwise the
@@ -1278,7 +1250,54 @@ mod work_list_view_tests {
         }
     }
 
-    fn work(name: &str, agents: Vec<ManagedAgentPane>, done: &[&str]) -> WorkInfo {
+    fn run(work: &str, aliases: &[(&str, bool)]) -> muxa::pipeline_run::PipelineRun {
+        use muxa::pipeline_run::{PipelineAliasState, PipelineAliasStatus};
+        muxa::pipeline_run::PipelineRun {
+            identity: muxa::work::WorkIdentity::new("callabo", work),
+            pipeline: "pair".into(),
+            desired: aliases
+                .iter()
+                .map(|(alias, _)| muxa::pipeline::DesiredAgent {
+                    alias: (*alias).to_string(),
+                    program: "claude".into(),
+                    role: None,
+                    task: None,
+                    prompt: None,
+                    direction: None,
+                    after: Vec::new(),
+                })
+                .collect(),
+            cwd: PathBuf::from("/repo"),
+            generation: 1,
+            window_id: None,
+            aliases: aliases
+                .iter()
+                .map(|(alias, done)| {
+                    (
+                        (*alias).to_string(),
+                        PipelineAliasState {
+                            alias: (*alias).to_string(),
+                            status: if *done {
+                                PipelineAliasStatus::Done
+                            } else {
+                                PipelineAliasStatus::Pending
+                            },
+                            generation: 1,
+                            completion_generation: None,
+                            pane: None,
+                            error: None,
+                            reconcile_pending: false,
+                            claim_started_at: None,
+                            updated_at: time::OffsetDateTime::UNIX_EPOCH,
+                        },
+                    )
+                })
+                .collect(),
+            updated_at: time::OffsetDateTime::UNIX_EPOCH,
+        }
+    }
+
+    fn work(name: &str, agents: Vec<ManagedAgentPane>) -> WorkInfo {
         WorkInfo {
             work: name.into(),
             workspace: "callabo".into(),
@@ -1289,7 +1308,6 @@ mod work_list_view_tests {
             window_name: name.into(),
             cwd: PathBuf::from("/repo"),
             external_item: None,
-            done: done.iter().map(|d| (*d).to_string()).collect(),
             agents,
         }
     }
@@ -1343,35 +1361,6 @@ mod work_list_view_tests {
 
     /// `done` records aliases, so only aliased panes can ever be in it. A pane
     /// the operator split by hand must not inflate the denominator and make a
-    /// converged pipeline read as unfinished.
-    #[test]
-    fn done_counts_only_pipeline_agents() {
-        let piped = work(
-            "CAL-1",
-            vec![
-                agent("%1", "claude", Some("impl")),
-                agent("%2", "codex", Some("review")),
-                agent("%3", "codex", None),
-            ],
-            &["impl", "review"],
-        );
-        assert_eq!(done_ratio(&piped), (2, 2));
-
-        let partial = work(
-            "CAL-2",
-            vec![
-                agent("%1", "claude", Some("impl")),
-                agent("%2", "codex", Some("review")),
-            ],
-            &["impl"],
-        );
-        assert_eq!(done_ratio(&partial), (1, 2));
-
-        // Hand-built window: no aliases at all, so there is no ratio to show.
-        let manual = work("ad-hoc", vec![agent("%1", "claude", None)], &[]);
-        assert_eq!(done_ratio(&manual), (0, 0));
-    }
-
     #[test]
     fn agents_read_as_aliases_or_collapsed_programs() {
         let piped = work(
@@ -1380,7 +1369,6 @@ mod work_list_view_tests {
                 agent("%1", "claude", Some("impl")),
                 agent("%2", "codex", Some("review")),
             ],
-            &[],
         );
         assert_eq!(agent_summary(&piped), "impl \u{b7} review");
 
@@ -1391,7 +1379,6 @@ mod work_list_view_tests {
                 agent("%2", "claude", None),
                 agent("%3", "codex", None),
             ],
-            &[],
         );
         assert_eq!(agent_summary(&manual), "claude x2 \u{b7} codex");
     }
@@ -1407,27 +1394,41 @@ mod work_list_view_tests {
                     agent("%1", "claude", Some("impl")),
                     agent("%2", "codex", Some("review")),
                 ],
-                &["impl", "review"],
             ),
-            work("RELEASE-1", vec![agent("%3", "claude", None)], &[]),
+            work("RELEASE-1", vec![agent("%3", "claude", None)]),
         ];
-        let out = work_list_table(&works, &[], &[], crate::theme::CliTheme::plain());
+        let runs = vec![run("CAL-1", &[("impl", true), ("review", true)])];
+        let out = work_list_table(&works, &[], &runs, crate::theme::CliTheme::plain());
         assert!(out.contains("CAL-1"), "{out}");
         assert!(out.contains("2/2"), "{out}");
-        assert!(out.contains("impl \u{b7} review"), "{out}");
-        // No pipeline aliases, so no ratio — not `0/1`.
-        assert!(!out.contains("0/1"), "{out}");
         // The stage column stays out of the way when nothing is staged.
         assert!(!out.contains("STAGE"), "{out}");
     }
 
+    /// The denominator is what the pipeline *asked for*, not what has been
+    /// launched — otherwise a pair whose reviewer has not started yet reads
+    /// `1/1`, which is indistinguishable from converged.
+    #[test]
+    fn an_unlaunched_agent_still_counts_against_the_total() {
+        let works = vec![work("CAL-1", vec![agent("%1", "claude", Some("impl"))])];
+        let runs = vec![run("CAL-1", &[("impl", true), ("review", false)])];
+        let out = work_list_table(&works, &[], &runs, crate::theme::CliTheme::plain());
+        assert!(out.contains("1/2"), "{out}");
+    }
+
+    /// A window with no Run has no completion record at all. `0/N` would say
+    /// nothing finished; the truth is that nothing here was ever asked to.
+    #[test]
+    fn a_work_without_a_run_reports_no_ratio() {
+        let works = vec![work("CAL-1", vec![agent("%1", "claude", Some("impl"))])];
+        let out = work_list_table(&works, &[], &[], crate::theme::CliTheme::plain());
+        assert!(!out.contains("0/1"), "{out}");
+        assert!(out.contains("CAL-1"), "{out}");
+    }
+
     #[test]
     fn table_uses_durable_desired_aliases_before_downstream_has_a_pane() {
-        let works = vec![work(
-            "CAL-1",
-            vec![agent("%1", "codex", Some("impl"))],
-            &["impl"],
-        )];
+        let works = vec![work("CAL-1", vec![agent("%1", "codex", Some("impl"))])];
         let out = work_list_table(
             &works,
             &[],
@@ -1449,14 +1450,6 @@ mod work_list_view_tests {
         assert!(out.contains("review:pending"), "{out}");
         assert!(out.contains("1/2"), "{out}");
     }
-}
-
-fn parse_done(raw: &str) -> Vec<String> {
-    raw.split(',')
-        .map(str::trim)
-        .filter(|alias| !alias.is_empty())
-        .map(str::to_ascii_lowercase)
-        .collect()
 }
 
 pub fn window_id_for_pane(pane: &str) -> Result<String> {
@@ -1657,7 +1650,6 @@ fn parse_work_window(
         window_name: fields[4].to_string(),
         cwd: PathBuf::from(fields[6]),
         external_item: parse_external_item(&fields),
-        done: parse_done(fields.get(15).copied().unwrap_or_default()),
         agents,
     })
 }
@@ -2001,7 +1993,6 @@ mod tests {
             window_name: work.into(),
             cwd: PathBuf::from("/work"),
             external_item: None,
-            done: Vec::new(),
             agents: Vec::new(),
         }
     }

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -5231,7 +5231,6 @@ fn finish_work_row(mut builder: WorkRowBuilder, sort_context: &SortContext<'_>) 
             },
         )
     });
-    let completion = work_completion(&builder.panes);
     WorkRow {
         display_name,
         group_key: builder.group_key,
@@ -5248,7 +5247,9 @@ fn finish_work_row(mut builder: WorkRowBuilder, sort_context: &SortContext<'_>) 
         pane_count: builder.panes.len(),
         bare_summary,
         activity: builder.activity,
-        completion,
+        // Set from the durable pipeline Run once one is matched to this row;
+        // tmux alone cannot say how far a pipeline has got.
+        completion: None,
         pipeline_run: None,
         agent_states,
     }
@@ -5317,24 +5318,6 @@ fn annotate_work_rows(rows: &mut Vec<WatchRow>, runs: &[muxa::pipeline_run::Pipe
             agent_states: HashMap::new(),
         })));
     }
-}
-
-/// Completion for the flat work row, over the same rule the topology uses —
-/// deferred to rather than restated, so the tree and the list can never
-/// disagree about whether a pipeline finished.
-fn work_completion(panes: &[PaneInfo]) -> Option<(usize, usize)> {
-    // `@muxa_work_done` is a window option, so whichever pane carries it speaks
-    // for the window.
-    let done = panes
-        .iter()
-        .find(|pane| !pane.work_done.is_empty())
-        .map(|pane| pane.work_done.clone())
-        .unwrap_or_default();
-    muxa::topology::work_completion(
-        panes.iter().filter_map(|pane| pane.agent_alias.as_deref()),
-        &done,
-    )
-    .map(|completion| (completion.done, completion.total))
 }
 
 fn build_work_rows(
@@ -5886,72 +5869,6 @@ mod work_up_key_tests {
             Action::None
         ));
         assert!(app.work_composer.is_none());
-    }
-}
-
-#[cfg(test)]
-mod work_completion_tests {
-    use super::*;
-
-    fn pane(id: &str, alias: Option<&str>, done: &[&str]) -> PaneInfo {
-        PaneInfo {
-            agent_role: None,
-            agent_alias: alias.map(Into::into),
-            work_done: done.iter().map(|d| (*d).to_string()).collect(),
-            pane_id: id.into(),
-            session_id: "$1".into(),
-            session: "callabo".into(),
-            window_id: "@1".into(),
-            window_name: "CAL-1".into(),
-            window_index: "0".into(),
-            pane_index: "0".into(),
-            tty: String::new(),
-            current_command: "claude".into(),
-            title: String::new(),
-            pane_pid: 0,
-            current_path: "/repo".into(),
-            socket: Some("default".into()),
-        }
-    }
-
-    /// The signal the TUI was missing: idle-and-converged looked exactly like
-    /// idle-and-stalled.
-    #[test]
-    fn a_converged_pipeline_reports_every_alias() {
-        let panes = vec![
-            pane("%1", Some("impl"), &["impl", "review"]),
-            pane("%2", Some("review"), &["impl", "review"]),
-        ];
-        assert_eq!(work_completion(&panes), Some((2, 2)));
-    }
-
-    #[test]
-    fn a_half_finished_pipeline_is_not_complete() {
-        let panes = vec![
-            pane("%1", Some("impl"), &["impl"]),
-            pane("%2", Some("review"), &["impl"]),
-        ];
-        assert_eq!(work_completion(&panes), Some((1, 2)));
-    }
-
-    /// A hand-split pane can never report, so counting it would show a
-    /// converged pair as 2/3 forever.
-    #[test]
-    fn hand_split_panes_stay_out_of_the_ratio() {
-        let panes = vec![
-            pane("%1", Some("impl"), &["impl", "review"]),
-            pane("%2", Some("review"), &["impl", "review"]),
-            pane("%3", None, &["impl", "review"]),
-        ];
-        assert_eq!(work_completion(&panes), Some((2, 2)));
-    }
-
-    /// A window with no pipeline at all has no completion to show — `0/1`
-    /// would libel an agent that was never asked to report.
-    #[test]
-    fn a_window_without_a_pipeline_has_no_ratio() {
-        assert_eq!(work_completion(&[pane("%1", None, &[])]), None);
-        assert_eq!(work_completion(&[]), None);
     }
 }
 
@@ -15644,7 +15561,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: pane.into(),
             session_id: String::new(),
@@ -15675,7 +15591,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: Some(socket.into()),
             pane_id: pane_id.into(),
             session_id: session_id.into(),
@@ -20097,7 +20012,6 @@ sort = ["state"]
         let panes = vec![PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: "%42".into(),
             session_id: String::new(),

--- a/crates/muxa-cli/src/work_up.rs
+++ b/crates/muxa-cli/src/work_up.rs
@@ -212,19 +212,16 @@ pub(crate) fn apply(resolved: Resolved, dry_run: bool) -> Result<UpResult> {
         bail!("non-dry pipeline reconciliation must use muxad's durable Run state");
     }
     let existing = existing_agents(&resolved.work, &resolved.workspace, &resolved.states)?;
-    // The completion set lives on the work window, so a re-run reads what
-    // previous runs' agents reported even though none of them still exist.
-    let done = if let Some(run) = resolved.durable_run.as_ref() {
+    // The durable Run is the completion record: it outlives the agents that
+    // reported, so a re-run reads what previous ones said. Before a Run is
+    // registered nothing has reported yet, which is what an empty set means.
+    let done: Vec<String> = resolved.durable_run.as_ref().map_or_else(Vec::new, |run| {
         run.aliases
             .values()
             .filter(|state| state.status == PipelineAliasStatus::Done)
             .map(|state| state.alias.clone())
             .collect()
-    } else {
-        crate::tmux_work::find_work_in(&resolved.work, Some(&resolved.workspace))?
-            .map(|info| info.done)
-            .unwrap_or_default()
-    };
+    });
     let broadcast = resolved
         .request
         .as_ref()
@@ -1675,7 +1672,6 @@ mod tests {
             window_name: "CAL-1".into(),
             cwd: PathBuf::from("/tmp/already-here"),
             external_item: None,
-            done: Vec::new(),
             agents: Vec::new(),
         };
         let (cwd, worktree, created) =

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -504,7 +504,6 @@ fn to_pane_info(pane: &HerdrPaneInfo, process: Option<&HerdrProcessInfo>) -> Pan
     PaneInfo {
         agent_role: None,
         agent_alias: None,
-        work_done: Vec::new(),
         pane_id: format!("{PANE_ID_PREFIX}{}", pane.pane_id),
         session_id: pane.workspace_id.clone(),
         session: pane.workspace_id.clone(),

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -965,7 +965,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/backend/zellij.rs
+++ b/crates/muxa/src/backend/zellij.rs
@@ -222,7 +222,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -1645,7 +1645,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             pane_id: pane_id.into(),
             session_id: "$1".into(),
             session: "main".into(),

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -2350,7 +2350,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: pane_id.into(),
             session_id: session_id.into(),
@@ -2720,7 +2719,6 @@ mod tests {
         let herdr = scanner::herdr_scan_result(vec![crate::tmux::PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: "herdr:p1".into(),
             session_id: "ws1".into(),
@@ -2750,7 +2748,6 @@ mod tests {
             vec![crate::tmux::PaneInfo {
                 agent_role: None,
                 agent_alias: None,
-                work_done: Vec::new(),
                 socket: Some("/tmp/rmux-user/default".into()),
                 pane_id: "rmux:%4".into(),
                 session_id: "$1".into(),
@@ -2782,7 +2779,6 @@ mod tests {
             panes: vec![crate::tmux::PaneInfo {
                 agent_role: None,
                 agent_alias: None,
-                work_done: Vec::new(),
                 socket: Some("/tmp/rmux-secondary/default".into()),
                 pane_id: "rmux:%8".into(),
                 session_id: "$2".into(),

--- a/crates/muxa/src/discovery.rs
+++ b/crates/muxa/src/discovery.rs
@@ -407,7 +407,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -3834,7 +3834,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             pane_id: pane_id.into(),
             session_id: "$1".into(),
             session: "collaboration".into(),
@@ -5078,7 +5077,6 @@ mod tests {
         let pane = PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: "zellij:3".into(),
             session_id: String::new(),

--- a/crates/muxa/src/reconcile.rs
+++ b/crates/muxa/src/reconcile.rs
@@ -701,7 +701,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -2561,7 +2561,6 @@ mod tests {
         let pane = PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: "%1".into(),
             session_id: String::new(),
@@ -4354,7 +4353,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -508,13 +508,6 @@ pub struct PaneInfo {
     /// `review`). Same provenance and caveats as [`Self::agent_role`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_alias: Option<String>,
-    /// `@muxa_work_done` — the aliases that have reported finishing on this
-    /// pane's *work*. A window option, so every pane of one work carries the
-    /// same list; it rides along here so a reader that already has the panes
-    /// can tell a converged pipeline from a stalled one without a second
-    /// tmux round trip.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub work_done: Vec<String>,
 }
 
 /// The short display name for a tmux socket path: its file basename
@@ -575,7 +568,7 @@ pub struct ClientInfo {
 /// `tmux -F` format string for `list-panes`. Tab-separated columns parsed
 /// in `parse_pane_lines`. Kept `pub(crate)` so [`scanner`] can reuse it.
 pub(crate) const PANE_FMT: &str =
-    "#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_tty}\t#{pane_current_command}\t#{pane_title}\t#{pane_pid}\t#{pane_current_path}\t#{session_id}\t#{window_id}\t#{window_name}\t#{@muxa_workspace_id}\t#{@muxa_workspace_cwd}\t#{@muxa_managed_workspace}\t#{@muxa_work_id}\t#{@muxa_work_cwd}\t#{@muxa_managed_work}\t#{@muxa_agent}\t#{@muxa_agent_role}\t#{@muxa_agent_task}\t#{@muxa_managed_agent}\t#{@muxa_agent_workspace_id}\t#{@muxa_agent_work_id}\t#{@muxa_external_source}\t#{@muxa_external_scope}\t#{@muxa_external_stable_id}\t#{@muxa_external_key}\t#{@muxa_external_title}\t#{@muxa_external_url}\t#{@muxa_external_status}\t#{@muxa_agent_alias}\t#{@muxa_work_done}";
+    "#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_tty}\t#{pane_current_command}\t#{pane_title}\t#{pane_pid}\t#{pane_current_path}\t#{session_id}\t#{window_id}\t#{window_name}\t#{@muxa_workspace_id}\t#{@muxa_workspace_cwd}\t#{@muxa_managed_workspace}\t#{@muxa_work_id}\t#{@muxa_work_cwd}\t#{@muxa_managed_work}\t#{@muxa_agent}\t#{@muxa_agent_role}\t#{@muxa_agent_task}\t#{@muxa_managed_agent}\t#{@muxa_agent_workspace_id}\t#{@muxa_agent_work_id}\t#{@muxa_external_source}\t#{@muxa_external_scope}\t#{@muxa_external_stable_id}\t#{@muxa_external_key}\t#{@muxa_external_title}\t#{@muxa_external_url}\t#{@muxa_external_status}\t#{@muxa_agent_alias}";
 
 pub(crate) const SESSION_FMT: &str = "#{session_id}\t#{session_name}\t#{session_attached}";
 pub(crate) const CLIENT_FMT: &str =
@@ -625,15 +618,6 @@ pub(crate) fn parse_pane_lines_for_socket(stdout: &str, socket: Option<&str>) ->
             socket: socket.map(Into::into),
             agent_role: non_empty(cols.get(19)),
             agent_alias: non_empty(cols.get(31)),
-            work_done: non_empty(cols.get(32))
-                .map(|raw| {
-                    raw.split(',')
-                        .map(str::trim)
-                        .filter(|alias| !alias.is_empty())
-                        .map(str::to_ascii_lowercase)
-                        .collect()
-                })
-                .unwrap_or_default(),
         });
     }
     panes
@@ -1252,7 +1236,6 @@ mod tests {
         assert_eq!(pane.pane_id, "%1");
         assert_eq!(pane.agent_role, None);
         assert_eq!(pane.agent_alias, None);
-        assert!(pane.work_done.is_empty());
     }
 
     /// And the reverse: an unaliased pane must not grow the payload it sends
@@ -1262,7 +1245,6 @@ mod tests {
         let pane = PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             pane_id: "%1".into(),
             session_id: String::new(),
             session: "s".into(),
@@ -1280,7 +1262,6 @@ mod tests {
         let json = serde_json::to_string(&pane).expect("serialize");
         assert!(!json.contains("agent_role"), "{json}");
         assert!(!json.contains("agent_alias"), "{json}");
-        assert!(!json.contains("work_done"), "{json}");
     }
 
     #[test]

--- a/crates/muxa/src/tmux/scanner.rs
+++ b/crates/muxa/src/tmux/scanner.rs
@@ -582,7 +582,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: None,
             pane_id: id.into(),
             session_id: String::new(),

--- a/crates/muxa/src/topology.rs
+++ b/crates/muxa/src/topology.rs
@@ -222,9 +222,13 @@ pub struct WindowNode {
     pub cwd: Option<String>,
     pub states: StateDistribution,
     pub panes: Vec<PaneNode>,
-    /// How far this window's pipeline has reported, or `None` when the window
-    /// is not a pipeline. Computed here so every surface — TUI tree, flat
-    /// list, dashboard — reads the same number instead of each deriving it.
+    /// How far this window's pipeline has reported, or `None` when nothing
+    /// knows.
+    ///
+    /// The durable pipeline Run is the only source: it holds both what the
+    /// pipeline asked for and what reported back. tmux carries neither, so
+    /// `TopologySnapshot::build` leaves this `None` and the surfaces that can
+    /// reach a Run fill it in.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completion: Option<WorkCompletion>,
     /// Durable daemon-owned pipeline state, when this window is bound to a
@@ -438,11 +442,7 @@ impl TopologySnapshot {
                     },
                     index: pane.window_index.clone(),
                     panes: Vec::new(),
-                    done: Vec::new(),
                 });
-            if window.done.is_empty() {
-                window.done.clone_from(&pane.work_done);
-            }
             window.panes.push(PaneNode {
                 key: pane_key,
                 index: pane.pane_index,
@@ -545,9 +545,6 @@ struct WindowBuilder {
     name: String,
     index: String,
     panes: Vec<PaneNode>,
-    /// Aliases this window has recorded as finished, from `@muxa_work_done`.
-    /// A window option, so whichever pane is seen first supplies it.
-    done: Vec<String>,
 }
 
 impl WindowBuilder {
@@ -562,12 +559,6 @@ impl WindowBuilder {
         for agent in self.panes.iter().filter_map(|pane| pane.agent.as_ref()) {
             states.add(agent.state);
         }
-        let completion = work_completion(
-            self.panes
-                .iter()
-                .filter_map(|pane| pane.agent_alias.as_deref()),
-            &self.done,
-        );
         WindowNode {
             key: self.key,
             name: self.name,
@@ -575,37 +566,12 @@ impl WindowBuilder {
             cwd,
             states,
             panes: self.panes,
-            completion,
+            // Both are filled in by whoever holds the durable pipeline Run;
+            // the tmux topology cannot know either.
+            completion: None,
             pipeline_run: None,
         }
     }
-}
-
-/// Completion over the *aliased* panes only.
-///
-/// `@muxa_work_done` records aliases, so a pane the operator split by hand can
-/// never appear in it; counting it would show a converged pair as 2/3 forever.
-/// A window with no aliases was never a pipeline and gets `None` rather than
-/// `0/1`, which would libel an agent nobody asked to report.
-pub fn work_completion<'a>(
-    aliases: impl IntoIterator<Item = &'a str>,
-    done: &[String],
-) -> Option<WorkCompletion> {
-    let aliases: Vec<&str> = aliases.into_iter().collect();
-    if aliases.is_empty() {
-        return None;
-    }
-    let reported = aliases
-        .iter()
-        .filter(|alias| {
-            done.iter()
-                .any(|reported| reported.eq_ignore_ascii_case(alias))
-        })
-        .count();
-    Some(WorkCompletion {
-        done: reported,
-        total: aliases.len(),
-    })
 }
 
 fn numeric_index(value: &str) -> u64 {
@@ -708,7 +674,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             pane_id: "%1".into(),
             session_id: "$1".into(),
             session: session_name.into(),

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -2285,7 +2285,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             pane_id: pane_id.into(),
             session_id: "$1".into(),
             session: "collaboration".into(),

--- a/crates/muxad/src/screen_detect.rs
+++ b/crates/muxad/src/screen_detect.rs
@@ -441,7 +441,6 @@ mod tests {
         PaneInfo {
             agent_role: None,
             agent_alias: None,
-            work_done: Vec::new(),
             socket: Some("default".into()),
             pane_id: pane_id.into(),
             session_id: String::new(),


### PR DESCRIPTION
Follow-up to the note left in #84.

Since #82 moved completion into the pipeline Run store, nothing writes
`@muxa_work_done` any more — but the readers stayed. `PaneInfo::work_done`,
`WorkInfo::done`, their two tmux format columns, and
`topology::work_completion` all still derived a ratio from an option with no
writer.

I called it dead weight in #84. Looking again, it lies in one case. The
aliases those functions count come from `@muxa_agent_alias`, which *is* still
written, so a work window with no registered Run reported `0/N` — "N agents,
none finished". The truth is that nothing there had a completion record at
all. Those are different statements, and the first is the one an operator
acts on.

`work list` now shows `-` there, which is what it already said for a window
that was never a pipeline. Every live path already preferred the Run, so
nothing changes for a work `muxa work up` created; what changes is that the
fallback no longer invents an answer. `WindowNode::completion` starts out
`None` for whoever holds the Run to fill in, instead of being computed twice
from two different sources that could disagree.

The tests move with it. They build a `PipelineRun` rather than a tmux marker,
and pin the property that motivated the denominator in the first place: an
agent the pipeline named but has not launched still counts, so a pair whose
reviewer has not started reads `1/2` rather than the `1/1` that is
indistinguishable from converged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
