### PR TITLE
fix(ipc): surface a refused request instead of reporting no agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A refused IPC request no longer reports "no active agents".** `snapshot`,
+  `by_pane`, and their timeout variants handed the response straight to a
+  lenient decoder that read the absent `agents` array as an empty registry, so
+  every daemon refusal became a confident, wrong, and perfectly stable answer
+  — and exited 0. The failure this hides in practice is a mixed install: a
+  `muxad` predating the protocol 5 bump answers `protocol mismatch: server=4
+  client=5` to every call, and `muxa status` reported no agents for a full day
+  on a host with 58 registered. Refusals now surface as `RuntimeError::Daemon`
+  carrying the daemon's own message, a protocol mismatch adds the restart it
+  needs, and a genuinely empty registry still reads as empty.
+
 - **Jumping from watch no longer drags a second terminal off its window.** The
   jump addressed the target as a bare pane id, which names a pane but not a
   session; tmux filled the gap from recent client activity. Under a session

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -130,6 +130,12 @@ pub enum RuntimeError {
 
     #[error("ipc request timed out after {0:?}")]
     Timeout(Duration),
+
+    /// The daemon answered, and said no. Carries the server's own message so
+    /// a refusal reaches the user as a refusal instead of being flattened
+    /// into an empty result — see [`decode_agents`].
+    #[error("{0}")]
+    Daemon(String),
 }
 
 impl RuntimeError {
@@ -2729,12 +2735,44 @@ fn collaboration_wait_is_unsupported(error: &str) -> bool {
     error.contains("unknown variant") && error.contains("collaboration_wait")
 }
 
-fn decode_agents(resp: &serde_json::Value) -> Vec<Agent> {
-    resp["agents"]
-        .as_array()
-        .cloned()
-        .map(|v| serde_json::from_value(serde_json::Value::Array(v)).unwrap_or_default())
-        .unwrap_or_default()
+/// Build the error for an `ok: false` response, from the daemon's own message.
+///
+/// A protocol mismatch gets a hint appended. It is the one refusal whose
+/// message names a cause the reader cannot act on — two version numbers say
+/// nothing about which half is stale or how to move it — and it is the
+/// refusal a mixed install produces every single call.
+fn response_error(resp: &serde_json::Value) -> RuntimeError {
+    let message = resp["error"].as_str().unwrap_or("request failed");
+    if message.starts_with("protocol mismatch") {
+        RuntimeError::Daemon(format!(
+            "{message} — the running daemon is older than this CLI. \
+             Restart it: `muxa upgrade` (add `--no-pull` to rebuild the current source)"
+        ))
+    } else {
+        RuntimeError::Daemon(message.to_string())
+    }
+}
+
+/// Decode the `agents` array out of a response, or surface the daemon's error.
+///
+/// The `ok` check is the point. A refusal and a genuinely empty registry are
+/// indistinguishable to a lenient decoder — neither carries an `agents` array
+/// — so returning `Vec::new()` for both turned every failure into "no active
+/// agents": a confident, wrong, and perfectly stable answer that looks like
+/// news about the user's agents rather than a broken connection.
+///
+/// Measured on a live host: a `muxad` built before the protocol 5 bump
+/// answered `protocol mismatch: server=4 client=5` to every request, and
+/// `muxa status` reported no agents for a full day while 58 were registered
+/// and the daemon was writing all 58 to its state snapshot every 30 seconds.
+fn decode_agents(resp: &serde_json::Value) -> Result<Vec<Agent>, RuntimeError> {
+    if !resp["ok"].as_bool().unwrap_or(false) {
+        return Err(response_error(resp));
+    }
+    let Some(agents) = resp["agents"].as_array().cloned() else {
+        return Ok(Vec::new());
+    };
+    serde_json::from_value(serde_json::Value::Array(agents)).map_err(RuntimeError::Json)
 }
 
 impl TransitionStream {
@@ -2834,7 +2872,7 @@ impl Client {
     pub async fn snapshot(&self) -> Result<Vec<Agent>, RuntimeError> {
         let req = serde_json::json!({ "protocol": PROTOCOL_VERSION, "kind": "snapshot" });
         let resp = self.call(&req).await?;
-        Ok(decode_agents(&resp))
+        decode_agents(&resp)
     }
 
     /// Read the central physical-host cache. This is a local Unix-socket
@@ -3287,7 +3325,7 @@ impl Client {
     ) -> Result<Vec<Agent>, RuntimeError> {
         let req = serde_json::json!({ "protocol": PROTOCOL_VERSION, "kind": "snapshot" });
         let resp = self.call_with_timeout(&req, deadline).await?;
-        Ok(decode_agents(&resp))
+        decode_agents(&resp)
     }
 
     pub async fn pipeline_runs(&self) -> Result<Vec<PipelineRun>, RuntimeError> {
@@ -3394,7 +3432,7 @@ impl Client {
             "pane": pane
         });
         let resp = self.call(&req).await?;
-        Ok(decode_agents(&resp))
+        decode_agents(&resp)
     }
 
     pub async fn by_pane_with_timeout(
@@ -3408,7 +3446,7 @@ impl Client {
             "pane": pane
         });
         let resp = self.call_with_timeout(&req, deadline).await?;
-        Ok(decode_agents(&resp))
+        decode_agents(&resp)
     }
 
     /// [`Self::recent_prompts`] under an explicit deadline, for callers on
@@ -3770,12 +3808,9 @@ impl Client {
         if resp["ok"].as_bool().unwrap_or(false) {
             Ok(resp)
         } else {
-            Err(RuntimeError::Json(serde::de::Error::custom(
-                resp["error"]
-                    .as_str()
-                    .unwrap_or("request failed")
-                    .to_string(),
-            )))
+            // One error shape for every refusal, so a protocol mismatch reads
+            // the same here as it does through `decode_agents`.
+            Err(response_error(&resp))
         }
     }
 }
@@ -3788,6 +3823,59 @@ mod tests {
     use std::collections::HashMap;
     use tempfile::tempdir;
     use time::OffsetDateTime;
+
+    #[test]
+    fn decode_agents_surfaces_a_refusal_instead_of_an_empty_registry() {
+        // The regression this guards: an `ok:false` response carries no
+        // `agents` array, and the lenient decoder read that absence as "no
+        // agents". A refusal must not be able to impersonate an answer.
+        let resp = serde_json::json!({ "ok": false, "error": "store unavailable" });
+        let error = decode_agents(&resp).expect_err("a refusal must not decode as agents");
+        assert!(
+            matches!(&error, RuntimeError::Daemon(message) if message == "store unavailable"),
+            "expected the daemon's own message, got: {error}"
+        );
+    }
+
+    #[test]
+    fn decode_agents_explains_a_protocol_mismatch() {
+        // Two bare version numbers do not tell the reader which half is stale
+        // or what to do about it, and a mixed install answers this to every
+        // single call — so this is the one refusal that earns a hint.
+        let resp = serde_json::json!({
+            "ok": false,
+            "error": "protocol mismatch: server=4 client=5",
+        });
+        let error = decode_agents(&resp).expect_err("a mismatch must not decode as agents");
+        let message = error.to_string();
+        assert!(
+            message.contains("protocol mismatch: server=4 client=5"),
+            "{message}"
+        );
+        assert!(message.contains("older than this CLI"), "{message}");
+        assert!(message.contains("muxa upgrade"), "{message}");
+    }
+
+    #[test]
+    fn decode_agents_keeps_a_genuinely_empty_registry_empty() {
+        // The other half of the distinction: a successful response really can
+        // carry no agents, and that must still read as none rather than as an
+        // error. Both the explicit empty array and an absent field count.
+        assert!(
+            decode_agents(&serde_json::json!({ "ok": true, "agents": [] }))
+                .expect("an empty registry is a valid answer")
+                .is_empty()
+        );
+        assert!(decode_agents(&serde_json::json!({ "ok": true }))
+            .expect("an absent agents field is a valid answer")
+            .is_empty());
+    }
+
+    #[test]
+    fn response_error_falls_back_when_the_daemon_sends_no_message() {
+        let error = response_error(&serde_json::json!({ "ok": false }));
+        assert_eq!(error.to_string(), "request failed");
+    }
 
     struct CollaborationTestBackend {
         panes: Vec<PaneInfo>,


### PR DESCRIPTION
## Problem

`Client::snapshot` passed the daemon's response straight to `decode_agents`:

```rust
pub async fn snapshot(&self) -> Result<Vec<Agent>, RuntimeError> {
    let resp = self.call(&req).await?;   // `call`, not `call_checked` — no `ok` check
    Ok(decode_agents(&resp))             // no `agents` array -> Vec::new()
}
```

An `ok: false` response carries no `agents` array, so **every refusal decoded as an empty registry**. `muxa status` printed `no active agents` and exited 0 — a confident, wrong, perfectly stable answer that reads as news about your agents rather than a broken connection.

### How it shows up

A mixed install. A `muxad` built before the protocol 5 bump (`7612909`, "persist generation-aware pipeline runs") answers every request with:

```
protocol mismatch: server=4 client=5
```

Measured on a live host, probing the daemon socket directly:

```
$ echo '{"protocol":5,"kind":"snapshot"}' | <unix socket>
{"ok": false, "protocol": 4, "error": "protocol mismatch: server=4 client=5"}

$ muxa status
no active agents
```

…while that same daemon held **58 agents** and was writing all 58 to `state.json` every 30 seconds. The CLI and the daemon's own snapshot file disagreed for a full day, with nothing anywhere saying why. `muxa status --json` likewise rendered 38 sessions and 80 panes with an `agent` field on exactly zero of them, which looks like a topology-join bug and sends you looking in the wrong place entirely.

## Fix

`decode_agents` checks `ok` before decoding, which fixes `snapshot`, `by_pane`, and both timeout variants at once — the check now lives where the ambiguity is, so a new call site cannot reintroduce it:

```rust
fn decode_agents(resp: &Value) -> Result<Vec<Agent>, RuntimeError> {
    if !resp["ok"].as_bool().unwrap_or(false) {
        return Err(response_error(resp));
    }
    ...
}
```

- New `RuntimeError::Daemon(String)` carries the daemon's own message. (No exhaustive `match` on `RuntimeError` exists in the workspace, so the variant is additive.)
- A **protocol mismatch** gets a hint appended. It is the one refusal whose message names a cause the reader cannot act on — two bare version numbers say nothing about which half is stale or how to move it — and it is the refusal a mixed install produces on every single call.
- `call_checked` now shares `response_error`, so a refusal reads identically whichever path produced it. It previously built its own `RuntimeError::Json`, which rendered as `json error: protocol mismatch: ...`.
- A **successful** response carrying no agents still decodes as empty. That distinction is the whole point and has its own test.

## Verification

Side by side against a stub daemon that answers exactly what the old `muxad` answered:

```
=== OLD CLI (origin/main) against a protocol-4 daemon ===
no active agents                                                    exit 0

=== NEW CLI (this branch) against the same daemon ===
Error: protocol mismatch: server=4 client=5 — the running daemon is older
than this CLI. Restart it: `muxa upgrade` (add `--no-pull` to rebuild the
current source)                                                     exit 1
```

The exit code matters too: the old behaviour reported success, so a script or a `muxa attend` loop had no way to notice either.

Four unit tests cover the distinction the bug erased — a refusal must not decode as agents, a mismatch explains itself, a genuinely empty registry stays empty (both the explicit `[]` and an absent field), and a refusal with no message falls back to `request failed`.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass.

## Not in scope

This makes the mismatch **legible**; it does not make a new CLI talk to an old daemon. The daemon already negotiates down to `MIN_PROTOCOL_VERSION` via `hello`, but the client sends `PROTOCOL_VERSION` on every request without negotiating first. Client-side negotiation is a real option and a separate change — worth deciding on its own merits rather than as a side effect of an error-handling fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)