### PR TITLE
fix(watch): address jump targets by session, not just pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,7 +217,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   separate. Jumps now address the window as `<session_id>:<window_id>`,
   preferring the asking client's own session when the window is linked there
   and otherwise the pane's recorded session, so a cross-session jump is
-  deterministic instead of activity-dependent.
+  deterministic instead of activity-dependent. The bare-shell path carried the
+  same defect more visibly — its pre-attach `select-window` moved a grouped
+  bystander session and left the session it then attached to on the wrong
+  window — and it now targets the session it is about to attach. That attach
+  also addresses the session by id rather than by name, which matched by
+  prefix (`callabo` against `callabo-set`).
 
 - **`muxa upgrade` no longer strands an old daemon when no service manager is
   usable.** A capable muxad now drains and re-execs itself on the exact socket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Jumping from watch no longer drags a second terminal off its window.** The
+  jump addressed the target as a bare pane id, which names a pane but not a
+  session; tmux filled the gap from recent client activity. Under a session
+  group — `tmux new-session -t <session>`, the supported way to keep two
+  terminals on two Work windows of one workspace — the same window is linked
+  into several sessions, and the guess was routinely wrong: measured on tmux
+  3.4, jumping one client pulled it into the grouped sibling and dragged the
+  other terminal's view along, re-coupling the terminals the group exists to
+  separate. Jumps now address the window as `<session_id>:<window_id>`,
+  preferring the asking client's own session when the window is linked there
+  and otherwise the pane's recorded session, so a cross-session jump is
+  deterministic instead of activity-dependent.
+
 - **`muxa upgrade` no longer strands an old daemon when no service manager is
   usable.** A capable muxad now drains and re-execs itself on the exact socket
   being upgraded, preserving its pid and launch context. The CLI confirms the

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -1687,26 +1687,65 @@ fn window_target(session_id: Option<&str>, window_id: &str, pane_id: &str) -> St
     }
 }
 
-/// Stable `$N` session id a jump should address on behalf of `client`.
+/// Session target for `attach-session`: the stable `$N` id when the scan
+/// carried one, else the session name.
 ///
-/// Prefers the session the asking client is *already* in whenever the target
-/// window is linked into it: inside a session group that makes the jump a pure
-/// window change, so no sibling session — and therefore no other terminal —
-/// moves. Otherwise this is a genuine cross-session jump, and `pane_session`
-/// (the session recorded for the pane itself) names a definite destination
-/// where tmux would otherwise pick one from client activity.
+/// Ids are exact. Names match by prefix unless anchored with `=`, and real
+/// session sets collide — `callabo` also matches `callabo-set`, so a
+/// name-targeted attach can hand the terminal to the wrong workspace. The
+/// name stays as a fallback only because a row parsed from an older
+/// `PANE_FMT` has no session id to use.
+fn session_target<'a>(session_id: &'a str, session_name: &'a str) -> &'a str {
+    if session_id.is_empty() {
+        session_name
+    } else {
+        session_id
+    }
+}
+
+/// Choose which session a jump should address, given the asking client's
+/// current session and the session recorded for the target pane.
 ///
-/// `None` only when neither is known, leaving [`window_target`] to fall back.
+/// Prefers the client's own session whenever the target window is linked into
+/// it: inside a session group that makes the jump a pure window change, so no
+/// sibling session — and therefore no other terminal — moves. Otherwise this
+/// is a genuine cross-session jump, and `pane_session` names a definite
+/// destination where tmux would otherwise pick one from client activity.
+///
+/// `window_linked` is the membership probe, taken as a closure so the decision
+/// is testable without a tmux server, and called *only* when it can change the
+/// answer. Identical session ids already imply membership — the ordinary
+/// same-session jump — so that case is answered without a round trip.
+///
+/// `None` only when neither session is known, leaving [`window_target`] to
+/// fall back to the bare pane id.
+fn resolve_jump_session(
+    client_session: Option<String>,
+    pane_session: &str,
+    window_linked: impl FnOnce(&str) -> bool,
+) -> Option<String> {
+    let fallback = || (!pane_session.is_empty()).then(|| pane_session.to_string());
+    let Some(client_session) = client_session.filter(|session| !session.is_empty()) else {
+        return fallback();
+    };
+    if client_session == pane_session || window_linked(&client_session) {
+        return Some(client_session);
+    }
+    fallback()
+}
+
+/// [`resolve_jump_session`] wired to tmux on the server named by `socket`.
 fn jump_session_id(
     socket: Option<&str>,
     client: Option<&str>,
     window_id: &str,
     pane_session: &str,
 ) -> Option<String> {
-    let own = client
-        .and_then(|client| muxa::tmux::client_session_id_on(socket, client))
-        .filter(|session| muxa::tmux::window_in_session_on(socket, session, window_id));
-    own.or_else(|| (!pane_session.is_empty()).then(|| pane_session.to_string()))
+    resolve_jump_session(
+        client.and_then(|client| muxa::tmux::client_session_id_on(socket, client)),
+        pane_session,
+        |session| muxa::tmux::window_in_session_on(socket, session, window_id),
+    )
 }
 
 fn jump_to_pane_tmux_key(key: &muxa::PaneKey) {
@@ -1737,7 +1776,17 @@ fn jump_to_pane_tmux_key(key: &muxa::PaneKey) {
         return;
     }
 
-    run(&["select-window", "-t", pane]);
+    // Pre-position the session we are about to attach to. Its id is already
+    // in the key, so qualify the window with it rather than letting a bare
+    // pane id send `select-window` at a grouped sibling — that would move a
+    // window in a session some *other* terminal is looking at, before this
+    // terminal has even attached.
+    let target = window_target(
+        Some(key.window.session.session_id.as_str()),
+        &key.window.window_id,
+        pane,
+    );
+    run(&["select-window", "-t", &target]);
     run(&["select-pane", "-t", pane]);
     match muxa::tmux::tmux_command_on(socket)
         .args([
@@ -1888,14 +1937,24 @@ fn jump_to_pane_tmux(pane_id: &str) {
         run_tmux(&["select-pane", "-t", pane_id]);
     } else {
         // Pre-position for the fresh attach below; there is no client of
-        // ours yet to pin, and the session is about to become ours.
-        run_tmux(&["select-window", "-t", pane_id]);
+        // ours yet to pin, and the session is about to become ours. Qualify
+        // the window with that session all the same: a bare pane id lets
+        // `select-window` land on a grouped sibling and move a window some
+        // other terminal is looking at, before we have attached anywhere.
+        let target = window_target(Some(&info.session_id), &info.window_id, pane_id);
+        run_tmux(&["select-window", "-t", &target]);
         run_tmux(&["select-pane", "-t", pane_id]);
         // Bare shell — hand our terminal to a fresh tmux attach-session.
+        // Target the session by id: names match by prefix unless anchored,
+        // and real session sets collide (`callabo` against `callabo-set`).
         // `.status()` waits for tmux to exit; on detach the user is back at
         // this shell prompt, which is the least-surprising behaviour.
         match muxa::tmux::tmux_command()
-            .args(["attach-session", "-t", &info.session])
+            .args([
+                "attach-session",
+                "-t",
+                session_target(&info.session_id, &info.session),
+            ])
             .status()
         {
             Ok(s) if s.success() => {}
@@ -2693,6 +2752,63 @@ mod tests {
         assert_eq!(window_target(None, "@4", "%9"), "%9");
         assert_eq!(window_target(Some("$1"), "", "%9"), "%9");
         assert_eq!(window_target(Some(""), "@4", "%9"), "%9");
+    }
+
+    #[test]
+    fn jump_stays_in_the_asking_client_session_without_probing() {
+        // The ordinary same-session jump: the ids already match, so the
+        // membership probe — a tmux round trip on a keypress path — must not
+        // run at all.
+        let answer = resolve_jump_session(Some("$0".into()), "$0", |_| {
+            panic!("probed tmux for a session we already know matches")
+        });
+        assert_eq!(answer.as_deref(), Some("$0"));
+    }
+
+    #[test]
+    fn jump_stays_in_the_asking_client_session_when_the_window_is_linked() {
+        // The session-group case, and the whole point of the change: the pane
+        // is recorded under `$0`, but the asking client sits in the grouped
+        // sibling `$1` where that window is linked too. Answering `$1` keeps
+        // this terminal in its own session, so `$0` — and whoever is looking
+        // at it — never moves.
+        let answer = resolve_jump_session(Some("$1".into()), "$0", |session| {
+            assert_eq!(session, "$1");
+            true
+        });
+        assert_eq!(answer.as_deref(), Some("$1"));
+    }
+
+    #[test]
+    fn jump_crosses_to_the_pane_session_when_the_window_is_not_linked() {
+        // A genuine cross-session jump. The pane's own session is a definite
+        // destination; tmux would otherwise choose one from client activity.
+        let answer = resolve_jump_session(Some("$1".into()), "$0", |_| false);
+        assert_eq!(answer.as_deref(), Some("$0"));
+    }
+
+    #[test]
+    fn jump_falls_back_when_the_client_session_is_unknown() {
+        // No caller client, or a client that detached mid-call: the pane's
+        // session still beats letting tmux guess.
+        assert_eq!(
+            resolve_jump_session(None, "$0", |_| unreachable!()).as_deref(),
+            Some("$0")
+        );
+        assert_eq!(
+            resolve_jump_session(Some(String::new()), "$0", |_| unreachable!()).as_deref(),
+            Some("$0")
+        );
+        // Neither known — `window_target` degrades to the bare pane id.
+        assert_eq!(resolve_jump_session(None, "", |_| unreachable!()), None);
+    }
+
+    #[test]
+    fn session_target_prefers_the_stable_id_over_the_name() {
+        // `callabo` matches `callabo-set` by prefix; `$3` matches nothing else.
+        assert_eq!(session_target("$3", "callabo"), "$3");
+        // Only a row with no id at all falls back to the ambiguous name.
+        assert_eq!(session_target("", "callabo"), "callabo");
     }
 
     fn agent(session_id: &str, pane: Option<&str>, state: AgentState, prompt: &str) -> Agent {

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -1661,6 +1661,54 @@ fn jump_to_topology_pane(key: &muxa::PaneKey) {
     }
 }
 
+/// Address for the *window* half of a jump.
+///
+/// `switch-client -t %pane` names a pane but not a session, and tmux fills the
+/// gap from recent client activity. That is unambiguous only while every
+/// window belongs to exactly one session. A **session group** — created by
+/// `tmux new-session -t <session>`, the supported way to keep two terminals on
+/// two different windows of one workspace — links the same window into every
+/// session in the group, and there the guess is routinely wrong. Measured on
+/// tmux 3.4 with two attached clients: jumping client A pulled it out of its
+/// own session into the grouped sibling and dragged client B's view along with
+/// it, re-coupling the two terminals the group exists to separate.
+///
+/// `<session_id>:<window_id>` closes the gap. Both are backend-native ids, so
+/// neither can prefix-match a neighbouring object the way session *names* do
+/// (`callabo` against `callabo-set`), and together they name exactly one
+/// window in exactly one session. Falls back to the bare pane id when no
+/// session id is known, which is the behaviour every jump had before.
+fn window_target(session_id: Option<&str>, window_id: &str, pane_id: &str) -> String {
+    match session_id {
+        Some(session) if !session.is_empty() && !window_id.is_empty() => {
+            format!("{session}:{window_id}")
+        }
+        _ => pane_id.to_string(),
+    }
+}
+
+/// Stable `$N` session id a jump should address on behalf of `client`.
+///
+/// Prefers the session the asking client is *already* in whenever the target
+/// window is linked into it: inside a session group that makes the jump a pure
+/// window change, so no sibling session — and therefore no other terminal —
+/// moves. Otherwise this is a genuine cross-session jump, and `pane_session`
+/// (the session recorded for the pane itself) names a definite destination
+/// where tmux would otherwise pick one from client activity.
+///
+/// `None` only when neither is known, leaving [`window_target`] to fall back.
+fn jump_session_id(
+    socket: Option<&str>,
+    client: Option<&str>,
+    window_id: &str,
+    pane_session: &str,
+) -> Option<String> {
+    let own = client
+        .and_then(|client| muxa::tmux::client_session_id_on(socket, client))
+        .filter(|session| muxa::tmux::window_in_session_on(socket, session, window_id));
+    own.or_else(|| (!pane_session.is_empty()).then(|| pane_session.to_string()))
+}
+
 fn jump_to_pane_tmux_key(key: &muxa::PaneKey) {
     let socket = Some(key.window.session.endpoint.socket.as_str());
     let pane = key.pane_id.as_str();
@@ -1671,12 +1719,20 @@ fn jump_to_pane_tmux_key(key: &muxa::PaneKey) {
     };
     if tmux::inside_tmux() {
         let pinned = CALLER_CLIENT.get().cloned().or_else(tmux::current_client);
+        // Address the window by session, not just by pane — see `window_target`.
+        let session = jump_session_id(
+            socket,
+            pinned.as_deref(),
+            &key.window.window_id,
+            &key.window.session.session_id,
+        );
+        let target = window_target(session.as_deref(), &key.window.window_id, pane);
         if let Some(client) = pinned.as_deref() {
-            run(&["switch-client", "-c", client, "-t", pane]);
+            run(&["switch-client", "-c", client, "-t", &target]);
         } else {
-            run(&["switch-client", "-t", pane]);
+            run(&["switch-client", "-t", &target]);
         }
-        run(&["select-window", "-t", pane]);
+        run(&["select-window", "-t", &target]);
         run(&["select-pane", "-t", pane]);
         return;
     }
@@ -1787,10 +1843,11 @@ fn jump_to_pane_tmux(pane_id: &str) {
         return;
     };
     if tmux::inside_tmux() {
-        // One command, addressed by pane id, pinned to the asking client.
+        // Switch after pre-positioning, addressed by stable ids, pinned to
+        // the asking client.
         //
-        // Each of those three matters, and the previous version had none
-        // of them. It pre-positioned with `select-window -t "<name>:<idx>"`
+        // Each of those three matters, and the version before them had
+        // none. It pre-positioned with `select-window -t "<name>:<idx>"`
         // *before* switching anyone: that mutates the target session's
         // current window immediately, so any other terminal already
         // attached to that session jumped on the spot — a window the user
@@ -1802,27 +1859,32 @@ fn jump_to_pane_tmux(pane_id: &str) {
         // activity, which with two terminals attached is routinely the
         // other one.
         //
-        // `switch-client -t <pane-id>` resolves session, window and pane
-        // together from an identifier that cannot be ambiguous, and only
-        // for the client we name.
+        // A pane id alone is *not* the unambiguous identifier it looks
+        // like. It names one pane, but `switch-client` needs a session,
+        // and a window can be linked into more than one — that is exactly
+        // what a session group is. `window_target` explains what tmux does
+        // with the ambiguity and why the answer is wrong often enough to
+        // matter. Address the window by `<session_id>:<window_id>` instead.
         // Prefer the binding-expanded client: it names who pressed the key.
         // `current_client()` is an activity-based guess and only acceptable
         // when nothing better exists (an old binding without the flag);
         // unpinned is last, safe only when a single client is attached.
         let pinned = CALLER_CLIENT.get().cloned().or_else(tmux::current_client);
+        let session = jump_session_id(None, pinned.as_deref(), &info.window_id, &info.session_id);
+        let target = window_target(session.as_deref(), &info.window_id, pane_id);
         if let Some(client) = pinned {
-            run_tmux(&["switch-client", "-c", &client, "-t", pane_id]);
+            run_tmux(&["switch-client", "-c", &client, "-t", &target]);
         } else {
-            run_tmux(&["switch-client", "-t", pane_id]);
+            run_tmux(&["switch-client", "-t", &target]);
         }
-        // `switch-client -t <pane>` resolves only the *session*: the client
-        // lands on whatever window that session had current, which in a
-        // multi-window session is not the pane's window. Selecting the
-        // window *after* the switch confines the shared-state mutation to
-        // the session we are entering — clients attached to it follow, which
-        // is tmux's model for a session's current window, but no bystander
-        // session is touched the way the old pre-switch select-window did.
-        run_tmux(&["select-window", "-t", pane_id]);
+        // Selecting the window *after* the switch confines the shared-state
+        // mutation to the session we are entering — clients attached to *it*
+        // follow, which is tmux's model for a session's current window, but
+        // no bystander session is touched the way the old pre-switch
+        // select-window did. With the session-qualified target above, a
+        // grouped sibling is a bystander too: it keeps its own current
+        // window, so the other terminal stays where the user left it.
+        run_tmux(&["select-window", "-t", &target]);
         run_tmux(&["select-pane", "-t", pane_id]);
     } else {
         // Pre-position for the fresh attach below; there is no client of
@@ -2614,6 +2676,23 @@ mod tests {
         // Unrecognized ids fall back to the process-global host.
         assert_eq!(dispatch_kind("legacy-id", HostKind::Tmux), HostKind::Tmux);
         assert_eq!(dispatch_kind("legacy-id", HostKind::Herdr), HostKind::Herdr);
+    }
+
+    #[test]
+    fn window_target_qualifies_the_window_with_its_session() {
+        // The whole point: a window addressed together with its session
+        // cannot be resolved into a *different* session of the same group.
+        assert_eq!(window_target(Some("$1"), "@4", "%9"), "$1:@4");
+    }
+
+    #[test]
+    fn window_target_falls_back_to_the_pane_id() {
+        // No session, no window, or an empty id from an older PANE_FMT: the
+        // pane id is what every jump used before, so degrade to it rather
+        // than emit a malformed target like `:@4` that tmux would reject.
+        assert_eq!(window_target(None, "@4", "%9"), "%9");
+        assert_eq!(window_target(Some("$1"), "", "%9"), "%9");
+        assert_eq!(window_target(Some(""), "@4", "%9"), "%9");
     }
 
     fn agent(session_id: &str, pane: Option<&str>, state: AgentState, prompt: &str) -> Agent {

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -933,6 +933,79 @@ pub fn current_client() -> Option<String> {
     (!client.is_empty()).then(|| client.to_string())
 }
 
+/// The stable session id (`$N`) the named client is currently attached to,
+/// on the server identified by `socket` (`None` ⇒ env-scoped default).
+///
+/// Pinned with `-t <client>` so the answer describes *that* terminal.
+/// An unpinned `display-message` resolves against whichever client tmux
+/// last saw activity on, which with two terminals attached is routinely
+/// the other one — the same hazard [`current_client`] documents.
+///
+/// `None` when tmux is unavailable, the client has detached mid-call, or
+/// the field comes back empty; callers treat that as "session unknown".
+pub fn client_session_id_on(socket: Option<&str>, client: &str) -> Option<String> {
+    let mut cmd = tmux_command_targeting(socket);
+    cmd.args(["display-message", "-p", "-t", client, "#{session_id}"]);
+    let out = command_output_with_timeout(
+        cmd,
+        TMUX_COMMAND_TIMEOUT,
+        format!("tmux display-message -t {client}"),
+    )
+    .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(out.stdout).ok()?;
+    let session = stdout.lines().next().unwrap_or("").trim();
+    (!session.is_empty()).then(|| session.to_string())
+}
+
+/// Whether `window_id` (`@N`) is linked into the session `session_id` (`$N`)
+/// on `socket`.
+///
+/// One window belongs to exactly one session in an ordinary tmux server, so
+/// this is normally just "is that the pane's session". It stops being a
+/// tautology under a *session group* (`tmux new-session -t <session>`), where
+/// one window is linked into every session in the group — which is what the
+/// jump path needs to know before it can address a window without guessing.
+///
+/// `false` on any failure: the caller's fallback is the un-qualified target
+/// it used before, so a failed probe degrades to the old behaviour rather
+/// than to a broken one.
+pub fn window_in_session_on(socket: Option<&str>, session_id: &str, window_id: &str) -> bool {
+    if session_id.is_empty() || window_id.is_empty() {
+        return false;
+    }
+    let mut cmd = tmux_command_targeting(socket);
+    cmd.args(["list-windows", "-t", session_id, "-F", "#{window_id}"]);
+    let Ok(out) = command_output_with_timeout(
+        cmd,
+        TMUX_COMMAND_TIMEOUT,
+        format!("tmux list-windows -t {session_id}"),
+    ) else {
+        return false;
+    };
+    if !out.status.success() {
+        return false;
+    }
+    let Ok(stdout) = String::from_utf8(out.stdout) else {
+        return false;
+    };
+    window_listed(&stdout, window_id)
+}
+
+/// Whether `list-windows -F '#{window_id}'` output contains exactly
+/// `window_id`.
+///
+/// Split out from [`window_in_session_on`] so the match rule is testable
+/// without a tmux server. Equality, never a prefix or substring: tmux window
+/// ids are `@` plus a decimal counter, so `@1` is a prefix of `@10` and a
+/// looser rule would report a window as linked into a session that has a
+/// different, higher-numbered one.
+fn window_listed(stdout: &str, window_id: &str) -> bool {
+    stdout.lines().any(|line| line.trim() == window_id)
+}
+
 pub fn current_pane() -> Option<String> {
     if let Some(p) = std::env::var("TMUX_PANE").ok().filter(|s| !s.is_empty()) {
         return Some(p);
@@ -1031,6 +1104,26 @@ pub(crate) fn parse_pane_pid_map(stdout: &str) -> std::collections::HashMap<u32,
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn window_listed_matches_whole_ids_only() {
+        let listing = "@0\n@1\n@12\n";
+        assert!(window_listed(listing, "@1"));
+        assert!(window_listed(listing, "@12"));
+        // `@1` is a prefix of `@12`, and `@2` a suffix — neither is a match.
+        assert!(!window_listed(listing, "@2"));
+        assert!(!window_listed(listing, "@120"));
+        // `lines()` yields no entry for the trailing newline, so an empty
+        // needle finds nothing here either; `window_in_session_on` rejects
+        // an empty id up front regardless.
+        assert!(!window_listed(listing, ""));
+    }
+
+    #[test]
+    fn window_listed_tolerates_padding_and_empty_output() {
+        assert!(window_listed("  @7  \n", "@7"));
+        assert!(!window_listed("", "@7"));
+    }
 
     /// Locks the `send-keys` argv shape: literal (`-l`) injection targeting
     /// the pane id, with `--` terminating options and the text passed verbatim

--- a/docs/WATCH.ko.md
+++ b/docs/WATCH.ko.md
@@ -290,12 +290,30 @@ tmux set-option -t "$new" destroy-unattached on
 `command-alias`로는 안 됩니다. tmux는 내장 명령 이름을 alias보다 먼저 해석하므로
 `attach-session` alias는 참조되지 않습니다.
 
-window 크기를 session에 붙은 가장 작은 client가 아니라 실제로 그 window를 보는
-client 기준으로 잡으려면 `aggressive-resize`를 함께 켜는 편이 좋습니다.
+window 크기를 session에 붙은 가장 작은 client가 아니라 실제로 그 window를 보고
+있는 터미널 기준으로 잡으려면 window 단위 sizing을 함께 켭니다.
 
 ```tmux
+set -g window-size smallest
 setw -g aggressive-resize on
 ```
+
+두 줄 모두 필요하며 `aggressive-resize`만으로는 아무 효과가 없습니다 — 이 옵션은
+`window-size`가 `smallest` 또는 `largest`인 window에만 적용되는데 tmux 3.x의
+기본값은 `latest`입니다. tmux 3.4에서 200x50과 80x24 client를 각각 다른 window에
+두고 실측한 결과:
+
+| 설정 | 200x50 client가 보는 window | 80x24 client가 보는 window |
+| --- | --- | --- |
+| `window-size latest` (기본값) | 80x23 | 80x23 |
+| `smallest` + `aggressive-resize on` | **200x49** | 80x23 |
+| `smallest` + `aggressive-resize off` | 80x23 | 80x23 |
+
+`smallest` 단독은 전형적인 함정입니다 — 어디든 작은 client가 하나 붙어 있으면
+내 window가 쪼그라듭니다. `aggressive-resize`가 "아무 client"를 "이 window를
+current로 갖는 client"로 좁혀 주는데, 이것이 위에서 만든 view 분리와 정확히
+맞물립니다. 터미널이 하나뿐이면 smallest가 곧 그 터미널이므로 일반적인 단일
+터미널 사용에는 변화가 없습니다.
 
 watch에서 `Enter`로 이동할 때는 대상 window를 session까지 포함해 지정하므로, 요청한
 터미널만 움직이고 group의 다른 session은 보고 있던 window를 유지합니다. 이때 watch가

--- a/docs/WATCH.ko.md
+++ b/docs/WATCH.ko.md
@@ -239,6 +239,44 @@ bind-key D display-popup -E -w 95% -h 90% "muxa dashboard"
 `prefix+s`가 관측과 협업의 기본 진입점입니다. `prefix+D`는 더 상세한 Dashboard를
 바로 여는 선택 단축키입니다.
 
+## 한 workspace를 터미널 두 개로 보기
+
+tmux session은 current window를 하나만 가지며, attach된 모든 client가 그 window를
+봅니다. 따라서 같은 session에 두 터미널을 붙이면 서로 다른 Work window에 머무를 수
+없고, 한쪽에서 window를 바꾸면 다른 쪽도 따라갑니다. muxa의 제약이 아니라 tmux의
+모델입니다.
+
+한 workspace의 Work Run 두 개를 나란히 보려면 두 번째 터미널을 *session group*으로
+attach하세요. window는 그대로 공유하되 group 안의 각 session이 자기 current window를
+따로 가집니다.
+
+```sh
+# 터미널 1
+tmux attach -t callabo
+
+# 터미널 2 — 같은 window, 독립적인 view, detach하면 사라짐
+tmux new-session -t callabo \; set-option destroy-unattached on
+```
+
+window 크기를 session에 붙은 가장 작은 client가 아니라 실제로 그 window를 보는
+client 기준으로 잡으려면 `aggressive-resize`를 함께 켜는 편이 좋습니다.
+
+```tmux
+setw -g aggressive-resize on
+```
+
+watch에서 `Enter`로 이동할 때는 대상 window를 session까지 포함해 지정하므로, 요청한
+터미널만 움직이고 group의 다른 session은 보고 있던 window를 유지합니다. 이때 watch가
+어느 client에서 키를 눌렀는지 알아야 하는데, `muxa init`이 심는 `prefix+s` 바인딩이
+`--caller-client '#{client_name}'`으로 그 값을 넘깁니다. 이 플래그가 없는 수동
+바인딩은 tmux의 활동 기반 추측으로 되돌아가고, 터미널이 둘일 때 그 추측은 자주
+틀립니다.
+
+알려진 거친 부분: grouped session은 별개의 tmux session id이므로 watch topology에
+같은 window/pane을 담은 두 번째 트리로 나타납니다. agent 메타데이터는 첫 트리에
+붙고 중복 트리는 맨 pane으로 보입니다. 집계와 통계는 pane 단위 키라서 중복으로
+세지지 않습니다.
+
 ## macOS 메뉴바 (BarShelf)
 
 [BarShelf](https://github.com/Open330/barshelf)에 포함된 `muxa Watch` widget을

--- a/docs/WATCH.ko.md
+++ b/docs/WATCH.ko.md
@@ -258,6 +258,38 @@ tmux attach -t callabo
 tmux new-session -t callabo \; set-option destroy-unattached on
 ```
 
+`tmux attach -t <session>` 자체가 이렇게 동작하게 하려면 — 따로 외울 명령 없이 —
+grouping을 `client-attached` hook 뒤에 둡니다. 이미 다른 client가 붙어 있을 때만
+동작하므로, 터미널이 하나뿐이면 평소대로 진짜 session에 붙고 여분의 session도
+생기지 않습니다.
+
+```tmux
+set-hook -g client-attached "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"~/.local/bin/tmux-attach-view #{session_name} #{client_name} #{client_pid}\"'"
+```
+
+스크립트는 view를 만들고 도착한 client를 그쪽으로 옮깁니다.
+
+```sh
+name="view~$3~$1"
+new=$(tmux new-session -dP -F '#{session_id}' -t "=$1" -s "$name")
+tmux switch-client -c "$2" -t "$new"
+tmux set-option -t "$new" destroy-unattached on
+```
+
+세 가지가 결정적이며 모두 tmux 3.4에서 실측했습니다. `destroy-unattached`는
+반드시 `switch-client` **뒤에** 걸어야 합니다 — client가 아직 없는 session에 걸면
+그 자리에서 reap되어 전체가 조용히 무효화됩니다. `#{session_id}`가 아니라 session
+이름을 넘깁니다 — id는 `$0`이고 `run-shell`은 명령을 셸에 넘기므로 셸이 이를
+확장해 버립니다. view 이름은 원본 session 이름이 아니라 `view~<pid>~<session>`
+입니다 — 그래야 `callabo`를 찾는 prefix 조회가 진짜 session 대신 view를 집어가는
+일이 없습니다.
+
+한 session만 예외로 두려면 `tmux set-option -t <session> @no_auto_view 1` —
+두 터미널이 *일부러* 같은 화면을 봐야 할 때(페어링, 화면 공유)입니다.
+
+`command-alias`로는 안 됩니다. tmux는 내장 명령 이름을 alias보다 먼저 해석하므로
+`attach-session` alias는 참조되지 않습니다.
+
 window 크기를 session에 붙은 가장 작은 client가 아니라 실제로 그 window를 보는
 client 기준으로 잡으려면 `aggressive-resize`를 함께 켜는 편이 좋습니다.
 

--- a/docs/WATCH.md
+++ b/docs/WATCH.md
@@ -315,6 +315,38 @@ tmux attach -t callabo
 tmux new-session -t callabo \; set-option destroy-unattached on
 ```
 
+To keep `tmux attach -t <session>` itself doing this — no second command to
+remember — put the grouping behind a `client-attached` hook. It fires only when
+the session already had another client, so a lone terminal still attaches to the
+real session and no extra session is created:
+
+```tmux
+set-hook -g client-attached "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"~/.local/bin/tmux-attach-view #{session_name} #{client_name} #{client_pid}\"'"
+```
+
+where the script creates the view and moves the arriving client into it:
+
+```sh
+name="view~$3~$1"
+new=$(tmux new-session -dP -F '#{session_id}' -t "=$1" -s "$name")
+tmux switch-client -c "$2" -t "$new"
+tmux set-option -t "$new" destroy-unattached on
+```
+
+Three details are load-bearing, each measured on tmux 3.4. `destroy-unattached`
+must be set *after* `switch-client`: on a session that still has no client tmux
+reaps it on the spot, silently undoing the whole thing. The session name is
+passed, not `#{session_id}` — the id is `$0`, and `run-shell` hands its command
+to a shell that expands it. And the view is named `view~<pid>~<session>` rather
+than after the session it mirrors, so a prefix lookup for `callabo` can never
+match a view instead of the real thing.
+
+`tmux set-option -t <session> @no_auto_view 1` opts one session out, for when
+two terminals *should* mirror each other (pairing, screen sharing).
+
+`command-alias` cannot do this: tmux resolves built-in command names before
+aliases, so an alias for `attach-session` is never consulted.
+
 `aggressive-resize` is worth pairing with it, so a window is sized to the
 clients actually viewing it rather than to the smallest client on the session:
 

--- a/docs/WATCH.md
+++ b/docs/WATCH.md
@@ -347,12 +347,30 @@ two terminals *should* mirror each other (pairing, screen sharing).
 `command-alias` cannot do this: tmux resolves built-in command names before
 aliases, so an alias for `attach-session` is never consulted.
 
-`aggressive-resize` is worth pairing with it, so a window is sized to the
-clients actually viewing it rather than to the smallest client on the session:
+Pair it with per-window sizing, so a window is sized to the terminals actually
+looking at it rather than to the smallest client anywhere on the session:
 
 ```tmux
+set -g window-size smallest
 setw -g aggressive-resize on
 ```
+
+Both lines are required, and `aggressive-resize` alone does nothing — it only
+applies to windows whose `window-size` is `smallest` or `largest`, and tmux 3.x
+defaults to `latest`. Measured on tmux 3.4 with a 200x50 and an 80x24 client,
+each on its own window:
+
+| setting | window the 200x50 client is on | window the 80x24 client is on |
+| --- | --- | --- |
+| `window-size latest` (default) | 80x23 | 80x23 |
+| `smallest` + `aggressive-resize on` | **200x49** | 80x23 |
+| `smallest` + `aggressive-resize off` | 80x23 | 80x23 |
+
+`smallest` on its own is the classic footgun — any small client anywhere
+shrinks your window. `aggressive-resize` is what narrows "any client" to "a
+client whose current window this is", which is exactly the separation the views
+above create. With one terminal attached, smallest is that terminal, so nothing
+changes for ordinary single-terminal use.
 
 Jumping from watch (`Enter`) addresses the target window by session, so it
 moves only the terminal that asked and leaves the grouped sibling on the window

--- a/docs/WATCH.md
+++ b/docs/WATCH.md
@@ -296,6 +296,45 @@ bind-key D display-popup -E -w 95% -h 90% "muxa dashboard"
 `prefix+s` is the normal watch and collaboration entry point. `prefix+D` is an
 optional shortcut to the richer Dashboard.
 
+## Two Terminals on One Workspace
+
+One tmux session has one current window, and every client attached to it shows
+that window. Two terminals attached to the same session therefore cannot sit on
+two different Work windows — switching one switches the other. That is tmux's
+model, not a muxa limitation.
+
+To watch two Work Runs of one workspace side by side, attach the second
+terminal to a *session group* instead. Windows stay shared, but each session in
+the group keeps its own current window:
+
+```sh
+# terminal 1
+tmux attach -t callabo
+
+# terminal 2 — same windows, independent view, disappears on detach
+tmux new-session -t callabo \; set-option destroy-unattached on
+```
+
+`aggressive-resize` is worth pairing with it, so a window is sized to the
+clients actually viewing it rather than to the smallest client on the session:
+
+```tmux
+setw -g aggressive-resize on
+```
+
+Jumping from watch (`Enter`) addresses the target window by session, so it
+moves only the terminal that asked and leaves the grouped sibling on the window
+it was showing. For that to hold, watch needs to know which client pressed the
+key — the `prefix+s` binding written by `muxa init` passes it as
+`--caller-client '#{client_name}'`. A hand-rolled binding without that flag
+falls back to tmux's activity-based guess, which with two terminals attached is
+routinely the wrong one.
+
+Known rough edge: the grouped session is a distinct tmux session id, so the
+watch topology lists it as a second tree carrying the same windows and panes.
+Agent metadata attaches to the first tree; the duplicate shows as bare panes.
+Counts and stats are keyed per pane and are not doubled.
+
 ## macOS Menu Bar with BarShelf
 
 The bundled [BarShelf](https://github.com/Open330/barshelf) `muxa Watch`


### PR DESCRIPTION
## Problem

`muxa watch`'s jump issued `switch-client -t %pane`. A pane id names a pane but **not a session**, and `switch-client` needs one — so tmux fills the gap from recent client activity. That is unambiguous only while every window belongs to exactly one session.

A **session group** (`tmux new-session -t <session>`) breaks that assumption. It is the supported way to keep two terminals on two different Work windows of one workspace: windows are shared across the group, but each session keeps its own current window. Under a group, one window is linked into several sessions and tmux's guess is routinely wrong.

Measured on tmux 3.4, two attached clients, `base` + grouped `base-b`:

```
BEFORE:  /dev/pts/64 session=base    window=w0
         /dev/pts/69 session=base-b  window=w2   <- most recently active
--- switch-client -c /dev/pts/64 -t %1 ; select-window -t %1 ; select-pane -t %1
AFTER:   /dev/pts/64 session=base-b  window=w1   <- wrong session
         /dev/pts/69 session=base-b  window=w1   <- dragged along
```

Client A was pulled out of its own session into the grouped sibling, which put both clients back in one session and dragged the other terminal's view. The two terminals the group exists to separate were re-coupled, and every jump after that moved both.

**The bare-shell path (watch run from a terminal outside tmux) had the same defect, more visibly.** It pre-positions with `select-window` before handing the terminal to `attach-session`; targeting a bare pane id meant it moved the *bystander* session and left the session it then attached to on the wrong window:

```
OLD  select-window -t %1  ->  base=w0    (attach target — wrong window)
                              base-b=w1  (bystander someone was watching — moved)
```

## Fix

Address the window as `<session_id>:<window_id>`.

**In-tmux jump** — pick the session:
- Prefer the **asking client's own session** when the target window is linked into it. Inside a group that makes the jump a pure window change, so no sibling session — and therefore no other terminal — moves.
- Otherwise use the **session recorded for the pane**. This is a genuine cross-session jump, and it now names a definite destination where tmux previously picked one from client activity.
- Fall back to the bare pane id when neither is known, which is exactly the old behaviour.

**Bare-shell jump** — the session is already in hand (it is the one about to be attached), so both branches qualify the window with it at no extra tmux call:

```
NEW  select-window -t $0:@1 ->  base=w1    (attach target — correct)
                                base-b=w2  (bystander — untouched)
```

`attach-session` now also targets the session **by id**. It was passing the session *name*, which tmux matches by prefix unless anchored — the exact collision this file's own comment warns about (`callabo` against `callabo-set`).

Session and window ids are backend-native, so neither can prefix-match a neighbouring object. Both jump entry points are covered: `jump_to_pane_tmux` (pane-id) and `jump_to_pane_tmux_key` (topology key, socket-scoped).

## Verification

In-tmux, same scenario as the repro, patched argv:

```
BEFORE:  /dev/pts/70 session=base    window=w0
         /dev/pts/71 session=base-b  window=w2   <- most recently active
  resolved target = $0:@1
AFTER:   /dev/pts/70 session=base    window=w1   <- moved, own session
         /dev/pts/71 session=base-b  window=w2   <- untouched
```

Cross-session regression check (client in `base`, target pane in unrelated `other`):

```
  resolved target = $2:@5
AFTER:   /dev/pts/70 session=other   window=o1   <- correct
         /dev/pts/71 session=base-b  window=w2   <- untouched
```

Both new tmux queries verified against two live clients — `display-message -p -t <client> '#{session_id}'` returns each client's own session (`$0` / `$1`), and `list-windows -t $N -F '#{window_id}'` lists the group's shared windows.

## Tests

The session choice is split into a pure `resolve_jump_session` that takes the membership probe as a closure, so every branch is unit-tested without a tmux server:

- stays in the client's session when the ids already match — and asserts the probe never runs, since that round trip is on a keypress path
- stays in the client's session when the window is linked there (the session-group case)
- crosses to the pane's session when it is not
- falls back when the client session is unknown or empty

Plus target construction and its fallbacks, whole-id matching (`@1` must never match `@12`), and id-over-name session targeting.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass.

## Docs

`docs/WATCH.md` / `docs/WATCH.ko.md` gain a **Two Terminals on One Workspace** section: why one session cannot show two windows at once, the session-group recipe with `destroy-unattached` and `aggressive-resize`, and why the `muxa init` binding's `--caller-client` flag matters for this to hold.

## Known rough edge (not in scope)

A grouped session is a distinct tmux session id, so `topology.rs` renders it as a second tree carrying the same windows and panes. `matching_agent` claims each agent once, so metadata lands on the first tree and the duplicate shows as bare panes; counts and stats are keyed per pane and are not doubled. Folding grouped sessions into one tree is a display-model decision worth its own change — documented as a known rough edge for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)