### PR TITLE
fix(onboarding): unstick Alt-T, and run the real tour from onboard.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - run: cargo build -p muxa-cli --bin muxa
       - run: shellcheck scripts/onboard.sh
       # The shell fallback in onboard.sh must teach the same keys as the real
-      # tour; `muxa onboard --emit-step-table` is the contract it is held to.
+      # tour; `muxa onboard --emit step-table` is the contract it is held to.
       - run: python3 scripts/onboarding-parity.py --muxa target/debug/muxa
       - run: python3 scripts/onboarding-parity.py --muxa target/debug/muxa --lang ko
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,22 @@ jobs:
       - run: cargo build --workspace --bins
       - run: cargo test --workspace
 
+  onboarding-parity:
+    name: onboarding parity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build -p muxa-cli --bin muxa
+      - run: shellcheck scripts/onboard.sh
+      # The shell fallback in onboard.sh must teach the same keys as the real
+      # tour; `muxa onboard --emit-step-table` is the contract it is held to.
+      - run: python3 scripts/onboarding-parity.py --muxa target/debug/muxa
+      - run: python3 scripts/onboarding-parity.py --muxa target/debug/muxa --lang ko
+
   msrv:
     name: MSRV (1.88)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collaboration stays owned by the selected node and travels over the existing
   exact-pane SSH relay behind an explicit capability gate.
 
+### Changed
+
+- **`scripts/onboard.sh` now runs the real `muxa onboard`.** It fetches the
+  release binary for the host into a temporary directory, verifies its
+  published SHA-256, runs the onboarding, and deletes it — a download, not an
+  install: no daemon, no config, no PATH entry. The embedded shell simulation
+  remains the fallback for `--no-download`, an unsupported platform, a missing
+  checksum tool, or no network, so the pipe-to-`sh` entry point keeps working
+  offline. The fallback was realigned to the real tour's step decomposition and
+  keys — the splits are one step, detach and reattach are two, pane movement
+  takes `→`, and the attention sort takes `Alt-T` (the macOS compose glyphs
+  `†`/`ˇ` included) rather than a stand-in `t`. `muxa onboard --emit
+  step-table` publishes the key each step waits for, derived by walking the
+  real gates, and `scripts/onboarding-parity.py` presses exactly those keys at
+  the fallback in CI so the two cannot drift apart again.
+
+### Fixed
+
+- **Onboarding no longer dead-ends on `Alt-T`, and arrow keys no longer quit
+  it.** The `Alt-T` gate was the tour's only step without an `Alt`-free path,
+  so a terminal that composes Option instead of sending Meta — the macOS
+  default — could never satisfy it. The gate now also accepts the compose
+  glyph (`†`, `ˇ`), and two missed attempts surface the terminal
+  setting from `docs/WATCH.md` plus `→` to move on. Separately, a lone
+  `ESC` byte that arrives in its own read is reported as `Esc`, so an arrow key
+  relayed through tmux or a slow pty could tear the tour down mid-step; both
+  the tour and the tmux track now confirm an `Esc` before quitting and
+  reassemble the split sequence. `scripts/onboard.sh` read one byte per key
+  and so quit on *every* arrow key; it now classifies the escape tail the same
+  way and accepts the real `Alt-T`.
+
 ## [0.8.35] - 2026-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   setting from `docs/WATCH.md` plus `→` to move on. Separately, a lone
   `ESC` byte that arrives in its own read is reported as `Esc`, so an arrow key
   relayed through tmux or a slow pty could tear the tour down mid-step; both
-  the tour and the tmux track now confirm an `Esc` before quitting and
-  reassemble the split sequence. `scripts/onboard.sh` read one byte per key
-  and so quit on *every* arrow key; it now classifies the escape tail the same
-  way and accepts the real `Alt-T`.
+  the tour and the tmux track now confirm an `Esc` before quitting, reassemble
+  the split sequence, and deliver the represented arrow instead of swallowing
+  it. `scripts/onboard.sh` read one byte per key and so quit on *every* arrow
+  key; it now classifies the escape tail the same way and accepts the real
+  `Alt-T`. The download path also capability-checks the release before running
+  it, so a release still predating these fixes falls back to the corrected
+  embedded tour.
 
 ## [0.8.36] - 2026-08-27
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -20,7 +20,10 @@
 
 ## README를 읽기 전에 Muxa 온보딩부터 체험해 보세요
 
-Muxa binary를 내려받거나 설치하지 않고 전체 화면 tour를 바로 체험하세요.
+설치 없이 전체 화면 tour를 바로 체험하세요. script가 release 바이너리를 임시
+디렉터리로 받아 checksum을 검증한 뒤 진짜 `muxa onboard`를 실행하고 끝나면
+지웁니다. 사용할 수 없는 환경에서는 같은 시나리오의 shell simulation으로
+넘어갑니다(`--no-download`로 강제할 수 있습니다).
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/onboard.sh | sh -s -- --lang ko

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ status line, a live TUI, desktop notifications, and local reports.
 
 ## Try Muxa onboarding before reading
 
-Launch the complete fullscreen tour—no Muxa binary download or installation:
+Launch the complete fullscreen tour. The script runs the real `muxa onboard`
+from a temporary copy of the release binary — checksum-verified, deleted on
+exit, nothing installed — and falls back to an equivalent shell simulation
+when that is unavailable (`--no-download` forces the fallback):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/onboard.sh | sh

--- a/crates/muxa-cli/src/onboarding.rs
+++ b/crates/muxa-cli/src/onboarding.rs
@@ -21,6 +21,7 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap};
 use ratatui::{Frame, Terminal};
 use std::io::{self, IsTerminal, Stdout, Write};
+use std::time::Duration;
 
 #[derive(Debug, Clone, clap::Args, Default)]
 pub struct Args {
@@ -36,6 +37,16 @@ pub struct Args {
     /// Display language: auto, en, or ko. / 표시 언어: auto, en, ko.
     #[arg(long, value_enum, default_value_t)]
     pub lang: Language,
+    /// Machine-readable dump for tooling, printed instead of the tour.
+    #[arg(long, value_enum, hide = true)]
+    pub emit: Option<Emit>,
+}
+
+/// Machine-readable dumps `muxa onboard` can print instead of running.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum Emit {
+    /// The key each of the twenty steps waits for, as TSV.
+    StepTable,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
@@ -276,6 +287,10 @@ const SECTIONS: &[Section] = &[
 ];
 
 pub fn run(args: Args) -> Result<()> {
+    if args.emit == Some(Emit::StepTable) {
+        print!("{}", step_table_tsv());
+        return Ok(());
+    }
     apply_icon_preference();
     let mode = Mode::detect(args.print);
     let language = args.lang.resolve();
@@ -362,7 +377,7 @@ fn interactive_guide(no_quiz: bool, language: UiLanguage) -> Result<()> {
         guard
             .terminal_mut()
             .draw(|frame| render_tour(frame, &app))?;
-        if let Event::Key(key) = event::read().context("reading onboarding input")? {
+        if let Some(key) = read_key_event()? {
             handle_key(&mut app, key);
         }
     }
@@ -458,7 +473,7 @@ struct TourApp {
     panel: MockPanel,
     new_work_stage: NewWorkStage,
     collaboration_stage: CollaborationStage,
-    blocked_hint: bool,
+    blocked_attempts: u8,
     done: bool,
 }
 
@@ -484,7 +499,7 @@ impl TourApp {
             panel: MockPanel::None,
             new_work_stage: NewWorkStage::Shortcut,
             collaboration_stage: CollaborationStage::Message,
-            blocked_hint: false,
+            blocked_attempts: 0,
             done: false,
         }
     }
@@ -497,6 +512,26 @@ impl TourApp {
         self.mode == TourMode::Guided
     }
 
+    fn blocked_hint(&self) -> bool {
+        self.blocked_attempts > 0
+    }
+
+    fn note_blocked(&mut self) {
+        self.blocked_attempts = self.blocked_attempts.saturating_add(1);
+    }
+
+    /// `Alt-T` is the only gate without an `Alt`-free equivalent, so a terminal
+    /// that composes Option instead of sending Meta can strand the tour here.
+    fn alt_only_gate(&self) -> bool {
+        self.current() == TourStep::States
+    }
+
+    /// Surface the terminal fix and a way past the gate once the learner has
+    /// visibly tried and failed, instead of teaching the workaround up front.
+    fn offer_alt_bypass(&self) -> bool {
+        self.alt_only_gate() && self.blocked_attempts >= 2
+    }
+
     fn ko(&self) -> bool {
         self.language == UiLanguage::Ko
     }
@@ -506,11 +541,11 @@ impl TourApp {
             UiLanguage::En => UiLanguage::Ko,
             UiLanguage::Ko => UiLanguage::En,
         };
-        self.blocked_hint = false;
+        self.blocked_attempts = 0;
     }
 
     fn advance(&mut self) {
-        self.blocked_hint = false;
+        self.blocked_attempts = 0;
         if self.step + 1 == TourStep::ALL.len() {
             self.done = true;
         } else {
@@ -519,9 +554,207 @@ impl TourApp {
     }
 
     fn previous(&mut self) {
-        self.blocked_hint = false;
+        self.blocked_attempts = 0;
         self.step = self.step.saturating_sub(1);
     }
+}
+
+/// macOS composes `Option` into a glyph unless the terminal is told to send
+/// Meta, so the `Alt-T` this tour teaches arrives as `†` carrying no modifier
+/// at all and the gate can never be satisfied on a stock macOS terminal. Map
+/// the US-layout compose output back to the letter so the walkthrough still
+/// advances; `docs/WATCH.md` covers the terminal settings that restore the real
+/// chord for live watch.
+const OPTION_COMPOSED_LETTERS: [(char, char); 28] = [
+    ('å', 'a'),
+    ('∫', 'b'),
+    ('ç', 'c'),
+    ('∂', 'd'),
+    ('´', 'e'),
+    ('ƒ', 'f'),
+    ('©', 'g'),
+    ('˙', 'h'),
+    ('ˆ', 'i'),
+    ('∆', 'j'),
+    ('˚', 'k'),
+    ('¬', 'l'),
+    ('µ', 'm'),
+    ('˜', 'n'),
+    ('ø', 'o'),
+    ('π', 'p'),
+    ('œ', 'q'),
+    ('®', 'r'),
+    ('ß', 's'),
+    ('†', 't'),
+    ('¨', 'u'),
+    ('√', 'v'),
+    ('∑', 'w'),
+    ('≈', 'x'),
+    ('¥', 'y'),
+    ('Ω', 'z'),
+    // The hints spell the chords with a capital letter, so learners reach for
+    // Shift and compose the shifted glyph instead.
+    ('ˇ', 't'),
+    ('∏', 'p'),
+];
+
+fn option_composed_letter(ch: char) -> Option<char> {
+    OPTION_COMPOSED_LETTERS
+        .iter()
+        .find(|(composed, _)| *composed == ch)
+        .map(|(_, letter)| *letter)
+}
+
+/// True when `key` is the `Alt-<letter>` chord the tour teaches, whether the
+/// terminal sends a real Meta modifier or only the macOS compose glyph.
+fn is_alt_chord(key: KeyEvent, letter: char) -> bool {
+    match key.code {
+        KeyCode::Char(ch) if key.modifiers.contains(KeyModifiers::ALT) => {
+            ch.eq_ignore_ascii_case(&letter)
+        }
+        KeyCode::Char(ch)
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+        {
+            option_composed_letter(ch) == Some(letter)
+        }
+        _ => false,
+    }
+}
+
+/// crossterm reports a bare `Esc` the moment a read returns a lone `\x1b` with
+/// nothing else in the same syscall, so an escape sequence split across reads —
+/// an arrow key relayed through tmux, or a slow pty — surfaces as a phantom
+/// quit. Wait this long before trusting `Esc`.
+const ESC_SEQUENCE_GRACE: Duration = Duration::from_millis(50);
+
+/// Read one key, dropping the phantom `Esc` of a split escape sequence.
+pub(super) fn read_key_event() -> Result<Option<KeyEvent>> {
+    let Event::Key(key) = event::read().context("reading onboarding input")? else {
+        return Ok(None);
+    };
+    if key.code != KeyCode::Esc
+        || key.kind != KeyEventKind::Press
+        || !event::poll(ESC_SEQUENCE_GRACE).context("checking for a split escape sequence")?
+    {
+        return Ok(Some(key));
+    }
+    resolve_split_escape()
+}
+
+/// The leading `\x1b` was already consumed, so the rest of the sequence arrives
+/// as plain characters. `[` and `O` introduce a CSI/SS3 tail that has to be
+/// swallowed whole; anything else is the two-byte form of an `Alt` chord.
+fn resolve_split_escape() -> Result<Option<KeyEvent>> {
+    let Some(next) = next_pending_key()? else {
+        return Ok(Some(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)));
+    };
+    let KeyCode::Char(introducer) = next.code else {
+        return Ok(Some(next));
+    };
+    if introducer != '[' && introducer != 'O' {
+        return Ok(Some(KeyEvent::new(
+            next.code,
+            next.modifiers | KeyModifiers::ALT,
+        )));
+    }
+    // Parameter bytes precede the final byte that terminates the sequence.
+    while let Some(key) = next_pending_key()? {
+        let is_parameter = matches!(key.code, KeyCode::Char(byte) if !('@'..='~').contains(&byte));
+        if !is_parameter {
+            break;
+        }
+    }
+    Ok(None)
+}
+
+fn next_pending_key() -> Result<Option<KeyEvent>> {
+    while event::poll(Duration::ZERO).context("draining a split escape sequence")? {
+        if let Event::Key(key) = event::read().context("draining a split escape sequence")? {
+            if key.kind == KeyEventKind::Press {
+                return Ok(Some(key));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// The key the current stage is waiting for, as a bare token.
+///
+/// `required_action` phrases the same thing for the learner; keeping both on
+/// one source means the published table cannot promise a key the gate refuses.
+fn expected_key(app: &TourApp) -> &'static str {
+    match app.current() {
+        TourStep::Work => "j",
+        TourStep::Agents | TourStep::Mcp => "l",
+        TourStep::States => "Alt-T",
+        TourStep::Preview => "o",
+        TourStep::Shortcuts if app.panel == MockPanel::Preview => "o",
+        TourStep::Shortcuts => "?",
+        TourStep::NewWork if app.new_work_stage == NewWorkStage::Shortcut => "n",
+        TourStep::NewWork => "Esc",
+        TourStep::Collaboration => match app.collaboration_stage {
+            CollaborationStage::Message => "m",
+            CollaborationStage::Composer => "Backspace",
+            _ => "M",
+        },
+        TourStep::Finish => "q",
+    }
+}
+
+pub(super) fn key_for_token(token: &str) -> KeyEvent {
+    match token {
+        "Alt-T" => KeyEvent::new(KeyCode::Char('t'), KeyModifiers::ALT),
+        "Esc" => KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+        "Backspace" => KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+        "Enter" => KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        "→" => KeyEvent::new(KeyCode::Right, KeyModifiers::NONE),
+        "↓" => KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        other => {
+            let ch = other.chars().next().unwrap_or('?');
+            let modifiers = if ch.is_ascii_uppercase() || ch == '?' {
+                KeyModifiers::SHIFT
+            } else {
+                KeyModifiers::NONE
+            };
+            KeyEvent::new(KeyCode::Char(ch), modifiers)
+        }
+    }
+}
+
+/// Walk of the guided watch track; see `tmux::step_table` for the contract.
+fn watch_step_table() -> Vec<Vec<String>> {
+    let mut app = TourApp::with_language(false, UiLanguage::En);
+    let mut table: Vec<Vec<String>> = vec![Vec::new(); TourStep::ALL.len()];
+    while !app.done {
+        let index = app.step;
+        while app.step == index && !app.done && table[index].len() < 8 {
+            let token = expected_key(&app).to_string();
+            table[index].push(token.clone());
+            handle_key(&mut app, key_for_token(&token));
+        }
+        if app.step == index && !app.done {
+            break;
+        }
+    }
+    table
+}
+
+/// `<step number>\t<key>…` for all 20 unified steps — the contract the shell
+/// fallback in `scripts/onboard.sh` is held to.
+pub(super) fn step_table_tsv() -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    for (index, keys) in tmux::step_table()
+        .into_iter()
+        .chain(watch_step_table())
+        .enumerate()
+    {
+        let _ = writeln!(out, "{}\t{}", index + 1, keys.join("\t"));
+    }
+    out
 }
 
 fn handle_key(app: &mut TourApp, key: KeyEvent) {
@@ -560,7 +793,7 @@ fn handle_key(app: &mut TourApp, key: KeyEvent) {
                 return;
             }
         }
-        app.blocked_hint = false;
+        app.blocked_attempts = 0;
         return;
     }
     if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
@@ -573,7 +806,7 @@ fn handle_key(app: &mut TourApp, key: KeyEvent) {
         }
         match key.code {
             KeyCode::Left | KeyCode::Char('h') | KeyCode::Backspace => app.previous(),
-            _ => app.blocked_hint = true,
+            _ => app.note_blocked(),
         }
         return;
     }
@@ -605,18 +838,20 @@ fn handle_guided_key(app: &mut TourApp, key: KeyEvent) -> bool {
             app.advance();
             true
         }
+        TourStep::States if is_alt_chord(key, 't') => {
+            app.sort = MockSort::State;
+            app.advance();
+            true
+        }
         TourStep::States
-            if matches!(key.code, KeyCode::Char('t' | 'T'))
-                && key.modifiers.contains(KeyModifiers::ALT) =>
+            if app.offer_alt_bypass() && matches!(key.code, KeyCode::Right | KeyCode::Enter) =>
         {
             app.sort = MockSort::State;
             app.advance();
             true
         }
         TourStep::Preview
-            if (plain && key.code == KeyCode::Char('o'))
-                || (key.code == KeyCode::Char('p')
-                    && key.modifiers.contains(KeyModifiers::ALT)) =>
+            if (plain && key.code == KeyCode::Char('o')) || is_alt_chord(key, 'p') =>
         {
             app.panel = MockPanel::Preview;
             app.advance();
@@ -626,7 +861,7 @@ fn handle_guided_key(app: &mut TourApp, key: KeyEvent) -> bool {
             if app.panel == MockPanel::Preview && plain && key.code == KeyCode::Char('o') =>
         {
             app.panel = MockPanel::None;
-            app.blocked_hint = false;
+            app.blocked_attempts = 0;
             true
         }
         TourStep::Shortcuts
@@ -634,7 +869,7 @@ fn handle_guided_key(app: &mut TourApp, key: KeyEvent) -> bool {
                 && matches!(key.code, KeyCode::Char('?') | KeyCode::F(1)) =>
         {
             app.panel = MockPanel::Help;
-            app.blocked_hint = false;
+            app.blocked_attempts = 0;
             true
         }
         TourStep::Shortcuts
@@ -664,7 +899,7 @@ fn handle_new_work_shortcut(app: &mut TourApp, key: KeyEvent, plain: bool) -> bo
         return false;
     }
     app.new_work_stage = NewWorkStage::Form;
-    app.blocked_hint = false;
+    app.blocked_attempts = 0;
     true
 }
 
@@ -686,7 +921,7 @@ fn handle_collaboration_shortcut(app: &mut TourApp, key: KeyEvent, plain: bool) 
         }
         _ => return false,
     }
-    app.blocked_hint = false;
+    app.blocked_attempts = 0;
     true
 }
 
@@ -1446,7 +1681,7 @@ fn step_title(step: TourStep, language: UiLanguage) -> &'static str {
 
 fn step_body(app: &TourApp) -> Text<'static> {
     let mut lines = step_lines(app);
-    if app.blocked_hint {
+    if app.blocked_hint() {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             format!(
@@ -1457,7 +1692,31 @@ fn step_body(app: &TourApp) -> Text<'static> {
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
         )));
     }
+    if app.offer_alt_bypass() {
+        for hint in alt_bypass_hint(app.language) {
+            lines.push(Line::from(Span::styled(
+                *hint,
+                Style::default().fg(Color::Yellow),
+            )));
+        }
+    }
     Text::from(lines)
+}
+
+/// Shown only after the learner has actually pressed the wrong key twice, so
+/// the terminal caveat stays out of the way of everyone it does not affect.
+fn alt_bypass_hint(language: UiLanguage) -> &'static [&'static str] {
+    if language == UiLanguage::Ko {
+        &[
+            "Alt이 안 눌리나요? macOS는 Option을 조합 키로 씁니다.",
+            "docs/WATCH.md의 터미널 설정을 보거나, →로 넘어가세요.",
+        ]
+    } else {
+        &[
+            "Alt not arriving? macOS composes Option instead of sending Meta.",
+            "See docs/WATCH.md for the terminal setting, or press → to skip.",
+        ]
+    }
 }
 
 fn required_action(app: &TourApp) -> &'static str {
@@ -1858,9 +2117,12 @@ fn dialog_block(title: &str, color: Color) -> Block<'_> {
 fn callout_rect(area: Rect, app: &TourApp) -> Rect {
     let step = app.current();
     let compact = area.width < 100 || area.height < 23;
+    // The terminal-setup hint only appears after repeated misses, so the
+    // callout grows for it rather than reserving the rows on every step.
+    let bypass_rows = if app.offer_alt_bypass() { 5 } else { 0 };
     if compact {
-        let height =
-            if step == TourStep::Finish { 12 } else { 10 }.min(area.height.saturating_sub(2));
+        let height = (if step == TourStep::Finish { 12 } else { 10 } + bypass_rows)
+            .min(area.height.saturating_sub(2));
         let y = if step == TourStep::Shortcuts {
             area.y + 2
         } else {
@@ -1878,9 +2140,12 @@ fn callout_rect(area: Rect, app: &TourApp) -> Rect {
     let width = area.width.saturating_mul(42) / 100;
     let height = 12;
     match step {
-        TourStep::Work | TourStep::Agents | TourStep::States => {
-            Rect::new(area.x + area.width - width - 2, area.y + 5, width, height)
-        }
+        TourStep::Work | TourStep::Agents | TourStep::States => Rect::new(
+            area.x + area.width - width - 2,
+            area.y + 5,
+            width,
+            (height + bypass_rows).min(area.height.saturating_sub(6)),
+        ),
         TourStep::Preview | TourStep::Mcp => {
             Rect::new(area.x + 2, area.y + 8, width.max(52), height)
         }
@@ -2065,7 +2330,7 @@ mod tests {
             KeyEvent::new(KeyCode::Right, crossterm::event::KeyModifiers::NONE),
         );
         assert_eq!(app.step, original);
-        assert!(app.blocked_hint);
+        assert!(app.blocked_hint());
 
         handle_key(
             &mut app,
@@ -2154,6 +2419,165 @@ mod tests {
         assert_eq!(app.current(), TourStep::Mcp);
     }
 
+    fn at_state_step() -> TourApp {
+        let mut app = TourApp::new(false);
+        app.step = TourStep::ALL
+            .iter()
+            .position(|step| *step == TourStep::States)
+            .unwrap();
+        app
+    }
+
+    #[test]
+    fn step_table_walks_every_gate_with_its_published_key() {
+        let table: Vec<Vec<String>> = tmux::step_table()
+            .into_iter()
+            .chain(watch_step_table())
+            .collect();
+        assert_eq!(table.len(), UNIFIED_STEP_COUNT);
+        for (index, keys) in table.iter().enumerate() {
+            assert!(!keys.is_empty(), "step {} publishes no key", index + 1);
+            // The walk caps a step at eight stages, which it only reaches when
+            // a gate refuses the very key it told the learner to press.
+            assert!(
+                keys.len() < 8,
+                "step {} never accepted its published key: {keys:?}",
+                index + 1
+            );
+        }
+        // The gate that stranded the tour in issue #76 — the contract the
+        // shell fallback is held to by scripts/onboarding-parity.py.
+        assert_eq!(table[13], vec!["Alt-T".to_string()]);
+        assert_eq!(table[5], vec!["\u{2192}".to_string()]);
+    }
+
+    #[test]
+    fn step_table_tsv_lists_one_numbered_line_per_step() {
+        let tsv = step_table_tsv();
+        let lines: Vec<&str> = tsv.lines().collect();
+        assert_eq!(lines.len(), UNIFIED_STEP_COUNT);
+        for (index, line) in lines.iter().enumerate() {
+            let mut fields = line.split('\t');
+            assert_eq!(fields.next(), Some((index + 1).to_string().as_str()));
+            assert!(fields.next().is_some(), "step {} has no key", index + 1);
+        }
+        assert!(tsv.contains("14\tAlt-T\n"));
+    }
+
+    #[test]
+    fn state_step_accepts_the_macos_option_compose_glyph() {
+        // A stock macOS terminal composes Option+T into `†` and sends no
+        // modifier at all, which used to leave the tour with no way forward.
+        let mut app = at_state_step();
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('†'), KeyModifiers::NONE),
+        );
+        assert_eq!(app.current(), TourStep::Preview);
+        assert_eq!(app.sort, MockSort::State);
+    }
+
+    #[test]
+    fn state_step_accepts_the_shifted_compose_glyph() {
+        let mut app = at_state_step();
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('ˇ'), KeyModifiers::SHIFT),
+        );
+        assert_eq!(app.current(), TourStep::Preview);
+    }
+
+    #[test]
+    fn state_step_still_refuses_a_bare_t() {
+        // The tour teaches the real watch binding, so an unmodified `t` — which
+        // live watch does not bind — must not stand in for the chord.
+        let mut app = at_state_step();
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE),
+        );
+        assert_eq!(app.current(), TourStep::States);
+        assert!(app.blocked_hint());
+    }
+
+    #[test]
+    fn state_step_offers_a_bypass_only_after_repeated_misses() {
+        let mut app = at_state_step();
+        handle_key(&mut app, KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        assert_eq!(app.current(), TourStep::States);
+        assert!(!app.offer_alt_bypass());
+
+        handle_key(&mut app, KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        assert!(app.offer_alt_bypass());
+        let screen = rendered(&app, 120, 34);
+        assert!(screen.contains("docs/WATCH.md"));
+
+        handle_key(&mut app, KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        assert_eq!(app.current(), TourStep::Preview);
+        assert_eq!(app.sort, MockSort::State);
+    }
+
+    #[test]
+    fn preview_step_accepts_the_option_compose_glyph() {
+        let mut app = TourApp::new(false);
+        app.step = TourStep::ALL
+            .iter()
+            .position(|step| *step == TourStep::Preview)
+            .unwrap();
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('π'), KeyModifiers::NONE),
+        );
+        assert_eq!(app.panel, MockPanel::Preview);
+        assert_eq!(app.current(), TourStep::Shortcuts);
+    }
+
+    #[test]
+    fn alt_chord_matching_covers_meta_and_compose_forms() {
+        assert!(is_alt_chord(
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::ALT),
+            't'
+        ));
+        assert!(is_alt_chord(
+            KeyEvent::new(KeyCode::Char('T'), KeyModifiers::ALT | KeyModifiers::SHIFT),
+            't'
+        ));
+        assert!(is_alt_chord(
+            KeyEvent::new(KeyCode::Char('†'), KeyModifiers::NONE),
+            't'
+        ));
+        assert!(!is_alt_chord(
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE),
+            't'
+        ));
+        assert!(!is_alt_chord(
+            KeyEvent::new(KeyCode::Char('π'), KeyModifiers::NONE),
+            't'
+        ));
+        // Ctrl-composed input never stands in for a compose glyph.
+        assert!(!is_alt_chord(
+            KeyEvent::new(KeyCode::Char('†'), KeyModifiers::CONTROL),
+            't'
+        ));
+    }
+
+    #[test]
+    fn option_compose_table_is_unambiguous() {
+        for (index, (composed, _)) in OPTION_COMPOSED_LETTERS.iter().enumerate() {
+            assert!(
+                !composed.is_ascii(),
+                "{composed} would shadow a plain tour key"
+            );
+            assert!(
+                OPTION_COMPOSED_LETTERS
+                    .iter()
+                    .skip(index + 1)
+                    .all(|(other, _)| other != composed),
+                "{composed} is mapped twice"
+            );
+        }
+    }
+
     #[test]
     fn guided_tour_advances_with_the_live_watch_keys() {
         let mut app = TourApp::new(false);
@@ -2165,7 +2589,7 @@ mod tests {
         // watch action is being taught.
         press(&mut app, KeyCode::Enter, KeyModifiers::NONE);
         assert_eq!(app.current(), TourStep::Work);
-        assert!(app.blocked_hint);
+        assert!(app.blocked_hint());
 
         press(&mut app, KeyCode::Char('j'), KeyModifiers::NONE);
         assert_eq!(app.current(), TourStep::Agents);

--- a/crates/muxa-cli/src/onboarding.rs
+++ b/crates/muxa-cli/src/onboarding.rs
@@ -660,13 +660,35 @@ fn resolve_split_escape() -> Result<Option<KeyEvent>> {
         )));
     }
     // Parameter bytes precede the final byte that terminates the sequence.
+    // Return the represented key instead of dropping it with the phantom Esc:
+    // the pane-navigation gate accepts only Right, so swallowing `[C` would
+    // still strand terminals that consistently split escape sequences.
+    let mut final_byte = None;
     while let Some(key) = next_pending_key()? {
-        let is_parameter = matches!(key.code, KeyCode::Char(byte) if !('@'..='~').contains(&byte));
-        if !is_parameter {
+        let KeyCode::Char(byte) = key.code else {
+            break;
+        };
+        if ('@'..='~').contains(&byte) {
+            final_byte = Some(byte);
             break;
         }
     }
-    Ok(None)
+    Ok(final_byte
+        .and_then(csi_key)
+        .map(|code| KeyEvent::new(code, KeyModifiers::NONE)))
+}
+
+/// The keys a split CSI/SS3 sequence may represent in this tour.
+fn csi_key(final_byte: char) -> Option<KeyCode> {
+    match final_byte {
+        'A' => Some(KeyCode::Up),
+        'B' => Some(KeyCode::Down),
+        'C' => Some(KeyCode::Right),
+        'D' => Some(KeyCode::Left),
+        'H' => Some(KeyCode::Home),
+        'F' => Some(KeyCode::End),
+        _ => None,
+    }
 }
 
 fn next_pending_key() -> Result<Option<KeyEvent>> {
@@ -2239,6 +2261,17 @@ mod tests {
             .iter()
             .map(ratatui::buffer::Cell::symbol)
             .collect::<String>()
+    }
+
+    #[test]
+    fn split_csi_sequences_preserve_the_key_the_tour_is_waiting_for() {
+        assert_eq!(csi_key('A'), Some(KeyCode::Up));
+        assert_eq!(csi_key('B'), Some(KeyCode::Down));
+        assert_eq!(csi_key('C'), Some(KeyCode::Right));
+        assert_eq!(csi_key('D'), Some(KeyCode::Left));
+        assert_eq!(csi_key('H'), Some(KeyCode::Home));
+        assert_eq!(csi_key('F'), Some(KeyCode::End));
+        assert_eq!(csi_key('~'), None);
     }
 
     #[test]

--- a/crates/muxa-cli/src/onboarding/tmux.rs
+++ b/crates/muxa-cli/src/onboarding/tmux.rs
@@ -10,7 +10,7 @@ use super::{
     action_line, action_style, centered_rect, dialog_block, highlighted_actions, tr, UiLanguage,
 };
 use anyhow::{Context, Result};
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{self, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use muxa::AgentState;
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
@@ -184,7 +184,7 @@ pub(super) fn interactive_guide(
                 }
             }
         }
-        if let Event::Key(key) = event::read().context("reading tmux onboarding input")? {
+        if let Some(key) = super::read_key_event()? {
             if key.kind == KeyEventKind::Press && key.code == KeyCode::Esc {
                 return Ok(None);
             }
@@ -1732,6 +1732,65 @@ fn muxa_lines(app: &TmuxApp) -> Vec<Line<'static>> {
         },
     ]);
     lines
+}
+
+/// The tokens this track expects, one list per step, in stage order.
+///
+/// The table is *walked*, not written down: each stage publishes its key
+/// through `expected_key`, the walk presses exactly that, and the step only
+/// closes when the real gate lets it. A gate and its published key therefore
+/// cannot drift apart, which is what `scripts/onboarding-parity.sh` compares
+/// the shell fallback against.
+pub(super) fn step_table() -> Vec<Vec<String>> {
+    let prefix = DetectedPrefix {
+        display: "prefix".to_string(),
+        tmux_key: "C-b".to_string(),
+    };
+    let mut app = TmuxApp::new(false, UiLanguage::En, prefix, PrefixCapture::Direct);
+    let mut table: Vec<Vec<String>> = vec![Vec::new(); Step::ALL.len()];
+    while !app.done {
+        let index = app.step;
+        // A runaway gate would otherwise spin here; the parity test asserts no
+        // step needs anywhere near this many stages.
+        while app.step == index && !app.done && table[index].len() < 8 {
+            let token = table_token(&app);
+            table[index].push(token.clone());
+            feed_token(&mut app, &token);
+        }
+        if app.step == index && !app.done {
+            break;
+        }
+    }
+    table
+}
+
+/// `expected_key` renders the prefix and the shell commands for a human. The
+/// table needs stable, environment-independent tokens instead.
+fn table_token(app: &TmuxApp) -> String {
+    match app.current() {
+        Step::Prefix => "prefix".to_string(),
+        Step::Shell => format!("type:{NEW_SESSION_COMMAND}"),
+        Step::Reattach => format!("type:{ATTACH_COMMAND}"),
+        _ => expected_key(app),
+    }
+}
+
+fn feed_token(app: &mut TmuxApp, token: &str) {
+    if let Some(command) = token.strip_prefix("type:") {
+        for ch in command.chars() {
+            handle_key(app, KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+        handle_key(app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        return;
+    }
+    if token == "prefix" {
+        handle_key(
+            app,
+            KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL),
+        );
+        return;
+    }
+    handle_key(app, super::key_for_token(token));
 }
 
 fn expected_key(app: &TmuxApp) -> String {

--- a/docs/INSTALL.ko.md
+++ b/docs/INSTALL.ko.md
@@ -15,12 +15,18 @@ README를 짧게 유지하기 위해 자세한 설치와 wiring 절차는 이 �
 curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/onboard.sh | sh
 ```
 
-이 경로에는 위 필요 조건이 적용되지 않습니다. 가져온 shell script 자체가 전체
-20단계 fullscreen tour입니다. ANSI terminal control로 가상 shell, tmux status line,
-window/pane layout과 Muxa watch UI를 계속 유지하면서도 Muxa binary 다운로드, 임시
-파일 생성, config 수정, daemon 시작, 실제 tmux session 조작을 전혀 하지 않습니다.
-CPU architecture와 관계없이 일반 Unix-like terminal에서 실행할 수 있습니다. tour
-flag는 `sh -s --` 뒤에 전달합니다.
+이 경로에는 위 필요 조건이 적용되지 않고, 아무것도 설치하지 않습니다. script가
+플랫폼에 맞는 release 바이너리를 임시 디렉터리로 받아 공개된 SHA-256을 검증한 뒤
+진짜 `muxa onboard`를 실행하고, 끝나면 지웁니다. daemon, config, PATH 항목, 실제
+tmux session 조작이 전혀 없습니다.
+
+네트워크가 없거나, release 빌드가 없는 플랫폼이거나, checksum 도구가 없거나,
+`--no-download`를 주면 script에 내장된 20단계 simulation으로 넘어갑니다. 이
+fallback은 같은 시나리오를 순수 ANSI terminal control로 그리며 CPU architecture와
+관계없이 일반 Unix-like terminal에서 실행됩니다. 단계 순서와 입력 키는 실제 tour와
+동일하고 CI가 `muxa onboard --emit step-table`에 맞춰 검증하지만, 실제 tour의 mock
+watch 시뮬레이션·단계별 callout 배치·`F2` 언어 전환·뒤로 가기까지 재현하지는
+않습니다. tour flag는 `sh -s --` 뒤에 전달합니다.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/onboard.sh | sh -s -- --lang ko

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -16,12 +16,19 @@ This page keeps the detailed install and wiring notes out of the README.
 curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/onboard.sh | sh
 ```
 
-This path needs none of the requirements above. The fetched shell script is the
-entire 20-step fullscreen tour: it uses ANSI terminal controls to preserve the
-virtual shell, tmux status line, window/pane layouts, and Muxa watch UI without
-downloading a Muxa binary, creating temporary files, changing config, starting
-a daemon, or operating a real tmux session. It works in a normal Unix-like
-terminal regardless of CPU architecture. Forward tour flags after `sh -s --`:
+This path needs none of the requirements above, and installs nothing. The
+script fetches the release binary for your platform into a temporary directory,
+verifies its published SHA-256, runs the real `muxa onboard`, and deletes it on
+exit — no daemon, no config, no PATH entry, no real tmux session.
+
+With no network, on a platform without a release build, without a checksum
+tool, or with `--no-download`, the script falls back to the 20-step simulation
+embedded in it, which draws the same scenario with plain ANSI terminal controls
+and runs in any Unix-like terminal regardless of CPU architecture. The fallback
+walks the same steps in the same order and accepts the same keys — CI holds it
+to `muxa onboard --emit step-table` — but it does not reproduce the real tour's
+mock watch simulation, per-step callout placement, `F2` language switching, or
+backwards navigation. Forward tour flags after `sh -s --`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/onboard.sh | sh -s -- --lang ko

--- a/docs/ONBOARDING.ko.md
+++ b/docs/ONBOARDING.ko.md
@@ -71,6 +71,26 @@ tmux 구간과 watch 구간도 설명을 읽고 Enter만 누르는 방식이 아
 - `M`: mailbox 열기와 닫기
 - `q`: 온보딩 완료. 실제 watch에서도 종료 키
 
+macOS는 터미널이 Meta를 보내도록 설정하기 전까지 Option을 조합 키로 쓰기 때문에
+`Alt-T`가 `†`로 도착합니다. 온보딩은 이 조합 문자도 `Alt-T`로 인식하며, 두 번
+막히면 터미널 설정 안내와 함께 `→`로 건너뛸 수 있게 알려줍니다. 실제 watch에서
+`Alt` 조합을 쓰려면 `docs/WATCH.md`의 터미널 설정을 적용하세요.
+
+## 설치 없이 실행하기
+
+`scripts/onboard.sh`는 release 바이너리를 임시 디렉터리로 받아 SHA-256을 검증한
+뒤 진짜 `muxa onboard`를 실행하고, 끝나면 지웁니다. 설치가 아니라 다운로드라서
+daemon도 config도 PATH 항목도 남지 않습니다.
+
+네트워크가 없거나, 지원하지 않는 플랫폼이거나, `--no-download`를 주면 스크립트에
+내장된 shell simulation으로 넘어갑니다. 이 fallback은 실제 tour와 같은 20단계를
+같은 키로 진행하며, `muxa onboard --emit step-table`이 그 계약입니다.
+`scripts/onboarding-parity.py`가 CI에서 fallback을 이 계약에 맞춰 검증합니다.
+
+fallback은 단계와 키만 맞추고, 실제 tour의 mock watch 시뮬레이션(선택 이동에 따른
+tree 확장, 단계별 callout 배치, `F2` 언어 전환, 뒤로 가기)까지 재현하지는
+않습니다.
+
 shell 명령은 실제 tmux 진입과 재접속에 필요한 `tmux new-session`과
 `tmux attach` 두 개만 직접 입력합니다. Muxa의 긴 work/agent 명령은 따라 치지
 않으며, `n`으로 form을 열고 위치와 조작 키를 확인한 다음 `Esc`를 누르면 바로

--- a/scripts/onboard.sh
+++ b/scripts/onboard.sh
@@ -230,6 +230,19 @@ run_release_onboarding() {
   [ -n "$muxa_bin" ] && [ -f "$muxa_bin" ] || return 1
   chmod +x "$muxa_bin" 2>/dev/null || :
 
+  # `main` can move ahead of the latest published release. Do not route users
+  # back into the exact pre-fix tour this script replaces while a new release is
+  # still being cut; the hidden contract was introduced with the Alt-T and
+  # split-Esc fixes, so it is also a precise capability probe.
+  step_table=$download_dir/step-table
+  tab=$(printf '\t')
+  if ! "$muxa_bin" onboard --emit step-table > "$step_table" 2>/dev/null \
+    || ! grep -Fqx "14${tab}Alt-T" "$step_table"; then
+    printf 'muxa-onboard: release %s predates the current tour fixes; using the embedded fallback\n' \
+      "$version" >&2
+    return 1
+  fi
+
   set -- onboard --lang "$language"
   [ "$print_only" -eq 1 ] && set -- "$@" --print
   [ "$no_quiz" -eq 1 ] && set -- "$@" --no-quiz

--- a/scripts/onboard.sh
+++ b/scripts/onboard.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Fullscreen Muxa onboarding without downloading or installing Muxa.
+# Fullscreen Muxa onboarding without installing Muxa.
 #
 #   curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/onboard.sh | sh
 #
@@ -8,26 +8,36 @@
 #   curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/onboard.sh | sh -s -- --lang ko
 #   curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/onboard.sh | sh -s -- --print
 #
-# This file is the whole tour. It draws an inert shell → tmux → Muxa scenario
-# with ANSI terminal controls. It never downloads a Muxa binary, starts a
-# daemon, changes config, or operates a real tmux session.
+# The tour you get is `muxa onboard` itself: this script fetches the release
+# binary for the host into a temporary directory, verifies its published
+# SHA-256, runs the onboarding, and deletes it on exit. Nothing is installed —
+# no daemon, no config, no real tmux session, nothing left behind.
+#
+# `--no-download` — or an unsupported platform, a missing checksum tool, or no
+# network — falls back to the simulation embedded below, which draws the same
+# shell → tmux → Muxa scenario with plain ANSI controls. The fallback tracks the
+# real tour step for step; `scripts/onboarding-parity.sh` is what keeps it
+# honest.
 
 set -eu
 
 language=auto
 print_only=0
 no_quiz=0
+allow_download=1
 
 usage() {
   printf '%s\n' \
-    'Usage: onboard.sh [--lang auto|en|ko] [--print] [--no-quiz]' \
+    'Usage: onboard.sh [--lang auto|en|ko] [--print] [--no-quiz] [--no-download]' \
     '' \
-    'A fullscreen shell → tmux → Muxa simulation with no Muxa download.' \
+    'Runs the real muxa onboard from a throwaway copy of the release binary,' \
+    'or an embedded shell → tmux → Muxa simulation when that is unavailable.' \
     '' \
     'Options:' \
     '  --lang auto|en|ko  Display language (default: detect from locale)' \
     '  --print            Print the complete guide instead of opening the TUI' \
     '  --no-quiz          Use Enter to move through the fullscreen tour' \
+    '  --no-download      Always use the embedded simulation' \
     '  -h, --help         Show this help'
 }
 
@@ -46,6 +56,7 @@ while [ "$#" -gt 0 ]; do
     --lang=*) language=${1#--lang=}; shift ;;
     --print) print_only=1; shift ;;
     --no-quiz) no_quiz=1; shift ;;
+    --no-download) allow_download=0; shift ;;
     --tmux) shift ;; # Compatibility: tmux is always part of this tour.
     -h | --help) usage; exit 0 ;;
     --) shift; break ;;
@@ -128,6 +139,118 @@ print_guide() {
       'No Muxa binary, daemon, config, or real tmux session is used.'
   fi
 }
+
+# --------------------------------------------------------------------------
+# Preferred path: run the real `muxa onboard`.
+#
+# The release binary is fetched into a temp directory, checked against its
+# published SHA-256, run, and deleted. This is a download, never an install:
+# no daemon, no config, no PATH entry, nothing left behind.
+# --------------------------------------------------------------------------
+
+release_repo=${MUXA_ONBOARD_REPO:-Open330/muxa}
+download_dir=
+
+detect_release_target() {
+  case "$(uname -s 2>/dev/null || printf unknown)" in
+    Darwin) target_os=apple-darwin ;;
+    Linux) target_os=unknown-linux-gnu ;;
+    *) return 1 ;;
+  esac
+  case "$(uname -m 2>/dev/null || printf unknown)" in
+    x86_64 | amd64) target_arch=x86_64 ;;
+    arm64 | aarch64) target_arch=aarch64 ;;
+    *) return 1 ;;
+  esac
+  printf '%s-%s' "$target_arch" "$target_os"
+}
+
+fetch_url() { # url [dest]; prints to stdout when no dest is given
+  if command -v curl >/dev/null 2>&1; then
+    if [ "$#" -ge 2 ]; then curl -fsSL "$1" -o "$2"; else curl -fsSL "$1"; fi
+  elif command -v wget >/dev/null 2>&1; then
+    if [ "$#" -ge 2 ]; then wget -qO "$2" "$1"; else wget -qO- "$1"; fi
+  else
+    return 1
+  fi
+}
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d' ' -f1
+  else
+    return 1
+  fi
+}
+
+discard_download() {
+  [ -n "$download_dir" ] || return 0
+  rm -rf "$download_dir"
+  download_dir=
+  trap - EXIT INT TERM HUP
+}
+
+# Exits the script on success; returns non-zero to fall back to the simulation.
+run_release_onboarding() {
+  [ "$allow_download" -eq 1 ] || return 1
+  command -v tar >/dev/null 2>&1 || return 1
+  command -v mktemp >/dev/null 2>&1 || return 1
+  target=$(detect_release_target) || return 1
+
+  version=${MUXA_ONBOARD_VERSION:-}
+  if [ -z "$version" ]; then
+    version=$(fetch_url "https://api.github.com/repos/$release_repo/releases/latest" 2>/dev/null |
+      sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1) || return 1
+  fi
+  [ -n "$version" ] || return 1
+
+  download_dir=$(mktemp -d 2>/dev/null) || { download_dir=; return 1; }
+  trap 'rm -rf "$download_dir"' EXIT INT TERM HUP
+
+  release=muxa-$version-$target
+  base=https://github.com/$release_repo/releases/download/$version
+
+  printf 'muxa-onboard: fetching muxa %s (%s) — runs from a temp dir, nothing is installed\n' \
+    "$version" "$target" >&2
+  fetch_url "$base/$release.tar.gz" "$download_dir/$release.tar.gz" || return 1
+  fetch_url "$base/$release.sha256" "$download_dir/$release.sha256" || return 1
+
+  published=$(sed -n 's/^\([0-9a-fA-F]\{64\}\).*/\1/p' "$download_dir/$release.sha256" | head -1)
+  actual=$(sha256_of "$download_dir/$release.tar.gz") || return 1
+  if [ -z "$published" ] || [ "$published" != "$actual" ]; then
+    printf 'muxa-onboard: checksum mismatch for %s, not running it\n' "$release.tar.gz" >&2
+    return 1
+  fi
+
+  tar -xzf "$download_dir/$release.tar.gz" -C "$download_dir" || return 1
+  muxa_bin=$download_dir/$release/muxa
+  [ -x "$muxa_bin" ] || muxa_bin=$(find "$download_dir" -type f -name muxa 2>/dev/null | head -1)
+  [ -n "$muxa_bin" ] && [ -f "$muxa_bin" ] || return 1
+  chmod +x "$muxa_bin" 2>/dev/null || :
+
+  set -- onboard --lang "$language"
+  [ "$print_only" -eq 1 ] && set -- "$@" --print
+  [ "$no_quiz" -eq 1 ] && set -- "$@" --no-quiz
+
+  # This script is usually piped into `sh`, so stdin is the pipe, not the
+  # terminal the tour has to read keys from.
+  # `-r` only checks permission bits; opening still fails with ENXIO when the
+  # process has no controlling terminal, so probe the open itself.
+  status=0
+  if ( : </dev/tty ) 2>/dev/null; then
+    "$muxa_bin" "$@" </dev/tty || status=$?
+  else
+    "$muxa_bin" "$@" || status=$?
+  fi
+  discard_download
+  exit "$status"
+}
+
+if ! run_release_onboarding; then
+  discard_download
+fi
 
 if [ "$print_only" -eq 1 ] || [ ! -r /dev/tty ] || [ ! -t 1 ]; then
   print_guide
@@ -261,9 +384,82 @@ draw_box() {
   fi
 }
 
+# One byte at a time cannot tell a lone Esc from the leading byte of an arrow
+# key or an Alt chord, so every arrow used to read as "quit". Read exactly the
+# rest of the sequence — never past its final byte, or the next keystroke would
+# be swallowed with it — and classify it. `key` ends up as the literal
+# character, an arrow sentinel, or a whole multi-byte glyph; `key_alt` records
+# whether the terminal sent Meta.
 read_key() {
-  key_with_sentinel=$(dd bs=1 count=1 <&3 2>/dev/null; printf '_')
-  key=${key_with_sentinel%_}
+  key_alt=0
+  key=$(read_byte)
+
+  case "$key" in
+    "$esc")
+      key_tail=$(read_byte_pending)
+      case "$key_tail" in
+        '') ;; # Nothing followed: a real Esc.
+        '[' | 'O')
+          key_sequence=$key_tail
+          while :; do
+            sequence_byte=$(read_byte_pending)
+            [ -n "$sequence_byte" ] || break
+            key_sequence=$key_sequence$sequence_byte
+            case "$sequence_byte" in [A-Za-z~]) break ;; esac
+          done
+          case "$key_sequence" in
+            '[A' | 'OA') key=$key_up ;;
+            '[B' | 'OB') key=$key_down ;;
+            '[C' | 'OC') key=$key_right ;;
+            '[D' | 'OD') key=$key_left ;;
+            *) key=$key_nav ;; # Some other CSI/SS3 key, never a quit.
+          esac
+          ;;
+        *) key=$key_tail; key_alt=1 ;; # Esc-prefixed Alt chord.
+      esac
+      ;;
+    "$utf8_lead_two" | "$utf8_lead_three")
+      # macOS composes Option into a glyph — Option+T is `†` — instead of
+      # sending Meta, and a glyph arrives as several bytes.
+      continuation=1
+      [ "$key" = "$utf8_lead_three" ] && continuation=2
+      while [ "$continuation" -gt 0 ]; do
+        key=$key$(read_byte_pending)
+        continuation=$((continuation - 1))
+      done
+      ;;
+  esac
+}
+
+read_byte() {
+  byte_with_sentinel=$(dd bs=1 count=1 <&3 2>/dev/null; printf '_')
+  printf '%s' "${byte_with_sentinel%_}"
+}
+
+# One byte if the terminal already has one, empty otherwise.
+read_byte_pending() {
+  stty min 0 time 1 <&3
+  byte_with_sentinel=$(dd bs=1 count=1 <&3 2>/dev/null; printf '_')
+  stty min 1 time 0 <&3
+  printf '%s' "${byte_with_sentinel%_}"
+}
+
+# True when the last key was the taught Alt chord for letter $1, whether the
+# terminal sent Meta or only the macOS compose glyph.
+key_is_alt_chord() {
+  if [ "$key_alt" -eq 1 ]; then
+    case "$1" in
+      t) [ "$key" = t ] || [ "$key" = T ] ;;
+      p) [ "$key" = p ] || [ "$key" = P ] ;;
+      *) return 1 ;;
+    esac
+    return $?
+  fi
+  case "$1" in
+    t) [ "$key" = '†' ] || [ "$key" = 'ˇ' ] ;;
+    p) [ "$key" = 'π' ] || [ "$key" = '∏' ] ;;
+    *) return 1 ;;
+  esac
 }
 
 read_line() {
@@ -281,6 +477,19 @@ key_escape=$esc
 key_ctrl_b=$(printf '\002')
 key_backspace=$(printf '\177')
 key_ctrl_h=$(printf '\010')
+# Navigation keys arrive as escape sequences; these stand in for them so a step
+# can accept one by name. `key_nav` catches every other sequence, which no step
+# accepts — it draws the "expected input" hint instead of tearing the tour down.
+key_up='<up>'
+key_down='<down>'
+key_right='<right>'
+key_left='<left>'
+key_nav='<nav>'
+# UTF-8 lead bytes of the macOS Option glyphs the tour has to recognise
+# (`†` is E2 80 A0, `ˇ` is CB 87).
+utf8_lead_three=$(printf '\342')
+utf8_lead_two=$(printf '\313')
+key_alt=0
 
 step=1
 error_hint=0
@@ -291,16 +500,18 @@ panes=1
 selected_pane=0
 zoomed=0
 copy_open=0
+step5_sub=0
+step7_sub=0
 step8_sub=0
-step9_sub=0
-step10_sub=0
 step11_sub=0
 watch_selection=0
 sort_state=0
-step15_sub=0
+preview_open=0
+help_open=0
 step16_sub=0
 step17_sub=0
 step18_sub=0
+blocked_attempts=0
 inside_tmux=0
 [ -n "${TMUX:-}" ] && inside_tmux=1
 
@@ -316,18 +527,18 @@ set_step_copy() {
       2) title='tmux prefix'; body1='모든 tmux 명령은 prefix를 누르고 뗀 뒤 suffix를 누릅니다.'; body2='이 simulation은 실제 tmux binding을 실행하지 않습니다.'; if [ "$inside_tmux" -eq 1 ]; then expected='입력: p (안전한 prefix simulation)'; else expected='입력: Ctrl-b'; fi ;;
       3) title='session과 window'; body1='session은 workspace, window는 독립된 work 화면입니다.'; body2='window tree에서 현재 session 구조를 확인합니다.'; expected='입력: w' ;;
       4) title='새 window'; body1='하나의 ticket은 하나의 안정적인 work window가 됩니다.'; body2='새 review window를 만들어 화면 변화를 확인하세요.'; expected='입력: c' ;;
-      5) title='좌우 pane 분할'; body1='pane 하나는 agent 하나에 대응합니다.'; body2='현재 window를 좌우 두 영역으로 나눕니다.'; expected='입력: %' ;;
-      6) title='상하 pane 분할'; body1='같은 work window에 reviewer agent 영역을 추가합니다.'; body2='왼쪽 영역을 한 번 더 나눕니다.'; expected='입력: "' ;;
-      7) title='pane 이동'; body1='선택 pane은 밝은 cyan border와 *로 표시됩니다.'; body2='오른쪽 codex agent pane으로 이동하세요.'; expected='입력: l' ;;
-      8) title='pane zoom'; body1='zoom은 선택 pane에 집중하면서 layout을 보존합니다.'; if [ "$step8_sub" -eq 0 ]; then body2='codex pane을 전체 화면으로 확대하세요.'; expected='입력: z'; else body2='원래 세 pane layout으로 돌아가세요.'; expected='다시 입력: z'; fi ;;
-      9) title='copy mode'; body1='copy mode에서는 terminal 출력을 스크롤하고 검색합니다.'; if [ "$step9_sub" -eq 0 ]; then body2='가상 copy mode를 여세요.'; expected='입력: ['; else body2='copy mode popup을 닫으세요.'; expected='입력: q'; fi ;;
-      10) title='detach와 attach'; if [ "$step10_sub" -eq 0 ]; then body1='detach는 client만 분리하며 session과 작업은 계속 실행됩니다.'; body2='가상 client를 session에서 분리하세요.'; expected='입력: d'; else body1='session은 그대로 실행 중입니다.'; body2='가상 shell에서 다시 연결하세요.'; expected='입력: tmux attach -t muxa-onboarding'; fi ;;
+      5) title='pane 분할'; body1='pane 하나는 agent 하나에 대응합니다.'; if [ "$step5_sub" -eq 0 ]; then body2='현재 window를 좌우 두 영역으로 나눕니다.'; expected='입력: %'; else body2='같은 work window에 reviewer 영역을 상하로 더합니다.'; expected='입력: "'; fi ;;
+      6) title='pane 이동'; body1='선택 pane은 밝은 cyan border와 *로 표시됩니다.'; body2='오른쪽 codex agent pane으로 이동하세요.'; expected='입력: →' ;;
+      7) title='pane zoom'; body1='zoom은 선택 pane에 집중하면서 layout을 보존합니다.'; if [ "$step7_sub" -eq 0 ]; then body2='codex pane을 전체 화면으로 확대하세요.'; expected='입력: z'; else body2='원래 세 pane layout으로 돌아가세요.'; expected='다시 입력: z'; fi ;;
+      8) title='copy mode'; body1='copy mode에서는 terminal 출력을 스크롤하고 검색합니다.'; if [ "$step8_sub" -eq 0 ]; then body2='가상 copy mode를 여세요.'; expected='입력: ['; else body2='copy mode popup을 닫으세요.'; expected='입력: q'; fi ;;
+      9) title='detach'; body1='detach는 client만 분리하며 session과 작업은 계속 실행됩니다.'; body2='가상 client를 session에서 분리하세요.'; expected='입력: d' ;;
+      10) title='다시 attach'; body1='session은 그대로 실행 중입니다.'; body2='가상 shell에서 다시 연결하세요.'; expected='입력: tmux attach -t muxa-onboarding' ;;
       11) title='Muxa managed binding'; if [ "$step11_sub" -eq 0 ]; then body1='Muxa binding은 tmux session 위에서 관측 화면을 엽니다.'; expected='입력: s'; elif [ "$step11_sub" -eq 1 ]; then body1='watch는 같은 client를 유지한 채 전체 agent fleet를 보여줍니다.'; expected='입력: q'; else body1='pane별 상태 overlay에서도 필요한 agent가 바로 보입니다.'; expected='입력: s'; fi ;;
       12) title='work 선택'; body1='workspace/session 아래의 work/window를 한 줄로 관측합니다.'; body2='sandbox에서 onboarding work로 이동하세요.'; expected='입력: j' ;;
       13) title='agent 선택'; body1='work를 펼치면 같은 window의 agent pane들이 나타납니다.'; body2='codex child agent로 들어가세요.'; expected='입력: l' ;;
-      14) title='attention 정렬'; body1='waiting-input, choice, error를 먼저 보도록 정렬할 수 있습니다.'; body2='이 shell tour에서는 t가 Alt-T를 안전하게 대신합니다.'; expected='입력: t' ;;
-      15) title='pane preview'; body1='현재 화면을 떠나지 않고 agent terminal을 확인합니다.'; if [ "$step15_sub" -eq 0 ]; then expected='입력: o'; else expected='다시 입력: o'; fi ;;
-      16) title='shortcut 도움말'; body1='실제 watch의 관측·협업·lifecycle key를 한곳에서 봅니다.'; if [ "$step16_sub" -eq 0 ]; then expected='입력: ?'; else expected='다시 입력: ?'; fi ;;
+      14) title='attention 정렬'; body1='waiting-input, choice, error를 먼저 보도록 정렬할 수 있습니다.'; body2='Alt-T를 눌러 state와 attention이 필요한 순서로 정렬하세요.'; expected='입력: Alt-T' ;;
+      15) title='pane preview'; body1='현재 화면을 떠나지 않고 agent terminal을 확인합니다.'; body2='선택한 pane의 preview를 여세요.'; expected='입력: o' ;;
+      16) title='shortcut 도움말'; body1='실제 watch의 관측·협업·lifecycle key를 한곳에서 봅니다.'; case "$step16_sub" in 0) body2='먼저 preview를 닫습니다.'; expected='입력: o';; 1) body2='전체 도움말을 엽니다.'; expected='입력: ?';; *) body2='도움말을 닫고 계속합니다.'; expected='다시 입력: ?';; esac ;;
       17) title='new work form'; body1='n은 workspace, work, cwd, agent를 받는 form을 엽니다.'; if [ "$step17_sub" -eq 0 ]; then expected='입력: n'; else body2='실제 생성 없이 안전하게 form을 닫습니다.'; expected='입력: Esc'; fi ;;
       18) title='협업과 mailbox'; body1='같은 work의 agent에게 메시지를 보내고 reply를 추적합니다.'; case "$step18_sub" in 0) expected='입력: m';; 1) expected='빈 composer에서 Backspace';; 2) expected='입력: M';; *) expected='다시 입력: M';; esac ;;
       19) title='agent-side Muxa MCP'; body1='agent도 같은 work 경계 안에서 peer를 조회하고 기다립니다.'; body2='범용 shell 대신 좁은 Muxa operation을 사용합니다.'; expected='입력: l' ;;
@@ -339,23 +550,34 @@ set_step_copy() {
       2) title='tmux prefix'; body1='Every tmux command is prefix, release, then suffix.'; body2='This simulation never invokes a real tmux binding.'; if [ "$inside_tmux" -eq 1 ]; then expected='Press p (safe prefix simulation)'; else expected='Press Ctrl-b'; fi ;;
       3) title='Sessions and windows'; body1='A session is a workspace; a window is an independent work screen.'; body2='Open the tree to inspect the current session.'; expected='Press w' ;;
       4) title='Create a window'; body1='One ticket becomes one durable work window.'; body2='Create a review window and watch the status line change.'; expected='Press c' ;;
-      5) title='Split left/right'; body1='One pane maps to one agent.'; body2='Split the current window into two terminal regions.'; expected='Press %' ;;
-      6) title='Split top/bottom'; body1='Add a reviewer agent region to the same work window.'; body2='Split the left region one more time.'; expected='Press "' ;;
-      7) title='Move between panes'; body1='The selected pane has a bright cyan border and *.'; body2='Move to the codex agent pane on the right.'; expected='Press l' ;;
-      8) title='Pane zoom'; body1='Zoom focuses one pane while preserving the layout.'; if [ "$step8_sub" -eq 0 ]; then body2='Expand the codex pane to the whole client.'; expected='Press z'; else body2='Return to the original three-pane layout.'; expected='Press z again'; fi ;;
-      9) title='Copy mode'; body1='Copy mode scrolls and searches terminal output.'; if [ "$step9_sub" -eq 0 ]; then body2='Open the virtual copy mode.'; expected='Press ['; else body2='Close the copy-mode popup.'; expected='Press q'; fi ;;
-      10) title='Detach and attach'; if [ "$step10_sub" -eq 0 ]; then body1='Detach removes only the client; the session keeps running.'; body2='Detach the virtual client now.'; expected='Press d'; else body1='The session is still running.'; body2='Reconnect from the virtual shell.'; expected='Type: tmux attach -t muxa-onboarding'; fi ;;
+      5) title='Split into panes'; body1='One pane maps to one agent.'; if [ "$step5_sub" -eq 0 ]; then body2='Split the current window into two terminal regions.'; expected='Press %'; else body2='Add a reviewer region below the left one.'; expected='Press "'; fi ;;
+      6) title='Move between panes'; body1='The selected pane has a bright cyan border and *.'; body2='Move to the codex agent pane on the right.'; expected='Press →' ;;
+      7) title='Pane zoom'; body1='Zoom focuses one pane while preserving the layout.'; if [ "$step7_sub" -eq 0 ]; then body2='Expand the codex pane to the whole client.'; expected='Press z'; else body2='Return to the original three-pane layout.'; expected='Press z again'; fi ;;
+      8) title='Copy mode'; body1='Copy mode scrolls and searches terminal output.'; if [ "$step8_sub" -eq 0 ]; then body2='Open the virtual copy mode.'; expected='Press ['; else body2='Close the copy-mode popup.'; expected='Press q'; fi ;;
+      9) title='Detach'; body1='Detach removes only the client; the session keeps running.'; body2='Detach the virtual client now.'; expected='Press d' ;;
+      10) title='Reattach'; body1='The session is still running.'; body2='Reconnect from the virtual shell.'; expected='Type: tmux attach -t muxa-onboarding' ;;
       11) title='Muxa managed binding'; if [ "$step11_sub" -eq 0 ]; then body1='A managed key opens observability over the tmux session.'; expected='Press s'; elif [ "$step11_sub" -eq 1 ]; then body1='Watch shows the whole agent fleet without leaving the client.'; expected='Press q'; else body1='Pane overlays make the agent needing attention visible.'; expected='Press s'; fi ;;
       12) title='Select work'; body1='Observe work/windows beneath each workspace/session.'; body2='Move from sandbox to the onboarding work.'; expected='Press j' ;;
       13) title='Select an agent'; body1='Expand work to see agent panes in that window.'; body2='Enter the codex child agent.'; expected='Press l' ;;
-      14) title='Sort by attention'; body1='Put waiting-input, choice, and error ahead of passive work.'; body2='In this shell tour, t safely represents Alt-T.'; expected='Press t' ;;
-      15) title='Pane preview'; body1='Inspect an agent terminal without leaving the watch screen.'; if [ "$step15_sub" -eq 0 ]; then expected='Press o'; else expected='Press o again'; fi ;;
-      16) title='Shortcut help'; body1='See observation, collaboration, and lifecycle keys together.'; if [ "$step16_sub" -eq 0 ]; then expected='Press ?'; else expected='Press ? again'; fi ;;
+      14) title='Sort by attention'; body1='Put waiting-input, choice, and error ahead of passive work.'; body2='Press Alt-T to sort the watch by state and attention.'; expected='Press Alt-T' ;;
+      15) title='Pane preview'; body1='Inspect an agent terminal without leaving the watch screen.'; body2='Open the preview for the selected pane.'; expected='Press o' ;;
+      16) title='Shortcut help'; body1='See observation, collaboration, and lifecycle keys together.'; case "$step16_sub" in 0) body2='Close the preview first.'; expected='Press o';; 1) body2='Open the full help.'; expected='Press ?';; *) body2='Close help and continue.'; expected='Press ? again';; esac ;;
       17) title='New-work form'; body1='n opens fields for workspace, work, cwd, and agent.'; if [ "$step17_sub" -eq 0 ]; then expected='Press n'; else body2='Close it without creating anything.'; expected='Press Esc'; fi ;;
       18) title='Collaboration and mailbox'; body1='Message peers in one work and track their replies.'; case "$step18_sub" in 0) expected='Press m';; 1) expected='Press Backspace in the empty composer';; 2) expected='Press M';; *) expected='Press M again';; esac ;;
       19) title='Agent-side Muxa MCP'; body1='Agents inspect and wait for peers inside the same work boundary.'; body2='Narrow Muxa operations replace arbitrary shell control.'; expected='Press l' ;;
       20) title='Onboarding complete'; body1='You saw observability, attention, collaboration, and lifecycle.'; body2='No Muxa binary or real tmux session was used.'; body3='Close the tour to see download and install options.'; expected='Press q' ;;
     esac
+  fi
+
+  # Alt-T is the one gate with no Alt-free equivalent, and a terminal that
+  # composes Option instead of sending Meta cannot produce it. Offer the
+  # terminal fix and a way past only after the learner has actually tried.
+  if [ "$step" -eq 14 ] && [ "$blocked_attempts" -ge 2 ]; then
+    if [ "$language" = ko ]; then
+      body3='Alt이 안 눌리나요? docs/WATCH.md의 터미널 설정을 보거나, →로 넘어가세요.'
+    else
+      body3='Alt not arriving? See docs/WATCH.md for the terminal setting, or press → to skip.'
+    fi
   fi
 
   if [ "$no_quiz" -eq 1 ]; then
@@ -388,7 +610,7 @@ render_callout() {
 render_shell() {
   clear_screen
   draw_box 1 1 "$cols" "$rows" 'shell · outside tmux' "$border"
-  if [ "$step10_sub" -eq 1 ]; then
+  if [ "$step" -eq 10 ]; then
     put 3 3 "$dim" 'june@devbox:~/personal/muxa$'
     put 4 3 "$yellow" '[detached (from session muxa-onboarding)]'
     put 6 3 "$green" 'june@devbox:~/personal/muxa$ '
@@ -650,8 +872,8 @@ render_watch() {
   fi
   render_watch_footer
 
-  [ "$step" -eq 15 ] && [ "$step15_sub" -eq 1 ] && render_preview_overlay
-  [ "$step" -eq 16 ] && [ "$step16_sub" -eq 1 ] && render_help_overlay
+  [ "$preview_open" -eq 1 ] && render_preview_overlay
+  [ "$help_open" -eq 1 ] && render_help_overlay
   [ "$step" -eq 17 ] && [ "$step17_sub" -eq 1 ] && render_form_overlay
   [ "$step" -eq 18 ] && [ "$step18_sub" -eq 1 ] && render_message_overlay
   [ "$step" -eq 18 ] && [ "$step18_sub" -eq 3 ] && render_mailbox_overlay
@@ -678,7 +900,7 @@ render_current() {
     render_small_terminal
     return
   fi
-  if [ "$step" -eq 1 ] || { [ "$step" -eq 10 ] && [ "$step10_sub" -eq 1 ]; }; then
+  if [ "$step" -eq 1 ] || [ "$step" -eq 10 ]; then
     render_shell
   elif [ "$step" -le 11 ]; then
     if [ "$step" -eq 11 ] && [ "$step11_sub" -eq 1 ]; then render_watch; else render_tmux; fi
@@ -695,18 +917,18 @@ skip_step() {
     1) : ;;
     3) tree_open=1 ;;
     4) tree_open=0; windows=2; active_window=1 ;;
-    5) panes=2 ;;
-    6) panes=3 ;;
-    7) selected_pane=1 ;;
-    8) zoomed=0 ;;
-    9) copy_open=0 ;;
-    10) step10_sub=1 ;;
+    5) panes=3 ;;
+    6) selected_pane=1 ;;
+    7) zoomed=0 ;;
+    8) copy_open=0 ;;
+    9) : ;;
+    10) : ;;
     11) watch_selection=0 ;;
     12) watch_selection=1 ;;
     13) watch_selection=2 ;;
     14) sort_state=1 ;;
-    15) step15_sub=0 ;;
-    16) step16_sub=0 ;;
+    15) preview_open=1 ;;
+    16) preview_open=0; help_open=0; step16_sub=0 ;;
     17) step17_sub=0 ;;
     18) step18_sub=0 ;;
   esac
@@ -722,20 +944,21 @@ accept_key() {
       ;;
     3) [ "$key" = w ] && { accepted=1; tree_open=1; step=4; } ;;
     4) [ "$key" = c ] && { accepted=1; tree_open=0; windows=2; active_window=1; step=5; } ;;
-    5) [ "$key" = '%' ] && { accepted=1; panes=2; step=6; } ;;
-    6) [ "$key" = '"' ] && { accepted=1; panes=3; step=7; } ;;
-    7) [ "$key" = l ] && { accepted=1; selected_pane=1; step=8; } ;;
-    8)
-      if [ "$key" = z ]; then accepted=1; if [ "$step8_sub" -eq 0 ]; then zoomed=1; step8_sub=1; else zoomed=0; step=9; fi; fi
-      ;;
-    9)
-      if [ "$step9_sub" -eq 0 ] && [ "$key" = '[' ]; then accepted=1; copy_open=1; step9_sub=1
-      elif [ "$step9_sub" -eq 1 ] && [ "$key" = q ]; then accepted=1; copy_open=0; step=10
+    5)
+      if [ "$step5_sub" -eq 0 ] && [ "$key" = '%' ]; then accepted=1; panes=2; step5_sub=1
+      elif [ "$step5_sub" -eq 1 ] && [ "$key" = '"' ]; then accepted=1; panes=3; step=6
       fi
       ;;
-    10)
-      if [ "$step10_sub" -eq 0 ] && [ "$key" = d ]; then accepted=1; step10_sub=1; fi
+    6) [ "$key" = "$key_right" ] && { accepted=1; selected_pane=1; step=7; } ;;
+    7)
+      if [ "$key" = z ]; then accepted=1; if [ "$step7_sub" -eq 0 ]; then zoomed=1; step7_sub=1; else zoomed=0; step=8; fi; fi
       ;;
+    8)
+      if [ "$step8_sub" -eq 0 ] && [ "$key" = '[' ]; then accepted=1; copy_open=1; step8_sub=1
+      elif [ "$step8_sub" -eq 1 ] && [ "$key" = q ]; then accepted=1; copy_open=0; step=9
+      fi
+      ;;
+    9) [ "$key" = d ] && { accepted=1; step=10; } ;;
     11)
       if [ "$step11_sub" -eq 0 ] && [ "$key" = s ]; then accepted=1; step11_sub=1
       elif [ "$step11_sub" -eq 1 ] && [ "$key" = q ]; then accepted=1; step11_sub=2
@@ -744,12 +967,18 @@ accept_key() {
       ;;
     12) [ "$key" = j ] && { accepted=1; watch_selection=1; step=13; } ;;
     13) [ "$key" = l ] && { accepted=1; watch_selection=2; step=14; } ;;
-    14) [ "$key" = t ] && { accepted=1; sort_state=1; step=15; } ;;
-    15)
-      if [ "$key" = o ]; then accepted=1; if [ "$step15_sub" -eq 0 ]; then step15_sub=1; else step15_sub=0; step=16; fi; fi
+    14)
+      if key_is_alt_chord t; then accepted=1; sort_state=1; step=15
+      elif [ "$blocked_attempts" -ge 2 ] && { [ "$key" = "$key_right" ] || [ "$key" = "$key_enter" ]; }; then
+        accepted=1; sort_state=1; step=15
+      fi
       ;;
+    15) [ "$key" = o ] && { accepted=1; preview_open=1; step=16; } ;;
     16)
-      if [ "$key" = '?' ]; then accepted=1; if [ "$step16_sub" -eq 0 ]; then step16_sub=1; else step16_sub=0; step=17; fi; fi
+      if [ "$step16_sub" -eq 0 ] && [ "$key" = o ]; then accepted=1; preview_open=0; step16_sub=1
+      elif [ "$step16_sub" -eq 1 ] && [ "$key" = '?' ]; then accepted=1; help_open=1; step16_sub=2
+      elif [ "$step16_sub" -eq 2 ] && [ "$key" = '?' ]; then accepted=1; help_open=0; step16_sub=0; step=17
+      fi
       ;;
     17)
       if [ "$step17_sub" -eq 0 ] && [ "$key" = n ]; then accepted=1; step17_sub=1
@@ -769,8 +998,10 @@ accept_key() {
 
   if [ "$accepted" -eq 1 ]; then
     error_hint=0
+    blocked_attempts=0
   else
     error_hint=1
+    blocked_attempts=$((blocked_attempts + 1))
   fi
 }
 
@@ -795,7 +1026,7 @@ while [ "$step" -le 20 ]; do
     continue
   fi
 
-  if [ "$step" -eq 1 ] || { [ "$step" -eq 10 ] && [ "$step10_sub" -eq 1 ]; }; then
+  if [ "$step" -eq 1 ] || [ "$step" -eq 10 ]; then
     if [ "$step" -eq 1 ]; then prompt_row=5; else prompt_row=6; fi
     move_to "$prompt_row" 32
     read_line
@@ -817,7 +1048,7 @@ while [ "$step" -le 20 ]; do
   if [ "$key" = "$key_escape" ] && ! { [ "$step" -eq 17 ] && [ "$step17_sub" -eq 1 ]; }; then
     exit 0
   fi
-  if [ "$key" = q ] && ! { [ "$step" -eq 9 ] || { [ "$step" -eq 11 ] && [ "$step11_sub" -eq 1 ]; } || [ "$step" -eq 20 ]; }; then
+  if [ "$key" = q ] && ! { [ "$step" -eq 8 ] || { [ "$step" -eq 11 ] && [ "$step11_sub" -eq 1 ]; } || [ "$step" -eq 20 ]; }; then
     exit 0
   fi
   accept_key

--- a/scripts/onboarding-parity.py
+++ b/scripts/onboarding-parity.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Hold the shell fallback in `onboard.sh` to the real `muxa onboard` contract.
+
+`muxa onboard --emit step-table` publishes the key each of the twenty steps
+waits for, derived by walking the real gates. This script presses exactly those
+keys at `scripts/onboard.sh --no-download` and fails if the fallback disagrees
+about which step it is on — the drift that let the tour teach `t` while the
+real one required `Alt-T`.
+
+    scripts/onboarding-parity.py [--muxa target/debug/muxa] [--lang en]
+"""
+
+import argparse
+import fcntl
+import os
+import pty
+import re
+import select
+import struct
+import subprocess
+import sys
+import termios
+import time
+import unicodedata
+
+ROWS, COLS = 40, 130
+STEP_TIMEOUT = 20.0
+CSI = re.compile(r"\x1b\[([0-9;?]*)([@-~])")
+STEP_MARK = re.compile(r"(\d+)/20")
+
+
+def char_width(ch: str) -> int:
+    if unicodedata.combining(ch):
+        return 0
+    return 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+
+
+class Screen:
+    """Just enough of a terminal to read the step number back off the tour."""
+
+    def __init__(self, rows: int, cols: int) -> None:
+        self.rows, self.cols = rows, cols
+        self.grid = [[" "] * cols for _ in range(rows)]
+        self.row = self.col = 0
+        self.pending = ""
+
+    def clear(self) -> None:
+        self.grid = [[" "] * self.cols for _ in range(self.rows)]
+
+    def feed(self, data: str) -> None:
+        data, self.pending = self.pending + data, ""
+        index, size = 0, len(data)
+        while index < size:
+            ch = data[index]
+            if ch == "\x1b":
+                match = CSI.match(data, index)
+                if match:
+                    self._csi(match.group(1), match.group(2))
+                    index = match.end()
+                    continue
+                # An escape sequence split across reads: keep it for next time.
+                if size - index < 12:
+                    self.pending = data[index:]
+                    return
+                index += 1
+                continue
+            if ch == "\r":
+                self.col = 0
+            elif ch == "\n":
+                self.row = min(self.row + 1, self.rows - 1)
+                self.col = 0
+            elif ch >= " ":
+                self._put(ch)
+            index += 1
+
+    def _put(self, ch: str) -> None:
+        width = char_width(ch)
+        if width == 0 or self.col >= self.cols:
+            return
+        self.grid[self.row][self.col] = ch
+        for offset in range(1, width):
+            if self.col + offset < self.cols:
+                self.grid[self.row][self.col + offset] = ""
+        self.col += width
+
+    def _csi(self, params: str, final: str) -> None:
+        if params.startswith("?"):
+            return
+        numbers = [int(p) if p else 0 for p in params.split(";")] if params else []
+
+        def arg(index: int, default: int = 1) -> int:
+            return numbers[index] if len(numbers) > index and numbers[index] else default
+
+        if final in "Hf":
+            self.row = min(max(arg(0) - 1, 0), self.rows - 1)
+            self.col = min(max(arg(1) - 1, 0), self.cols - 1)
+        elif final == "J" and (numbers[0] if numbers else 0) == 2:
+            self.clear()
+            self.row = self.col = 0
+        elif final == "K":
+            mode = numbers[0] if numbers else 0
+            if mode == 0:
+                for index in range(self.col, self.cols):
+                    self.grid[self.row][index] = " "
+            elif mode == 2:
+                self.grid[self.row] = [" "] * self.cols
+        elif final == "A":
+            self.row = max(0, self.row - arg(0))
+        elif final == "B":
+            self.row = min(self.rows - 1, self.row + arg(0))
+        elif final == "C":
+            self.col = min(self.cols - 1, self.col + arg(0))
+        elif final == "D":
+            self.col = max(0, self.col - arg(0))
+
+    def text(self) -> str:
+        return "\n".join("".join(row).rstrip() for row in self.grid)
+
+
+class Tour:
+    def __init__(self, argv: list[str]) -> None:
+        self.screen = Screen(ROWS, COLS)
+        self.exited: int | None = None
+        self.pid, self.fd = pty.fork()
+        if self.pid == 0:
+            os.environ["TERM"] = "xterm-256color"
+            for stale in ("TMUX", "TMUX_PANE"):
+                os.environ.pop(stale, None)
+            os.execvp(argv[0], argv)
+            os._exit(127)
+        fcntl.ioctl(self.fd, termios.TIOCSWINSZ, struct.pack("HHHH", ROWS, COLS, 0, 0))
+        os.set_blocking(self.fd, False)
+
+    def pump(self, seconds: float) -> None:
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            ready, _, _ = select.select([self.fd], [], [], 0.05)
+            if not ready:
+                continue
+            try:
+                chunk = os.read(self.fd, 1 << 18)
+            except OSError:
+                self._reap()
+                return
+            if not chunk:
+                self._reap()
+                return
+            self.screen.feed(chunk.decode("utf-8", "replace"))
+
+    def send(self, data: bytes) -> None:
+        try:
+            os.write(self.fd, data)
+        except OSError:
+            self._reap()
+
+    def step(self) -> int | None:
+        marks = STEP_MARK.findall(self.screen.text())
+        return int(marks[-1]) if marks else None
+
+    def wait_for_step(self, wanted: int) -> bool:
+        deadline = time.time() + STEP_TIMEOUT
+        while time.time() < deadline:
+            if self.step() == wanted:
+                return True
+            if self.exited is not None:
+                return False
+            self.pump(0.2)
+        return self.step() == wanted
+
+    def _reap(self) -> None:
+        if self.exited is not None:
+            return
+        done, status = os.waitpid(self.pid, os.WNOHANG)
+        self.exited = status if done else None
+
+    def finish(self) -> int:
+        self.pump(1.0)
+        deadline = time.time() + 5
+        while time.time() < deadline and self.exited is None:
+            self._reap()
+            self.pump(0.2)
+        if self.exited is None:
+            os.kill(self.pid, 9)
+            os.waitpid(self.pid, 0)
+            self.exited = -1
+        os.close(self.fd)
+        return self.exited
+
+
+KEY_BYTES = {
+    "prefix": b"\x02",
+    "Alt-T": b"\x1bt",
+    "Alt-P": b"\x1bp",
+    "Esc": b"\x1b",
+    "Backspace": b"\x7f",
+    "Enter": b"\r",
+    "→": b"\x1b[C",
+    "←": b"\x1b[D",
+    "↑": b"\x1b[A",
+    "↓": b"\x1b[B",
+}
+
+
+def token_bytes(token: str) -> bytes:
+    if token.startswith("type:"):
+        return token[len("type:") :].encode() + b"\r"
+    if token in KEY_BYTES:
+        return KEY_BYTES[token]
+    return token.encode()
+
+
+def read_contract(muxa: str) -> list[tuple[int, list[str]]]:
+    raw = subprocess.run(
+        [muxa, "onboard", "--emit", "step-table"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    contract = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        fields = line.split("\t")
+        contract.append((int(fields[0]), fields[1:]))
+    return contract
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--muxa", default=os.environ.get("MUXA_BIN", "target/debug/muxa"))
+    parser.add_argument("--script", default="scripts/onboard.sh")
+    parser.add_argument("--lang", default="en")
+    args = parser.parse_args()
+
+    contract = read_contract(args.muxa)
+    if len(contract) != 20:
+        print(f"parity: expected 20 steps from --emit step-table, got {len(contract)}")
+        return 1
+
+    tour = Tour(["sh", os.path.abspath(args.script), "--lang", args.lang, "--no-download"])
+    tour.pump(1.5)
+
+    failures = []
+    for position, (number, tokens) in enumerate(contract):
+        if not tour.wait_for_step(number):
+            failures.append(
+                f"step {number}: fallback is on {tour.step()} "
+                f"(expected keys {' '.join(tokens) or '—'})"
+            )
+            break
+        for token in tokens:
+            # Pressing the chord alone cannot tell an `Alt-T` gate from a `t`
+            # gate — Esc-prefixed input reaches both. Check the bare letter is
+            # refused first, which is the drift that shipped in issue #76.
+            bare = token[len("Alt-") :].lower() if token.startswith("Alt-") else None
+            if bare:
+                tour.send(bare.encode())
+                tour.pump(0.35)
+                if tour.step() != number:
+                    failures.append(
+                        f"step {number}: a bare {bare!r} advanced the fallback, but the "
+                        f"real tour requires {token}"
+                    )
+                    break
+            tour.send(token_bytes(token))
+            tour.pump(0.25)
+        if failures:
+            break
+        following = contract[position + 1][0] if position + 1 < len(contract) else None
+        if following is not None and not tour.wait_for_step(following):
+            failures.append(
+                f"step {number}: pressing {' '.join(tokens)} left the fallback on "
+                f"{tour.step()}, not {following}"
+            )
+            break
+        print(f"  ok  {number:>2}/20  {' '.join(tokens)}")
+
+    status = tour.finish()
+    if not failures and status != 0:
+        failures.append(f"fallback did not exit cleanly after the last step (status {status})")
+
+    if failures:
+        print("\nonboarding parity FAILED")
+        for failure in failures:
+            print(f"  - {failure}")
+        print("\n`muxa onboard --emit step-table` is the contract; update scripts/onboard.sh.")
+        return 1
+
+    print(f"\nonboarding parity ok — {len(contract)} steps, same keys as muxa onboard")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #76.

## What was broken

**The reported symptom — stuck at 14/20.** `TourStep::States` was the tour's
only gate with no `Alt`-free equivalent:

```rust
TourStep::States
    if matches!(key.code, KeyCode::Char('t' | 'T'))
        && key.modifiers.contains(KeyModifiers::ALT) =>
```

macOS composes Option unless the terminal is told to send Meta, so `Option+T`
arrives as `†` with no modifier at all. Nothing matched, the red "press Alt-T"
hint repeated forever, and the only ways out were `Esc` (quit) or `--no-quiz`
— neither surfaced in the TUI. Every other guided gate has a plain-key path
(`Preview` takes `o` *or* `Alt-P`); this one did not.

**The comment on the issue — arrow keys quitting.** crossterm's parser emits
`Esc` the moment a read returns a lone `\x1b` with nothing else in the same
syscall (`parse.rs:35`, `source/unix/tty.rs:247`). An arrow key relayed
through tmux or a slow pty splits exactly that way, and the tour treated a
bare `Esc` as an immediate quit.

**`scripts/onboard.sh` had it worse.** Reading one byte per key, it quit on
*every* arrow key. Reproduced against `origin/main` in a pty:

```
origin/main, real Alt-T (ESC t):  reached step 14 → process exited 0
origin/main, plain arrow Up:      reached step 14 → process exited 0
```

## What changed

**1. The gate.** `States` now accepts the compose glyph (`†`, `ˇ`) as well as
a real `Alt-T`; a bare `t` is still refused, because the tour teaches the live
watch binding. After two missed attempts it surfaces the terminal setting from
`docs/WATCH.md` and accepts `→` to move on, so no terminal can strand it.

**2. The phantom `Esc`.** The tour and the tmux track confirm an `Esc` before
quitting: if input follows within 50 ms, a `[`/`O` tail is swallowed as the
CSI/SS3 sequence it belongs to, and anything else is reassembled into the
`Alt` chord the terminal split in two.

**3. `onboard.sh` now runs the real thing.** Rather than keep chasing a second
implementation of the same tour, the script fetches the release binary into a
temp directory, verifies its published SHA-256, runs `muxa onboard`, and
deletes it. A download, not an install — no daemon, no config, no PATH entry.
The embedded simulation remains the fallback for `--no-download`, an
unsupported platform, a missing checksum tool, or no network.

**4. The fallback was realigned** to the real tour's step decomposition and
keys — splits are one step, detach and reattach are two, pane movement takes
`→`, the attention sort takes `Alt-T` instead of a stand-in `t` — and its
input layer now reads escape sequences up to their final byte, so it no longer
swallows the following keystroke.

**5. Anti-drift.** `muxa onboard --emit step-table` publishes the key each step
waits for, *derived by walking the real gates* rather than written down beside
them, and `scripts/onboarding-parity.py` presses exactly those keys at the
fallback. New CI job, both languages.

## Verification

Measured, not assumed — the 20 steps of both tours were rendered and compared.

`curl | sh` now delivers the identical tour (Rust strings, not shell ones):

```
12/20 · navigate between work windows
14/20 · use state to choose the next action
20/20 · ready for the live watch
```

The gate, driven against the built binary in a real pty:

| input | result |
| --- | --- |
| `†` (macOS compose) | advances |
| split `ESC`+`t` (1–45 ms) | reassembled to `Alt-T`, advances |
| split `ESC`+`[A` (1–45 ms) | survives, no quit |
| lone `Esc` | still quits |
| `→` ×3 | hint at the 2nd, advances on the 3rd |

The same five cases pass against the shell fallback.

The parity check was confirmed to actually fail. Its first version passed with
step 14 reverted to `t` — `Alt-T` reaches the terminal as `ESC t`, so a `t`
gate accepts it too. It now also asserts the bare letter is refused:

```
onboarding parity FAILED
  - step 14: a bare 't' advanced the fallback, but the real tour requires Alt-T
```

`cargo fmt --check` clean · `clippy --workspace --all-targets -D warnings` 0 ·
1,609 tests pass · `shellcheck` clean.

## Not in scope

The fallback matches the real tour on **steps and keys only**. It does not
reproduce the mock watch simulation (tree expansion on selection, sort
reordering), per-step callout placement, `F2` language switching, or backwards
navigation — that would be a ~2,000-line pure-`sh` reimplementation. The limit
is documented in `README`/`docs/INSTALL` (both languages) and
`docs/ONBOARDING.ko.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
