### PR TITLE
fix(watch): fold tmux session groups into one tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A workspace open in two terminals is one tree again.** A tmux session group
+  shares one window list across several sessions — the supported way to put two
+  terminals on two Work windows of one workspace — and `list-panes -a` walks
+  sessions, so it reports every pane once per member. Topology showed the same
+  workspace two or three times over, with the agent attached to whichever copy
+  was scanned first and the rest rendered as bare panes. Grouped sessions now
+  fold onto the member the group is named after, deduplicated by pane; if that
+  session is gone the choice falls back to the lexically first id so it stays
+  put across ticks. `watch` sums `attached_clients` across the group, since the
+  members it no longer shows are still terminals on that workspace. `PaneInfo`
+  and `SessionInfo` carry `#{session_group}`, both `serde(default)` for peers
+  built before the field.
+
 - **A refused IPC request no longer reports "no active agents".** `snapshot`,
   `by_pane`, and their timeout variants handed the response straight to a
   lenient decoder that read the absent `agents` array as an empty registry, so

--- a/crates/muxa-cli/src/attend.rs
+++ b/crates/muxa-cli/src/attend.rs
@@ -394,6 +394,7 @@ mod tests {
 
     fn pane(id: &str, session: &str, window: u32, idx: u32) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,

--- a/crates/muxa-cli/src/dashboard_tui.rs
+++ b/crates/muxa-cli/src/dashboard_tui.rs
@@ -5177,6 +5177,7 @@ mod tests {
 
     fn fake_pane(pane_id: &str, session: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,

--- a/crates/muxa-cli/src/fleet_watch.rs
+++ b/crates/muxa-cli/src/fleet_watch.rs
@@ -4115,6 +4115,7 @@ mod tests {
                 observed_at: OffsetDateTime::now_utc(),
                 agents: Vec::new(),
                 panes: vec![PaneInfo {
+                    session_group: None,
                     agent_role: None,
                     agent_alias: None,
                     pane_id: "%1".into(),

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -2877,6 +2877,7 @@ mod tests {
 
     fn pane(id: &str, session: &str) -> muxa::tmux::PaneInfo {
         muxa::tmux::PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -2710,6 +2710,7 @@ mod tests {
 
     fn registration_pane(pane_id: &str, pane_index: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             pane_id: pane_id.into(),

--- a/crates/muxa-cli/src/relay.rs
+++ b/crates/muxa-cli/src/relay.rs
@@ -492,6 +492,7 @@ fn sessions_for_backend(kind: HostKind) -> Vec<SessionInfo> {
             muxa::backend::herdr::herdr_list_workspaces(&socket)
                 .into_iter()
                 .map(|workspace| SessionInfo {
+                    group: None,
                     session_id: workspace.id,
                     name: workspace.label,
                     attached_clients: 0,

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -5029,6 +5029,23 @@ fn session_group_key(host: Option<muxa::HostKind>, session: &str) -> String {
     }
 }
 
+/// Terminals attached to the workspace `info` names, counting the whole
+/// session group.
+///
+/// `attached_clients` is per session, and topology folds a session group into
+/// one node — so the members' counts belong on that node too. Without the sum
+/// a workspace open in two terminals reports one, which is the count for a row
+/// the user is deliberately no longer being shown.
+fn group_attached_clients(info: &SessionInfo, all: &[SessionInfo]) -> u32 {
+    let Some(group) = info.group.as_deref() else {
+        return info.attached_clients;
+    };
+    all.iter()
+        .filter(|member| member.group.as_deref() == Some(group))
+        .map(|member| member.attached_clients)
+        .sum()
+}
+
 fn build_watch_topology(
     agents: &[Agent],
     panes: &[PaneInfo],
@@ -5081,7 +5098,12 @@ fn build_watch_topology(
         if let Some(info) = matches.next() {
             if matches.next().is_none() {
                 node.name.clone_from(&info.name);
-                node.attached_clients = Some(info.attached_clients);
+                // `attached_clients` is per session, and topology folded this
+                // node's session group into one row — so the count for the
+                // group's other members belongs here too. Without the sum a
+                // workspace open in two terminals reports one, which is the
+                // number for the row the user is no longer being shown.
+                node.attached_clients = Some(group_attached_clients(info, session_info));
             }
         }
     }
@@ -6544,6 +6566,7 @@ fn sessions_for_host(host: muxa::HostKind) -> Vec<SessionInfo> {
             muxa::backend::herdr::herdr_list_workspaces(&socket)
                 .into_iter()
                 .map(|ws| SessionInfo {
+                    group: None,
                     session_id: ws.id,
                     name: ws.label,
                     // herdr's socket API exposes no client-attach state
@@ -15563,6 +15586,7 @@ mod tests {
 
     fn fake_pane(pane: &str, session: &str, window: u32, pane_idx: u32, cmd: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,
@@ -15593,6 +15617,7 @@ mod tests {
         pane_index: u32,
     ) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: Some(socket.into()),
@@ -18339,8 +18364,48 @@ mod tests {
         assert!(dump.contains("review the auth change"));
     }
 
+    fn grouped_session(id: &str, name: &str, attached: u32, group: &str) -> SessionInfo {
+        SessionInfo {
+            session_id: id.into(),
+            name: name.into(),
+            attached_clients: attached,
+            group: Some(group.into()),
+        }
+    }
+
+    #[test]
+    fn a_folded_workspace_counts_every_terminal_on_it() {
+        // Two terminals on one workspace via a session group: tmux reports one
+        // attached client per member, and topology shows the members as a
+        // single node. Reporting either member's own count would understate
+        // the workspace by exactly the terminals the group exists to allow.
+        let all = vec![
+            grouped_session("$0", "callabo", 1, "callabo"),
+            grouped_session("$1", "view~9~callabo", 1, "callabo"),
+            fake_session("$2", "unrelated", 3),
+        ];
+        assert_eq!(group_attached_clients(&all[0], &all), 2);
+        // Either member answers for the whole group — the caller does not have
+        // to know which one topology kept.
+        assert_eq!(group_attached_clients(&all[1], &all), 2);
+        // An ungrouped session is only ever itself.
+        assert_eq!(group_attached_clients(&all[2], &all), 3);
+    }
+
+    #[test]
+    fn a_detached_group_member_adds_nothing() {
+        // A view whose terminal has gone is still a session until tmux reaps
+        // it. It must not inflate the count while it lingers.
+        let all = vec![
+            grouped_session("$0", "callabo", 1, "callabo"),
+            grouped_session("$1", "view~9~callabo", 0, "callabo"),
+        ];
+        assert_eq!(group_attached_clients(&all[0], &all), 1);
+    }
+
     fn fake_session(id: &str, name: &str, attached_clients: u32) -> SessionInfo {
         SessionInfo {
+            group: None,
             session_id: id.into(),
             name: name.into(),
             attached_clients,
@@ -20014,6 +20079,7 @@ sort = ["state"]
     #[test]
     fn pane_display_resolves_against_cached_panes() {
         let panes = vec![PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,

--- a/crates/muxa/src/backend/cmux.rs
+++ b/crates/muxa/src/backend/cmux.rs
@@ -192,6 +192,7 @@ fn current_pane_info_from(
         .filter(|id| !id.trim().is_empty())
         .unwrap_or_else(|| "cmux".into());
     Some(PaneInfo {
+        session_group: None,
         agent_role: None,
         agent_alias: None,
         socket: endpoint,

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -502,6 +502,7 @@ fn to_pane_info(pane: &HerdrPaneInfo, process: Option<&HerdrProcessInfo>) -> Pan
         None => (String::new(), 0, String::new()),
     };
     PaneInfo {
+        session_group: None,
         agent_role: None,
         agent_alias: None,
         pane_id: format!("{PANE_ID_PREFIX}{}", pane.pane_id),

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -1022,6 +1022,7 @@ mod tests {
 
     fn fake_pane(id: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,

--- a/crates/muxa/src/backend/zellij.rs
+++ b/crates/muxa/src/backend/zellij.rs
@@ -220,6 +220,7 @@ mod tests {
 
     fn fake_pane(id: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -1643,6 +1643,7 @@ mod tests {
 
     fn pane_info(pane_id: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             pane_id: pane_id.into(),

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -2348,6 +2348,7 @@ mod tests {
         window_name: &str,
     ) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,
@@ -2717,6 +2718,7 @@ mod tests {
             fetched_at: OffsetDateTime::now_utc(),
         };
         let herdr = scanner::herdr_scan_result(vec![crate::tmux::PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,
@@ -2746,6 +2748,7 @@ mod tests {
         let scan = backend_scan_result(
             HostKind::Rmux,
             vec![crate::tmux::PaneInfo {
+                session_group: None,
                 agent_role: None,
                 agent_alias: None,
                 socket: Some("/tmp/rmux-user/default".into()),
@@ -2777,6 +2780,7 @@ mod tests {
         let rmux: SharedBackend = Arc::new(InventoryBackend {
             kind: HostKind::Rmux,
             panes: vec![crate::tmux::PaneInfo {
+                session_group: None,
                 agent_role: None,
                 agent_alias: None,
                 socket: Some("/tmp/rmux-secondary/default".into()),

--- a/crates/muxa/src/discovery.rs
+++ b/crates/muxa/src/discovery.rs
@@ -405,6 +405,7 @@ mod tests {
 
     fn pane(id: &str, cmd: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -3919,6 +3919,7 @@ mod tests {
 
     fn collaboration_test_pane(pane_id: &str, pane_index: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             pane_id: pane_id.into(),
@@ -5162,6 +5163,7 @@ mod tests {
         assert!(backend.list_panes().is_empty());
 
         let pane = PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,

--- a/crates/muxa/src/reconcile.rs
+++ b/crates/muxa/src/reconcile.rs
@@ -717,6 +717,7 @@ mod tests {
 
     fn pane(id: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,

--- a/crates/muxa/src/session_activity.rs
+++ b/crates/muxa/src/session_activity.rs
@@ -586,6 +586,7 @@ fn sample_activity() -> Result<ActivitySample, String> {
 fn sample_herdr_activity(socket_path: &Path) -> ActivitySample {
     let sessions = match herdr::herdr_focused_workspace(socket_path) {
         Some(ws) => vec![SessionInfo {
+            group: None,
             session_id: ws.id,
             name: ws.label,
             attached_clients: 1,
@@ -724,6 +725,7 @@ mod tests {
 
     fn session(id: &str, name: &str, attached_clients: u32) -> SessionInfo {
         SessionInfo {
+            group: None,
             session_id: id.into(),
             name: name.into(),
             attached_clients,

--- a/crates/muxa/src/state.rs
+++ b/crates/muxa/src/state.rs
@@ -2661,6 +2661,7 @@ mod tests {
             .await
             .unwrap();
         let pane = PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,
@@ -4453,6 +4454,7 @@ mod tests {
 
     fn pane(id: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -465,6 +465,20 @@ pub struct PaneInfo {
     #[serde(default)]
     pub session_id: String,
     pub session: String,
+    /// tmux `#{session_group}` — the name of the session group this session
+    /// belongs to, or `None` when it belongs to none.
+    ///
+    /// A session group shares one window list across several sessions, each
+    /// keeping its own current window. That is the supported way to put two
+    /// terminals on two windows of one workspace, and it means the same window
+    /// is reported once per member. Topology folds on this so one window set
+    /// is one tree.
+    ///
+    /// `serde(default)`, like every additive field here: pane snapshots cross
+    /// the wire (CLI → daemon over IPC, host → host over the fleet relay), so
+    /// a peer built before this field existed must not fail to deserialize.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_group: Option<String>,
     /// tmux's stable window id (for example `@7`). Collaboration rooms use
     /// `(socket, window_id)` rather than the mutable name/index.
     #[serde(default)]
@@ -530,7 +544,15 @@ pub struct SessionInfo {
     pub name: String,
     /// Number of attached clients. A session is "active" for muxa's
     /// cumulative timer when this is greater than zero.
+    ///
+    /// Per *session*, not per group: a workspace viewed by two terminals
+    /// through a session group reports 1 here on each member, so a caller
+    /// describing the workspace has to sum across [`Self::group`].
     pub attached_clients: u32,
+    /// tmux `#{session_group}`, or `None` when this session is in no group.
+    /// Additive, hence `serde(default)` — this type crosses the fleet wire.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -568,9 +590,10 @@ pub struct ClientInfo {
 /// `tmux -F` format string for `list-panes`. Tab-separated columns parsed
 /// in `parse_pane_lines`. Kept `pub(crate)` so [`scanner`] can reuse it.
 pub(crate) const PANE_FMT: &str =
-    "#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_tty}\t#{pane_current_command}\t#{pane_title}\t#{pane_pid}\t#{pane_current_path}\t#{session_id}\t#{window_id}\t#{window_name}\t#{@muxa_workspace_id}\t#{@muxa_workspace_cwd}\t#{@muxa_managed_workspace}\t#{@muxa_work_id}\t#{@muxa_work_cwd}\t#{@muxa_managed_work}\t#{@muxa_agent}\t#{@muxa_agent_role}\t#{@muxa_agent_task}\t#{@muxa_managed_agent}\t#{@muxa_agent_workspace_id}\t#{@muxa_agent_work_id}\t#{@muxa_external_source}\t#{@muxa_external_scope}\t#{@muxa_external_stable_id}\t#{@muxa_external_key}\t#{@muxa_external_title}\t#{@muxa_external_url}\t#{@muxa_external_status}\t#{@muxa_agent_alias}";
+    "#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_tty}\t#{pane_current_command}\t#{pane_title}\t#{pane_pid}\t#{pane_current_path}\t#{session_id}\t#{window_id}\t#{window_name}\t#{@muxa_workspace_id}\t#{@muxa_workspace_cwd}\t#{@muxa_managed_workspace}\t#{@muxa_work_id}\t#{@muxa_work_cwd}\t#{@muxa_managed_work}\t#{@muxa_agent}\t#{@muxa_agent_role}\t#{@muxa_agent_task}\t#{@muxa_managed_agent}\t#{@muxa_agent_workspace_id}\t#{@muxa_agent_work_id}\t#{@muxa_external_source}\t#{@muxa_external_scope}\t#{@muxa_external_stable_id}\t#{@muxa_external_key}\t#{@muxa_external_title}\t#{@muxa_external_url}\t#{@muxa_external_status}\t#{@muxa_agent_alias}\t#{session_group}";
 
-pub(crate) const SESSION_FMT: &str = "#{session_id}\t#{session_name}\t#{session_attached}";
+pub(crate) const SESSION_FMT: &str =
+    "#{session_id}\t#{session_name}\t#{session_attached}\t#{session_group}";
 pub(crate) const CLIENT_FMT: &str =
     "#{client_name}\t#{client_session}\t#{client_control_mode}\t#{client_activity}\t#{client_created}\t#{pane_in_mode}";
 
@@ -618,6 +641,7 @@ pub(crate) fn parse_pane_lines_for_socket(stdout: &str, socket: Option<&str>) ->
             socket: socket.map(Into::into),
             agent_role: non_empty(cols.get(19)),
             agent_alias: non_empty(cols.get(31)),
+            session_group: non_empty(cols.get(32)),
         });
     }
     panes
@@ -652,6 +676,7 @@ pub(crate) fn parse_session_lines(stdout: &str) -> Vec<SessionInfo> {
             session_id: cols[0].into(),
             name: cols[1].into(),
             attached_clients,
+            group: non_empty(cols.get(3)),
         });
     }
     sessions
@@ -1106,6 +1131,45 @@ mod tests {
     use super::*;
 
     #[test]
+    fn pane_and_session_parsers_read_the_session_group_column() {
+        // `session_group` is the last column of each format, which makes it the
+        // one an off-by-one silently empties — and an empty group reads as "not
+        // grouped", so the tree would quietly stop folding rather than fail.
+        let cols: Vec<String> = PANE_FMT
+            .split('\t')
+            .enumerate()
+            .map(|(index, field)| match field {
+                "#{pane_id}" => "%7".to_string(),
+                "#{session_name}" => "base".to_string(),
+                "#{session_group}" => "grp".to_string(),
+                _ => format!("c{index}"),
+            })
+            .collect();
+        let panes = parse_pane_lines(&cols.join("\t"));
+        assert_eq!(panes.len(), 1);
+        assert_eq!(panes[0].pane_id, "%7");
+        assert_eq!(panes[0].session, "base");
+        assert_eq!(panes[0].session_group.as_deref(), Some("grp"));
+
+        let sessions = parse_session_lines("$3\tbase\t2\tgrp\n");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, "$3");
+        assert_eq!(sessions[0].attached_clients, 2);
+        assert_eq!(sessions[0].group.as_deref(), Some("grp"));
+    }
+
+    #[test]
+    fn an_ungrouped_session_reports_no_group() {
+        // tmux emits an empty field, not a missing one, for a session in no
+        // group — and a row from an older `PANE_FMT` has no field at all.
+        // Both mean "not grouped", never `Some("")`.
+        let sessions = parse_session_lines("$3\tbase\t1\t\n");
+        assert_eq!(sessions[0].group, None);
+        let short = parse_session_lines("$3\tbase\t1\n");
+        assert_eq!(short[0].group, None);
+    }
+
+    #[test]
     fn window_listed_matches_whole_ids_only() {
         let listing = "@0\n@1\n@12\n";
         assert!(window_listed(listing, "@1"));
@@ -1336,6 +1400,7 @@ mod tests {
     #[test]
     fn an_unaliased_pane_serializes_without_the_new_keys() {
         let pane = PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             pane_id: "%1".into(),

--- a/crates/muxa/src/tmux/scanner.rs
+++ b/crates/muxa/src/tmux/scanner.rs
@@ -580,6 +580,7 @@ mod tests {
     use std::sync::Arc;
     fn fake_pane(id: &str, session: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: None,

--- a/crates/muxa/src/topology.rs
+++ b/crates/muxa/src/topology.rs
@@ -368,6 +368,70 @@ pub struct TopologySnapshot {
     pub unassigned_agents: Vec<Agent>,
 }
 
+/// Collapse tmux session groups so one window set produces one tree.
+///
+/// A session group (`tmux new-session -t <session>`) shares one window list
+/// across several sessions, each keeping its own current window. That is what
+/// lets two terminals sit on two windows of one workspace — and it means
+/// `list-panes -a`, which walks sessions, reports every pane once per member.
+/// Left alone the topology shows the same workspace two or three times over,
+/// with the agents attached to whichever copy happened to be scanned first.
+///
+/// The surviving member is the one whose name *is* the group name: tmux names
+/// a group after the session it was created from, so that one is the real
+/// workspace and the rest are per-terminal views of it. If it is gone — a view
+/// outliving the session it was opened from — the lexically first session id
+/// wins. Which member that is matters less than that it is the same one on
+/// every tick, instead of whichever the scan happened to reach first.
+///
+/// Rows for the other members are rewritten onto the survivor's identity and
+/// then deduplicated by pane, which is what actually merges the trees: the
+/// duplicates were only ever distinguished by the session half of their key.
+fn fold_session_groups(rows: Vec<(HostKind, PaneInfo)>) -> Vec<(HostKind, PaneInfo)> {
+    // Nothing is grouped in the overwhelmingly common case; skip the work
+    // rather than pay two passes and a map on every tick.
+    if rows.iter().all(|(_, pane)| pane.session_group.is_none()) {
+        return rows;
+    }
+    let mut survivors: HashMap<(HostKind, Option<String>, String), (String, String)> =
+        HashMap::new();
+    for (host, pane) in &rows {
+        let Some(group) = pane.session_group.clone() else {
+            continue;
+        };
+        let key = (*host, pane.socket.clone(), group.clone());
+        let candidate = (pane.session_id.clone(), pane.session.clone());
+        match survivors.get(&key) {
+            // The group's namesake always wins, whatever order it arrives in.
+            Some((_, name)) if *name == group => {}
+            Some((id, _)) if *id <= candidate.0 && pane.session != group => {}
+            _ => {
+                survivors.insert(key, candidate);
+            }
+        }
+    }
+    let mut seen = HashSet::new();
+    let mut folded = Vec::with_capacity(rows.len());
+    for (host, mut pane) in rows {
+        if let Some(group) = pane.session_group.clone() {
+            if let Some((id, name)) = survivors.get(&(host, pane.socket.clone(), group)) {
+                pane.session_id.clone_from(id);
+                pane.session.clone_from(name);
+            }
+        }
+        if seen.insert((
+            host,
+            pane.socket.clone(),
+            pane.session_id.clone(),
+            pane.window_id.clone(),
+            pane.pane_id.clone(),
+        )) {
+            folded.push((host, pane));
+        }
+    }
+    folded
+}
+
 impl TopologySnapshot {
     /// Build a nested snapshot and join agents by the complete
     /// `(host, socket, pane_id)` identity. An agent without endpoint metadata
@@ -407,6 +471,7 @@ impl TopologySnapshot {
             }
         }
         append_cmux_hook_panes(&mut pane_rows, &agents, &mut capabilities);
+        let pane_rows = fold_session_groups(pane_rows);
         capabilities.sort_by_key(|caps| caps.host);
 
         let candidate_counts = pane_candidate_counts(&pane_rows);
@@ -680,6 +745,7 @@ fn append_cmux_hook_panes(
         panes.push((
             HostKind::Cmux,
             PaneInfo {
+                session_group: None,
                 agent_role: None,
                 agent_alias: None,
                 socket: agent.tmux_socket.clone(),
@@ -749,6 +815,7 @@ mod tests {
 
     fn pane(socket: &str, session_name: &str, window_name: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             pane_id: "%1".into(),
@@ -800,6 +867,104 @@ mod tests {
             last_activity_at: now,
             state_entered_at: now,
         }
+    }
+
+    /// One pane of a session group, as it is reported for `member`.
+    fn grouped(session_id: &str, session: &str, group: &str) -> (HostKind, PaneInfo) {
+        let mut pane = pane("default", session, "w0");
+        pane.session_id = session_id.into();
+        pane.session_group = Some(group.into());
+        (HostKind::Tmux, pane)
+    }
+
+    #[test]
+    fn folding_keeps_the_session_the_group_is_named_after() {
+        // `view~9~base` is a per-terminal view of `base`; `base` is the
+        // workspace. Whichever order the scan reports them in, the workspace
+        // is what survives — the view is an artifact of how someone attached.
+        for rows in [
+            vec![
+                grouped("$0", "base", "base"),
+                grouped("$1", "view~9~base", "base"),
+            ],
+            vec![
+                grouped("$1", "view~9~base", "base"),
+                grouped("$0", "base", "base"),
+            ],
+        ] {
+            let folded = fold_session_groups(rows);
+            assert_eq!(folded.len(), 1, "the duplicate row must be dropped");
+            assert_eq!(folded[0].1.session, "base");
+            assert_eq!(folded[0].1.session_id, "$0");
+        }
+    }
+
+    #[test]
+    fn folding_is_stable_when_the_namesake_session_is_gone() {
+        // A view can outlive the session it was opened from. There is then no
+        // right answer, only a stable one: the same member every tick, not
+        // whichever the scan reached first.
+        let a = grouped("$1", "view~9~base", "base");
+        let b = grouped("$2", "view~8~base", "base");
+        let forward = fold_session_groups(vec![a.clone(), b.clone()]);
+        let reverse = fold_session_groups(vec![b, a]);
+        assert_eq!(forward.len(), 1);
+        assert_eq!(forward[0].1.session_id, "$1");
+        assert_eq!(reverse[0].1.session_id, forward[0].1.session_id);
+    }
+
+    #[test]
+    fn folding_leaves_ungrouped_sessions_alone() {
+        // Two ordinary sessions are two workspaces, however similar they look.
+        let mut one = pane("default", "main", "w0");
+        one.session_id = "$0".into();
+        let mut two = pane("default", "other", "w0");
+        two.session_id = "$1".into();
+        let folded = fold_session_groups(vec![(HostKind::Tmux, one), (HostKind::Tmux, two)]);
+        assert_eq!(folded.len(), 2);
+    }
+
+    #[test]
+    fn folding_does_not_reach_across_servers() {
+        // Session ids and group names are only unique per tmux server, so a
+        // group named `base` on one socket says nothing about `base` on
+        // another. Folding them together would merge two real workspaces.
+        let (_, mut other) = grouped("$0", "base", "base");
+        other.socket = Some("amux".into());
+        let folded =
+            fold_session_groups(vec![grouped("$0", "base", "base"), (HostKind::Tmux, other)]);
+        assert_eq!(folded.len(), 2);
+    }
+
+    #[test]
+    fn a_grouped_workspace_is_one_tree_with_its_agent_attached() {
+        // The user-visible point. Before folding, `list-panes -a` reported this
+        // pane once per member, the topology showed the workspace twice, and
+        // `matching_agent` claimed the agent for whichever copy was scanned
+        // first — leaving the other tree a bare pane.
+        let snapshot = TopologySnapshot::build(
+            OffsetDateTime::UNIX_EPOCH,
+            vec![TopologyInput {
+                host: HostKind::Tmux,
+                capabilities: BackendTopologyCapabilities::for_host(HostKind::Tmux),
+                panes: vec![
+                    grouped("$0", "base", "base").1,
+                    grouped("$1", "view~9~base", "base").1,
+                ],
+                sessions: Vec::new(),
+            }],
+            vec![agent("agent-base", Some("default"))],
+        );
+
+        assert_eq!(snapshot.sessions.len(), 1, "one workspace, one tree");
+        let session = &snapshot.sessions[0];
+        assert_eq!(session.name, "base");
+        assert_eq!(session.windows.len(), 1);
+        assert_eq!(session.windows[0].panes.len(), 1);
+        assert!(
+            session.windows[0].panes[0].agent.is_some(),
+            "the surviving tree keeps the agent"
+        );
     }
 
     #[test]

--- a/crates/muxad/src/fleet_manager.rs
+++ b/crates/muxad/src/fleet_manager.rs
@@ -506,6 +506,7 @@ fn local_sessions_for_backend(kind: HostKind) -> Vec<SessionInfo> {
             muxa::backend::herdr::herdr_list_workspaces(&socket)
                 .into_iter()
                 .map(|workspace| SessionInfo {
+                    group: None,
                     session_id: workspace.id,
                     name: workspace.label,
                     attached_clients: 0,

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -2283,6 +2283,7 @@ mod tests {
 
     fn collaboration_pane(pane_id: &str, pane_index: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             pane_id: pane_id.into(),

--- a/crates/muxad/src/screen_detect.rs
+++ b/crates/muxad/src/screen_detect.rs
@@ -439,6 +439,7 @@ mod tests {
 
     fn pane(pane_id: &str, command: &str) -> PaneInfo {
         PaneInfo {
+            session_group: None,
             agent_role: None,
             agent_alias: None,
             socket: Some("default".into()),


### PR DESCRIPTION
## Problem

A tmux **session group** shares one window list across several sessions, each keeping its own current window. That is the supported way to put two terminals on two Work windows of one workspace — and `list-panes -a` walks sessions, so it reports every pane **once per member**.

`topology.rs` keys sessions by `session_id`, and group members have different ids. So the same workspace appeared once per attached terminal:

```
$ tmux list-sessions
  foldcheck              group='foldcheck' attached=1
  view~2570291~foldcheck group='foldcheck' attached=1

$ muxa status --json
  sessions: [foldcheck, view~2570291~foldcheck]
  pane %1261 appears 2x
```

Worse than cosmetic: `matching_agent` claims each agent once, so the agent landed on whichever copy was scanned first and the other trees rendered as bare panes.

This shipped as a documented "known rough edge" in #88, when session groups were an occasional thing. **They are not anymore** — the `client-attached` recipe added to `docs/WATCH.md` makes every second terminal create one, so the duplicate is what a two-terminal workspace now looks like all the time. That is a consequence of the earlier change, which makes this the other half of it rather than a nice-to-have.

## Fix

Fold grouped rows onto one member and deduplicate by pane — the duplicates were only ever distinguished by the session half of their key.

**Which member survives** is the session the group is named after. tmux names a group after the session it was created from, so that one is the real workspace and the rest are per-terminal views of it. When it is gone — a view outliving the session it was opened from — the lexically first session id wins; which member that is matters less than that it is the same one on every tick, instead of whichever the scan reached first.

**`watch` sums `attached_clients` across the group.** The count is per session, so reporting the survivor's own would say one terminal for a workspace open in two — the count for a row the fold deliberately stopped showing.

**Wire.** `PaneInfo` and `SessionInfo` carry `#{session_group}`. Both cross the wire (pane snapshots CLI → daemon over IPC, host → host over the fleet relay), so both fields are `serde(default)` like every other additive field there — the pattern `8251683` established. Parsers read an absent or empty column as "not grouped", never `Some("")`.

`fold_session_groups` returns early when nothing is grouped, which is the overwhelmingly common case, rather than paying a map and two passes on every tick.

## Verification

Live, against the same tmux server, one grouped session with two attached terminals:

```
installed build (main)   sessions: [foldcheck, view~2570291~foldcheck]
                         pane %1261 appears 2x
this build               sessions: [foldcheck]
                         pane %1261 appears 1x
```

Unit tests cover the decisions, not just the happy path:

- the namesake survives **whichever order** the scan reports members in
- the survivor is **stable** when the namesake is gone (forward and reverse input agree)
- ungrouped sessions are left alone
- folding **does not reach across servers** — group names and session ids are only unique per tmux server, so merging `base` on two sockets would merge two real workspaces
- end to end: a grouped workspace builds one tree and it is the one that **keeps the agent**
- the group column is read from the **last** position of both formats (the one an off-by-one silently empties — and an empty group reads as "not grouped", so the tree would quietly stop folding rather than fail)
- `attached_clients` sums the group, either member answers for the whole group, and a **detached** member adds nothing

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass.

## Note

Most `TopologyInput` call sites use `TopologyInput::new`, which leaves `sessions` empty — so `attached_clients` only appears in `watch`, which patches it from a separate `SessionInfo` lookup. That is where the sum lives; `muxa status --json` never carried the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)