### PR TITLE
feat(runtime): add native PTY default and cmux backend

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -229,11 +229,12 @@ footer에서 굵은 노란색으로 강조합니다. `j`, `l`, `Alt-T`, `o`, `?`
 | `muxa timeline --since today` | session별로 묶은 interactive timeline. `--session main`, `--agent codex`로 필터링하고 `--sort waiting` 정렬이나 `--view heatmap`을 사용할 수 있음. |
 | `muxa activity --type agent\|tmux\|human` | raw activity ledger interval 조회. |
 | `muxa sync` | tmux pane scan으로 registry backfill. |
+| `muxa agent start --agent codex [--host auto\|native\|tmux]` | allowlist agent 실행. `auto`는 실제 tmux 셸에서는 tmux를, 일반 터미널에서는 muxa-owned PTY를 사용. |
 | `muxa work start muxa-onboarding --workspace muxa --agent codex ...` | workspace session과 work window를 만들거나 재사용하고 agent pane을 추가. |
 | `muxa workspace list/show/close` | workspace/project session을 조회하거나 명시적으로 종료. |
 | `muxa work list/show/close [--workspace muxa]` | Work와 현재 Run binding을 조회하거나 Run window를 명시적으로 종료. |
-| `muxa agent start --workspace muxa --work muxa-onboarding ...` | allowlist agent pane을 work window에 추가. MCP에서는 `muxa_start_agent`로 제공. |
-| `muxa agent control --pane %N --action interrupt` | managed agent pane 하나를 중단하거나 명시적으로 종료. |
+| `muxa agent start --host tmux --workspace muxa --work muxa-onboarding ...` | allowlist agent pane을 managed tmux Work window에 추가. MCP에서는 `muxa_start_agent`로 제공. |
+| `muxa agent control (--pane %N\|--session pty-N) --action interrupt` | managed tmux pane 또는 muxa-owned PTY agent session 하나를 중단하거나 명시적으로 종료. |
 | `muxa onboard [--lang auto\|en\|ko]` | shell → tmux → Muxa 통합 fullscreen walkthrough. `F2` 언어 전환, `--no-quiz` gate 생략, `--print` 통합 guide 출력 지원. |
 | `muxa mcp` | coding agent가 상태 확인, 메시지, pane capture, 변경 대기, tmux lifecycle을 Muxa를 통해 수행하는 MCP stdio server. [docs/MCP.md](docs/MCP.md) 참고. |
 | `muxa init` | install/uninstall wizard. |

--- a/README.md
+++ b/README.md
@@ -268,13 +268,14 @@ Korean is selected automatically for a Korean locale, can be requested with
 | `muxa sync` | Backfill the registry by scanning active pane hosts. |
 | `muxa register --name X [--pid N]` | Surface an arbitrary background process (script, game, automation loop) as a pid-tracked row in `muxa status`. |
 | `muxa run --detach --name X -- <cmd>` | Run a command in a muxa-owned PTY; it also appears in `muxa status` as a task. |
+| `muxa agent start --agent codex [--host auto\|native\|tmux]` | Start an allowlisted agent. `auto` uses tmux inside tmux and a muxa-owned PTY in a plain terminal. |
 | `muxa work init` | Describe a work pipeline in your own words; an agent writes the `[ticket]`/`[[route]]`/`[pipeline.*]` config, validated and shown before anything is written. |
 | `muxa work up cal-1234 --body "..."` | Resolve the ticket, route it to a workspace, and create whichever pipeline agent panes are missing — delivering the request to the ones already running. Re-running converges; also `muxa_start_work` over MCP. See [docs/PIPELINE.md](docs/PIPELINE.md). |
 | `muxa work start muxa-onboarding --workspace muxa --agent codex ...` | Create/reuse workspace session `muxa`, create/reuse its work window, and add an agent pane. |
 | `muxa workspace list/show/close` | Inspect or explicitly close workspace/project sessions. |
 | `muxa work list/show/close [--workspace muxa]` | Inspect Work and its current Run binding, or explicitly close that Run window. |
-| `muxa agent start --workspace muxa --work muxa-onboarding ...` | Add an allowlisted agent pane to one work window; also exposed as MCP `muxa_start_agent`. |
-| `muxa agent control --pane %N --action interrupt` | Interrupt or explicitly terminate one managed agent pane. |
+| `muxa agent start --host tmux --workspace muxa --work muxa-onboarding ...` | Add an allowlisted agent pane to one managed tmux Work window; also exposed as MCP `muxa_start_agent`. |
+| `muxa agent control (--pane %N\|--session pty-N) --action interrupt` | Interrupt or explicitly terminate one managed tmux pane or muxa-owned PTY agent session. |
 | `muxa onboard [--lang auto\|en\|ko]` | Unified shell → tmux → Muxa fullscreen walkthrough. `F2` switches language, `--no-quiz` skips gates, and `--print` emits the combined guide. |
 | `muxa mcp` | MCP stdio server so a coding agent can orchestrate muxa — inspect agents, send prompts, capture panes, wait for changes (`claude mcp add --scope user muxa -- muxa mcp`, see [docs/MCP.md](docs/MCP.md)). |
 | `muxa init` | Interactive install/uninstall wizard. |

--- a/crates/muxa-cli/src/agent_launch.rs
+++ b/crates/muxa-cli/src/agent_launch.rs
@@ -10,6 +10,9 @@ use clap::ValueEnum;
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 
+use muxa::backend::HostKind;
+use muxa::ipc::Client;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentProgram {
@@ -76,6 +79,71 @@ impl AgentProgram {
             (Self::Opencode, None) => "opencode".into(),
         }
     }
+
+    fn native_launch(self, prompt: Option<&str>) -> NativeLaunch {
+        let mut args = match self {
+            Self::Claude | Self::Antigravity => {
+                vec!["--dangerously-skip-permissions".into()]
+            }
+            Self::Codex => vec!["--yolo".into()],
+            Self::Gemini => vec![
+                "--approval-mode".into(),
+                "yolo".into(),
+                "--skip-trust".into(),
+            ],
+            Self::Opencode => Vec::new(),
+        };
+        if let Some(prompt) = prompt {
+            match self {
+                Self::Claude | Self::Codex => args.push(prompt.into()),
+                Self::Gemini | Self::Antigravity => {
+                    args.push("-i".into());
+                    args.push(prompt.into());
+                }
+                Self::Opencode => {
+                    args.push("--prompt".into());
+                    args.push(prompt.into());
+                }
+            }
+        }
+        NativeLaunch {
+            command: self.label().into(),
+            args,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NativeLaunch {
+    command: String,
+    args: Vec<String>,
+}
+
+/// Execution host selection for the user-facing agent launcher.
+///
+/// The first native slice deliberately exposes only hosts that can create a
+/// new surface today. Observation-only pane backends remain available to the
+/// daemon and will join this enum as their launch lifecycle lands.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum LaunchHost {
+    /// Use tmux when this shell is in a real tmux pane; otherwise use muxa's PTY.
+    #[default]
+    Auto,
+    /// Spawn a muxa-owned PTY session through muxad.
+    Native,
+    /// Use the existing managed tmux launcher.
+    Tmux,
+}
+
+impl LaunchHost {
+    fn resolve(self, detected: Option<HostKind>) -> Self {
+        match self {
+            Self::Auto if detected == Some(HostKind::Tmux) => Self::Tmux,
+            Self::Auto => Self::Native,
+            explicit => explicit,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, ValueEnum)]
@@ -129,6 +197,9 @@ pub struct StartArgs {
     /// Known agent CLI to launch. codex expands the local cx profile (codex --yolo).
     #[arg(long, value_enum)]
     pub agent: AgentProgram,
+    /// Execution host. Auto uses tmux inside tmux and a muxa-owned PTY elsewhere.
+    #[arg(long, value_enum, default_value = "auto")]
+    pub host: LaunchHost,
     /// Create a split pane (default), window, or independent session.
     #[arg(long, value_enum, default_value = "pane")]
     pub placement: Placement,
@@ -242,6 +313,7 @@ impl From<&StartArgs> for StartRequest {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct StartResult {
+    pub host: LaunchHost,
     pub pane: String,
     pub agent: AgentProgram,
     pub placement: Placement,
@@ -266,11 +338,72 @@ pub struct StartResult {
     pub prompt_supplied: bool,
 }
 
-pub fn run(args: StartArgs) -> Result<()> {
+/// Stable `muxa agent start --json` envelope across execution hosts.
+///
+/// Host-specific coordinates remain optional, but every key is serialized so
+/// consumers can parse one schema and branch only on `host`. `StartResult`
+/// remains the tmux lifecycle result used by managed Work/MCP internals.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct AgentStartOutput {
+    schema_version: u8,
+    host: LaunchHost,
+    agent: AgentProgram,
+    placement: Placement,
+    pane: Option<String>,
+    session: Option<String>,
+    window: Option<String>,
+    name: Option<String>,
+    workspace: Option<String>,
+    work: Option<String>,
+    created_workspace: bool,
+    created_work: bool,
+    role: Option<String>,
+    task: Option<String>,
+    alias: Option<String>,
+    cwd: PathBuf,
+    prompt_supplied: bool,
+}
+
+impl AgentStartOutput {
+    fn tmux(result: &StartResult) -> Self {
+        Self {
+            schema_version: 1,
+            host: result.host,
+            agent: result.agent,
+            placement: result.placement,
+            pane: Some(result.pane.clone()),
+            session: result.session.clone(),
+            window: result.window.clone(),
+            name: result.name.clone(),
+            workspace: result.workspace.clone(),
+            work: result.work.clone(),
+            created_workspace: result.created_workspace,
+            created_work: result.created_work,
+            role: result.role.clone(),
+            task: result.task.clone(),
+            alias: result.alias.clone(),
+            cwd: result.cwd.clone(),
+            prompt_supplied: result.prompt_supplied,
+        }
+    }
+}
+
+pub async fn run(args: StartArgs, client: &Client, socket_path: &Path) -> Result<()> {
+    match args.host.resolve(muxa::backend::detect_host_env()) {
+        LaunchHost::Native => run_native(args, client, socket_path).await,
+        LaunchHost::Tmux => run_tmux(args),
+        LaunchHost::Auto => unreachable!("auto launch host is resolved above"),
+    }
+}
+
+fn run_tmux(args: StartArgs) -> Result<()> {
     let json = args.json;
     let result = start(StartRequest::from(&args))?;
     if json {
-        println!("{}", serde_json::to_string_pretty(&result)?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&AgentStartOutput::tmux(&result))?
+        );
     } else {
         println!(
             "started {} in {} {} (cwd {})",
@@ -282,6 +415,92 @@ pub fn run(args: StartArgs) -> Result<()> {
             },
             result.pane,
             result.cwd.display()
+        );
+    }
+    Ok(())
+}
+
+async fn run_native(args: StartArgs, client: &Client, socket_path: &Path) -> Result<()> {
+    if args.work.is_some() || args.workspace.is_some() {
+        bail!(
+            "managed --work/--workspace launch is not available on the native host yet; use --host tmux or `muxa run`"
+        );
+    }
+    if args.target.is_some() || args.placement != Placement::Pane {
+        bail!(
+            "--target and non-pane --placement require tmux; omit them for a native session or use --host tmux"
+        );
+    }
+    if args.direction != SplitDirection::Right {
+        bail!("--direction requires tmux; omit it for a native session or use --host tmux");
+    }
+    if args.role.is_some() || args.task.is_some() || args.alias.is_some() {
+        bail!(
+            "--role, --task, and --alias require a managed Work binding, which is not available on the native host yet"
+        );
+    }
+
+    let cwd_source = args.cwd.unwrap_or(std::env::current_dir()?);
+    let cwd = std::fs::canonicalize(&cwd_source)
+        .with_context(|| format!("resolve cwd {}", cwd_source.display()))?;
+    if !cwd.is_dir() {
+        bail!("cwd is not a directory: {}", cwd.display());
+    }
+    let prompt = args
+        .prompt
+        .as_deref()
+        .filter(|prompt| !prompt.trim().is_empty());
+    let launch = args.agent.native_launch(prompt);
+    let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
+    let session = client
+        .spawn_session(muxa::SpawnSession {
+            command: launch.command,
+            args: launch.args,
+            env: crate::caller_env(socket_path),
+            cwd: Some(cwd.clone()),
+            name: args
+                .name
+                .clone()
+                .or_else(|| Some(args.agent.label().into())),
+            cols: Some(cols),
+            rows: Some(rows),
+        })
+        .await
+        .context("spawning native muxa agent session")?;
+    let result = AgentStartOutput {
+        schema_version: 1,
+        host: LaunchHost::Native,
+        agent: args.agent,
+        placement: Placement::Session,
+        pane: None,
+        session: Some(session.id),
+        window: None,
+        name: session.display_name,
+        workspace: None,
+        work: None,
+        created_workspace: false,
+        created_work: false,
+        role: None,
+        task: None,
+        alias: None,
+        cwd,
+        prompt_supplied: prompt.is_some(),
+    };
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!(
+            "started {} in native session {} (cwd {})\nattach with: muxa attach {}",
+            result.agent.label(),
+            result
+                .session
+                .as_deref()
+                .expect("native result has a session"),
+            result.cwd.display(),
+            result
+                .session
+                .as_deref()
+                .expect("native result has a session"),
         );
     }
     Ok(())
@@ -418,6 +637,7 @@ pub fn start(mut request: StartRequest) -> Result<StartResult> {
     }
 
     Ok(StartResult {
+        host: LaunchHost::Tmux,
         pane,
         agent: request.agent,
         placement: request.placement,
@@ -776,6 +996,78 @@ mod tests {
         assert_eq!(
             AgentProgram::Codex.launch_command(Some("review June's changes; don't edit")),
             "codex --yolo 'review June'\\''s changes; don'\\''t edit'"
+        );
+    }
+
+    #[test]
+    fn native_launch_keeps_the_prompt_as_one_argv_value() {
+        let launch = AgentProgram::Codex.native_launch(Some("review June's changes; don't edit"));
+        assert_eq!(launch.command, "codex");
+        assert_eq!(launch.args, ["--yolo", "review June's changes; don't edit"]);
+
+        let gemini = AgentProgram::Gemini.native_launch(Some("review it"));
+        assert_eq!(gemini.command, "gemini");
+        assert_eq!(
+            gemini.args,
+            ["--approval-mode", "yolo", "--skip-trust", "-i", "review it"]
+        );
+    }
+
+    #[test]
+    fn agent_start_json_uses_one_schema_for_tmux_and_native() {
+        let tmux = AgentStartOutput {
+            schema_version: 1,
+            host: LaunchHost::Tmux,
+            agent: AgentProgram::Codex,
+            placement: Placement::Pane,
+            pane: Some("%7".into()),
+            session: Some("$1".into()),
+            window: Some("@2".into()),
+            name: Some("review".into()),
+            workspace: None,
+            work: None,
+            created_workspace: false,
+            created_work: false,
+            role: None,
+            task: None,
+            alias: None,
+            cwd: PathBuf::from("/repo"),
+            prompt_supplied: true,
+        };
+        let native = AgentStartOutput {
+            host: LaunchHost::Native,
+            placement: Placement::Session,
+            pane: None,
+            session: Some("pty-7".into()),
+            window: None,
+            ..tmux.clone()
+        };
+        let tmux = serde_json::to_value(tmux).unwrap();
+        let native = serde_json::to_value(native).unwrap();
+
+        let tmux_keys = tmux.as_object().unwrap().keys().collect::<Vec<_>>();
+        let native_keys = native.as_object().unwrap().keys().collect::<Vec<_>>();
+        assert_eq!(tmux_keys, native_keys);
+        assert_eq!(tmux["pane"], "%7");
+        assert!(native["pane"].is_null());
+        assert_eq!(native["session"], "pty-7");
+        assert_eq!(native["placement"], "session");
+    }
+
+    #[test]
+    fn auto_launch_uses_tmux_only_for_a_tmux_shell() {
+        assert_eq!(
+            LaunchHost::Auto.resolve(Some(HostKind::Tmux)),
+            LaunchHost::Tmux
+        );
+        assert_eq!(LaunchHost::Auto.resolve(None), LaunchHost::Native);
+        assert_eq!(
+            LaunchHost::Auto.resolve(Some(HostKind::Rmux)),
+            LaunchHost::Native
+        );
+        assert_eq!(
+            LaunchHost::Native.resolve(Some(HostKind::Tmux)),
+            LaunchHost::Native
         );
     }
 

--- a/crates/muxa-cli/src/attend.rs
+++ b/crates/muxa-cli/src/attend.rs
@@ -97,6 +97,11 @@ struct Candidate<'a> {
     key: SpatialKey,
 }
 
+pub struct Target {
+    pub pane: String,
+    pub endpoint: Option<String>,
+}
+
 /// Filter the snapshot down to attention-needing agents that have a pane,
 /// sorted into spatial order. Agents with no pane are dropped: there's
 /// nothing to focus, and `muxa watch` already surfaces paneless agents.
@@ -148,9 +153,10 @@ fn next_after<'c>(
 }
 
 /// Choose a pane to attend to, or print the queue / a "nothing to do"
-/// line. Returns the pane id the caller should jump to, or `None` when
-/// there's nothing to jump to (`--list`, or no agent needs attention).
-pub async fn run(client: &Client, panes: Vec<PaneInfo>, args: Args) -> Result<Option<String>> {
+/// line. Returns the pane plus its recorded endpoint so multi-instance hosts
+/// such as cmux can focus the exact server. Returns `None` for `--list` or
+/// when no agent needs attention.
+pub async fn run(client: &Client, panes: Vec<PaneInfo>, args: Args) -> Result<Option<Target>> {
     let agents = client.snapshot().await?;
     // Panes are enumerated by the caller across every active host (spatial
     // ordering + `pane_display` both read them); empty is harmless on
@@ -198,7 +204,10 @@ pub async fn run(client: &Client, panes: Vec<PaneInfo>, args: Args) -> Result<Op
         longest_waiting(&cands)
     };
 
-    Ok(chosen.map(|c| c.pane.to_string()))
+    Ok(chosen.map(|candidate| Target {
+        pane: candidate.pane.to_string(),
+        endpoint: candidate.agent.tmux_socket.clone(),
+    }))
 }
 
 /// Render the attention queue, longest-waiting first. Each row is the

--- a/crates/muxa-cli/src/dashboard_tui.rs
+++ b/crates/muxa-cli/src/dashboard_tui.rs
@@ -554,6 +554,7 @@ fn push_action_target(targets: &mut Vec<ActionTarget>, target: ActionTarget) {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CardHost {
     Tmux,
+    Cmux,
     Rmux,
     Zellij,
     Herdr,
@@ -567,6 +568,7 @@ impl CardHost {
     fn label(self) -> &'static str {
         match self {
             Self::Tmux => "tmux",
+            Self::Cmux => "cmux",
             Self::Rmux => "rmux",
             Self::Zellij => "zellij",
             Self::Herdr => "herdr",
@@ -1498,6 +1500,7 @@ fn dashboard_collaboration_origin_from(
     let pane = pane.filter(|pane| !pane.is_empty());
     let socket = pane.as_deref().and_then(|pane| {
         let endpoint = match muxa::backend::pane_id_host_kind(pane)? {
+            HostKind::Cmux => Some(muxa::backend::cmux::endpoint_from_env()),
             HostKind::Rmux => rmux,
             HostKind::Tmux => tmux,
             HostKind::Zellij | HostKind::Herdr => None,
@@ -1684,6 +1687,7 @@ fn build_work_dashboard_data(
 fn card_host(host: HostKind) -> CardHost {
     match host {
         HostKind::Tmux => CardHost::Tmux,
+        HostKind::Cmux => CardHost::Cmux,
         HostKind::Rmux => CardHost::Rmux,
         HostKind::Zellij => CardHost::Zellij,
         HostKind::Herdr => CardHost::Herdr,
@@ -1719,12 +1723,7 @@ fn build_dashboard_data(
     let mut builders = BTreeMap::<String, CardBuilder>::new();
 
     for pane in &panes {
-        let card_host = match host {
-            HostKind::Tmux => CardHost::Tmux,
-            HostKind::Rmux => CardHost::Rmux,
-            HostKind::Zellij => CardHost::Zellij,
-            HostKind::Herdr => CardHost::Herdr,
-        };
+        let card_host = card_host(host);
         let key = format!("{}:{}", card_host.label(), pane.session);
         let builder = builders
             .entry(key.clone())
@@ -1884,12 +1883,7 @@ fn card_identity(
 
     if let Some(pane) = agent.pane.as_ref() {
         if let Some(info) = pane_by_id.get(pane) {
-            let card_host = match host {
-                HostKind::Tmux => CardHost::Tmux,
-                HostKind::Rmux => CardHost::Rmux,
-                HostKind::Zellij => CardHost::Zellij,
-                HostKind::Herdr => CardHost::Herdr,
-            };
+            let card_host = card_host(host);
             return CardIdentity {
                 key: format!("{}:{}", card_host.label(), info.session),
                 label: info.session.clone(),
@@ -3411,7 +3405,7 @@ fn card_title(card: &SessionCard) -> String {
         return format!("{work_id} · {}", card.label);
     }
     let prefix = match card.host {
-        CardHost::Tmux | CardHost::Rmux | CardHost::Zellij | CardHost::Herdr => "",
+        CardHost::Tmux | CardHost::Cmux | CardHost::Rmux | CardHost::Zellij | CardHost::Herdr => "",
         CardHost::Pty => "pty:",
         CardHost::Pane => "pane:",
         CardHost::Agent => "agent:",
@@ -5359,6 +5353,7 @@ mod tests {
         agent.surface = Some(SurfaceRef {
             kind: SurfaceKind::Pty,
             id: "pty-1".into(),
+            workspace: None,
         });
         let data = build_dashboard_data(
             now,

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -380,9 +380,9 @@ enum MsgCmd {
 
 #[derive(Debug, Subcommand)]
 enum AgentCmd {
-    /// Start an allowlisted agent in a detached pane, window, or session.
+    /// Start an allowlisted agent in tmux or a muxa-owned PTY session.
     Start(agent_launch::StartArgs),
-    /// Interrupt or terminate one muxa-managed agent pane.
+    /// Interrupt or terminate one muxa-managed tmux pane or native PTY session.
     Control(tmux_work::AgentControlArgs),
 }
 
@@ -552,10 +552,10 @@ impl WatchSortArg {
     }
 }
 
-fn run_agent_cmd(action: AgentCmd) -> Result<()> {
+async fn run_agent_cmd(action: AgentCmd, client: &Client, socket_path: &Path) -> Result<()> {
     match action {
-        AgentCmd::Start(args) => agent_launch::run(args),
-        AgentCmd::Control(args) => tmux_work::run_agent_control(args),
+        AgentCmd::Start(args) => agent_launch::run(args, client, socket_path).await,
+        AgentCmd::Control(args) => tmux_work::run_agent_control(args, client).await,
     }
 }
 
@@ -654,7 +654,7 @@ async fn main() -> Result<()> {
         Cmd::Skill(a) => message_skill::run(a, &cfg.message, skill_path.as_deref()),
         Cmd::Host(a) => fleet_cli::run_host(a, &client, &cfg, config_path.as_deref()).await,
         Cmd::Fleet(a) => fleet_cli::run_fleet(a, &client, &cfg, config_path.as_deref()).await,
-        Cmd::Agent { action } => run_agent_cmd(action),
+        Cmd::Agent { action } => run_agent_cmd(action, &client, &socket).await,
         Cmd::Window { action } => run_window_cmd(action),
         Cmd::Work { action } => run_work_cmd(action, &cfg, config_path, &client).await,
         Cmd::Workspace { action } => run_workspace_cmd(action),
@@ -1145,7 +1145,7 @@ async fn cmd_run(
     Ok(())
 }
 
-fn caller_env(socket_path: &Path) -> Vec<(String, String)> {
+pub(crate) fn caller_env(socket_path: &Path) -> Vec<(String, String)> {
     let mut env = std::env::vars_os()
         .filter_map(|(key, value)| Some((key.into_string().ok()?, value.into_string().ok()?)))
         .collect::<Vec<_>>();
@@ -1312,7 +1312,7 @@ fn key_to_pty_input(key: crossterm::event::KeyEvent) -> Option<String> {
 }
 
 /// Jump to (or list) the agent that needs you. `attend::run` picks the
-/// pane — reusing the same selection that drives `--list` — and we perform
+/// pane and endpoint — reusing the same selection that drives `--list` — and we perform
 /// the actual focus through `jump_to_pane`, the identical machinery the
 /// `muxa watch` Enter action uses, so a jump lands the same way from both.
 async fn cmd_attend(client: &Client, args: attend::Args) -> Result<()> {
@@ -1320,8 +1320,16 @@ async fn cmd_attend(client: &Client, args: attend::Args) -> Result<()> {
     // a human is jumpable from a tmux-primary shell (and vice versa). The
     // jump itself dispatches per-row in `jump_to_pane`.
     let panes = all_panes().await;
-    if let Some(pane) = attend::run(client, panes, args).await? {
-        jump_to_pane(&pane);
+    if let Some(target) = attend::run(client, panes, args).await? {
+        if muxa::backend::pane_id_host_kind(&target.pane) == Some(muxa::HostKind::Cmux) {
+            let backend = target.endpoint.map_or_else(
+                muxa::backend::cmux::CmuxBackend::new,
+                muxa::backend::cmux::CmuxBackend::with_endpoint,
+            );
+            jump_to_pane_cmux(&backend, &target.pane);
+        } else {
+            jump_to_pane(&target.pane);
+        }
     }
     Ok(())
 }
@@ -1637,6 +1645,10 @@ fn jump_to_pane(pane_id: &str) {
     match kind {
         // tmux jumps go straight through `tmux::` helpers and need no backend.
         muxa::HostKind::Tmux => jump_to_pane_tmux(pane_id),
+        muxa::HostKind::Cmux => {
+            let backend = backend_for_dispatch(kind, &fallback);
+            jump_to_pane_cmux(backend.as_ref(), pane_id);
+        }
         muxa::HostKind::Rmux => {
             let backend = backend_for_dispatch(kind, &fallback);
             jump_to_pane_rmux(backend.as_ref(), pane_id);
@@ -1655,6 +1667,12 @@ fn jump_to_pane(pane_id: &str) {
 fn jump_to_topology_pane(key: &muxa::PaneKey) {
     match key.window.session.endpoint.host {
         muxa::HostKind::Tmux => jump_to_pane_tmux_key(key),
+        muxa::HostKind::Cmux => {
+            let backend = muxa::backend::cmux::CmuxBackend::with_endpoint(
+                key.window.session.endpoint.socket.clone(),
+            );
+            jump_to_pane_cmux(&backend, &key.pane_id);
+        }
         muxa::HostKind::Rmux | muxa::HostKind::Zellij | muxa::HostKind::Herdr => {
             jump_to_pane(&key.pane_id);
         }
@@ -1729,6 +1747,7 @@ fn backend_for_dispatch(
 pub(crate) fn backend_for_kind(kind: muxa::HostKind) -> muxa::SharedBackend {
     match kind {
         muxa::HostKind::Tmux => std::sync::Arc::new(muxa::TmuxBackend::new()),
+        muxa::HostKind::Cmux => std::sync::Arc::new(muxa::backend::cmux::CmuxBackend::new()),
         muxa::HostKind::Rmux => std::sync::Arc::new(muxa::RmuxBackend::new()),
         muxa::HostKind::Zellij => std::sync::Arc::new(muxa::ZellijBackend::new()),
         muxa::HostKind::Herdr => std::sync::Arc::new(muxa::backend::herdr::HerdrBackend::new()),
@@ -1856,6 +1875,14 @@ fn jump_to_pane_tmux(pane_id: &str) {
 fn jump_to_pane_zellij(backend: &dyn muxa::PaneBackend, pane_id: &str) {
     if !backend.focus_pane(pane_id) {
         eprintln!("muxa: zellij focus-pane-with-id {pane_id} failed — pane may have closed");
+    }
+}
+
+fn jump_to_pane_cmux(backend: &dyn muxa::PaneBackend, pane_id: &str) {
+    if !backend.focus_pane(pane_id) {
+        eprintln!(
+            "muxa: cmux surface.focus {pane_id} failed — surface may have closed or socket access may be disabled"
+        );
     }
 }
 
@@ -2259,6 +2286,9 @@ fn cmd_panes() -> Result<()> {
 fn empty_pane_hint(backend: &dyn muxa::PaneBackend) -> &'static str {
     match backend.kind() {
         muxa::HostKind::Tmux => "(no tmux panes — server may be down)",
+        muxa::HostKind::Cmux => {
+            "(cmux first slice: only the current env surface is visible; full inventory is pending)"
+        }
         muxa::HostKind::Rmux => "(no rmux panes — server may be down or endpoint unreachable)",
         muxa::HostKind::Zellij if !backend.caps().current_command => {
             "(zellij CLI baseline: pane inventory is plugin-only — install the muxa zellij plugin to populate)"
@@ -2744,6 +2774,7 @@ mod tests {
             panic!("expected agent start");
         };
         assert_eq!(start.agent, agent_launch::AgentProgram::Codex);
+        assert_eq!(start.host, agent_launch::LaunchHost::Auto);
         assert_eq!(start.placement, agent_launch::Placement::Pane);
         assert_eq!(start.target.as_deref(), Some("%42"));
         assert_eq!(start.direction, agent_launch::SplitDirection::Down);
@@ -2905,12 +2936,47 @@ mod tests {
             "interrupt",
         ])
         .unwrap();
-        assert!(matches!(
-            args.cmd,
-            Cmd::Agent {
-                action: AgentCmd::Control(_)
-            }
-        ));
+        let Cmd::Agent {
+            action: AgentCmd::Control(control),
+        } = args.cmd
+        else {
+            panic!("expected agent control");
+        };
+        assert_eq!(control.pane.as_deref(), Some("%42"));
+        assert!(control.session.is_none());
+
+        let args = Args::try_parse_from([
+            "muxa",
+            "agent",
+            "control",
+            "--session",
+            "pty-7",
+            "--action",
+            "terminate",
+            "--yes",
+        ])
+        .unwrap();
+        let Cmd::Agent {
+            action: AgentCmd::Control(control),
+        } = args.cmd
+        else {
+            panic!("expected native agent control");
+        };
+        assert_eq!(control.session.as_deref(), Some("pty-7"));
+        assert!(control.pane.is_none());
+
+        assert!(Args::try_parse_from([
+            "muxa",
+            "agent",
+            "control",
+            "--pane",
+            "%42",
+            "--session",
+            "pty-7",
+            "--action",
+            "interrupt",
+        ])
+        .is_err());
 
         let args = Args::try_parse_from(["muxa", "onboard", "--print", "--no-quiz"]).unwrap();
         let Cmd::Onboard(onboard) = args.cmd else {

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -30,7 +30,7 @@ use muxa::collaboration::{
     RequestKind, RequestMailbox, RequestStatus, RoomContext, WorkMode,
 };
 use muxa::event::{AgentKind, AgentState};
-use muxa::ipc::{Client, TransitionStream};
+use muxa::ipc::{Client, SendPromptOutcome, TransitionStream};
 use muxa::state::{Agent, Transition};
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -943,16 +943,18 @@ async fn call_tool(
             };
             // Submit defaults to true — the common case is "prompt and run".
             let submit = args.get("submit").and_then(Value::as_bool).unwrap_or(true);
-            Ok(match client.send_prompt(pane, text, submit).await {
-                // The daemon distinguishes "text injected" (`sent`) from
-                // "Enter delivered" (`submitted`); surface the latter so a
-                // caller whose submit was requested but not delivered learns
-                // the text already landed and must not blindly resend it.
-                Ok(outcome) => {
-                    render_send_result(text.len(), pane, submit, Some(outcome.submitted))
-                }
-                Err(e) => error_result(&format!("send_prompt failed: {e}")),
-            })
+            Ok(
+                match send_prompt_with_local_cmux(client, pane, text, submit).await {
+                    // The daemon distinguishes "text injected" (`sent`) from
+                    // "Enter delivered" (`submitted`); surface the latter so a
+                    // caller whose submit was requested but not delivered learns
+                    // the text already landed and must not blindly resend it.
+                    Ok(outcome) => {
+                        render_send_result(text.len(), pane, submit, Some(outcome.submitted))
+                    }
+                    Err(e) => error_result(&format!("send_prompt failed: {e}")),
+                },
+            )
         }
         "muxa_capture_pane" => {
             let Some(pane) = args.get("pane").and_then(Value::as_str) else {
@@ -1971,6 +1973,7 @@ fn current_collaboration_origin() -> std::result::Result<CollaborationOrigin, St
                 .to_string()
         })?;
     let endpoint = match muxa::backend::pane_id_host_kind(&pane) {
+        Some(muxa::HostKind::Cmux) => Some(muxa::backend::cmux::endpoint_from_env()),
         Some(muxa::HostKind::Rmux) => std::env::var("RMUX").ok(),
         Some(muxa::HostKind::Tmux) => std::env::var("TMUX").ok(),
         Some(muxa::HostKind::Zellij | muxa::HostKind::Herdr) | None => None,
@@ -2135,6 +2138,72 @@ fn render_send_result(text_len: usize, pane: &str, submit: bool, submitted: Opti
             ))
         }
     }
+}
+
+/// Prefer a direct cmux socket call from the MCP process when it is itself
+/// running inside cmux. cmux's default socket policy accepts descendants of a
+/// cmux terminal but rejects a separately launched login daemon, so proxying
+/// every request through muxad would make the default secure mode unusable.
+/// A failed first text injection is safe to retry through the daemon; once text
+/// lands, submit is reported separately and the text is never resent.
+async fn send_prompt_with_local_cmux(
+    client: &Client,
+    pane: &str,
+    prompt: &str,
+    submit: bool,
+) -> std::result::Result<SendPromptOutcome, String> {
+    let inside_cmux = std::env::var("CMUX_SURFACE_ID").is_ok_and(|id| !id.trim().is_empty());
+    if muxa::backend::pane_id_host_kind(pane) == Some(muxa::HostKind::Cmux) && inside_cmux {
+        let env_endpoint = muxa::backend::cmux::endpoint_from_env();
+        let mut endpoints = client
+            .snapshot()
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|agent| agent.pane.as_deref() == Some(pane))
+            .filter_map(|agent| agent.tmux_socket)
+            .collect::<Vec<_>>();
+        endpoints.sort();
+        endpoints.dedup();
+        let endpoint = if endpoints.is_empty() || endpoints.contains(&env_endpoint) {
+            env_endpoint
+        } else if endpoints.len() == 1 {
+            endpoints.remove(0)
+        } else {
+            return Err(format!(
+                "cmux pane {pane} exists on multiple socket endpoints; run muxa mcp inside the target cmux instance"
+            ));
+        };
+        let target_pane = pane.to_string();
+        let target_prompt = prompt.to_string();
+        if let Ok(Some(outcome)) = tokio::task::spawn_blocking(move || {
+            let backend = muxa::backend::cmux::CmuxBackend::with_endpoint(endpoint);
+            if !muxa::PaneBackend::send_text(&backend, &target_pane, &target_prompt) {
+                return None;
+            }
+            let submitted = if submit {
+                if !target_prompt.is_empty() {
+                    std::thread::sleep(muxa::backend::PROMPT_SUBMIT_GRACE);
+                }
+                muxa::PaneBackend::send_text(&backend, &target_pane, "\r")
+            } else {
+                false
+            };
+            Some(SendPromptOutcome {
+                sent: true,
+                submitted,
+            })
+        })
+        .await
+        {
+            return Ok(outcome);
+        }
+    }
+
+    client
+        .send_prompt(pane, prompt, submit)
+        .await
+        .map_err(|error| error.to_string())
 }
 
 /// Terminal outcome of a `muxa_wait_for_change` race, before it's rendered

--- a/crates/muxa-cli/src/onboarding.rs
+++ b/crates/muxa-cli/src/onboarding.rs
@@ -205,7 +205,7 @@ terminate_agent, close_work, and close_workspace require confirm=true.";
 
 const SAFETY: &str = "\
 Muxa deliberately does not expose arbitrary shell or generic tmux commands.\n\
-Use exact pane ids for agent control. Destructive actions require confirmation.\n\
+Use exact pane ids or native PTY session ids for agent control. Destructive actions require confirmation.\n\
 Use collaboration review + read_only by default; grant execute only with narrow paths.";
 
 const POLICY_KO: &str = "\
@@ -245,7 +245,7 @@ terminate_agent, close_work, close_workspace는 confirm=true가 필요합니다.
 
 const SAFETY_KO: &str = "\
 Muxa는 임의 shell 실행이나 범용 tmux 명령을 노출하지 않습니다.\n\
-Agent 제어에는 정확한 pane id를 사용하고 파괴적 동작은 확인을 요구합니다.\n\
+Agent 제어에는 정확한 pane id 또는 native PTY session id를 사용하고 파괴적 동작은 확인을 요구합니다.\n\
 협업은 review + read_only를 기본으로 하고 execute는 좁은 경로에만 허용합니다.";
 
 const SECTIONS: &[Section] = &[

--- a/crates/muxa-cli/src/relay.rs
+++ b/crates/muxa-cli/src/relay.rs
@@ -498,7 +498,7 @@ fn sessions_for_backend(kind: HostKind) -> Vec<SessionInfo> {
                 })
                 .collect()
         }
-        HostKind::Rmux | HostKind::Zellij => Vec::new(),
+        HostKind::Cmux | HostKind::Rmux | HostKind::Zellij => Vec::new(),
     }
 }
 

--- a/crates/muxa-cli/src/tmux_work.rs
+++ b/crates/muxa-cli/src/tmux_work.rs
@@ -11,6 +11,7 @@
 use crate::theme::TableTone;
 use anyhow::{bail, Context, Result};
 use clap::ValueEnum;
+use muxa::ipc::Client;
 use muxa::work::{WorkRecord, WorkStage};
 use serde::Serialize;
 use std::io::IsTerminal;
@@ -195,6 +196,10 @@ pub enum ManageResult {
         action: AgentControlAction,
         pane: String,
     },
+    SessionControl {
+        action: AgentControlAction,
+        session: String,
+    },
     WorkClosed {
         work: String,
         workspace: String,
@@ -209,10 +214,13 @@ pub enum ManageResult {
 
 #[derive(Debug, clap::Args)]
 pub struct AgentControlArgs {
-    /// Exact managed tmux pane id, for example %42.
-    #[arg(long)]
-    pub pane: String,
-    /// Interrupt the current turn or terminate the whole pane.
+    /// Exact managed tmux pane id, for example %42. Conflicts with --session.
+    #[arg(long, required_unless_present = "session", conflicts_with = "session")]
+    pub pane: Option<String>,
+    /// Muxa-owned native PTY session id or display name. Conflicts with --pane.
+    #[arg(long, required_unless_present = "pane", conflicts_with = "pane")]
+    pub session: Option<String>,
+    /// Interrupt the current turn or terminate the whole pane/session.
     #[arg(long, value_enum)]
     pub action: AgentControlAction,
     /// Confirm the destructive terminate action.
@@ -330,17 +338,51 @@ pub struct WorkspaceCloseArgs {
     pub json: bool,
 }
 
-pub fn run_agent_control(args: AgentControlArgs) -> Result<()> {
-    if args.action == AgentControlAction::Terminate
-        && !confirm_destructive(
-            args.yes,
-            &format!("Terminate managed agent pane {}?", args.pane),
-        )?
-    {
-        println!("cancelled");
-        return Ok(());
-    }
-    let result = control_agent(&args.pane, args.action, args.yes)?;
+pub async fn run_agent_control(args: AgentControlArgs, client: &Client) -> Result<()> {
+    let result = if let Some(session) = args.session.as_deref() {
+        let sessions = client
+            .list_sessions()
+            .await
+            .context("listing native muxa sessions")?;
+        let session_id = sessions
+            .iter()
+            .find(|candidate| {
+                candidate.id == session || candidate.display_name.as_deref() == Some(session)
+            })
+            .map_or_else(|| session.to_string(), |candidate| candidate.id.clone());
+        if args.action == AgentControlAction::Terminate
+            && !confirm_destructive(
+                args.yes,
+                &format!("Terminate native agent session {session_id}?"),
+            )?
+        {
+            println!("cancelled");
+            return Ok(());
+        }
+        match args.action {
+            AgentControlAction::Interrupt => client
+                .write_session(&session_id, "\u{3}")
+                .await
+                .context("interrupting native agent session")?,
+            AgentControlAction::Terminate => client
+                .terminate_session(&session_id)
+                .await
+                .context("terminating native agent session")?,
+        }
+        ManageResult::SessionControl {
+            action: args.action,
+            session: session_id,
+        }
+    } else {
+        let pane = args.pane.as_deref().expect("clap requires pane or session");
+        if args.action == AgentControlAction::Terminate
+            && !confirm_destructive(args.yes, &format!("Terminate managed agent pane {pane}?"))?
+        {
+            println!("cancelled");
+            return Ok(());
+        }
+        control_agent(pane, args.action, args.yes)?
+    };
     print_result(&result, args.json)
 }
 
@@ -1876,6 +1918,9 @@ fn print_result(result: &ManageResult, json: bool) -> Result<()> {
         match result {
             ManageResult::AgentControl { action, pane } => {
                 println!("{action:?} agent pane {pane}");
+            }
+            ManageResult::SessionControl { action, session } => {
+                println!("{action:?} native agent session {session}");
             }
             ManageResult::WorkClosed {
                 work,

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -5021,6 +5021,7 @@ fn sort_agents(
 fn session_group_key(host: Option<muxa::HostKind>, session: &str) -> String {
     match host {
         Some(muxa::HostKind::Tmux) => format!("tmux:{session}"),
+        Some(muxa::HostKind::Cmux) => format!("cmux:{session}"),
         Some(muxa::HostKind::Rmux) => format!("rmux:{session}"),
         Some(muxa::HostKind::Herdr) => format!("herdr:{session}"),
         Some(muxa::HostKind::Zellij) => format!("zellij:{session}"),
@@ -5439,6 +5440,7 @@ fn rows_multi_host(rows: &[WatchRow]) -> bool {
 fn host_badge_label(host: muxa::HostKind) -> &'static str {
     match host {
         muxa::HostKind::Tmux => "tmux",
+        muxa::HostKind::Cmux => "cmux",
         muxa::HostKind::Rmux => "rmux",
         muxa::HostKind::Zellij => "zellij",
         muxa::HostKind::Herdr => "herdr",
@@ -6551,7 +6553,7 @@ fn sessions_for_host(host: muxa::HostKind) -> Vec<SessionInfo> {
                 })
                 .collect()
         }
-        muxa::HostKind::Rmux | muxa::HostKind::Zellij => Vec::new(),
+        muxa::HostKind::Cmux | muxa::HostKind::Rmux | muxa::HostKind::Zellij => Vec::new(),
     }
 }
 
@@ -6768,6 +6770,7 @@ fn current_backend_endpoint(host: muxa::HostKind, pane_id: &str) -> Option<Backe
                 .filter(|socket| !socket.trim().is_empty())
         }),
         muxa::HostKind::Rmux => muxa::backend::rmux::endpoint_from_env(),
+        muxa::HostKind::Cmux => Some(muxa::backend::cmux::endpoint_from_env()),
         muxa::HostKind::Zellij => Some("zellij".into()),
         muxa::HostKind::Herdr => Some("herdr".into()),
     }?;
@@ -7587,6 +7590,7 @@ fn watch_collaboration_origin_from(
     let pane = initial_pane.filter(|pane| !pane.is_empty());
     let socket = pane.as_deref().and_then(|pane| {
         let endpoint = match muxa::backend::pane_id_host_kind(pane)? {
+            muxa::HostKind::Cmux => Some(muxa::backend::cmux::endpoint_from_env()),
             muxa::HostKind::Rmux => rmux,
             muxa::HostKind::Tmux => tmux,
             muxa::HostKind::Zellij | muxa::HostKind::Herdr => None,

--- a/crates/muxa/src/adapters/hook.rs
+++ b/crates/muxa/src/adapters/hook.rs
@@ -42,8 +42,9 @@ pub trait HookAdapter {
 /// 2. `$RMUX_PANE`, namespaced to `rmux:%N`.
 /// 3. `$ZELLIJ_PANE_ID` (zellij's "this pane" var).
 /// 4. `$HERDR_PANE_ID` (herdr's analog), namespaced to `herdr:<id>`.
-/// 5. `$TMUX_PANE` (tmux and rmux compatibility set this).
-/// 6. Walk the parent-pid chain and match against the active backend's
+/// 5. `$CMUX_SURFACE_ID`, namespaced to `cmux:<id>`.
+/// 6. `$TMUX_PANE` (tmux and rmux compatibility set this).
+/// 7. Walk the parent-pid chain and match against the active backend's
 ///    `pane_pid_map()`. Linux reads `/proc`; macOS/BSD take one `ps` process
 ///    snapshot and walk it in memory. Useful when an agent hook subprocess
 ///    didn't inherit the host env var. Skipped when the backend's
@@ -73,8 +74,19 @@ where
     let mut ev = A::normalize(event, input, pane);
     if let Some(surface) = surface {
         ev.id_mut().surface = Some(surface);
+    } else if ev
+        .id()
+        .pane
+        .as_deref()
+        .and_then(crate::backend::pane_id_host_kind)
+        == Some(crate::backend::HostKind::Cmux)
+    {
+        ev.id_mut().surface = cmux_surface_env();
     }
-    if ev.id_mut().tmux_socket.is_none() {
+    // Endpoint metadata belongs to an external pane binding. A muxa-owned PTY
+    // may inherit CMUX/TMUX variables from the terminal that requested it, but
+    // that outer socket does not own the daemon-created PTY surface.
+    if ev.id().pane.is_some() && ev.id().tmux_socket.is_none() {
         ev.id_mut().tmux_socket = host_endpoint_env();
     }
     Ok(ev)
@@ -93,11 +105,12 @@ fn tmux_socket_env() -> Option<String> {
 }
 
 /// Control endpoint for the detected pane host. The persisted field retains
-/// its historical `tmux_socket` name for protocol compatibility, but rmux
-/// rows carry rmux's native socket path from `$RMUX` here.
+/// its historical `tmux_socket` name for protocol compatibility, but rmux and
+/// cmux rows carry their native socket paths here.
 fn host_endpoint_env() -> Option<String> {
     match crate::backend::detect_host_env() {
         Some(crate::backend::HostKind::Rmux) => crate::backend::rmux::endpoint_from_env(),
+        Some(crate::backend::HostKind::Cmux) => Some(crate::backend::cmux::endpoint_from_env()),
         _ => tmux_socket_env(),
     }
 }
@@ -112,19 +125,39 @@ fn muxa_session_env() -> Option<SurfaceRef> {
         "zellij" => SurfaceKind::Zellij,
         _ => SurfaceKind::Pty,
     };
-    Some(SurfaceRef { kind, id })
+    Some(SurfaceRef {
+        kind,
+        id,
+        workspace: None,
+    })
+}
+
+fn cmux_surface_env() -> Option<SurfaceRef> {
+    cmux_surface_env_from(|name| std::env::var(name).ok())
+}
+
+fn cmux_surface_env_from(read: impl Fn(&str) -> Option<String>) -> Option<SurfaceRef> {
+    let id = read("CMUX_SURFACE_ID").filter(|id| !id.trim().is_empty())?;
+    let workspace = read("CMUX_WORKSPACE_ID").filter(|id| !id.trim().is_empty());
+    Some(SurfaceRef {
+        kind: SurfaceKind::Cmux,
+        id,
+        workspace,
+    })
 }
 
 /// Read whichever host-set "this pane" env var identifies the *innermost*
-/// host, in `MUXA_HOST` override → `RMUX_PANE` → `ZELLIJ_PANE_ID` → `HERDR_PANE_ID` →
-/// `TMUX_PANE` order. Empty string is treated as unset. This mirrors
+/// host, in `MUXA_HOST` override → `RMUX_PANE` → `ZELLIJ_PANE_ID` →
+/// `HERDR_PANE_ID` → `CMUX_SURFACE_ID` → `TMUX_PANE` order. Empty string is
+/// treated as unset. This mirrors
 /// `crate::backend::detect_from`'s host-selection precedence exactly, so the
 /// pane a hook is stamped onto and the backend that observes it always agree.
 ///
 /// tmux/zellij ids are returned verbatim (`%N`, `zellij:<id>` — the latter
-/// already carries its namespace). herdr's raw pane id is *not* namespaced
-/// by herdr, so we stamp `crate::backend::herdr::PANE_ID_PREFIX` (`herdr:`)
-/// here to match the `herdr:<id>` shape muxa uses everywhere internally
+/// already carries its namespace). cmux and herdr raw ids are namespaced
+/// with their respective prefixes; herdr uses
+/// `crate::backend::herdr::PANE_ID_PREFIX` (`herdr:`) to match the
+/// `herdr:<id>` shape muxa uses everywhere internally
 /// (registry rows, `by_pane`, and the cross-host reaping guard's
 /// `pane_id_host_kind`); the prefix is stripped again before the id goes
 /// back over the herdr socket.
@@ -156,6 +189,7 @@ fn host_pane_env_from(read: impl Fn(&str) -> Option<String>) -> Option<String> {
     if let Some(raw) = read("MUXA_HOST") {
         let forced = match raw.trim().to_ascii_lowercase().as_str() {
             "tmux" => Some(HostKind::Tmux),
+            "cmux" => Some(HostKind::Cmux),
             "rmux" => Some(HostKind::Rmux),
             "zellij" => Some(HostKind::Zellij),
             "herdr" => Some(HostKind::Herdr),
@@ -169,17 +203,18 @@ fn host_pane_env_from(read: impl Fn(&str) -> Option<String>) -> Option<String> {
     }
 
     // Auto-detect: native rmux first (it also sets TMUX_PANE), then zellij,
-    // herdr, and finally tmux. Byte-for-byte the same order as
+    // herdr, cmux, and finally tmux. Byte-for-byte the same order as
     // `detect_from`, so hook stamping and backend observation never disagree.
     pane_env_for(HostKind::Rmux, &read)
         .or_else(|| pane_env_for(HostKind::Zellij, &read))
         .or_else(|| pane_env_for(HostKind::Herdr, &read))
+        .or_else(|| pane_env_for(HostKind::Cmux, &read))
         .or_else(|| pane_env_for(HostKind::Tmux, &read))
 }
 
 /// The muxa pane id for one host from its "this pane" env var, or `None` when
-/// that var is unset/empty. tmux/zellij ids pass through verbatim; herdr's raw
-/// id is stamped with the `herdr:` namespace prefix.
+/// that var is unset/empty. tmux/zellij ids pass through verbatim; cmux and
+/// herdr raw ids receive their host namespace prefixes.
 fn pane_env_for(
     host: crate::backend::HostKind,
     read: &impl Fn(&str) -> Option<String>,
@@ -187,6 +222,9 @@ fn pane_env_for(
     use crate::backend::HostKind;
     match host {
         HostKind::Tmux => read("TMUX_PANE").filter(|v| !v.is_empty()),
+        HostKind::Cmux => read("CMUX_SURFACE_ID")
+            .filter(|v| !v.is_empty())
+            .map(|v| crate::backend::cmux::namespace_pane_id(&v)),
         HostKind::Rmux => read("RMUX_PANE")
             .filter(|v| !v.is_empty())
             .map(|v| format!("{}{v}", crate::backend::rmux::PANE_ID_PREFIX)),
@@ -281,6 +319,37 @@ mod tests {
         assert_eq!(
             host_pane_env_from(env_reader(&[("HERDR_PANE_ID", "42")])),
             Some(format!("{}42", crate::backend::herdr::PANE_ID_PREFIX)),
+        );
+    }
+
+    #[test]
+    fn host_pane_env_prefixes_cmux_surface_id() {
+        assert_eq!(
+            host_pane_env_from(env_reader(&[("CMUX_SURFACE_ID", "surface-7")])),
+            Some("cmux:surface-7".to_string()),
+        );
+        assert_eq!(
+            host_pane_env_from(env_reader(&[
+                ("MUXA_HOST", "cmux"),
+                ("CMUX_SURFACE_ID", "surface-8"),
+                ("TMUX_PANE", "%3"),
+            ])),
+            Some("cmux:surface-8".to_string()),
+        );
+    }
+
+    #[test]
+    fn cmux_surface_metadata_retains_workspace_identity() {
+        assert_eq!(
+            cmux_surface_env_from(env_reader(&[
+                ("CMUX_SURFACE_ID", "surface-7"),
+                ("CMUX_WORKSPACE_ID", "workspace-2"),
+            ])),
+            Some(SurfaceRef {
+                kind: SurfaceKind::Cmux,
+                id: "surface-7".into(),
+                workspace: Some("workspace-2".into()),
+            }),
         );
     }
 

--- a/crates/muxa/src/backend/cmux.rs
+++ b/crates/muxa/src/backend/cmux.rs
@@ -1,0 +1,306 @@
+//! cmux implementation of [`crate::backend::PaneBackend`].
+//!
+//! This first slice uses only cmux's documented environment and Unix-socket
+//! API. It can identify the current surface, focus an exact surface, and send
+//! targeted text. Full workspace/surface enumeration waits for a versioned
+//! JSON fixture; until then observations are deliberately partial so the
+//! reconciler never treats an absent cmux row as proof that an agent exited.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::time::Duration;
+
+use serde_json::json;
+
+use super::{BackendCaps, HostKind, PaneBackend, PaneObservation};
+use crate::tmux::PaneInfo;
+
+/// Namespace prefix for cmux surface UUIDs inside muxa.
+pub const PANE_ID_PREFIX: &str = "cmux:";
+pub const DEFAULT_SOCKET_PATH: &str = "/tmp/cmux.sock";
+
+const SOCKET_TIMEOUT: Duration = Duration::from_secs(1);
+const MAX_RESPONSE_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct CmuxBackend {
+    endpoint: String,
+}
+
+impl CmuxBackend {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            endpoint: endpoint_from_env(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_endpoint(endpoint: impl Into<String>) -> Self {
+        let endpoint = endpoint.into();
+        Self {
+            endpoint: if endpoint.trim().is_empty() {
+                DEFAULT_SOCKET_PATH.into()
+            } else {
+                endpoint
+            },
+        }
+    }
+
+    fn current_pane_info(&self) -> Option<PaneInfo> {
+        current_pane_info_from(|name| std::env::var(name).ok(), Some(self.endpoint.clone()))
+    }
+
+    fn rpc(&self, endpoint: Option<&str>, method: &str, params: serde_json::Value) -> bool {
+        let endpoint = endpoint.unwrap_or(&self.endpoint);
+        let Ok(mut stream) = UnixStream::connect(endpoint) else {
+            return false;
+        };
+        if stream.set_read_timeout(Some(SOCKET_TIMEOUT)).is_err()
+            || stream.set_write_timeout(Some(SOCKET_TIMEOUT)).is_err()
+        {
+            return false;
+        }
+        let request = json!({
+            "id": "muxa-pane-control",
+            "method": method,
+            "params": params,
+        });
+        let Ok(mut bytes) = serde_json::to_vec(&request) else {
+            return false;
+        };
+        bytes.push(b'\n');
+        if stream.write_all(&bytes).is_err() || stream.flush().is_err() {
+            return false;
+        }
+        let mut response = String::new();
+        let mut reader = BufReader::new(stream).take(MAX_RESPONSE_BYTES + 1);
+        let Ok(read) = reader.read_line(&mut response) else {
+            return false;
+        };
+        if read == 0 || u64::try_from(response.len()).unwrap_or(u64::MAX) > MAX_RESPONSE_BYTES {
+            return false;
+        }
+        serde_json::from_str::<serde_json::Value>(&response)
+            .ok()
+            .and_then(|value| value.get("ok").and_then(serde_json::Value::as_bool))
+            .unwrap_or(false)
+    }
+}
+
+impl Default for CmuxBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PaneBackend for CmuxBackend {
+    fn kind(&self) -> HostKind {
+        HostKind::Cmux
+    }
+
+    fn list_panes(&self) -> Vec<PaneInfo> {
+        self.current_pane_info().into_iter().collect()
+    }
+
+    fn observe_panes(&self) -> PaneObservation {
+        // The env identifies only this process's surface, not every surface
+        // owned by cmux. Absence is therefore never authoritative yet.
+        PaneObservation::partial(self.list_panes())
+    }
+
+    fn resolve_pane(&self, pane_id: &str) -> Option<PaneInfo> {
+        self.current_pane_info()
+            .filter(|pane| pane.pane_id == namespace_pane_id(pane_id))
+    }
+
+    fn capture_pane(&self, _pane_id: &str) -> Option<String> {
+        None
+    }
+
+    fn pane_pid_map(&self) -> HashMap<u32, String> {
+        HashMap::new()
+    }
+
+    fn current_pane(&self) -> Option<String> {
+        std::env::var("CMUX_SURFACE_ID")
+            .ok()
+            .filter(|id| !id.trim().is_empty())
+            .map(|id| namespace_pane_id(&id))
+    }
+
+    fn focus_pane(&self, pane_id: &str) -> bool {
+        self.rpc(
+            None,
+            "surface.focus",
+            json!({ "surface_id": strip_prefix(pane_id) }),
+        )
+    }
+
+    fn send_text(&self, pane_id: &str, text: &str) -> bool {
+        self.send_text_on(None, pane_id, text)
+    }
+
+    fn send_text_on(&self, endpoint: Option<&str>, pane_id: &str, text: &str) -> bool {
+        self.rpc(
+            endpoint,
+            "surface.send_text",
+            json!({ "surface_id": strip_prefix(pane_id), "text": text }),
+        )
+    }
+
+    fn caps(&self) -> BackendCaps {
+        BackendCaps {
+            current_command: false,
+            pane_pid_map: false,
+            capture_pane: false,
+            focus_pane: true,
+            send_text: true,
+        }
+    }
+}
+
+#[must_use]
+pub fn endpoint_from_env() -> String {
+    std::env::var("CMUX_SOCKET_PATH")
+        .ok()
+        .filter(|path| !path.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_SOCKET_PATH.into())
+}
+
+#[must_use]
+pub fn namespace_pane_id(pane_id: &str) -> String {
+    if pane_id.starts_with(PANE_ID_PREFIX) {
+        pane_id.to_string()
+    } else {
+        format!("{PANE_ID_PREFIX}{pane_id}")
+    }
+}
+
+#[must_use]
+pub fn strip_prefix(pane_id: &str) -> &str {
+    pane_id.strip_prefix(PANE_ID_PREFIX).unwrap_or(pane_id)
+}
+
+fn current_pane_info_from(
+    read: impl Fn(&str) -> Option<String>,
+    endpoint: Option<String>,
+) -> Option<PaneInfo> {
+    let surface = read("CMUX_SURFACE_ID").filter(|id| !id.trim().is_empty())?;
+    let workspace = read("CMUX_WORKSPACE_ID")
+        .filter(|id| !id.trim().is_empty())
+        .unwrap_or_else(|| "cmux".into());
+    Some(PaneInfo {
+        agent_role: None,
+        agent_alias: None,
+        socket: endpoint,
+        pane_id: namespace_pane_id(&surface),
+        session_id: workspace.clone(),
+        session: workspace.clone(),
+        window_id: workspace,
+        window_name: String::new(),
+        window_index: "0".into(),
+        pane_index: "0".into(),
+        tty: String::new(),
+        current_command: String::new(),
+        title: String::new(),
+        pane_pid: 0,
+        // cmux's environment contract does not expose another surface's cwd.
+        // The daemon cwd is not a safe substitute for terminal metadata.
+        current_path: String::new(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env_reader(
+        pairs: &'static [(&'static str, &'static str)],
+    ) -> impl Fn(&str) -> Option<String> {
+        move |name| {
+            pairs
+                .iter()
+                .find(|(key, _)| *key == name)
+                .map(|(_, value)| (*value).to_string())
+        }
+    }
+
+    #[test]
+    fn namespaces_surface_ids_once() {
+        assert_eq!(namespace_pane_id("surface-7"), "cmux:surface-7");
+        assert_eq!(namespace_pane_id("cmux:surface-7"), "cmux:surface-7");
+        assert_eq!(strip_prefix("cmux:surface-7"), "surface-7");
+    }
+
+    #[test]
+    fn current_env_becomes_a_partial_namespaced_observation() {
+        let pane = current_pane_info_from(
+            env_reader(&[
+                ("CMUX_SURFACE_ID", "surface-7"),
+                ("CMUX_WORKSPACE_ID", "workspace-2"),
+            ]),
+            Some("/tmp/cmux-debug.sock".into()),
+        )
+        .unwrap();
+        assert_eq!(pane.pane_id, "cmux:surface-7");
+        assert_eq!(pane.session_id, "workspace-2");
+        assert_eq!(pane.socket.as_deref(), Some("/tmp/cmux-debug.sock"));
+    }
+
+    #[test]
+    fn capabilities_match_the_environment_only_first_slice() {
+        let caps = CmuxBackend::new().caps();
+        assert!(!caps.current_command);
+        assert!(!caps.pane_pid_map);
+        assert!(!caps.capture_pane);
+        assert!(caps.focus_pane);
+        assert!(caps.send_text);
+    }
+
+    #[test]
+    fn send_text_uses_the_exact_surface_and_socket_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("cmux.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = String::new();
+            BufReader::new(stream.try_clone().unwrap())
+                .read_line(&mut request)
+                .unwrap();
+            let request: serde_json::Value = serde_json::from_str(&request).unwrap();
+            assert_eq!(request["method"], "surface.send_text");
+            assert_eq!(request["params"]["surface_id"], "surface-7");
+            assert_eq!(request["params"]["text"], "hello\n");
+            stream
+                .write_all(b"{\"id\":\"muxa-pane-control\",\"ok\":true}\n")
+                .unwrap();
+        });
+
+        let backend = CmuxBackend::with_endpoint(socket.display().to_string());
+        assert!(backend.send_text("cmux:surface-7", "hello\n"));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn oversized_socket_response_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("cmux.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = String::new();
+            BufReader::new(stream.try_clone().unwrap())
+                .read_line(&mut request)
+                .unwrap();
+            let oversized = vec![b' '; usize::try_from(MAX_RESPONSE_BYTES + 1).unwrap()];
+            let _ = stream.write_all(&oversized);
+        });
+
+        let backend = CmuxBackend::with_endpoint(socket.display().to_string());
+        assert!(!backend.focus_pane("cmux:surface-7"));
+        server.join().unwrap();
+    }
+}

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -52,6 +52,7 @@
 //! when zellij CLI cannot populate `pane_pid_map`), call sites consult
 //! [`BackendCaps`] returned by [`PaneBackend::caps`] before degrading.
 
+pub mod cmux;
 pub mod herdr;
 pub mod rmux;
 pub mod tmux;
@@ -72,13 +73,16 @@ pub const PROMPT_SUBMIT_GRACE: Duration = Duration::from_millis(120);
 
 /// Whether a pane observation is authoritative enough for destructive use.
 ///
-/// A snapshot can still carry useful panes when it is [`Incomplete`](Self::Incomplete)
-/// (for example, one tmux server answered while another timed out). Callers
-/// may use those rows for best-effort enrichment, but absence from that
-/// snapshot is not evidence that a pane died.
+/// A snapshot can still carry useful panes when it is partial or incomplete.
+/// `Partial` is a backend's stable contract (for example, cmux deliberately
+/// exposes only the invoking surface) and must never age out rows outside that
+/// subset. `Incomplete` means a normally-authoritative scan failed or timed
+/// out; absence is not immediate death evidence, but chronically unreachable
+/// hosts may still be aged out after the configured stale window.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ObservationCompleteness {
     Complete,
+    Partial,
     Incomplete,
 }
 
@@ -105,8 +109,24 @@ impl PaneObservation {
         }
     }
 
+    /// Construct an intentionally partial observation. Unlike a transient
+    /// [`Self::incomplete`] result, this backend is not expected to enumerate
+    /// its whole namespace, so cross-host stale aging must keep its hook rows.
+    pub fn partial(panes: Vec<PaneInfo>) -> Self {
+        Self {
+            panes,
+            completeness: ObservationCompleteness::Partial,
+        }
+    }
+
     pub fn is_complete(&self) -> bool {
         self.completeness == ObservationCompleteness::Complete
+    }
+
+    /// Whether this observation proves the backend is intentionally present
+    /// and therefore protects its namespace from cross-host age-out.
+    pub fn protects_stale_rows(&self) -> bool {
+        self.completeness != ObservationCompleteness::Incomplete
     }
 }
 
@@ -137,6 +157,7 @@ pub type SharedBackend = Arc<dyn PaneBackend>;
 /// this fallback if that assumption stops holding.
 pub fn default_backend() -> SharedBackend {
     match detect_host_env() {
+        Some(HostKind::Cmux) => Arc::new(cmux::CmuxBackend::new()),
         Some(HostKind::Rmux) => Arc::new(rmux::RmuxBackend::new()),
         Some(HostKind::Zellij) => Arc::new(zellij::ZellijBackend::new()),
         Some(HostKind::Herdr) => Arc::new(herdr::HerdrBackend::new()),
@@ -147,6 +168,7 @@ pub fn default_backend() -> SharedBackend {
 /// Build one backend of the given kind.
 fn backend_of(kind: HostKind) -> SharedBackend {
     match kind {
+        HostKind::Cmux => Arc::new(cmux::CmuxBackend::new()),
         HostKind::Tmux => Arc::new(tmux::TmuxBackend::new()),
         HostKind::Rmux => Arc::new(rmux::RmuxBackend::new()),
         HostKind::Zellij => Arc::new(zellij::ZellijBackend::new()),
@@ -168,8 +190,10 @@ fn backend_of(kind: HostKind) -> SharedBackend {
 ///    — consumers treat the first backend as "primary" (dashboard, watch
 ///    initial cursor). tmux is always in the set (its methods degrade to
 ///    empty when no server is running, and it remains muxa's default
-///    market); rmux joins when its native env is present or its CLI is
-///    installed, so a server started after the daemon is still discovered;
+///    market); cmux is always kept ready as a partial observer so a GUI
+///    started after muxad can still route hook control; rmux joins when its
+///    native env is present or its CLI is installed, so a server started after
+///    the daemon is still discovered;
 ///    herdr joins when a herdr server actually **answers** on its
 ///    socket (a live connect, not a stale socket file — see
 ///    [`herdr::server_reachable`]) or its pane env is present; zellij only
@@ -194,7 +218,7 @@ pub fn active_backends() -> Vec<SharedBackend> {
             HostKind::Rmux => rmux::binary_available(),
             // tmux/zellij reachability is not probed here; see the
             // resolution rules above.
-            HostKind::Tmux | HostKind::Zellij => false,
+            HostKind::Cmux | HostKind::Tmux | HostKind::Zellij => false,
         },
     )
 }
@@ -226,6 +250,7 @@ fn active_kinds_from(
         for name in raw.split(',') {
             let kind = match name.trim().to_ascii_lowercase().as_str() {
                 "tmux" => Some(HostKind::Tmux),
+                "cmux" => Some(HostKind::Cmux),
                 "rmux" => Some(HostKind::Rmux),
                 "zellij" => Some(HostKind::Zellij),
                 "herdr" => Some(HostKind::Herdr),
@@ -250,7 +275,7 @@ fn active_kinds_from(
     }
 
     // 3. Auto-detect. The env-preferred host — whatever `detect_from`
-    // resolves the current shell to (rmux > zellij > herdr > tmux on a nested-env
+    // resolves the current shell to (rmux > zellij > herdr > cmux > tmux on a nested-env
     // tie) — leads the set so `backends[0]` is the host the shell actually
     // lives in; consumers (dashboard, watch initial cursor) treat the first
     // backend as primary. The remaining detected hosts follow in a stable
@@ -266,6 +291,10 @@ fn active_kinds_from(
         add(&mut kinds, env_host);
     }
     add(&mut kinds, HostKind::Tmux);
+    // Keep a capability-honest cmux backend ready even when muxad was
+    // launched before cmux and inherited none of its environment. Its first
+    // slice reports partial observations, so it cannot reap other rows.
+    add(&mut kinds, HostKind::Cmux);
     if read("RMUX").is_some() || read("RMUX_PANE").is_some() || probe(HostKind::Rmux) {
         add(&mut kinds, HostKind::Rmux);
     }
@@ -285,6 +314,7 @@ fn detect_from_override(read: &impl Fn(&str) -> Option<String>) -> Option<HostKi
     let raw = read("MUXA_HOST")?;
     match raw.trim().to_ascii_lowercase().as_str() {
         "tmux" => Some(HostKind::Tmux),
+        "cmux" => Some(HostKind::Cmux),
         "rmux" => Some(HostKind::Rmux),
         "zellij" => Some(HostKind::Zellij),
         "herdr" => Some(HostKind::Herdr),
@@ -312,6 +342,7 @@ fn detect_from_override(read: &impl Fn(&str) -> Option<String>) -> Option<HostKi
 #[strum(serialize_all = "lowercase")]
 pub enum HostKind {
     Tmux,
+    Cmux,
     Rmux,
     Zellij,
     Herdr,
@@ -571,7 +602,7 @@ impl<T: PaneBackend + ?Sized> PaneBackend for Arc<T> {
 ///
 /// Resolution order:
 ///
-/// 1. **`MUXA_HOST`** — if set to `"tmux"`, `"rmux"`, `"zellij"`, or `"herdr"`
+/// 1. **`MUXA_HOST`** — if set to `"tmux"`, `"cmux"`, `"rmux"`, `"zellij"`, or `"herdr"`
 ///    (case-insensitive), that wins regardless of what `TMUX` / `ZELLIJ` /
 ///    `HERDR_*` look like. Provides an unambiguous override for
 ///    nested-multiplexer setups (zellij inside tmux, `tmux new-session` from
@@ -581,7 +612,8 @@ impl<T: PaneBackend + ?Sized> PaneBackend for Arc<T> {
 /// 2. **`RMUX` / `RMUX_PANE`** set → [`HostKind::Rmux`].
 /// 3. **`ZELLIJ`** set → [`HostKind::Zellij`].
 /// 4. **`HERDR_PANE_ID` / `HERDR_ENV`** set → [`HostKind::Herdr`].
-/// 5. **`TMUX`** set → [`HostKind::Tmux`].
+/// 5. **`CMUX_SURFACE_ID` / `CMUX_WORKSPACE_ID`** set → [`HostKind::Cmux`].
+/// 6. **`TMUX`** set → [`HostKind::Tmux`].
 ///
 /// The tie-break for nested hosts (all ancestors' vars are inherited) is
 /// **native rmux first**, then zellij, herdr, and tmux. rmux must precede tmux
@@ -608,6 +640,7 @@ fn detect_from(read: impl Fn(&str) -> Option<String>) -> Option<HostKind> {
     if let Some(raw) = read("MUXA_HOST") {
         match raw.trim().to_ascii_lowercase().as_str() {
             "tmux" => return Some(HostKind::Tmux),
+            "cmux" => return Some(HostKind::Cmux),
             "rmux" => return Some(HostKind::Rmux),
             "zellij" => return Some(HostKind::Zellij),
             "herdr" => return Some(HostKind::Herdr),
@@ -637,6 +670,9 @@ fn detect_from(read: impl Fn(&str) -> Option<String>) -> Option<HostKind> {
     if read("HERDR_PANE_ID").is_some() || read("HERDR_ENV").is_some() {
         return Some(HostKind::Herdr);
     }
+    if read("CMUX_SURFACE_ID").is_some() || read("CMUX_WORKSPACE_ID").is_some() {
+        return Some(HostKind::Cmux);
+    }
     if read("TMUX").is_some() {
         return Some(HostKind::Tmux);
     }
@@ -645,8 +681,9 @@ fn detect_from(read: impl Fn(&str) -> Option<String>) -> Option<HostKind> {
 
 /// Classify a namespaced pane id back to the host that governs it.
 ///
-/// muxa namespaces every non-tmux pane id — `rmux:%N` for rmux, `zellij:<id>` for zellij,
-/// `herdr:<id>` (see [`herdr::PANE_ID_PREFIX`]) for herdr — and leaves
+/// muxa namespaces every non-tmux pane id — `cmux:<id>` for cmux, `rmux:%N`
+/// for rmux, `zellij:<id>` for zellij, `herdr:<id>` (see
+/// [`herdr::PANE_ID_PREFIX`]) for herdr — and leaves
 /// tmux's native `%N` ids as-is. The reconciler's cross-host reaping guard
 /// uses this to tell whether a registry row belongs to the *observing*
 /// backend: a `%`-id is tmux's, a `herdr:`-id is herdr's, a `zellij:`-id is
@@ -660,6 +697,8 @@ fn detect_from(read: impl Fn(&str) -> Option<String>) -> Option<HostKind> {
 pub fn pane_id_host_kind(pane_id: &str) -> Option<HostKind> {
     if pane_id.starts_with(rmux::PANE_ID_PREFIX) {
         Some(HostKind::Rmux)
+    } else if pane_id.starts_with(cmux::PANE_ID_PREFIX) {
+        Some(HostKind::Cmux)
     } else if pane_id.starts_with('%') {
         Some(HostKind::Tmux)
     } else if pane_id.starts_with("zellij:") {
@@ -677,12 +716,15 @@ pub fn pane_id_host_kind(pane_id: &str) -> Option<HostKind> {
 /// Canonical endpoint identity for a pane host.
 ///
 /// tmux pane scans store a short socket name while hooks inherit a full path,
-/// so tmux keeps its historical basename normalization. rmux uses the native
-/// full socket path for `rmux -S`; shortening it would make control operations
+/// so tmux keeps its historical basename normalization. rmux and cmux use
+/// native full socket paths; shortening them would make control operations
 /// unable to target the recorded server and could collide across directories.
 #[must_use]
 pub fn pane_endpoint_identity(pane_id: Option<&str>, endpoint: &str) -> String {
-    if pane_id.and_then(pane_id_host_kind) == Some(HostKind::Rmux) {
+    if matches!(
+        pane_id.and_then(pane_id_host_kind),
+        Some(HostKind::Rmux | HostKind::Cmux)
+    ) {
         endpoint.to_string()
     } else {
         crate::tmux::socket_short_name(endpoint)
@@ -736,6 +778,17 @@ mod tests {
         assert_eq!(
             detect_from(env_reader(&[("RMUX", "/tmp/rmux.sock,42,$1")])),
             Some(HostKind::Rmux),
+        );
+        assert_eq!(
+            detect_from(env_reader(&[("CMUX_SURFACE_ID", "surface-7")])),
+            Some(HostKind::Cmux),
+        );
+        assert_eq!(
+            detect_from(env_reader(&[
+                ("CMUX_SURFACE_ID", "surface-7"),
+                ("TMUX", "/tmp/outer,1,0"),
+            ])),
+            Some(HostKind::Cmux),
         );
     }
 
@@ -854,6 +907,7 @@ mod tests {
     #[test]
     fn host_kind_display_is_lowercase_stable() {
         assert_eq!(HostKind::Tmux.to_string(), "tmux");
+        assert_eq!(HostKind::Cmux.to_string(), "cmux");
         assert_eq!(HostKind::Rmux.to_string(), "rmux");
         assert_eq!(HostKind::Zellij.to_string(), "zellij");
     }
@@ -868,6 +922,7 @@ mod tests {
         assert_eq!(pane_id_host_kind("%3"), Some(HostKind::Tmux));
         assert_eq!(pane_id_host_kind("%0"), Some(HostKind::Tmux));
         assert_eq!(pane_id_host_kind("rmux:%3"), Some(HostKind::Rmux));
+        assert_eq!(pane_id_host_kind("cmux:surface-7"), Some(HostKind::Cmux));
         assert_eq!(pane_id_host_kind("zellij:7"), Some(HostKind::Zellij));
         assert_eq!(
             pane_id_host_kind("zellij:terminal:7"),
@@ -891,6 +946,10 @@ mod tests {
         assert_eq!(
             pane_endpoint_identity(Some("rmux:%3"), "/tmp/rmux-501/default"),
             "/tmp/rmux-501/default",
+        );
+        assert_eq!(
+            pane_endpoint_identity(Some("cmux:surface-7"), "/tmp/cmux-debug.sock"),
+            "/tmp/cmux-debug.sock",
         );
         assert_eq!(
             pane_endpoint_identity(Some("%3"), "/tmp/tmux-501/default"),
@@ -1069,10 +1128,13 @@ mod tests {
         assert_eq!(kinds, vec![HostKind::Herdr, HostKind::Tmux]);
 
         let fallthrough = active_kinds_from(&env_reader(&[("MUXA_HOSTS", "bogus,")]), &|_| false);
-        assert_eq!(fallthrough, vec![HostKind::Tmux]);
+        assert_eq!(fallthrough, vec![HostKind::Tmux, HostKind::Cmux]);
 
         let rmux = active_kinds_from(&env_reader(&[("MUXA_HOSTS", "rmux,tmux")]), &|_| false);
         assert_eq!(rmux, vec![HostKind::Rmux, HostKind::Tmux]);
+
+        let cmux = active_kinds_from(&env_reader(&[("MUXA_HOSTS", "cmux,tmux")]), &|_| false);
+        assert_eq!(cmux, vec![HostKind::Cmux, HostKind::Tmux]);
     }
 
     /// `MUXA_HOST` (singular) keeps meaning "exactly this one" even in
@@ -1095,15 +1157,15 @@ mod tests {
     fn active_kinds_auto_detect() {
         assert_eq!(
             active_kinds_from(&env_reader(&[]), &|_| false),
-            vec![HostKind::Tmux],
+            vec![HostKind::Tmux, HostKind::Cmux],
         );
         assert_eq!(
             active_kinds_from(&env_reader(&[]), &|k| k == HostKind::Herdr),
-            vec![HostKind::Tmux, HostKind::Herdr],
+            vec![HostKind::Tmux, HostKind::Cmux, HostKind::Herdr],
         );
         assert_eq!(
             active_kinds_from(&env_reader(&[]), &|k| k == HostKind::Rmux),
-            vec![HostKind::Tmux, HostKind::Rmux],
+            vec![HostKind::Tmux, HostKind::Cmux, HostKind::Rmux],
         );
         // Both HERDR and ZELLIJ env present: zellij is the env-preferred host
         // (nested-env tie-break), so it leads; tmux is auto-added; herdr trails
@@ -1112,7 +1174,12 @@ mod tests {
             active_kinds_from(&env_reader(&[("HERDR_ENV", "1"), ("ZELLIJ", "1")]), &|_| {
                 false
             },),
-            vec![HostKind::Zellij, HostKind::Tmux, HostKind::Herdr],
+            vec![
+                HostKind::Zellij,
+                HostKind::Tmux,
+                HostKind::Cmux,
+                HostKind::Herdr
+            ],
         );
     }
 
@@ -1126,20 +1193,20 @@ mod tests {
     fn active_kinds_env_preferred_host_leads() {
         assert_eq!(
             active_kinds_from(&env_reader(&[("HERDR_ENV", "1")]), &|_| false),
-            vec![HostKind::Herdr, HostKind::Tmux],
+            vec![HostKind::Herdr, HostKind::Tmux, HostKind::Cmux],
         );
         // A herdr pane env plus a reachable-socket probe must not double-add
         // herdr; it still leads, tmux trails.
         assert_eq!(
             active_kinds_from(&env_reader(&[("HERDR_PANE_ID", "9")]), &|k| k
                 == HostKind::Herdr),
-            vec![HostKind::Herdr, HostKind::Tmux],
+            vec![HostKind::Herdr, HostKind::Tmux, HostKind::Cmux],
         );
         // A plain tmux shell (only `TMUX`) is already tmux-first; the env
         // preference and the unconditional tmux add resolve to a single entry.
         assert_eq!(
             active_kinds_from(&env_reader(&[("TMUX", "/tmp/t,1,0")]), &|_| false),
-            vec![HostKind::Tmux],
+            vec![HostKind::Tmux, HostKind::Cmux],
         );
         // rmux exports TMUX too; native rmux remains primary while tmux stays
         // in the observed set for any real tmux server also running.
@@ -1151,7 +1218,7 @@ mod tests {
                 ]),
                 &|_| false,
             ),
-            vec![HostKind::Rmux, HostKind::Tmux],
+            vec![HostKind::Rmux, HostKind::Tmux, HostKind::Cmux],
         );
     }
 }

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -287,10 +287,10 @@ fn backend_scan_result(kind: HostKind, panes: Vec<crate::tmux::PaneInfo>) -> sca
         .into_iter()
         .map(|pane| {
             let socket = match kind {
-                HostKind::Rmux => pane
+                HostKind::Rmux | HostKind::Cmux => pane
                     .socket
                     .as_deref()
-                    .map_or_else(|| PathBuf::from("rmux"), PathBuf::from),
+                    .map_or_else(|| PathBuf::from(kind.to_string()), PathBuf::from),
                 HostKind::Herdr => PathBuf::from("herdr"),
                 HostKind::Zellij => PathBuf::from("zellij"),
                 HostKind::Tmux => pane

--- a/crates/muxa/src/event.rs
+++ b/crates/muxa/src/event.rs
@@ -118,6 +118,7 @@ pub enum AgentState {
 #[strum(serialize_all = "snake_case")]
 pub enum SurfaceKind {
     Tmux,
+    Cmux,
     Zellij,
     Pty,
 }
@@ -126,6 +127,10 @@ pub enum SurfaceKind {
 pub struct SurfaceRef {
     pub kind: SurfaceKind,
     pub id: String,
+    /// Optional backend-native parent context. cmux uses its workspace UUID;
+    /// muxa-owned PTY sessions and legacy snapshots leave it unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<String>,
 }
 
 /// Identity of an agent instance.

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -1796,19 +1796,18 @@ async fn handle(
                 }
                 RequestBody::Ingest { event } => {
                     kind = "ingest";
-                    // Drop events from tmux servers outside the configured
-                    // `MUXA_TMUX_SOCKET` scope. muxa's agent hooks are
-                    // installed globally, so an agent another multiplexer
-                    // (e.g. cmux) launched on its own server would otherwise
-                    // register here with pane ids muxa can't correlate —
-                    // unmappable `%NN` ghost rows. Ack it either way so the
-                    // agent's hook never sees an error on its critical path.
+                    // Drop only tmux events from servers outside the configured
+                    // `MUXA_TMUX_SOCKET` scope. Namespaced non-tmux panes have
+                    // their own endpoint rules and must not be compared with a
+                    // tmux socket path (notably cmux, which also retains a full
+                    // Unix-socket endpoint). Ack it either way so the agent's
+                    // hook never sees an error on its critical path.
                     let pane_host = event
                         .id()
                         .pane
                         .as_deref()
                         .and_then(crate::backend::pane_id_host_kind);
-                    let in_scope = pane_host == Some(HostKind::Rmux)
+                    let in_scope = pane_host.is_some_and(|host| host != HostKind::Tmux)
                         || crate::tmux::scanner::event_tmux_socket_in_scope(
                             event.id().tmux_socket.as_deref(),
                         );
@@ -2522,14 +2521,14 @@ async fn handle(
                             // Best-effort: a name collision with a real agent
                             // just skips the task row, the session still runs.
                             let _ = store
-                                .register_task(
+                                .register_surface_task(
                                     session
                                         .display_name
                                         .clone()
                                         .unwrap_or_else(|| session.id.clone()),
                                     session.pid,
                                     session.cwd.clone(),
-                                    None,
+                                    session.surface(),
                                     None,
                                 )
                                 .await;

--- a/crates/muxa/src/reconcile.rs
+++ b/crates/muxa/src/reconcile.rs
@@ -161,10 +161,12 @@ impl<L: LivenessSource> Reconciler<L> {
     /// multi-host analog of [`Self::new`]. Every source is observed
     /// concurrently and reconciled under its own [`HostKind`]; the ghost
     /// age-out sweep ([`Store::mark_stale_cross_host_stopped`](crate::state::Store::mark_stale_cross_host_stopped))
-    /// receives the kinds whose observation was *complete* this tick, so a row
-    /// on a host that answered is governed by that host's reconcile pass while a
-    /// row on a host NOT in the set — or one that can't answer past the
-    /// inactivity window — ages out. An empty `sources` degrades to a store-maintenance-only
+    /// receives complete kinds plus intentionally-partial kinds. A complete
+    /// source governs its rows directly; a partial source (such as cmux's
+    /// current-surface-only adapter) protects hook-authoritative rows it cannot
+    /// enumerate. A host outside the set, or a normally-authoritative source
+    /// that cannot answer past the inactivity window, ages out. An empty
+    /// `sources` degrades to a store-maintenance-only
     /// loop (no observation, but the stuck/paneless/codex sweeps still run);
     /// the daemon never constructs one that way — `active_backends()` is never
     /// empty.
@@ -407,6 +409,17 @@ impl<L: LivenessSource> Reconciler<L> {
             .filter(|(_, o)| o.is_complete())
             .map(|(k, _)| *k)
             .collect();
+        // Complete scans govern their namespace directly. Intentionally
+        // partial adapters cannot use absence as negative liveness evidence,
+        // but their successful partial observation still proves the host is
+        // structurally present and must protect hook rows from cross-host
+        // stale aging. Transiently incomplete/failed scans do not join this
+        // set and retain the existing 24h age-out behavior.
+        let stale_protected_kinds: Vec<HostKind> = observations
+            .iter()
+            .filter(|(_, o)| o.protects_stale_rows())
+            .map(|(k, _)| *k)
+            .collect();
         let total_panes: usize = observations.iter().map(|(_, o)| o.panes.len()).sum();
         // Fix 3/5: the union of panes from COMPLETE observations only. An
         // incompletely-observed host contributes no panes, so its rows are
@@ -503,26 +516,25 @@ impl<L: LivenessSource> Reconciler<L> {
                 "orphan-row sweep flipped {stale_paneless} paneless agent(s) to Stopped",
             );
         }
-        // Age out rows whose pane belongs to a host that did NOT answer with a
-        // complete observation this tick (e.g. a `zellij:` row while the set is
-        // tmux + herdr, a `herdr:` row left behind after narrowing the set back
-        // to tmux, or a host in the set that is chronically unable to answer).
+        // Age out rows whose pane belongs to a host that neither answered with
+        // a complete observation nor intentionally exposes a partial namespace
+        // this tick (e.g. a `zellij:` row while the set is tmux + herdr, a
+        // `herdr:` row left behind after narrowing the set back to tmux, or a
+        // normally-authoritative host that is chronically unable to answer).
         // The cross-host guard exempts foreign rows from *immediate* reaping,
         // and no observation reaps them, so without this they'd ghost forever.
-        // Fix 4: pass the COMPLETE-this-tick kinds, not every kind in the set —
-        // a host that answers governs its rows via reaping and is spared here,
-        // while a host that can't answer past the inactivity window ages out
-        // exactly like a host outside the set. Transient incompleteness is safe:
-        // the threshold is the (24h-default) paneless window on last-activity,
-        // not a single tick. Same inactivity window as the paneless sweep.
+        // Pass complete + intentionally-partial kinds, not every configured
+        // kind. A failed authoritative host still ages out after the inactivity
+        // window, while a structurally partial host such as cmux never turns an
+        // unobserved-but-valid surface into a false Stopped row.
         let stale_cross_host = self
             .store
-            .mark_stale_cross_host_stopped(&complete_kinds, self.paneless_stale_timeout)
+            .mark_stale_cross_host_stopped(&stale_protected_kinds, self.paneless_stale_timeout)
             .await;
         if stale_cross_host > 0 {
             tracing::info!(
                 stale_cross_host,
-                complete = ?complete_kinds,
+                protected = ?stale_protected_kinds,
                 "cross-host sweep flipped {stale_cross_host} foreign-host agent(s) to Stopped",
             );
         }
@@ -662,6 +674,12 @@ mod tests {
         fn incomplete(panes: Vec<PaneInfo>) -> Self {
             Self {
                 observation: Mutex::new(PaneObservation::incomplete(panes)),
+                kind: HostKind::Tmux,
+            }
+        }
+        fn partial(panes: Vec<PaneInfo>) -> Self {
+            Self {
+                observation: Mutex::new(PaneObservation::partial(panes)),
                 kind: HostKind::Tmux,
             }
         }
@@ -889,6 +907,33 @@ mod tests {
                 .map(|a| a.state),
             Some(AgentState::Idle),
             "a freshly-active row on the same host survives",
+        );
+    }
+
+    #[tokio::test]
+    async fn intentionally_partial_host_protects_unobserved_hook_rows() {
+        let store = Store::shared();
+        let old = datetime!(2026-04-24 12:00:00 UTC);
+        store
+            .apply(&started("cmux-unobserved", "cmux:surface-2", old))
+            .await;
+
+        let tmux = FakeLiveness::new(vec![pane("%1")]).with_kind(HostKind::Tmux);
+        // cmux's first slice deliberately sees only the invoking surface. An
+        // empty partial result is not evidence that another hooked surface
+        // exited, even when its last event is older than the stale window.
+        let cmux = FakeLiveness::partial(Vec::new()).with_kind(HostKind::Cmux);
+        let r =
+            Reconciler::with_sources(store.clone(), vec![tmux, cmux], Duration::from_millis(10))
+                .with_paneless_stale_timeout(Duration::from_secs(1));
+        r.reconcile_once().await;
+
+        assert_eq!(
+            store
+                .by_session("cmux-unobserved")
+                .await
+                .map(|agent| agent.state),
+            Some(AgentState::Idle),
         );
     }
 

--- a/crates/muxa/src/session.rs
+++ b/crates/muxa/src/session.rs
@@ -67,6 +67,7 @@ impl SessionRef {
         SurfaceRef {
             kind: self.backend.into(),
             id: self.id.clone(),
+            workspace: None,
         }
     }
 }

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -547,6 +547,37 @@ impl Store {
         pane: Option<String>,
         command: Option<String>,
     ) -> Result<String, String> {
+        self.register_task_inner(name, pid, cwd, pane, None, command)
+            .await
+    }
+
+    /// Register a pid-tracked placeholder for a muxa-owned terminal surface.
+    ///
+    /// The generic `spawn_session` path needs a row immediately, before an
+    /// allowlisted agent has emitted its first hook. Once a real hook arrives
+    /// with the same surface, [`Self::apply`] atomically removes this Task row
+    /// and installs the runtime-owned Agent row instead of displaying both.
+    pub async fn register_surface_task(
+        &self,
+        name: String,
+        pid: Option<u32>,
+        cwd: Option<String>,
+        surface: SurfaceRef,
+        command: Option<String>,
+    ) -> Result<String, String> {
+        self.register_task_inner(name, pid, cwd, None, Some(surface), command)
+            .await
+    }
+
+    async fn register_task_inner(
+        &self,
+        name: String,
+        pid: Option<u32>,
+        cwd: Option<String>,
+        pane: Option<String>,
+        surface: Option<SurfaceRef>,
+        command: Option<String>,
+    ) -> Result<String, String> {
         let now = OffsetDateTime::now_utc();
         let base = if name.trim().is_empty() {
             format!("task-{}", pid.unwrap_or(0))
@@ -580,7 +611,7 @@ impl Store {
             }
             None => base.clone(),
         };
-        let mut agent = Agent::new(AgentKind::Task, key.clone(), None, pane, cwd, now);
+        let mut agent = Agent::new(AgentKind::Task, key.clone(), surface, pane, cwd, now);
         agent.state = AgentState::Working;
         agent.pid = pid;
         agent.last_prompt = command;
@@ -1047,6 +1078,20 @@ fn reconcile_pane_for_started(
     true
 }
 
+/// Replace the pid-tracked placeholder created for a muxa-owned PTY once the
+/// real agent runtime claims that same execution surface.
+fn remove_surface_task_placeholder(agents: &mut HashMap<String, Agent>, id: &AgentId) {
+    if id.kind == AgentKind::Task {
+        return;
+    }
+    let Some(surface) = id.surface.as_ref() else {
+        return;
+    };
+    agents.retain(|_, agent| {
+        !(agent.kind == AgentKind::Task && agent.surface.as_ref() == Some(surface))
+    });
+}
+
 impl Store {
     pub fn shared() -> SharedStore {
         Arc::new(Self::default())
@@ -1102,6 +1147,14 @@ impl Store {
         };
         tracing::Span::current().record("event_type", event_type);
 
+        // A muxa-owned PTY is surfaced immediately as a pid-tracked Task so
+        // users can attach/control it before an agent's first hook. The hook's
+        // runtime session id is deliberately different from the PTY id, so a
+        // plain session-id upsert would leave duplicate Task + Agent rows.
+        // Surface identity is the shared execution binding: once a real agent
+        // claims it, remove only the temporary Task placeholder.
+        remove_surface_task_placeholder(&mut agents, id);
+
         if let Some(pane) = id.pane.as_deref() {
             if matches!(ev, AgentEvent::Started { .. }) {
                 if !reconcile_pane_for_started(
@@ -1152,6 +1205,13 @@ impl Store {
         }
         if agent.surface.is_none() {
             agent.surface.clone_from(&id.surface);
+        } else if let (Some(existing), Some(incoming)) = (&mut agent.surface, &id.surface) {
+            if existing.kind == incoming.kind
+                && existing.id == incoming.id
+                && existing.workspace.is_none()
+            {
+                existing.workspace.clone_from(&incoming.workspace);
+            }
         }
         if agent.cwd.is_none() {
             agent.cwd.clone_from(&id.cwd);
@@ -2040,7 +2100,7 @@ enum RemovalReason {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::{AgentEvent, AgentId, AgentKind, NotificationLevel};
+    use crate::event::{AgentEvent, AgentId, AgentKind, NotificationLevel, SurfaceKind};
     use time::macros::datetime;
 
     fn id(session: &str) -> AgentId {
@@ -2113,6 +2173,47 @@ mod tests {
         assert_eq!(agent.state, AgentState::Working);
         assert_eq!(agent.pid, Some(4242));
         assert_eq!(agent.last_prompt.as_deref(), Some("./play.sh"));
+    }
+
+    #[tokio::test]
+    async fn real_hook_replaces_surface_bound_task_placeholder() {
+        let store = Store::shared();
+        let surface = SurfaceRef {
+            kind: SurfaceKind::Pty,
+            id: "pty-7".into(),
+            workspace: None,
+        };
+        store
+            .register_surface_task(
+                "codex".into(),
+                Some(std::process::id()),
+                Some("/repo".into()),
+                surface.clone(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    tmux_socket: None,
+                    kind: AgentKind::Codex,
+                    session_id: "codex-runtime-session".into(),
+                    surface: Some(surface.clone()),
+                    pane: None,
+                    cwd: Some("/repo".into()),
+                },
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+
+        let snapshot = store.snapshot().await;
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].kind, AgentKind::Codex);
+        assert_eq!(snapshot[0].session_id, "codex-runtime-session");
+        assert_eq!(snapshot[0].surface.as_ref(), Some(&surface));
+        assert!(snapshot[0].pid.is_none());
     }
 
     #[tokio::test]
@@ -2237,6 +2338,7 @@ mod tests {
                 Some(SurfaceRef {
                     kind: SurfaceKind::Pty,
                     id: "s1".into(),
+                    workspace: None,
                 }),
                 old,
             ))

--- a/crates/muxa/src/topology.rs
+++ b/crates/muxa/src/topology.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use crate::backend::{pane_endpoint_identity, pane_id_host_kind, HostKind};
-use crate::event::AgentState;
+use crate::event::{AgentState, SurfaceKind};
 use crate::state::Agent;
 use crate::tmux::PaneInfo;
 
@@ -126,6 +126,12 @@ impl BackendTopologyCapabilities {
             HostKind::Herdr => Self {
                 host,
                 session: HierarchyCapability::Mapped,
+                window: HierarchyCapability::Mapped,
+                pane: HierarchyCapability::Native,
+            },
+            HostKind::Cmux => Self {
+                host,
+                session: HierarchyCapability::Native,
                 window: HierarchyCapability::Mapped,
                 pane: HierarchyCapability::Native,
             },
@@ -400,6 +406,7 @@ impl TopologySnapshot {
                 unmapped_panes.extend(input.panes);
             }
         }
+        append_cmux_hook_panes(&mut pane_rows, &agents, &mut capabilities);
         capabilities.sort_by_key(|caps| caps.host);
 
         let candidate_counts = pane_candidate_counts(&pane_rows);
@@ -602,6 +609,7 @@ fn stable_window_id(pane: &PaneInfo) -> String {
 fn default_socket(host: HostKind) -> &'static str {
     match host {
         HostKind::Tmux | HostKind::Rmux => "default",
+        HostKind::Cmux => "cmux",
         HostKind::Zellij => "zellij",
         HostKind::Herdr => "herdr",
     }
@@ -621,6 +629,75 @@ fn pane_candidate_counts(panes: &[(HostKind, PaneInfo)]) -> HashMap<(HostKind, S
         *counts.entry((*host, pane.pane_id.clone())).or_default() += 1;
     }
     counts
+}
+
+/// Turn authoritative cmux hook metadata into a topology pane when the
+/// environment-only backend cannot enumerate that surface. This is not a fake
+/// durable Work node: the hook supplies the exact surface UUID, workspace UUID,
+/// and socket endpoint, so the row is an execution binding with the same shape
+/// a future full cmux inventory scan will produce.
+fn append_cmux_hook_panes(
+    panes: &mut Vec<(HostKind, PaneInfo)>,
+    agents: &[Agent],
+    capabilities: &mut Vec<BackendTopologyCapabilities>,
+) {
+    for agent in agents {
+        let Some(surface) = agent
+            .surface
+            .as_ref()
+            .filter(|surface| surface.kind == SurfaceKind::Cmux)
+        else {
+            continue;
+        };
+        let Some(workspace) = surface
+            .workspace
+            .as_deref()
+            .filter(|workspace| !workspace.trim().is_empty())
+        else {
+            continue;
+        };
+        let Some(pane_id) = agent.pane.as_deref() else {
+            continue;
+        };
+        if pane_id != crate::backend::cmux::namespace_pane_id(&surface.id) {
+            continue;
+        }
+        let wanted_endpoint = agent.tmux_socket.as_deref().map_or_else(
+            || default_socket(HostKind::Cmux).to_string(),
+            |socket| pane_endpoint_identity(Some(pane_id), socket),
+        );
+        let already_observed = panes.iter().any(|(host, pane)| {
+            *host == HostKind::Cmux
+                && pane.pane_id == pane_id
+                && endpoint_for(*host, pane).socket == wanted_endpoint
+        });
+        if already_observed {
+            continue;
+        }
+        if !capabilities.iter().any(|caps| caps.host == HostKind::Cmux) {
+            capabilities.push(BackendTopologyCapabilities::for_host(HostKind::Cmux));
+        }
+        panes.push((
+            HostKind::Cmux,
+            PaneInfo {
+                agent_role: None,
+                agent_alias: None,
+                socket: agent.tmux_socket.clone(),
+                pane_id: pane_id.to_string(),
+                session_id: workspace.to_string(),
+                session: workspace.to_string(),
+                window_id: workspace.to_string(),
+                window_name: String::new(),
+                window_index: "0".into(),
+                pane_index: "0".into(),
+                tty: String::new(),
+                current_command: agent.kind.to_string(),
+                title: String::new(),
+                pane_pid: agent.pid.unwrap_or(0),
+                current_path: agent.cwd.clone().unwrap_or_default(),
+            },
+        ));
+    }
 }
 
 fn matching_agent(
@@ -655,7 +732,7 @@ fn matching_agent(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::AgentKind;
+    use crate::event::{AgentKind, SurfaceRef};
     use crate::process_tree::WorkloadSummary;
 
     struct IsolatedTmuxServers(Vec<std::path::PathBuf>);
@@ -813,6 +890,35 @@ mod tests {
             snapshot.capabilities[0].session,
             HierarchyCapability::Unsupported
         );
+    }
+
+    #[test]
+    fn cmux_hook_metadata_builds_workspace_topology_without_daemon_env() {
+        let mut hooked = agent("cmux-agent", Some("/tmp/cmux-debug.sock"));
+        hooked.pane = Some("cmux:surface-7".into());
+        hooked.surface = Some(SurfaceRef {
+            kind: SurfaceKind::Cmux,
+            id: "surface-7".into(),
+            workspace: Some("workspace-2".into()),
+        });
+
+        let snapshot =
+            TopologySnapshot::build(OffsetDateTime::UNIX_EPOCH, Vec::new(), vec![hooked]);
+
+        assert_eq!(snapshot.sessions.len(), 1);
+        let session = &snapshot.sessions[0];
+        assert_eq!(session.key.endpoint.host, HostKind::Cmux);
+        assert_eq!(session.key.endpoint.socket, "/tmp/cmux-debug.sock");
+        assert_eq!(session.key.session_id, "workspace-2");
+        assert_eq!(session.windows[0].panes[0].key.pane_id, "cmux:surface-7");
+        assert_eq!(
+            session.windows[0].panes[0]
+                .agent
+                .as_ref()
+                .map(|agent| agent.session_id.as_str()),
+            Some("cmux-agent"),
+        );
+        assert!(snapshot.unassigned_agents.is_empty());
     }
 
     /// Exercise the contract against two real isolated tmux servers. Each

--- a/crates/muxad/src/fleet_manager.rs
+++ b/crates/muxad/src/fleet_manager.rs
@@ -512,7 +512,7 @@ fn local_sessions_for_backend(kind: HostKind) -> Vec<SessionInfo> {
                 })
                 .collect()
         }
-        HostKind::Rmux | HostKind::Zellij => Vec::new(),
+        HostKind::Cmux | HostKind::Rmux | HostKind::Zellij => Vec::new(),
     }
 }
 

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -1681,7 +1681,7 @@ fn spawn_session_activity_task(
             muxa::HostKind::Herdr => sources.push(muxa::SessionActivitySource::Herdr {
                 socket_path: muxa::backend::herdr::default_socket_path(),
             }),
-            muxa::HostKind::Rmux | muxa::HostKind::Zellij => {}
+            muxa::HostKind::Cmux | muxa::HostKind::Rmux | muxa::HostKind::Zellij => {}
         }
     }
     let source_kinds: Vec<muxa::HostKind> = backends

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,7 +62,7 @@ slow full-snapshot reconciliation poll.
 | `muxad` | Long-running daemon. Owns the registry, IPC server, background tasks, and optional dashboard. |
 | `muxa` | CLI for status, watch, attend, recap, stats, reports, activity queries, init, hook entrypoints, and the `mcp` control server. |
 | Agent adapters | Translate Claude/Codex/Gemini/Antigravity hook events into muxa state transitions. |
-| Pane backends | Resolve panes, sessions, captures, and foreground activity per host (tmux, rmux, herdr, zellij). The daemon can observe several at once; each non-tmux pane id is namespaced by host. |
+| Pane backends | Resolve panes, sessions, captures, and foreground activity per host (tmux, cmux, rmux, herdr, zellij). The daemon can observe several at once; each non-tmux pane id is namespaced by host. |
 | herdr bridge | Translates herdr's own `agent_status` stream into synthetic rows for agents muxa has no hooks for. |
 | Screen detection | Classifies hook-less agents (cursor, amp, …) from pane captures against TOML manifests; synthetic, hook-authoritative. |
 | Activity ledger | Append-only duration source for state/foreground/human intervals. |

--- a/docs/CMUX.md
+++ b/docs/CMUX.md
@@ -1,0 +1,64 @@
+# cmux backend
+
+Status: **initial identity and control slice implemented.** Muxa can identify
+the current cmux surface from hook environment, keep its socket endpoint, focus
+that exact surface, and send targeted text through cmux's documented Unix
+socket API. Full workspace/surface enumeration and sidebar presentation remain
+tracked in [issue #90](https://github.com/Open330/muxa/issues/90).
+
+## Identity
+
+cmux exports `CMUX_WORKSPACE_ID` and `CMUX_SURFACE_ID` in managed terminals.
+Muxa stores a surface as `cmux:<surface-id>` so it cannot collide with tmux,
+rmux, zellij, or herdr pane ids. The hook adapter retains the workspace UUID
+on the execution surface and `CMUX_SOCKET_PATH` (falling back to
+`/tmp/cmux.sock`) in the existing endpoint field used by control routing. That
+metadata is enough to reconstruct a hook-authoritative workspace/surface row
+even when muxad started outside cmux and inherited none of its environment.
+
+The logical Workspace → Work → Run → Agent hierarchy remains muxa-owned. A
+cmux workspace or surface is an execution binding, not durable Work identity.
+
+## First-slice capabilities
+
+| Capability | Current behavior |
+| --- | --- |
+| Hook identity | `CMUX_SURFACE_ID` → `cmux:<surface-id>` |
+| Current surface | Environment- or hook-backed row with cmux workspace identity |
+| Full inventory | Not yet implemented; observations are structurally partial |
+| Current command / PID | Unsupported |
+| Screen capture | Unsupported by the documented API used in this slice |
+| Focus | `surface.focus` over the cmux Unix socket |
+| Targeted input | `surface.send_text` over the cmux Unix socket |
+
+Partial observation is intentional: seeing only the invoking surface must
+never make the reconciler reap or age out hook-authoritative agents on other
+cmux surfaces. Muxa distinguishes this structural `Partial` result from a
+normally-authoritative backend's transient `Incomplete` failure. The backend
+stays in the daemon's default multi-host set even when
+muxad started before cmux, allowing later `cmux:` hook rows to route control
+without restarting muxad.
+
+## Socket access
+
+cmux defaults to allowing only processes spawned inside cmux terminals to use
+its socket. Operators should keep that mode on shared machines. A separately
+launched muxad may observe hook state while focus/input calls are refused by
+cmux until its access mode permits that daemon process. `muxa mcp` therefore
+uses the recorded endpoint directly when the MCP process is running inside
+cmux, preserving the default descendant-only access mode; daemon-hosted web or
+fleet control still requires an access mode that admits muxad.
+
+Official API references:
+
+- <https://cmux.com/docs/api>
+- <https://cmux.com/docs/dock>
+
+## Next slices
+
+- Lock a supported cmux JSON schema into fixtures and enumerate every
+  workspace/surface defensively.
+- Add host-neutral managed launch/reuse on top of the execution seam from
+  [issue #89](https://github.com/Open330/muxa/issues/89).
+- Mirror agent attention/progress into namespaced cmux sidebar status and ship
+  an optional Dock control example.

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -296,8 +296,8 @@ forward합니다. 자세한 내용은 [SINKS.md](SINKS.md).
 
 ## Pane host 선택
 
-`MUXA_HOST=tmux|rmux|herdr|zellij`로 단일 host를 고정할 수 있습니다.
+`MUXA_HOST=tmux|cmux|rmux|herdr|zellij`로 단일 host를 고정할 수 있습니다.
 `MUXA_HOSTS`에는 `MUXA_HOSTS=rmux,tmux`처럼 순서가 있는 host 목록을 지정합니다.
 rmux가 tmux 호환 환경변수도 함께 설정하므로 native `RMUX` 환경변수를 먼저
-판별합니다. 자세한 내용은 [RMUX.md](RMUX.md), [HERDR.md](HERDR.md),
+판별합니다. 자세한 내용은 [CMUX.md](CMUX.md), [RMUX.md](RMUX.md), [HERDR.md](HERDR.md),
 [ZELLIJ.md](ZELLIJ.md)을 참고하세요.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -302,8 +302,8 @@ prompts to oh-my-prompt. See [SINKS.md](SINKS.md).
 
 ## Pane host selection
 
-`MUXA_HOST=tmux|rmux|herdr|zellij` pins a single host. `MUXA_HOSTS` accepts an
+`MUXA_HOST=tmux|cmux|rmux|herdr|zellij` pins a single host. `MUXA_HOSTS` accepts an
 ordered comma-separated set, for example `MUXA_HOSTS=rmux,tmux`. rmux's native
 `RMUX` variables take precedence over the `TMUX` compatibility variables it
-also exports. See [RMUX.md](RMUX.md), [HERDR.md](HERDR.md), and
+also exports. See [CMUX.md](CMUX.md), [RMUX.md](RMUX.md), [HERDR.md](HERDR.md), and
 [ZELLIJ.md](ZELLIJ.md).

--- a/docs/FLEET.ko.md
+++ b/docs/FLEET.ko.md
@@ -18,7 +18,7 @@ host마다 독립적인 OpenSSH process 하나를 유지합니다. 원격에서�
 통신합니다. 원격 TCP port를 열거나 agent socket을 forwarding하지 않으며 terminal
 내용도 상시 복제하지 않습니다.
 
-여기서 Fleet host는 물리 node입니다. 기존 문서에서 사용하던 tmux/rmux/herdr/
+여기서 Fleet host는 물리 node입니다. 기존 문서에서 사용하던 tmux/cmux/rmux/herdr/
 zellij “pane host”는 각 node 내부의 backend kind로 그대로 유지됩니다.
 
 ## 준비

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -19,7 +19,7 @@ owner-only muxad Unix socket. Fleet does not expose a remote TCP port, forward
 an agent socket, or copy terminal contents continuously.
 
 This is distinct from Muxa's historical “pane host” terminology. A Fleet host
-is a physical node. tmux, rmux, herdr, and zellij remain backend kinds inside
+is a physical node. tmux, cmux, rmux, herdr, and zellij remain backend kinds inside
 that node.
 
 ## Prerequisites

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -34,7 +34,7 @@ args = ["mcp"]
 env_vars = ["RMUX", "RMUX_PANE", "TMUX", "TMUX_PANE", "MUXA_SOCKET"]
 ```
 
-This preserves the exact pane, tmux/rmux endpoint, and non-default muxa socket.
+This preserves the exact pane, tmux/cmux/rmux endpoint, and non-default muxa socket.
 For existing Codex registrations, muxa can recover a default-endpoint pane by
 walking the MCP process ancestry across active backends back to the pane shell.
 Explicit forwarding remains the reliable configuration for custom or multiple
@@ -138,7 +138,7 @@ it:
 
 `muxa_send_prompt` is refused (surfaced to the model as a tool error) when the
 pane's backend can't inject keystrokes — e.g. zellij, where CLI `write-chars`
-only reaches the focused pane. tmux, rmux, and herdr support it.
+only reaches the focused pane. tmux, cmux, rmux, and herdr support targeted input.
 
 Pane ids carry their host namespace: tmux `%12`, rmux `rmux:%12`, herdr
 `herdr:p1`. Use the `pane` field from `muxa_status` verbatim.

--- a/docs/MULTI_HOST.md
+++ b/docs/MULTI_HOST.md
@@ -1,7 +1,7 @@
 # Multi-host observation
 
 > This document uses the original “host” name for local pane backends
-> (tmux/rmux/herdr/zellij) inside one physical machine. For central management
+> (tmux/cmux/rmux/herdr/zellij) inside one physical machine. For central management
 > of several SSH-reachable physical nodes, see [FLEET.md](FLEET.md). Fleet
 > preserves this backend set independently inside every node.
 
@@ -48,7 +48,9 @@ The herdr work landed the key enablers:
 
 - `active_backends() -> Vec<SharedBackend>`: tmux unconditionally (its
   methods degrade to empty), rmux when its native env is present or the CLI is
-  installed (so a login daemon notices servers started later), herdr if its server actually **answers** on
+  installed (so a login daemon notices servers started later), cmux as an
+  always-ready partial observer/control adapter (so a login daemon can
+  route hooks from cmux started later), herdr if its server actually **answers** on
   the socket (a live `connect`, not a stale socket file — a crashed
   server's leftover socket must not ghost a dead backend into the set),
   zellij per current detection. The **env-preferred host** (whatever the
@@ -82,11 +84,11 @@ The herdr work landed the key enablers:
       whose codex actually lives in the other host's pane at the same cwd)
       while this tick's dedup still demotes the redundant synthetic.
     - The cross-host age-out (`mark_stale_cross_host_stopped`) receives the
-      **complete-this-tick** kinds, so a row on a host that answered is
-      governed by that host's reconcile pass, while a row on a host *not*
-      in the set — or one that can't answer past the (24h-default)
-      inactivity window — ages out. A single incomplete tick is harmless
-      because the threshold is a last-activity window, not one tick.
+      complete-this-tick kinds plus hosts whose contract is structurally
+      **partial**. Complete hosts govern their own rows; partial hosts such as
+      cmux protect hook-authoritative rows outside their visible subset. A row
+      on a host *not* in the set — or a normally-authoritative host that cannot
+      answer past the (24h-default) inactivity window — ages out.
   - **Discovery**: startup + periodic passes iterate the set and concat
     pane scans (`run_discovery` per backend, reports summed).
   - **Session activity**: a **single** tracker samples one source per

--- a/docs/WORK_MODEL.md
+++ b/docs/WORK_MODEL.md
@@ -9,7 +9,7 @@ Workspace
     ├── External issue reference (optional: Linear, GitHub, Jira, ...)
     └── Run (execution attempt)
         └── Agent session
-            └── tmux/rmux/herdr/zellij binding
+            └── tmux/cmux/rmux/herdr/zellij/native PTY binding
 ```
 
 | Entity | Identity | State |


### PR DESCRIPTION
## Summary

- make `muxa agent start --host auto` use muxa-owned PTY sessions outside tmux, add native session control, and keep one stable JSON output contract across native/tmux launches
- promote native PTY placeholders into their real hooked Agent rows so status surfaces never show duplicate Task + Agent entries
- add a first-class cmux backend with namespaced surface identity, workspace-aware hook topology, structurally partial observations, and exact focus/input routing
- preserve cmux's default descendant-only socket policy for MCP prompt delivery and bound socket responses defensively
- document native and cmux behavior across README, architecture, work model, MCP, fleet, configuration, and multi-host guides

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace --bins`
- [x] `cargo test --workspace --quiet -- --skip upgrade::tests::dry_run_renders_plan` — 1,612 passed, 1 ignored
- [x] `cargo test -p muxa-cli --test e2e -- --test-threads=1` — 12 passed
- [x] `git diff --check`

The filtered local test is a pre-existing macOS-only mismatch: it asserts that the upgrade dry-run contains Linux `systemctl --user restart muxad`. Linux CI runs the unfiltered workspace suite.

Advances #89 and #90. Durable native Work/Run bindings and full cmux inventory/sidebar presentation remain tracked there.
