### PR TITLE
feat(sandbox): promote the demo fixture into a supported sandbox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,22 @@ jobs:
       - run: cargo build --workspace --bins
       - run: cargo test --workspace
 
+  sandbox:
+    name: sandbox
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - run: sudo apt-get update && sudo apt-get install -y tmux
+      - run: cargo build --workspace --bins
+      - run: shellcheck scripts/muxa-sandbox.sh scripts/sandbox-smoke.sh
+      # A sandbox that leaks a daemon or a tmux server is worse than no
+      # sandbox, so the suite asserts teardown is total from every state.
+      - run: scripts/sandbox-smoke.sh
+
   msrv:
     name: MSRV (1.88)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       # tour; `muxa onboard --emit step-table` is the contract it is held to.
       - run: python3 scripts/onboarding-parity.py --muxa target/debug/muxa
       - run: python3 scripts/onboarding-parity.py --muxa target/debug/muxa --lang ko
+      # Step 6 accepts an arrow and nothing else, so an arrow the terminal
+      # tears in two has to survive the split-escape handler.
+      - run: python3 scripts/split-arrow-check.py --muxa target/debug/muxa
 
   sandbox:
     name: sandbox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tears down anything a previous run left behind before building. `status`
   distinguishes healthy from partial and names every artifact it found; `down`
   reaps daemons the pidfile lost track of, waits for them to actually exit, then
-  verifies and reports what survived. A pidfile is only trusted after its
-  process is confirmed as this sandbox's `muxad`, and starting the daemon again
-  reuses the healthy process rather than creating a socket race.
+  verifies and reports what survived. Every artifact lives below a mode-0700
+  root carrying an ownership marker, so a same-named `/tmp` path is refused
+  rather than deleted, and tmux uses an explicit socket path that stays stable
+  across `TMUX_TMPDIR` changes. A pidfile is only trusted after its process is
+  confirmed against this sandbox's exact config, while custom-named `muxad`
+  binaries remain discoverable; starting the daemon again reuses the healthy
+  process rather than creating a socket race.
   `scripts/sandbox-smoke.sh` holds it to that, asserting teardown is total from
   each state a crash can leave.
   `docs/demo-setup.sh` is the first consumer and now carries only the fixture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`scripts/muxa-sandbox.sh` — a throwaway muxa that cannot reach the real
+  one.** The isolation the demo recordings had grown privately is now a
+  supported command: `up` / `daemon` / `env` / `status` / `down` over a private
+  `MUXA_SOCKET`, `MUXA_CONFIG` and `XDG_DATA_HOME`, an isolated tmux server
+  pinned through `MUXA_TMUX_SOCKET`, and a `tmux` PATH shim so child processes
+  land on that server too. `up` refuses to nest inside an existing tmux session
+  unless told otherwise, checks that `muxa` and `muxad` are the same build, and
+  tears down anything a previous run left behind before building. `status`
+  distinguishes healthy from partial and names every artifact it found; `down`
+  reaps daemons the pidfile lost track of, waits for them to actually exit, then
+  verifies and reports what survived. `scripts/sandbox-smoke.sh` holds it to
+  that, asserting teardown is total from each state a crash can leave.
+  `docs/demo-setup.sh` is the first consumer and now carries only the fixture.
+
+### Fixed
+
+- **The demo fixture could not be rebuilt.** `docs/demo-setup.sh` wrote
+  `[watch] view = 'work'`, a value that stopped existing when the watch view
+  enum became `session` / `window` / `pane`, so `muxad` refused the config and
+  every GIF regeneration failed at daemon start.
+
 ### Changed
 
 - **Work pipelines now have daemon-owned, generation-aware Run state.** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tears down anything a previous run left behind before building. `status`
   distinguishes healthy from partial and names every artifact it found; `down`
   reaps daemons the pidfile lost track of, waits for them to actually exit, then
-  verifies and reports what survived. `scripts/sandbox-smoke.sh` holds it to
-  that, asserting teardown is total from each state a crash can leave.
+  verifies and reports what survived. A pidfile is only trusted after its
+  process is confirmed as this sandbox's `muxad`, and starting the daemon again
+  reuses the healthy process rather than creating a socket race.
+  `scripts/sandbox-smoke.sh` holds it to that, asserting teardown is total from
+  each state a crash can leave.
   `docs/demo-setup.sh` is the first consumer and now carries only the fixture.
 
 ### Changed
@@ -45,6 +48,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `[watch] view = 'work'`, a value that stopped existing when the watch view
   enum became `session` / `window` / `pane`, so `muxad` refused the config and
   every GIF regeneration failed at daemon start.
+- **An arrow torn across two reads still counts.** The handler added here to
+  drop the phantom `Esc` of a split escape sequence swallowed the CSI tail and
+  returned nothing, which drops the arrow along with the `Esc` — on the one
+  step whose contract accepts an arrow and no letter. A terminal that ships
+  `\x1b` and `[C` in separate writes therefore hit the same dead end this
+  change exists to remove. The final byte now says which key it was.
+  `scripts/split-arrow-check.py` drives the real tour with the sequence torn at
+  1, 20 and 45 ms and is wired into CI.
 - **Onboarding no longer dead-ends on `Alt-T`, and arrow keys no longer quit
   it.** The `Alt-T` gate was the tour's only step without an `Alt`-free path,
   so a terminal that composes Option instead of sending Meta — the macOS

--- a/crates/muxa-cli/src/onboarding.rs
+++ b/crates/muxa-cli/src/onboarding.rs
@@ -660,13 +660,41 @@ fn resolve_split_escape() -> Result<Option<KeyEvent>> {
         )));
     }
     // Parameter bytes precede the final byte that terminates the sequence.
+    // Swallowing the tail and returning nothing drops the *key* along with the
+    // phantom `Esc`, which is the same dead end this function exists to
+    // remove: `Step::Panes` accepts nothing but `Right`, so a transport that
+    // splits `Esc` `[C` across reads leaves the learner pressing an arrow that
+    // never arrives. The final byte says which key it was.
+    let mut final_byte = None;
     while let Some(key) = next_pending_key()? {
-        let is_parameter = matches!(key.code, KeyCode::Char(byte) if !('@'..='~').contains(&byte));
-        if !is_parameter {
+        let KeyCode::Char(byte) = key.code else {
+            break;
+        };
+        if ('@'..='~').contains(&byte) {
+            final_byte = Some(byte);
             break;
         }
     }
-    Ok(None)
+    Ok(final_byte
+        .and_then(csi_key)
+        .map(|code| KeyEvent::new(code, KeyModifiers::NONE)))
+}
+
+/// The key a CSI/SS3 sequence terminating in this byte stands for.
+///
+/// Only the keys the tour gates on. Anything else stays swallowed: reporting a
+/// wrong key is worse than reporting none, because a gate that advances on the
+/// wrong press teaches the wrong thing.
+fn csi_key(final_byte: char) -> Option<KeyCode> {
+    match final_byte {
+        'A' => Some(KeyCode::Up),
+        'B' => Some(KeyCode::Down),
+        'C' => Some(KeyCode::Right),
+        'D' => Some(KeyCode::Left),
+        'H' => Some(KeyCode::Home),
+        'F' => Some(KeyCode::End),
+        _ => None,
+    }
 }
 
 fn next_pending_key() -> Result<Option<KeyEvent>> {

--- a/docs/demo-README.md
+++ b/docs/demo-README.md
@@ -11,9 +11,11 @@ new keybinds, layout shifts, a renamed subcommand, a new panel.
 | `docs/demo.tape`          | [VHS](https://github.com/charmbracelet/vhs) script for the hero GIF.                      |
 | `docs/demo-collab.tape`   | VHS script for the collaboration GIF.                                                     |
 | `docs/demo-onboard.tape`  | Unified shell → tmux → Muxa fullscreen walkthrough; no fixture or daemon needed.           |
-| `docs/demo-setup.sh`      | Builds the whole fixture: config, PATH shims, tmux server, `muxad`, the seeded fleet, the mailbox, and the ask history. |
+| `scripts/muxa-sandbox.sh` | The isolation itself: private socket, config, data dir, tmux server, and the `tmux` PATH shim. `up` / `daemon` / `env` / `status` / `down`. |
+| `scripts/sandbox-smoke.sh`| Lifecycle test for the sandbox — proves `down` returns the machine to clean from every state, including the ones a crash leaves. |
+| `docs/demo-setup.sh`      | The fixture layered on the sandbox: the seeded fleet, the mailbox, the ask history, and the painted panes. |
 | `docs/demo-paint.sh`      | Emits one agent's screen — `demo-paint.sh <agent> <state> <prompt> [tool]...` — so panes hold a believable frame instead of a bare `cat`. |
-| `docs/demo-teardown.sh`   | Removes all of it. Safe to run at any time, including after a half-finished render.        |
+| `docs/demo-teardown.sh`   | Removes all of it — delegates to the sandbox, then clears the fixture-only files. Safe at any time, including after a half-finished render. |
 | `docs/demo-optimize.sh`   | Rebuilds a rendered GIF on a 64-colour palette. Run it after `vhs`, before committing.     |
 | `docs/demo.gif`           | Hero output. 1320 × 620, ~1.7 MB after optimizing.                                          |
 | `docs/demo-collab.gif`    | Collaboration output. 1320 × 720, ~1.7 MB after optimizing.                                 |

--- a/docs/demo-setup.sh
+++ b/docs/demo-setup.sh
@@ -8,16 +8,21 @@
 # isolated tmux server, feed muxad the same hook payloads the real agent
 # CLIs send, and seed the mailbox through the real `muxa msg` path.
 #
+# The isolation itself is not this script's job — `scripts/muxa-sandbox.sh`
+# owns the private socket, config, data directory, tmux server and PATH shim,
+# and `scripts/sandbox-smoke.sh` is what proves its teardown is total. This
+# script is the fixture layered on top.
+#
 # Steps:
-#   1. Write the demo config and the PATH shims. The `tmux` shim routes
-#      every later tmux call (ours *and* muxa's children) at the labelled
-#      demo server; the `claude`/`codex` shims make `muxa watch`'s ask
-#      feature answer instantly, for free, and identically on every render.
-#   2. Stand up the isolated tmux server and its sessions.
-#   3. Start muxad against that server only.
+#   1. Write the demo config, then bring up the sandbox with it. Add the
+#      `claude`/`codex` shims, which make `muxa watch`'s ask feature answer
+#      instantly, for free, and identically on every render.
+#   2. Create the demo's own sessions on the sandbox tmux server.
+#   3. Seed the ask history, then start the daemon — in that order, because
+#      the ask store is read once at boot.
 #   4. Seed agents across every state muxa can render, including two with
 #      live Task subagents so the swarm view has trees to expand.
-#   5. Seed the collaboration mailbox and the ask history.
+#   5. Seed the collaboration mailbox.
 #   6. Seed the activity ledger so durations read as real.
 #
 # Idempotent — safe to re-run between vhs renders. `demo-teardown.sh`
@@ -25,32 +30,22 @@
 
 set -euo pipefail
 
-# Hardcoded, not `${VAR:=default}`. This script starts a daemon and then
-# feeds it a dozen fabricated agents; if it inherited a real MUXA_SOCKET
-# from the caller's shell it would inject that fixture fleet into the
-# user's actual registry. There is no scenario where the demo wants to
-# talk to a non-demo daemon, so the override simply is not offered.
-MUXA_SOCKET=/tmp/muxa-demo.sock
-MUXA_CONFIG=/tmp/muxa-demo-config.toml
-XDG_DATA_HOME=/tmp/muxa-demo-data
-export MUXA_SOCKET MUXA_CONFIG XDG_DATA_HOME
-
 TMUX_LBL=muxa-demo
-SHIM_DIR=/tmp/muxa-demo-shim
-PID_FILE=/tmp/muxa-demo.pid
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SANDBOX="$REPO_DIR/scripts/muxa-sandbox.sh"
 PAINT="$SCRIPT_DIR/demo-paint.sh"  # believable agent frames instead of bare `cat`
-MUXAD_BIN="${MUXA_DEMO_MUXAD:-$REPO_DIR/target/debug/muxad}"
-MUXAD_LOG=/tmp/muxa-demo-muxad.log
+CONFIG_SRC=/tmp/muxa-demo-config.src.toml
 
+MUXAD_BIN="${MUXA_DEMO_MUXAD:-$REPO_DIR/target/debug/muxad}"
 if [ ! -x "$MUXAD_BIN" ]; then
   MUXAD_BIN=$(command -v muxad)
 fi
 
-# Real tmux binary, resolved absolutely so it bypasses the PATH shim below.
-# Docker/CI has it at /usr/bin/tmux; a Homebrew mac has it elsewhere, so the
-# tape passes MUXA_DEMO_TMUX after resolving `command -v tmux` pre-shim.
+# Real tmux binary, resolved absolutely so it bypasses the PATH shim the
+# sandbox installs. Docker/CI has it at /usr/bin/tmux; a Homebrew mac has it
+# elsewhere, so the tape passes MUXA_DEMO_TMUX after resolving `command -v
+# tmux` pre-shim.
 TM="${MUXA_DEMO_TMUX:-/usr/bin/tmux}"
 
 rfc3339_ago() {
@@ -65,15 +60,14 @@ rfc3339_ago() {
 # ---------------------------------------------------------------------------
 # 0) Clear whatever the last run left behind
 # ---------------------------------------------------------------------------
-# Not belt-and-braces — required. This script unlinks the demo socket and
-# starts a fresh muxad, but a daemon left over from an interrupted render
-# is still running and still holds its own copy. Two of them then trade the
-# socket back and forth and the recording shows "daemon not reachable" at
-# random points, which reads as muxa crashing.
+# Not belt-and-braces — required. A daemon left over from an interrupted
+# render is still running and still holds its own copy of the socket. Two of
+# them then trade it back and forth and the recording shows "daemon not
+# reachable" at random points, which reads as muxa crashing.
 bash "$SCRIPT_DIR/demo-teardown.sh"
 
 # ---------------------------------------------------------------------------
-# 1) Config + PATH shims
+# 1) Config + sandbox + PATH shims
 # ---------------------------------------------------------------------------
 
 # Config lives here rather than in the tape so the tape's prelude stays
@@ -83,7 +77,11 @@ bash "$SCRIPT_DIR/demo-teardown.sh"
 # `wake = "never"` matters. The default `idle_only` lets muxad inject the
 # wake prompt into a recipient's pane — which, in a recording whose panes
 # are painted fixtures, would scribble over the frame mid-take.
-cat > "$MUXA_CONFIG" <<'TOML'
+#
+# The subsystems are off because the fleet is fabricated: a live reconciler
+# would reap panes parked on `cat`, and a live state store would survive the
+# teardown into the next render.
+cat > "$CONFIG_SRC" <<'TOML'
 [ui]
 theme = 'oh-my-muxa'
 
@@ -116,19 +114,29 @@ cwd = '/tmp'
 
 [watch]
 theme = 'oh-my-muxa'
-view = 'work'
+# `window` is the work level: a window is a Work's current Run.
+view = 'window'
 sort = ['state']
 
 [watch.preview]
 default_content = 'prompt_response'
 TOML
 
-mkdir -p "$SHIM_DIR"
-cat > "$SHIM_DIR/tmux" <<EOF
-#!/bin/sh
-exec $TM -u -L $TMUX_LBL "\$@"
-EOF
-chmod +x "$SHIM_DIR/tmux"
+# `--allow-inside-tmux` because regenerating the GIFs from inside your own
+# tmux session is the normal case for a maintainer; the seeding below already
+# stamps every hook event with the sandbox server explicitly.
+bash "$SANDBOX" up \
+  --name "$TMUX_LBL" \
+  --config "$CONFIG_SRC" \
+  --tmux "$TM" \
+  --muxad "$MUXAD_BIN" \
+  --extra-path "$REPO_DIR/target/debug" \
+  --allow-inside-tmux
+
+# MUXA_SOCKET, MUXA_CONFIG, XDG_DATA_HOME, MUXA_TMUX_SOCKET and the shimmed
+# PATH all arrive here. Nothing below may reach a real muxa surface.
+eval "$(bash "$SANDBOX" env --name "$TMUX_LBL")"
+SHIM_DIR=$MUXA_SANDBOX_SHIM
 
 # Ask stand-ins. `muxa watch`'s `a` shells out to the real agent CLI, which
 # would bill the user, take an unpredictable 10-40s, and answer differently
@@ -225,24 +233,15 @@ EOF
 # Every other pane sits on `cat` or a painted frame so there is no prompt
 # noise behind the TUI.
 
-"$TM" -u -L "$TMUX_LBL" kill-server 2>/dev/null || true
 cat > /tmp/muxa-demo-bashrc <<'BASHRC'
 export PS1='$ '
 unset PROMPT_COMMAND
 BASHRC
 
-# Bring the server up on a throwaway session first, purely to learn its
-# socket path. MUXA_TMUX_SOCKET has to be exported *before* the real
-# sessions are created, because every pane inherits its environment at
-# creation time — and a pane without the pin enumerates every tmux server
-# on the host, so the recording fills up with the maintainer's own
-# sessions. Learned the hard way: the first take showed 59.
-"$TM" -u -L "$TMUX_LBL" new-session -d -s _boot cat
-MUXA_TMUX_SOCKET=$("$TM" -u -L "$TMUX_LBL" display-message -p '#{socket_path}')
-export MUXA_TMUX_SOCKET
-# Belt-and-braces for panes created by hand later, which inherit from the
-# server rather than from this script.
-"$TM" -u -L "$TMUX_LBL" set-environment -g MUXA_TMUX_SOCKET "$MUXA_TMUX_SOCKET"
+# The server, and the MUXA_TMUX_SOCKET pin every pane inherits at creation
+# time, are already in place from `sandbox up`. Without that pin a pane
+# enumerates every tmux server on the host and the recording fills up with
+# the maintainer's own sessions — the first take showed 59.
 
 # Every agent pane gets a painted frame. The inspector and the preview both
 # render the selected pane's live screen, so a fleet parked on bare `cat`
@@ -337,7 +336,9 @@ P_WEB_E2E=$(mkpane web 0 "$(frame web-e2e claude done 're-record the playwright 
 
 # Belt-and-suspenders: be explicit about which window the recording
 # should attach to.
-"$TM" -u -L "$TMUX_LBL" kill-session -t _boot
+# The sandbox's placeholder kept the server alive until the demo had sessions
+# of its own; it would otherwise show up as an empty row in the recording.
+"$TM" -u -L "$TMUX_LBL" kill-session -t "$MUXA_SANDBOX_HOLDER"
 "$TM" -u -L "$TMUX_LBL" select-window -t ctl:0
 
 # The operator's pane: where the recording types, and the origin the
@@ -349,34 +350,12 @@ PB=$("$TM" -u -L "$TMUX_LBL" display-message -p -t main:1.0 '#{pane_id}')
 # ---------------------------------------------------------------------------
 # 3) muxad, scoped to the demo server
 # ---------------------------------------------------------------------------
-# MUXA_TMUX_SOCKET was pinned back in step 2 and muxad inherits it here, so
-# its scan cannot reach a real fleet on the same host.
-
 # The ask store is read once, at daemon start. Seeding it afterwards and
 # restarting muxad to pick it up would be worse than useless: `[state]` is
 # disabled for the demo, so the restart would drop the whole seeded fleet.
 seed_ask_history
 
-rm -f "$MUXA_SOCKET" "$MUXAD_LOG"
-# `nohup` so the daemon outlives this script's shell. Without it, running
-# setup on its own — seed now, render later — leaves you with a fleet and
-# no daemon to serve it. demo-teardown.sh kills it by pid.
-nohup "$MUXAD_BIN" --config "$MUXA_CONFIG" >"$MUXAD_LOG" 2>&1 &
-echo $! > "$PID_FILE"
-for _ in $(seq 1 100); do
-  [ -S "$MUXA_SOCKET" ] && break
-  if ! kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
-    echo "demo muxad exited before creating its socket" >&2
-    cat "$MUXAD_LOG" >&2
-    exit 1
-  fi
-  sleep 0.1
-done
-if [ ! -S "$MUXA_SOCKET" ]; then
-  echo "demo muxad did not create $MUXA_SOCKET within 10 seconds" >&2
-  cat "$MUXAD_LOG" >&2
-  exit 1
-fi
+bash "$SANDBOX" daemon --name "$TMUX_LBL" --tmux "$TM" --muxad "$MUXAD_BIN"
 
 # ---------------------------------------------------------------------------
 # 4) Seed the fleet
@@ -388,7 +367,7 @@ fi
 # your real server and every seeded event is silently skipped. So each
 # seeding call claims the demo server explicitly rather than inheriting
 # whatever the caller happens to be sitting in.
-DEMO_TMUX_ENV="$MUXA_TMUX_SOCKET,0,0"
+DEMO_TMUX_ENV=$MUXA_SANDBOX_TMUX_ENV
 
 hook() { # <pane> <agent> <event> <json>
   TMUX="$DEMO_TMUX_ENV" TMUX_PANE="$1" muxa hook "$2" --event "$3" <<<"$4"

--- a/docs/demo-teardown.sh
+++ b/docs/demo-teardown.sh
@@ -1,48 +1,25 @@
 #!/usr/bin/env bash
 # Undo docs/demo-setup.sh.
 #
-# Split out of the tape so a render that dies halfway — vhs timeout, ^C,
-# a panic in the TUI — can be cleaned up with one command instead of
-# leaving a stray muxad and a labelled tmux server behind.
+# Split out of the tape so a render that dies halfway — vhs timeout, ^C, a
+# panic in the TUI — can be cleaned up with one command instead of leaving a
+# stray muxad and a labelled tmux server behind.
 #
-# Deliberately not `set -e`: every step here is best-effort, and the
-# common case is tearing down a partial setup where half of it never
-# existed.
-
-# Hardcoded for the same reason demo-setup.sh hardcodes them: this script
-# deletes a data directory, and honouring an inherited XDG_DATA_HOME would
-# aim that `rm -rf` at the caller's real one.
-MUXA_SOCKET=/tmp/muxa-demo.sock
-MUXA_CONFIG=/tmp/muxa-demo-config.toml
-XDG_DATA_HOME=/tmp/muxa-demo-data
-
-TM="${MUXA_DEMO_TMUX:-/usr/bin/tmux}"
-PID_FILE=/tmp/muxa-demo.pid
-
-"$TM" -u -L muxa-demo kill-server 2>/dev/null
-
-if [ -f "$PID_FILE" ]; then
-  kill "$(cat "$PID_FILE")" 2>/dev/null
-  rm -f "$PID_FILE"
-fi
-
-# Sweep any demo daemon the pidfile lost track of — an interrupted setup, or
-# a render killed before its postlude. Two of these racing for the same
-# socket makes muxa look like it dies at random, which costs an hour to
-# diagnose the first time.
+# The sandbox owns the socket, config, data directory, tmux server and shims,
+# and verifies its own teardown. Only the fixture files layered on top are
+# this script's to remove.
 #
-# Matched by config path, then confirmed by process name. `pkill -f` alone
-# is wrong twice over: the pattern also matches the shell running *this*
-# script, and `pkill muxad` would take out the user's real daemon.
-for pid in $(pgrep -f 'muxa-demo-config\.toml' 2>/dev/null); do
-  case "$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ')" in
-    muxad) kill "$pid" 2>/dev/null ;;
-  esac
-done
+# Deliberately not `set -e`: every step is best-effort, and the common case is
+# tearing down a partial setup where half of it never existed.
 
-rm -rf /tmp/muxa-demo-shim /tmp/muxa-demo-bashrc /tmp/muxa-demo-transcripts /tmp/muxa-demo-frames
-rm -f "$MUXA_SOCKET" "$MUXA_CONFIG"
-# Only ever the demo's own data dir — refuse to touch a real one.
-case "$XDG_DATA_HOME" in
-  /tmp/muxa-demo-data*) rm -rf "$XDG_DATA_HOME" ;;
-esac
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+bash "$REPO_DIR/scripts/muxa-sandbox.sh" down \
+  --name muxa-demo \
+  ${MUXA_DEMO_TMUX:+--tmux "$MUXA_DEMO_TMUX"}
+
+# Fixture-only paths. The sandbox never knew about these, so it cannot have
+# removed them.
+rm -rf /tmp/muxa-demo-bashrc /tmp/muxa-demo-transcripts /tmp/muxa-demo-frames
+rm -f /tmp/muxa-demo-config.src.toml

--- a/scripts/muxa-sandbox.sh
+++ b/scripts/muxa-sandbox.sh
@@ -1,0 +1,460 @@
+#!/usr/bin/env bash
+# A throwaway muxa that cannot touch the one you actually use.
+#
+#   scripts/muxa-sandbox.sh up --name muxa-demo --config /tmp/demo.toml
+#   eval "$(scripts/muxa-sandbox.sh env --name muxa-demo)"
+#   …seed whatever the consumer needs…
+#   scripts/muxa-sandbox.sh daemon --name muxa-demo
+#   scripts/muxa-sandbox.sh down   --name muxa-demo
+#
+# Every muxa surface is redirected at once, because redirecting only some of
+# them is worse than redirecting none: a daemon on a private socket that still
+# scans every tmux server on the host will happily register the caller's real
+# agents into a fixture registry.
+#
+#   MUXA_SOCKET        private daemon socket
+#   MUXA_CONFIG        private config
+#   XDG_DATA_HOME      private state, history, activity, mailbox
+#   MUXA_TMUX_SOCKET   pins the pane scan *and* hook ingest to one tmux server
+#   PATH               a `tmux` shim so child processes land on that server too
+#
+# `up` never starts the daemon. Consumers that seed a store muxad reads once at
+# boot — the ask history, for one — need a point between "the data directory
+# exists" and "the daemon is running", and a `--seed-hook` flag would only be a
+# worse spelling of running the two commands in order.
+#
+# Consumed by `docs/demo-setup.sh`; `scripts/sandbox-smoke.sh` is the test.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+NAME=muxa-sandbox
+CONFIG_SRC=
+MUXAD_BIN=
+MUXA_BIN=
+TMUX_BIN=
+ALLOW_INSIDE_TMUX=0
+KEEP_HOLDER=0
+EXTRA_PATHS=()
+
+HOLDER_SESSION=_sandbox
+
+usage() {
+  cat <<'USAGE'
+Usage: muxa-sandbox.sh <up|daemon|env|status|down> [options]
+
+Commands:
+  up       Preflight, clear leftovers, then create the sandbox: config, shims,
+           and an isolated tmux server. Does not start the daemon.
+  daemon   Start muxad against the sandbox and wait for its socket.
+  env      Print the `export` lines a consumer needs. Use with `eval`.
+  status   Report what exists. Exit 0 healthy, 3 partial, 4 absent.
+  down     Destroy everything, verify it is gone, and report what survived.
+
+Options:
+  --name <slug>         Sandbox name; namespaces every path (default: muxa-sandbox)
+  --config <file>       Config to install (default: a built-in isolated profile)
+  --muxad <path>        muxad binary (default: target/debug, then $PATH)
+  --muxa <path>         muxa binary (default: target/debug, then $PATH)
+  --tmux <path>         Real tmux binary, resolved before the shim shadows it
+  --extra-path <dir>    Prepend to the sandbox PATH; repeatable
+  --allow-inside-tmux   Permit `up` while $TMUX is set
+  --keep-holder         Leave the placeholder session alive after `up`
+  -h, --help            Show this help
+USAGE
+}
+
+die() { printf 'muxa-sandbox: %s\n' "$*" >&2; exit 1; }
+note() { printf 'muxa-sandbox: %s\n' "$*" >&2; }
+
+# --------------------------------------------------------------------------
+# Arguments and derived paths
+# --------------------------------------------------------------------------
+
+[ "$#" -ge 1 ] || { usage >&2; exit 1; }
+COMMAND=$1
+shift
+
+case "$COMMAND" in
+  up | daemon | env | status | down) ;;
+  -h | --help) usage; exit 0 ;;
+  *) usage >&2; die "unknown command: $COMMAND" ;;
+esac
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --name) [ "$#" -ge 2 ] || die '--name needs a value'; NAME=$2; shift 2 ;;
+    --name=*) NAME=${1#--name=}; shift ;;
+    --config) [ "$#" -ge 2 ] || die '--config needs a path'; CONFIG_SRC=$2; shift 2 ;;
+    --config=*) CONFIG_SRC=${1#--config=}; shift ;;
+    --muxad) [ "$#" -ge 2 ] || die '--muxad needs a path'; MUXAD_BIN=$2; shift 2 ;;
+    --muxad=*) MUXAD_BIN=${1#--muxad=}; shift ;;
+    --muxa) [ "$#" -ge 2 ] || die '--muxa needs a path'; MUXA_BIN=$2; shift 2 ;;
+    --muxa=*) MUXA_BIN=${1#--muxa=}; shift ;;
+    --tmux) [ "$#" -ge 2 ] || die '--tmux needs a path'; TMUX_BIN=$2; shift 2 ;;
+    --tmux=*) TMUX_BIN=${1#--tmux=}; shift ;;
+    --extra-path) [ "$#" -ge 2 ] || die '--extra-path needs a directory'; EXTRA_PATHS+=("$2"); shift 2 ;;
+    --extra-path=*) EXTRA_PATHS+=("${1#--extra-path=}"); shift ;;
+    --allow-inside-tmux) ALLOW_INSIDE_TMUX=1; shift ;;
+    --keep-holder) KEEP_HOLDER=1; shift ;;
+    -h | --help) usage; exit 0 ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+
+# `down` rm -rf's these paths, so the name they are built from is validated
+# rather than trusted. Anything outside this alphabet — a slash, a `..`, an
+# empty string — would aim the cleanup somewhere it has no business being.
+[[ "$NAME" =~ ^[a-z0-9][a-z0-9-]{0,30}$ ]] \
+  || die "invalid --name '$NAME' (expected lowercase letters, digits and dashes)"
+
+SB_SOCKET=/tmp/$NAME.sock
+SB_CONFIG=/tmp/$NAME-config.toml
+SB_DATA=/tmp/$NAME-data
+SB_SHIM=/tmp/$NAME-shim
+SB_PID=/tmp/$NAME.pid
+SB_LOG=/tmp/$NAME-muxad.log
+# Recorded at `up` so `env` reproduces the same PATH without the caller
+# having to repeat --extra-path on every invocation.
+SB_EXTRA=/tmp/$NAME-shim/.extra-path
+
+resolve_bins() {
+  if [ -z "$MUXAD_BIN" ]; then
+    MUXAD_BIN=$REPO_DIR/target/debug/muxad
+    [ -x "$MUXAD_BIN" ] || MUXAD_BIN=$(command -v muxad || true)
+  fi
+  if [ -z "$MUXA_BIN" ]; then
+    MUXA_BIN=$REPO_DIR/target/debug/muxa
+    [ -x "$MUXA_BIN" ] || MUXA_BIN=$(command -v muxa || true)
+  fi
+  # Resolved before the shim can shadow it, and kept absolute: the shim's whole
+  # job is to make `tmux` mean the sandbox server, which would recurse if the
+  # shim resolved `tmux` through PATH.
+  if [ -z "$TMUX_BIN" ]; then
+    TMUX_BIN=$(command -v tmux || true)
+  fi
+}
+
+tm() { "$TMUX_BIN" -u -L "$NAME" "$@"; }
+
+# --------------------------------------------------------------------------
+# status / down
+# --------------------------------------------------------------------------
+
+daemon_pid() {
+  [ -f "$SB_PID" ] || return 1
+  local pid
+  pid=$(cat "$SB_PID" 2>/dev/null) || return 1
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  printf '%s' "$pid"
+}
+
+server_running() {
+  [ -n "$TMUX_BIN" ] && tm has-session -t "$HOLDER_SESSION" >/dev/null 2>&1 && return 0
+  [ -n "$TMUX_BIN" ] && tm list-sessions >/dev/null 2>&1
+}
+
+# Every daemon belonging to this sandbox. Matched by the sandbox config path
+# and then confirmed by process name — `pkill -f` alone would also match the
+# shell running this script, and `pkill muxad` would take out the real daemon.
+all_daemons() {
+  local pid
+  for pid in $(pgrep -f "$NAME-config\\.toml" 2>/dev/null || true); do
+    case "$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ')" in
+      muxad) printf '%s\n' "$pid" ;;
+    esac
+  done
+}
+
+# The ones the pidfile lost track of: an interrupted `up`, or a consumer killed
+# before its own cleanup ran. The daemon this sandbox started is *not* a stray,
+# so health checks must not count it as one.
+stray_daemons() {
+  local tracked pid
+  tracked=$(daemon_pid || true)
+  for pid in $(all_daemons); do
+    [ "$pid" = "$tracked" ] && continue
+    printf '%s\n' "$pid"
+  done
+}
+
+present_artifacts() {
+  local found=()
+  server_running && found+=("tmux server ($NAME)")
+  daemon_pid >/dev/null && found+=("muxad pid $(daemon_pid)")
+  [ -S "$SB_SOCKET" ] && found+=("socket $SB_SOCKET")
+  [ -f "$SB_CONFIG" ] && found+=("config $SB_CONFIG")
+  [ -d "$SB_DATA" ] && found+=("data $SB_DATA")
+  [ -d "$SB_SHIM" ] && found+=("shims $SB_SHIM")
+  [ -f "$SB_PID" ] && found+=("pidfile $SB_PID")
+  local stray
+  stray=$(stray_daemons | tr '\n' ' ')
+  [ -n "${stray// /}" ] && found+=("stray muxad: ${stray% }")
+  printf '%s\n' "${found[@]:-}"
+}
+
+cmd_status() {
+  resolve_bins
+  local artifacts=() line
+  while IFS= read -r line; do
+    [ -n "$line" ] && artifacts+=("$line")
+  done < <(present_artifacts)
+
+  if [ "${#artifacts[@]}" -eq 0 ]; then
+    echo "absent — nothing named '$NAME' exists"
+    return 4
+  fi
+
+  printf 'present:\n'
+  printf '  %s\n' "${artifacts[@]}"
+
+  local healthy=1
+  server_running || healthy=0
+  daemon_pid >/dev/null || healthy=0
+  [ -S "$SB_SOCKET" ] || healthy=0
+  [ -n "$(stray_daemons)" ] && healthy=0
+
+  if [ "$healthy" -eq 1 ]; then
+    echo "healthy — sandbox '$NAME' is up"
+    return 0
+  fi
+  echo "partial — sandbox '$NAME' is incomplete or has strays; run 'down'"
+  return 3
+}
+
+cmd_down() {
+  resolve_bins
+
+  [ -n "$TMUX_BIN" ] && tm kill-server 2>/dev/null || true
+
+  local pid
+  if pid=$(daemon_pid); then
+    kill "$pid" 2>/dev/null || true
+  fi
+  for pid in $(all_daemons); do
+    kill "$pid" 2>/dev/null || true
+  done
+
+  # SIGTERM is asynchronous; without the wait, `down` can report success while
+  # a daemon is still holding its socket, and the next `up` races it.
+  local waited=0
+  while [ "$waited" -lt 50 ]; do
+    [ -z "$(all_daemons)" ] && break
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  for pid in $(all_daemons); do
+    kill -9 "$pid" 2>/dev/null || true
+  done
+
+  rm -f "$SB_SOCKET" "$SB_CONFIG" "$SB_PID" "$SB_LOG"
+  # Belt and braces on top of the --name validation: never recurse into
+  # anything that is not the /tmp path this sandbox owns.
+  case "$SB_DATA" in /tmp/"$NAME"-data) rm -rf "$SB_DATA" ;; esac
+  case "$SB_SHIM" in /tmp/"$NAME"-shim) rm -rf "$SB_SHIM" ;; esac
+
+  local survivors=() line
+  while IFS= read -r line; do
+    [ -n "$line" ] && survivors+=("$line")
+  done < <(present_artifacts)
+  if [ "${#survivors[@]}" -gt 0 ]; then
+    note "these survived teardown:"
+    printf '  %s\n' "${survivors[@]}" >&2
+    return 1
+  fi
+  return 0
+}
+
+# --------------------------------------------------------------------------
+# up
+# --------------------------------------------------------------------------
+
+DEFAULT_CONFIG=$(cat <<'TOML'
+# Built-in sandbox profile: observable, but unable to reach out.
+#
+# `wake = "never"` is the load-bearing line. The default `idle_only` lets the
+# daemon type a wake notice into a recipient's pane, which in a sandbox means
+# writing into a pane the consumer is painting or a learner is reading.
+[discovery]
+enabled = false
+
+[collaboration]
+enabled = true
+wake = 'never'
+scope = 'host'
+TOML
+)
+
+preflight() {
+  resolve_bins
+
+  [ -n "$TMUX_BIN" ] || die 'tmux not found; pass --tmux <path>'
+  [ -n "$MUXAD_BIN" ] && [ -x "$MUXAD_BIN" ] || die 'muxad not found; pass --muxad <path> or run cargo build'
+  [ -n "$MUXA_BIN" ] && [ -x "$MUXA_BIN" ] || die 'muxa not found; pass --muxa <path> or run cargo build'
+
+  # A CLI and a daemon from different builds negotiate a protocol version that
+  # does not exist, and the symptom — "no active agents" while agents are
+  # plainly running — reads as a muxa bug rather than a stale binary.
+  local muxa_version muxad_version
+  muxa_version=$("$MUXA_BIN" --version 2>/dev/null | awk '{print $2}')
+  muxad_version=$("$MUXAD_BIN" --version 2>/dev/null | awk '{print $2}')
+  if [ -n "$muxa_version" ] && [ -n "$muxad_version" ] && [ "$muxa_version" != "$muxad_version" ]; then
+    die "muxa $muxa_version and muxad $muxad_version are different builds; rebuild both"
+  fi
+
+  if [ -n "${TMUX:-}" ] && [ "$ALLOW_INSIDE_TMUX" -eq 0 ]; then
+    printf '%s\n' \
+      "muxa-sandbox: refusing to build a sandbox from inside tmux." \
+      "" \
+      "  The sandbox runs its own tmux server. Nested inside yours, the prefix" \
+      "  becomes ambiguous and it stops being obvious which server a key reaches." \
+      "" \
+      "  Detach with your prefix + d, or open a terminal outside tmux, and run" \
+      "  this again. Pass --allow-inside-tmux if you know you want the nesting." \
+      >&2
+    exit 2
+  fi
+}
+
+cmd_up() {
+  local extra
+  preflight
+
+  # Required, not defensive: an interrupted previous run leaves a daemon that
+  # still holds its own copy of the socket, and two of them trading it back and
+  # forth looks exactly like muxa crashing at random.
+  cmd_down >/dev/null 2>&1 || true
+
+  # From here until the sandbox is complete, any failure or interrupt must take
+  # the half-built sandbox with it — a partial sandbox is the state that costs
+  # an hour to diagnose.
+  trap 'cmd_down >/dev/null 2>&1 || true' EXIT INT TERM HUP
+
+  if [ -n "$CONFIG_SRC" ]; then
+    [ -f "$CONFIG_SRC" ] || die "config not found: $CONFIG_SRC"
+    cp "$CONFIG_SRC" "$SB_CONFIG"
+  else
+    printf '%s\n' "$DEFAULT_CONFIG" > "$SB_CONFIG"
+  fi
+  mkdir -p "$SB_DATA"
+
+  mkdir -p "$SB_SHIM"
+  cat > "$SB_SHIM/tmux" <<EOF
+#!/bin/sh
+# Sandbox shim: every tmux call, including ones muxa's children make, lands on
+# the sandbox server rather than the caller's.
+exec $TMUX_BIN -u -L $NAME "\$@"
+EOF
+  chmod +x "$SB_SHIM/tmux"
+
+  : > "$SB_EXTRA"
+  for extra in ${EXTRA_PATHS[@]+"${EXTRA_PATHS[@]}"}; do
+    printf '%s\n' "$extra" >> "$SB_EXTRA"
+  done
+
+  # The server has to exist before MUXA_TMUX_SOCKET can be read off it, and the
+  # pin has to be in the server environment before any real session is created:
+  # panes inherit their environment at creation time, and an unpinned pane
+  # enumerates every tmux server on the host.
+  tm new-session -d -s "$HOLDER_SESSION" cat
+  local tmux_socket
+  tmux_socket=$(tm display-message -p '#{socket_path}')
+  [ -n "$tmux_socket" ] || die 'could not read the sandbox tmux socket path'
+  tm set-environment -g MUXA_TMUX_SOCKET "$tmux_socket"
+  tm set-environment -g MUXA_SOCKET "$SB_SOCKET"
+  tm set-environment -g MUXA_CONFIG "$SB_CONFIG"
+  tm set-environment -g XDG_DATA_HOME "$SB_DATA"
+
+  if [ "$KEEP_HOLDER" -eq 0 ]; then
+    # Left running on purpose: killing it before the consumer creates its own
+    # sessions would take the server down with it. `env` reports the name so a
+    # consumer can drop it once its own sessions exist.
+    :
+  fi
+
+  trap - EXIT INT TERM HUP
+  return 0
+}
+
+# --------------------------------------------------------------------------
+# daemon / env
+# --------------------------------------------------------------------------
+
+cmd_daemon() {
+  resolve_bins
+  [ -f "$SB_CONFIG" ] || die "sandbox '$NAME' is not up; run 'up' first"
+  server_running || die "sandbox '$NAME' has no tmux server; run 'up' first"
+
+  local tmux_socket
+  tmux_socket=$(tm display-message -p '#{socket_path}')
+
+  rm -f "$SB_SOCKET" "$SB_LOG"
+  # `nohup` so the daemon outlives this invocation — a consumer that sets up now
+  # and runs later would otherwise be left with a fixture and no daemon.
+  MUXA_SOCKET="$SB_SOCKET" \
+  MUXA_CONFIG="$SB_CONFIG" \
+  XDG_DATA_HOME="$SB_DATA" \
+  MUXA_TMUX_SOCKET="$tmux_socket" \
+    nohup "$MUXAD_BIN" --config "$SB_CONFIG" >"$SB_LOG" 2>&1 &
+  echo $! > "$SB_PID"
+
+  local waited=0
+  while [ "$waited" -lt 100 ]; do
+    [ -S "$SB_SOCKET" ] && return 0
+    if ! kill -0 "$(cat "$SB_PID")" 2>/dev/null; then
+      note "muxad exited before creating its socket:"
+      cat "$SB_LOG" >&2 || true
+      return 1
+    fi
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  note "muxad did not create $SB_SOCKET within 10 seconds:"
+  cat "$SB_LOG" >&2 || true
+  return 1
+}
+
+cmd_env() {
+  resolve_bins
+  [ -f "$SB_CONFIG" ] || die "sandbox '$NAME' is not up; run 'up' first"
+  server_running || die "sandbox '$NAME' has no tmux server; run 'up' first"
+
+  local tmux_socket path_prefix extra
+  tmux_socket=$(tm display-message -p '#{socket_path}')
+  path_prefix=$SB_SHIM
+  if [ -f "$SB_EXTRA" ]; then
+    while IFS= read -r extra; do
+      [ -n "$extra" ] && path_prefix=$path_prefix:$extra
+    done < "$SB_EXTRA"
+  fi
+  for extra in ${EXTRA_PATHS[@]+"${EXTRA_PATHS[@]}"}; do
+    path_prefix=$path_prefix:$extra
+  done
+
+  cat <<EOF
+export MUXA_SOCKET='$SB_SOCKET'
+export MUXA_CONFIG='$SB_CONFIG'
+export XDG_DATA_HOME='$SB_DATA'
+export MUXA_TMUX_SOCKET='$tmux_socket'
+export PATH='$path_prefix':"\$PATH"
+export MUXA_SANDBOX_NAME='$NAME'
+export MUXA_SANDBOX_SHIM='$SB_SHIM'
+export MUXA_SANDBOX_HOLDER='$HOLDER_SESSION'
+export MUXA_SANDBOX_TMUX='$TMUX_BIN'
+export MUXA_SANDBOX_LOG='$SB_LOG'
+# A hook client stamps events with \$TMUX. Seeding from your own tmux session
+# without this makes muxad drop every event as out-of-scope.
+export MUXA_SANDBOX_TMUX_ENV='$tmux_socket,0,0'
+EOF
+}
+
+case "$COMMAND" in
+  up) cmd_up ;;
+  daemon) cmd_daemon ;;
+  env) cmd_env ;;
+  status) cmd_status ;;
+  down) cmd_down ;;
+esac

--- a/scripts/muxa-sandbox.sh
+++ b/scripts/muxa-sandbox.sh
@@ -36,7 +36,6 @@ MUXAD_BIN=
 MUXA_BIN=
 TMUX_BIN=
 ALLOW_INSIDE_TMUX=0
-KEEP_HOLDER=0
 EXTRA_PATHS=()
 
 HOLDER_SESSION=_sandbox
@@ -61,7 +60,6 @@ Options:
   --tmux <path>         Real tmux binary, resolved before the shim shadows it
   --extra-path <dir>    Prepend to the sandbox PATH; repeatable
   --allow-inside-tmux   Permit `up` while $TMUX is set
-  --keep-holder         Leave the placeholder session alive after `up`
   -h, --help            Show this help
 USAGE
 }
@@ -98,27 +96,31 @@ while [ "$#" -gt 0 ]; do
     --extra-path) [ "$#" -ge 2 ] || die '--extra-path needs a directory'; EXTRA_PATHS+=("$2"); shift 2 ;;
     --extra-path=*) EXTRA_PATHS+=("${1#--extra-path=}"); shift ;;
     --allow-inside-tmux) ALLOW_INSIDE_TMUX=1; shift ;;
-    --keep-holder) KEEP_HOLDER=1; shift ;;
     -h | --help) usage; exit 0 ;;
     *) die "unknown option: $1" ;;
   esac
 done
 
-# `down` rm -rf's these paths, so the name they are built from is validated
-# rather than trusted. Anything outside this alphabet — a slash, a `..`, an
-# empty string — would aim the cleanup somewhere it has no business being.
+# `down` recursively removes two directories below an owned root, so the name
+# that root is built from is validated rather than trusted. Anything outside
+# this alphabet — a slash, a `..`, an empty string — would aim cleanup somewhere
+# it has no business being.
 [[ "$NAME" =~ ^[a-z0-9][a-z0-9-]{0,30}$ ]] \
   || die "invalid --name '$NAME' (expected lowercase letters, digits and dashes)"
 
-SB_SOCKET=/tmp/$NAME.sock
-SB_CONFIG=/tmp/$NAME-config.toml
-SB_DATA=/tmp/$NAME-data
-SB_SHIM=/tmp/$NAME-shim
-SB_PID=/tmp/$NAME.pid
-SB_LOG=/tmp/$NAME-muxad.log
+SB_ROOT=/tmp/$NAME-sandbox
+SB_OWNER=$SB_ROOT/.owner
+SB_SOCKET=$SB_ROOT/muxad.sock
+SB_CONFIG=$SB_ROOT/config.toml
+SB_DATA=$SB_ROOT/data
+SB_SHIM=$SB_ROOT/shim
+SB_PID=$SB_ROOT/muxad.pid
+SB_LOG=$SB_ROOT/muxad.log
+SB_TMUX_SOCKET=$SB_ROOT/tmux.sock
 # Recorded at `up` so `env` reproduces the same PATH without the caller
 # having to repeat --extra-path on every invocation.
-SB_EXTRA=/tmp/$NAME-shim/.extra-path
+SB_EXTRA=$SB_SHIM/.extra-path
+OWNER_MARK="muxa-sandbox-v1:$NAME"
 
 resolve_bins() {
   if [ -z "$MUXAD_BIN" ]; then
@@ -137,18 +139,34 @@ resolve_bins() {
   fi
 }
 
-tm() { "$TMUX_BIN" -u -L "$NAME" "$@"; }
+tm() { "$TMUX_BIN" -u -S "$SB_TMUX_SOCKET" "$@"; }
 
 # --------------------------------------------------------------------------
 # status / down
 # --------------------------------------------------------------------------
 
+owned_sandbox() {
+  [ -d "$SB_ROOT" ] && [ ! -L "$SB_ROOT" ] \
+    && [ -f "$SB_OWNER" ] && [ ! -L "$SB_OWNER" ] \
+    && [ "$(cat "$SB_OWNER" 2>/dev/null)" = "$OWNER_MARK" ]
+}
+
+daemon_belongs_to_sandbox() {
+  local pid=$1 process_command
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  process_command=$(ps -o command= -p "$pid" 2>/dev/null) || return 1
+  case " $process_command " in
+    *" --config $SB_CONFIG "* | *" --config=$SB_CONFIG "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 daemon_pid() {
   [ -f "$SB_PID" ] || return 1
   local pid
   pid=$(cat "$SB_PID" 2>/dev/null) || return 1
-  [ -n "$pid" ] || return 1
-  kill -0 "$pid" 2>/dev/null || return 1
+  daemon_belongs_to_sandbox "$pid" || return 1
   printf '%s' "$pid"
 }
 
@@ -157,15 +175,14 @@ server_running() {
   [ -n "$TMUX_BIN" ] && tm list-sessions >/dev/null 2>&1
 }
 
-# Every daemon belonging to this sandbox. Matched by the sandbox config path
-# and then confirmed by process name — `pkill -f` alone would also match the
-# shell running this script, and `pkill muxad` would take out the real daemon.
+# Every daemon belonging to this sandbox. The initial pgrep is only a candidate
+# set; each result is checked for the exact config argument before it can be
+# killed. No executable-name check: --muxad deliberately supports renamed
+# same-version binaries.
 all_daemons() {
   local pid
-  for pid in $(pgrep -f "$NAME-config\\.toml" 2>/dev/null || true); do
-    case "$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ')" in
-      muxad) printf '%s\n' "$pid" ;;
-    esac
+  for pid in $(pgrep -f "$SB_ROOT/config\\.toml" 2>/dev/null || true); do
+    daemon_belongs_to_sandbox "$pid" && printf '%s\n' "$pid"
   done
 }
 
@@ -186,6 +203,7 @@ present_artifacts() {
   server_running && found+=("tmux server ($NAME)")
   daemon_pid >/dev/null && found+=("muxad pid $(daemon_pid)")
   [ -S "$SB_SOCKET" ] && found+=("socket $SB_SOCKET")
+  [ -S "$SB_TMUX_SOCKET" ] && found+=("tmux socket $SB_TMUX_SOCKET")
   [ -f "$SB_CONFIG" ] && found+=("config $SB_CONFIG")
   [ -d "$SB_DATA" ] && found+=("data $SB_DATA")
   [ -d "$SB_SHIM" ] && found+=("shims $SB_SHIM")
@@ -198,14 +216,23 @@ present_artifacts() {
 
 cmd_status() {
   resolve_bins
+  if [ ! -e "$SB_ROOT" ] && [ ! -L "$SB_ROOT" ]; then
+    echo "absent — nothing named '$NAME' exists"
+    return 4
+  fi
+  if ! owned_sandbox; then
+    echo "partial — $SB_ROOT exists but is not owned by muxa-sandbox; refusing to inspect it"
+    return 3
+  fi
   local artifacts=() line
   while IFS= read -r line; do
     [ -n "$line" ] && artifacts+=("$line")
   done < <(present_artifacts)
 
   if [ "${#artifacts[@]}" -eq 0 ]; then
-    echo "absent — nothing named '$NAME' exists"
-    return 4
+    printf 'present:\n  owned root %s\n' "$SB_ROOT"
+    echo "partial — sandbox '$NAME' has no live components; run 'down'"
+    return 3
   fi
 
   printf 'present:\n'
@@ -227,6 +254,12 @@ cmd_status() {
 
 cmd_down() {
   resolve_bins
+
+  if [ ! -e "$SB_ROOT" ] && [ ! -L "$SB_ROOT" ]; then
+    return 0
+  fi
+  owned_sandbox \
+    || die "$SB_ROOT exists but is not owned by muxa-sandbox; refusing to delete it"
 
   if [ -n "$TMUX_BIN" ]; then
     tm kill-server 2>/dev/null || true
@@ -252,11 +285,11 @@ cmd_down() {
     kill -9 "$pid" 2>/dev/null || true
   done
 
-  rm -f "$SB_SOCKET" "$SB_CONFIG" "$SB_PID" "$SB_LOG"
-  # Belt and braces on top of the --name validation: never recurse into
-  # anything that is not the /tmp path this sandbox owns.
-  case "$SB_DATA" in /tmp/"$NAME"-data) rm -rf "$SB_DATA" ;; esac
-  case "$SB_SHIM" in /tmp/"$NAME"-shim) rm -rf "$SB_SHIM" ;; esac
+  rm -f "$SB_SOCKET" "$SB_TMUX_SOCKET" "$SB_CONFIG" "$SB_PID" "$SB_LOG"
+  # Belt and braces on top of the ownership marker: recurse only into the two
+  # exact child directories created by this script.
+  case "$SB_DATA" in "$SB_ROOT"/data) rm -rf "$SB_DATA" ;; esac
+  case "$SB_SHIM" in "$SB_ROOT"/shim) rm -rf "$SB_SHIM" ;; esac
 
   local survivors=() line
   while IFS= read -r line; do
@@ -267,6 +300,15 @@ cmd_down() {
     printf '  %s\n' "${survivors[@]}" >&2
     return 1
   fi
+  local unknown
+  unknown=$(find "$SB_ROOT" -mindepth 1 -maxdepth 1 ! -name .owner -print 2>/dev/null | head -1)
+  if [ -n "$unknown" ]; then
+    note "refusing to remove unrecognized sandbox artifact: $unknown"
+    return 1
+  fi
+  rm -f "$SB_OWNER"
+  rmdir "$SB_ROOT" 2>/dev/null \
+    || { note "could not remove sandbox root $SB_ROOT"; return 1; }
   return 0
 }
 
@@ -328,7 +370,14 @@ cmd_up() {
   # Required, not defensive: an interrupted previous run leaves a daemon that
   # still holds its own copy of the socket, and two of them trading it back and
   # forth looks exactly like muxa crashing at random.
-  cmd_down >/dev/null 2>&1 || true
+  if [ -e "$SB_ROOT" ] || [ -L "$SB_ROOT" ]; then
+    owned_sandbox \
+      || die "$SB_ROOT already exists and is not owned by muxa-sandbox"
+    cmd_down >/dev/null
+  fi
+
+  mkdir -m 700 "$SB_ROOT" || die "could not create sandbox root $SB_ROOT"
+  printf '%s\n' "$OWNER_MARK" > "$SB_OWNER"
 
   # From here until the sandbox is complete, any failure or interrupt must take
   # the half-built sandbox with it — a partial sandbox is the state that costs
@@ -348,7 +397,7 @@ cmd_up() {
 #!/bin/sh
 # Sandbox shim: every tmux call, including ones muxa's children make, lands on
 # the sandbox server rather than the caller's.
-exec $TMUX_BIN -u -L $NAME "\$@"
+exec $TMUX_BIN -u -S $SB_TMUX_SOCKET "\$@"
 EOF
   chmod +x "$SB_SHIM/tmux"
 
@@ -370,12 +419,9 @@ EOF
   tm set-environment -g MUXA_CONFIG "$SB_CONFIG"
   tm set-environment -g XDG_DATA_HOME "$SB_DATA"
 
-  if [ "$KEEP_HOLDER" -eq 0 ]; then
-    # Left running on purpose: killing it before the consumer creates its own
-    # sessions would take the server down with it. `env` reports the name so a
-    # consumer can drop it once its own sessions exist.
-    :
-  fi
+  # Left running on purpose: killing it before the consumer creates its own
+  # sessions would take the server down with it. `env` reports the name so a
+  # consumer can drop it once its own sessions exist.
 
   trap - EXIT INT TERM HUP
   return 0
@@ -387,8 +433,21 @@ EOF
 
 cmd_daemon() {
   resolve_bins
+  owned_sandbox || die "sandbox '$NAME' is not up; run 'up' first"
   [ -f "$SB_CONFIG" ] || die "sandbox '$NAME' is not up; run 'up' first"
   server_running || die "sandbox '$NAME' has no tmux server; run 'up' first"
+
+  local pid existing
+  if pid=$(daemon_pid); then
+    if [ -S "$SB_SOCKET" ]; then
+      echo "already running — sandbox '$NAME' muxad pid $pid"
+      return 0
+    fi
+    die "sandbox '$NAME' muxad pid $pid is running without its socket; run 'down'"
+  fi
+  existing=$(all_daemons | tr '\n' ' ')
+  [ -z "${existing// /}" ] \
+    || die "sandbox '$NAME' already has untracked muxad: ${existing% }; run 'down'"
 
   local tmux_socket
   tmux_socket=$(tm display-message -p '#{socket_path}')
@@ -421,6 +480,7 @@ cmd_daemon() {
 
 cmd_env() {
   resolve_bins
+  owned_sandbox || die "sandbox '$NAME' is not up; run 'up' first"
   [ -f "$SB_CONFIG" ] || die "sandbox '$NAME' is not up; run 'up' first"
   server_running || die "sandbox '$NAME' has no tmux server; run 'up' first"
 

--- a/scripts/muxa-sandbox.sh
+++ b/scripts/muxa-sandbox.sh
@@ -155,7 +155,7 @@ daemon_belongs_to_sandbox() {
   local pid=$1 process_command
   [[ "$pid" =~ ^[0-9]+$ ]] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
-  process_command=$(ps -o command= -p "$pid" 2>/dev/null) || return 1
+  process_command=$(ps -ww -o command= -p "$pid" 2>/dev/null) || return 1
   case " $process_command " in
     *" --config $SB_CONFIG "* | *" --config=$SB_CONFIG "*) return 0 ;;
     *) return 1 ;;
@@ -397,7 +397,7 @@ cmd_up() {
 #!/bin/sh
 # Sandbox shim: every tmux call, including ones muxa's children make, lands on
 # the sandbox server rather than the caller's.
-exec $TMUX_BIN -u -S $SB_TMUX_SOCKET "\$@"
+exec "$TMUX_BIN" -u -S "$SB_TMUX_SOCKET" "\$@"
 EOF
   chmod +x "$SB_SHIM/tmux"
 

--- a/scripts/muxa-sandbox.sh
+++ b/scripts/muxa-sandbox.sh
@@ -228,7 +228,9 @@ cmd_status() {
 cmd_down() {
   resolve_bins
 
-  [ -n "$TMUX_BIN" ] && tm kill-server 2>/dev/null || true
+  if [ -n "$TMUX_BIN" ]; then
+    tm kill-server 2>/dev/null || true
+  fi
 
   local pid
   if pid=$(daemon_pid); then
@@ -292,8 +294,8 @@ preflight() {
   resolve_bins
 
   [ -n "$TMUX_BIN" ] || die 'tmux not found; pass --tmux <path>'
-  [ -n "$MUXAD_BIN" ] && [ -x "$MUXAD_BIN" ] || die 'muxad not found; pass --muxad <path> or run cargo build'
-  [ -n "$MUXA_BIN" ] && [ -x "$MUXA_BIN" ] || die 'muxa not found; pass --muxa <path> or run cargo build'
+  [ -x "${MUXAD_BIN:-}" ] || die 'muxad not found; pass --muxad <path> or run cargo build'
+  [ -x "${MUXA_BIN:-}" ] || die 'muxa not found; pass --muxa <path> or run cargo build'
 
   # A CLI and a daemon from different builds negotiate a protocol version that
   # does not exist, and the symptom — "no active agents" while agents are

--- a/scripts/sandbox-smoke.sh
+++ b/scripts/sandbox-smoke.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Lifecycle test for scripts/muxa-sandbox.sh.
+#
+#   scripts/sandbox-smoke.sh
+#
+# The property worth testing is not that `up` works — a broken `up` is loud.
+# It is that `down` returns the machine to clean from *any* state the sandbox
+# can be left in, including the states a crash produces, because a sandbox that
+# leaks a daemon or a tmux server is worse than no sandbox at all.
+#
+# Runs against its own name so it can never collide with a real sandbox.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SANDBOX="$SCRIPT_DIR/muxa-sandbox.sh"
+NAME=muxa-smoke
+
+# The suite deliberately runs inside whatever the caller is sitting in, so the
+# nesting refusal has to be waived for every call except the one testing it.
+sb() { # <command> [args…]
+  local command=$1
+  shift
+  bash "$SANDBOX" "$command" --name "$NAME" --allow-inside-tmux "$@"
+}
+
+passed=0
+failed=0
+
+ok() { printf '  ok    %s\n' "$1"; passed=$((passed + 1)); }
+no() { printf '  FAIL  %s\n' "$1"; [ "$#" -ge 2 ] && printf '        %s\n' "$2"; failed=$((failed + 1)); }
+
+check() { # <label> <expected-exit> <actual-exit>
+  if [ "$2" -eq "$3" ]; then ok "$1"; else no "$1" "expected exit $2, got $3"; fi
+}
+
+cleanup() { sb down >/dev/null 2>&1 || true; }
+trap cleanup EXIT INT TERM HUP
+
+echo "sandbox smoke — name '$NAME'"
+cleanup
+
+# --------------------------------------------------------------------------
+echo "lifecycle"
+
+sb status >/dev/null 2>&1
+check "status is 'absent' before anything exists" 4 $?
+
+sb up >/dev/null 2>&1
+check "up succeeds" 0 $?
+
+sb status >/dev/null 2>&1
+check "status is 'partial' with no daemon yet" 3 $?
+
+sb daemon >/dev/null 2>&1
+check "daemon starts and its socket appears" 0 $?
+
+sb status >/dev/null 2>&1
+check "status is 'healthy' once the daemon is up" 0 $?
+
+# --------------------------------------------------------------------------
+echo "isolation"
+
+env_output=$(sb env 2>/dev/null)
+
+# Fail closed. `eval ""` is not a no-op here — it leaves the caller's real
+# MUXA_SOCKET and real tmux in place, so an isolation suite that evaluated an
+# empty `env` would go on to inspect the host fleet and report it as isolated.
+if [ -z "$env_output" ]; then
+  no "env prints exports" "nothing to evaluate; skipping the isolation checks"
+  no "MUXA_SOCKET points at the sandbox" "no env"
+  no "the tmux shim sees only the sandbox server" "no env"
+  no "the sandbox daemon answers, with an empty fleet" "no env"
+else
+  ok "env prints exports"
+
+  # The whole point of the sandbox: a consumer that evaluates `env` must not be
+  # able to reach the caller's daemon or the caller's tmux server.
+  isolation=$(
+    eval "$env_output"
+    printf 'socket=%s\n' "$MUXA_SOCKET"
+    printf 'sessions=%s\n' "$(tmux list-sessions -F '#{session_name}' 2>/dev/null | tr '\n' ',')"
+    printf 'agents=%s\n' "$(muxa status 2>&1 | head -1)"
+  )
+
+  case "$isolation" in
+    *"socket=/tmp/$NAME.sock"*) ok "MUXA_SOCKET points at the sandbox" ;;
+    *) no "MUXA_SOCKET points at the sandbox" "$isolation" ;;
+  esac
+
+  case "$isolation" in
+    *'sessions=_sandbox,'*) ok "the tmux shim sees only the sandbox server" ;;
+    *) no "the tmux shim sees only the sandbox server" "$isolation" ;;
+  esac
+
+  case "$isolation" in
+    *'agents=no active agents'*) ok "the sandbox daemon answers, with an empty fleet" ;;
+    *) no "the sandbox daemon answers, with an empty fleet" "$isolation" ;;
+  esac
+fi
+
+# --------------------------------------------------------------------------
+echo "crash recovery"
+
+# A consumer killed before its cleanup ran leaves a live daemon that the
+# pidfile no longer names. That is the state two daemons end up fighting over
+# the same socket from, so it has to be both detected and cleanable.
+rm -f "/tmp/$NAME.pid"
+sb status >/dev/null 2>&1
+check "an untracked daemon is reported as a stray" 3 $?
+
+sb down >/dev/null 2>&1
+check "down reaps the stray" 0 $?
+
+sb status >/dev/null 2>&1
+check "status is 'absent' after down" 4 $?
+
+# --------------------------------------------------------------------------
+echo "nothing left behind"
+
+leftovers=$(find /tmp -maxdepth 1 -name "$NAME*" 2>/dev/null | tr '\n' ' ')
+if [ -z "${leftovers// /}" ]; then ok "no files under /tmp"; else no "no files under /tmp" "$leftovers"; fi
+
+procs=$(pgrep -f "$NAME-config" 2>/dev/null | tr '\n' ' ')
+if [ -z "${procs// /}" ]; then ok "no daemon processes"; else no "no daemon processes" "$procs"; fi
+
+if tmux -L "$NAME" list-sessions >/dev/null 2>&1; then
+  no "no tmux server"
+else
+  ok "no tmux server"
+fi
+
+# --------------------------------------------------------------------------
+echo "down is safe from any state"
+
+# Never set up at all.
+sb down >/dev/null 2>&1
+check "down on a sandbox that never existed" 0 $?
+
+# Half-built: a server and a config, but no daemon and no data directory —
+# roughly what an interrupted `up` leaves if its trap never fires.
+tmux -u -L "$NAME" new-session -d -s _sandbox cat 2>/dev/null
+: > "/tmp/$NAME-config.toml"
+sb down >/dev/null 2>&1
+check "down on a half-built sandbox" 0 $?
+
+sb status >/dev/null 2>&1
+check "status is 'absent' afterwards" 4 $?
+
+# --------------------------------------------------------------------------
+echo "guards"
+
+bash "$SANDBOX" status --name '../escape' >/dev/null 2>&1
+check "a name that could escape /tmp is rejected" 1 $?
+
+TMUX='/tmp/fake-tmux-socket,1,0' bash "$SANDBOX" up --name "$NAME" >/dev/null 2>&1
+check "up refuses to nest inside tmux" 2 $?
+
+sb status >/dev/null 2>&1
+check "the refused up created nothing" 4 $?
+
+# --------------------------------------------------------------------------
+printf '\n%d passed, %d failed\n' "$passed" "$failed"
+[ "$failed" -eq 0 ]

--- a/scripts/sandbox-smoke.sh
+++ b/scripts/sandbox-smoke.sh
@@ -16,6 +16,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SANDBOX="$SCRIPT_DIR/muxa-sandbox.sh"
 NAME=muxa-smoke
+ROOT=/tmp/$NAME-sandbox
+PIDFILE=$ROOT/muxad.pid
+SANDBOX_TMUX_SOCKET=$ROOT/tmux.sock
+CUSTOM_MUXAD=/tmp/$NAME-muxad-review
 
 # The suite deliberately runs inside whatever the caller is sitting in, so the
 # nesting refusal has to be waived for every call except the one testing it.
@@ -36,6 +40,8 @@ sb() { # <command> [args…]
 
 passed=0
 failed=0
+innocent_pid=
+foreign_root_created=0
 
 ok() { printf '  ok    %s\n' "$1"; passed=$((passed + 1)); }
 no() { printf '  FAIL  %s\n' "$1"; [ "$#" -ge 2 ] && printf '        %s\n' "$2"; failed=$((failed + 1)); }
@@ -44,7 +50,18 @@ check() { # <label> <expected-exit> <actual-exit>
   if [ "$2" -eq "$3" ]; then ok "$1"; else no "$1" "expected exit $2, got $3"; fi
 }
 
-cleanup() { sb down >/dev/null 2>&1 || true; }
+cleanup() {
+  if [ -n "$innocent_pid" ]; then
+    kill "$innocent_pid" 2>/dev/null || true
+    wait "$innocent_pid" 2>/dev/null || true
+  fi
+  sb down >/dev/null 2>&1 || true
+  rm -f "$CUSTOM_MUXAD"
+  if [ "$foreign_root_created" -eq 1 ]; then
+    rm -f "$ROOT/sentinel"
+    rmdir "$ROOT" 2>/dev/null || true
+  fi
+}
 trap cleanup EXIT INT TERM HUP
 
 echo "sandbox smoke — name '$NAME'"
@@ -64,6 +81,16 @@ check "status is 'partial' with no daemon yet" 3 $?
 
 sb daemon >/dev/null 2>&1
 check "daemon starts and its socket appears" 0 $?
+
+first_pid=$(cat "$PIDFILE")
+sb daemon >/dev/null 2>&1
+check "starting the daemon twice is safe" 0 $?
+second_pid=$(cat "$PIDFILE")
+if [ "$first_pid" = "$second_pid" ]; then
+  ok "starting the daemon twice reuses the original process"
+else
+  no "starting the daemon twice reuses the original process" "first $first_pid, second $second_pid"
+fi
 
 sb status >/dev/null 2>&1
 check "status is 'healthy' once the daemon is up" 0 $?
@@ -94,7 +121,7 @@ else
   )
 
   case "$isolation" in
-    *"socket=/tmp/$NAME.sock"*) ok "MUXA_SOCKET points at the sandbox" ;;
+    *"socket=$ROOT/muxad.sock"*) ok "MUXA_SOCKET points at the sandbox" ;;
     *) no "MUXA_SOCKET points at the sandbox" "$isolation" ;;
   esac
 
@@ -115,7 +142,7 @@ echo "crash recovery"
 # A consumer killed before its cleanup ran leaves a live daemon that the
 # pidfile no longer names. That is the state two daemons end up fighting over
 # the same socket from, so it has to be both detected and cleanable.
-rm -f "/tmp/$NAME.pid"
+rm -f "$PIDFILE"
 sb status >/dev/null 2>&1
 check "an untracked daemon is reported as a stray" 3 $?
 
@@ -125,16 +152,31 @@ check "down reaps the stray" 0 $?
 sb status >/dev/null 2>&1
 check "status is 'absent' after down" 4 $?
 
+cp "$REPO_DIR/target/debug/muxad" "$CUSTOM_MUXAD"
+chmod +x "$CUSTOM_MUXAD"
+sb up >/dev/null 2>&1
+sb daemon --muxad "$CUSTOM_MUXAD" >/dev/null 2>&1
+custom_pid=$(cat "$PIDFILE")
+rm -f "$PIDFILE"
+sb down >/dev/null 2>&1
+check "down finds a custom-named daemon after its pidfile is lost" 0 $?
+if kill -0 "$custom_pid" 2>/dev/null; then
+  no "the custom-named daemon is gone" "pid $custom_pid survived"
+else
+  ok "the custom-named daemon is gone"
+fi
+rm -f "$CUSTOM_MUXAD"
+
 # --------------------------------------------------------------------------
 echo "nothing left behind"
 
 leftovers=$(find /tmp -maxdepth 1 -name "$NAME*" 2>/dev/null | tr '\n' ' ')
 if [ -z "${leftovers// /}" ]; then ok "no files under /tmp"; else no "no files under /tmp" "$leftovers"; fi
 
-procs=$(pgrep -f "$NAME-config" 2>/dev/null | tr '\n' ' ')
+procs=$(pgrep -f "$ROOT/config\.toml" 2>/dev/null | tr '\n' ' ')
 if [ -z "${procs// /}" ]; then ok "no daemon processes"; else no "no daemon processes" "$procs"; fi
 
-if tmux -L "$NAME" list-sessions >/dev/null 2>&1; then
+if tmux -S "$SANDBOX_TMUX_SOCKET" list-sessions >/dev/null 2>&1; then
   no "no tmux server"
 else
   ok "no tmux server"
@@ -147,10 +189,10 @@ echo "down is safe from any state"
 sb down >/dev/null 2>&1
 check "down on a sandbox that never existed" 0 $?
 
-# Half-built: a server and a config, but no daemon and no data directory —
-# roughly what an interrupted `up` leaves if its trap never fires.
-tmux -u -L "$NAME" new-session -d -s _sandbox cat 2>/dev/null
-: > "/tmp/$NAME-config.toml"
+# Half-built: a server and a config, but no daemon and no data or shim — roughly
+# what an interrupted consumer can leave after `up`.
+sb up >/dev/null 2>&1
+rm -rf "$ROOT/data" "$ROOT/shim"
 sb down >/dev/null 2>&1
 check "down on a half-built sandbox" 0 $?
 
@@ -160,6 +202,19 @@ check "status is 'absent' afterwards" 4 $?
 # --------------------------------------------------------------------------
 echo "guards"
 
+sb up >/dev/null 2>&1
+sleep 30 & innocent_pid=$!
+printf '%s\n' "$innocent_pid" > "$PIDFILE"
+sb down >/dev/null 2>&1
+if kill -0 "$innocent_pid" 2>/dev/null; then
+  ok "a stale pidfile cannot kill an unrelated process"
+else
+  no "a stale pidfile cannot kill an unrelated process" "pid $innocent_pid was terminated"
+fi
+kill "$innocent_pid" 2>/dev/null || true
+wait "$innocent_pid" 2>/dev/null || true
+innocent_pid=
+
 bash "$SANDBOX" status --name '../escape' >/dev/null 2>&1
 check "a name that could escape /tmp is rejected" 1 $?
 
@@ -168,6 +223,33 @@ check "up refuses to nest inside tmux" 2 $?
 
 sb status >/dev/null 2>&1
 check "the refused up created nothing" 4 $?
+
+mkdir -m 700 "$ROOT"
+foreign_root_created=1
+printf '%s\n' 'keep me' > "$ROOT/sentinel"
+sb down >/dev/null 2>&1
+check "down refuses an unowned path collision" 1 $?
+if [ -f "$ROOT/sentinel" ]; then
+  ok "refused teardown preserves unrelated data"
+else
+  no "refused teardown preserves unrelated data"
+fi
+rm -f "$ROOT/sentinel"
+rmdir "$ROOT"
+foreign_root_created=0
+
+tmux_a=$(mktemp -d)
+tmux_b=$(mktemp -d)
+TMUX_TMPDIR=$tmux_a sb up >/dev/null 2>&1
+check "up succeeds under a custom TMUX_TMPDIR" 0 $?
+TMUX_TMPDIR=$tmux_b sb down >/dev/null 2>&1
+check "down reaches the same server under a different TMUX_TMPDIR" 0 $?
+if tmux -S "$SANDBOX_TMUX_SOCKET" list-sessions >/dev/null 2>&1; then
+  no "the explicit tmux socket is gone"
+else
+  ok "the explicit tmux socket is gone"
+fi
+rmdir "$tmux_a" "$tmux_b"
 
 # --------------------------------------------------------------------------
 printf '\n%d passed, %d failed\n' "$passed" "$failed"

--- a/scripts/sandbox-smoke.sh
+++ b/scripts/sandbox-smoke.sh
@@ -13,15 +13,25 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SANDBOX="$SCRIPT_DIR/muxa-sandbox.sh"
 NAME=muxa-smoke
 
 # The suite deliberately runs inside whatever the caller is sitting in, so the
 # nesting refusal has to be waived for every call except the one testing it.
+# `--extra-path` puts the freshly built `muxa` on the sandbox PATH. Without it
+# the isolation checks below reach for whatever `muxa` the host happens to have
+# installed, which passes on a developer machine and fails on a clean runner —
+# and a suite that only works where muxa is already installed is testing the
+# wrong thing.
 sb() { # <command> [args…]
   local command=$1
   shift
-  bash "$SANDBOX" "$command" --name "$NAME" --allow-inside-tmux "$@"
+  bash "$SANDBOX" "$command" \
+    --name "$NAME" \
+    --allow-inside-tmux \
+    --extra-path "$REPO_DIR/target/debug" \
+    "$@"
 }
 
 passed=0

--- a/scripts/split-arrow-check.py
+++ b/scripts/split-arrow-check.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Step 6 takes an arrow and nothing else. It must accept one that arrives torn.
+
+Issue #76 was a gate with no way past. The split-escape handler added to close
+it swallowed the CSI tail and returned nothing, which drops the arrow along
+with the phantom `Esc` — the same dead end, on the one step whose contract has
+no letter equivalent. A terminal that ships `\\x1b` and `[C` in separate writes
+is not exotic; it is what the original report described.
+
+Held against the real tour, driven with the keys `--emit step-table` publishes,
+and read from the tour's own step counter rather than from screen churn.
+"""
+import argparse
+import importlib.util
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("parity", HERE / "onboarding-parity.py")
+parity = importlib.util.module_from_spec(spec)
+sys.argv = ["parity"]
+spec.loader.exec_module(parity)
+
+ARROW_STEP = 6
+
+
+def reach_arrow_step(muxa: str) -> "parity.Tour":
+    """Drive the published keys up to — but not through — the arrow gate."""
+    tour = parity.Tour([muxa, "onboard", "--lang", "en"])
+    tour.pump(1.0)
+    for number, tokens in parity.read_contract(muxa):
+        if number == ARROW_STEP:
+            if not tour.wait_for_step(ARROW_STEP):
+                tour.close()
+                raise SystemExit(f"could not reach step {ARROW_STEP} (at {tour.step()})")
+            return tour
+        for token in tokens:
+            tour.send(parity.token_bytes(token))
+            tour.pump(0.25)
+    tour.finish()
+    raise SystemExit(f"step {ARROW_STEP} is no longer the arrow gate; update this check")
+
+
+def probe(muxa: str, gap_ms: int | None) -> bool:
+    """True when the arrow advanced the tour. `gap_ms=None` sends it whole."""
+    tour = reach_arrow_step(muxa)
+    try:
+        if gap_ms is None:
+            tour.send(b"\x1b[C")
+        else:
+            tour.send(b"\x1b")
+            tour.pump(gap_ms / 1000)
+            tour.send(b"[C")
+        return tour.wait_for_step(ARROW_STEP + 1)
+    finally:
+        tour.finish()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--muxa", default="target/debug/muxa")
+    ap.add_argument("--gaps", default="1,20,45", help="split delays in ms")
+    args = ap.parse_args()
+
+    failures = 0
+    whole = probe(args.muxa, None)
+    print(f"  {'ok  ' if whole else 'FAIL'}  arrow in one write")
+    failures += not whole
+    for gap in [int(g) for g in args.gaps.split(",")]:
+        torn = probe(args.muxa, gap)
+        print(f"  {'ok  ' if torn else 'FAIL'}  arrow split across two writes, {gap}ms apart")
+        failures += not torn
+
+    print("split arrow ok — step 6 accepts a torn escape sequence" if not failures
+          else f"{failures} failed — step 6 drops the arrow it is the only gate for")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/split-arrow-check.py
+++ b/scripts/split-arrow-check.py
@@ -18,7 +18,9 @@ import sys
 HERE = pathlib.Path(__file__).resolve().parent
 spec = importlib.util.spec_from_file_location("parity", HERE / "onboarding-parity.py")
 parity = importlib.util.module_from_spec(spec)
-sys.argv = ["parity"]
+# The parity harness parses `sys.argv` at import. Hand it none and keep our own,
+# or every flag below is silently ignored and the check runs on its defaults.
+ARGV, sys.argv = sys.argv[1:], [sys.argv[0]]
 spec.loader.exec_module(parity)
 
 ARROW_STEP = 6
@@ -56,18 +58,33 @@ def probe(muxa: str, gap_ms: int | None) -> bool:
         tour.finish()
 
 
+def advances(muxa: str, gap_ms: int | None, attempts: int) -> bool:
+    """Whether the arrow ever gets through.
+
+    Driving a TUI over a pty is timing-sensitive: reaching the gate, or seeing
+    the step counter move, times out perhaps one run in ten under load. Retry
+    rather than ship a flaky gate — the signal survives it, because a binary
+    that drops the key fails every attempt, not one in ten.
+    """
+    return any(probe(muxa, gap_ms) for _ in range(attempts))
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--muxa", default="target/debug/muxa")
-    ap.add_argument("--gaps", default="1,20,45", help="split delays in ms")
-    args = ap.parse_args()
+    ap.add_argument("--attempts", type=int, default=3, help="retries before failing")
+    # Below about 5 ms the two writes coalesce in the pty often enough to be
+    # nondeterministic, which exercises the *un*-split path and makes the check
+    # flaky rather than strict. Real split escapes are milliseconds apart.
+    ap.add_argument("--gaps", default="10,20,45", help="split delays in ms")
+    args = ap.parse_args(ARGV)
 
     failures = 0
-    whole = probe(args.muxa, None)
+    whole = advances(args.muxa, None, args.attempts)
     print(f"  {'ok  ' if whole else 'FAIL'}  arrow in one write")
     failures += not whole
     for gap in [int(g) for g in args.gaps.split(",")]:
-        torn = probe(args.muxa, gap)
+        torn = advances(args.muxa, gap, args.attempts)
         print(f"  {'ok  ' if torn else 'FAIL'}  arrow split across two writes, {gap}ms apart")
         failures += not torn
 


### PR DESCRIPTION
Phase 1 of the live-onboarding direction. Nothing in the onboarding surface
changes yet — this makes the thing every later phase stands on supported and
tested.

## Why

The GIF recordings had quietly grown the hard part of a live onboarding: a
complete muxa that cannot reach the real one. `docs/demo-setup.sh` pinned a
private socket, config and data directory, stood up its own tmux server,
pinned `MUXA_TMUX_SOCKET` at it, shimmed `tmux` on `PATH` so muxa's children
landed there too, and fed `muxad` the same hook payloads the real agent CLIs
send — so `working` / `waiting` / `idle` / `error` arrive through the real
pipeline rather than being drawn.

All of that was private to one script and reachable only by recording a GIF.

## What changed

`scripts/muxa-sandbox.sh` — `up` / `daemon` / `env` / `status` / `down`. It
lifts the isolation out and hardens what a recording never needed:

- **Refuses to nest inside tmux.** A sandbox server inside the caller's makes
  the prefix ambiguous. `--allow-inside-tmux` is the escape hatch the demo
  uses, since regenerating GIFs from inside tmux is normal.
- **Checks `muxa` and `muxad` are the same build.** A protocol-skewed pair
  reports "no active agents" while agents are plainly running, which reads as
  a muxa bug rather than a stale binary.
- **Clears leftovers first, and traps its own interruption**, so a failed
  setup does not leave the half-built state that costs an hour to diagnose.
- **`status` separates healthy from partial** and names every artifact it
  found. Exit 0 / 3 / 4.
- **`down` reaps daemons the pidfile lost track of**, waits for them to
  actually exit rather than assuming SIGTERM was synchronous, then verifies
  and reports anything that survived.
- **Teardown targets an explicit path list, never a glob.** The name is
  validated against `^[a-z0-9][a-z0-9-]{0,30}$` before anything is removed.
  This is not theoretical: `/tmp/muxa-demo*` on my machine also matches a
  dozen screenshots I would rather keep.

`docs/demo-setup.sh` becomes the first consumer and keeps only the fixture —
the seeded fleet, the mailbox, the ask history, the painted panes. 44 lines
shorter, and now tested.

## Also fixes: the demo fixture could not be rebuilt

`docs/demo-setup.sh` wrote `[watch] view = 'work'`, a value that stopped
existing when the watch view enum became `session` / `window` / `pane`. `muxad`
refused the config and every GIF regeneration died at daemon start:

```
muxad exited before creating its socket:
  unknown variant `work`, expected one of `session`, `window`, `pane`
```

Pre-existing on `main`; found by running the thing.

## Verification

`scripts/sandbox-smoke.sh`, new, 21 assertions, wired into CI:

```
lifecycle          absent → up → partial → daemon → healthy
isolation          MUXA_SOCKET is the sandbox's; the tmux shim sees only
                   `_sandbox`; the sandbox daemon answers with an empty fleet
crash recovery     an untracked daemon is reported as a stray, and reaped
nothing left       no files under /tmp, no daemon processes, no tmux server
down from any      never-existed, and half-built
guards             a name that could escape /tmp is rejected;
                   up refuses to nest, and creates nothing when it does
```

The suite **fails closed**. Its first version passed 5/21 for the wrong
reason: the sandbox died on an argument-order bug, `env` returned empty, and
`eval ""` left my real environment in place — so the isolation checks happily
inspected my actual 37-session fleet and would have called it isolated. An
empty `env` is now a failure rather than something to evaluate.

End-to-end, the demo round-trips on the new core:

```
setup=0
healthy — sandbox 'muxa-demo' is up
seeded agents: 19
teardown=0
absent — nothing named 'muxa-demo' exists
```

and my real fleet was untouched throughout.

`mapfile` was removed after the fact — it is bash 4, and macOS still ships 3.2
as `/bin/bash`, which is where these GIFs actually get regenerated.

## Not in scope

The pre-existing `SC1010` / `SC2016` warnings in `docs/demo-setup.sh` are
untouched (8 of them on `main`), so CI shellchecks only the two new scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
