### PR TITLE
feat(onboarding): add the live tour — fifteen steps, real muxa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
       # reachable by typing the command the narration asks for. This types them.
       - run: scripts/live-tour-smoke.py --muxa target/debug/muxa
       - run: scripts/live-tour-smoke.py --muxa target/debug/muxa --lang ko
+      # Issue #76 was a gate with no way around it; this is the check that
+      # the live tour cannot repeat that.
+      - run: scripts/live-tour-smoke.py --muxa target/debug/muxa --mode skip
 
   msrv:
     name: MSRV (1.88)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,21 @@ jobs:
       # sandbox, so the suite asserts teardown is total from every state.
       - run: scripts/sandbox-smoke.sh
 
+  live-tour:
+    name: live tour
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - run: sudo apt-get update && sudo apt-get install -y tmux
+      - run: cargo build --workspace --bins
+      # The tour claims it never intercepts a keystroke, so every step has to be
+      # reachable by typing the command the narration asks for. This types them.
+      - run: scripts/live-tour-smoke.py --muxa target/debug/muxa
+
   msrv:
     name: MSRV (1.88)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
       # The tour claims it never intercepts a keystroke, so every step has to be
       # reachable by typing the command the narration asks for. This types them.
       - run: scripts/live-tour-smoke.py --muxa target/debug/muxa
+      - run: scripts/live-tour-smoke.py --muxa target/debug/muxa --lang ko
 
   msrv:
     name: MSRV (1.88)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `checkout · 3 agents` instead of `muxa` and `bash`. None of it shells out to
   an agent CLI, and each transcript says so on its first line.
 
+  Fourteen steps, not nine, and one action each. Compressing them put two
+  instructions on a line — "see both: Ctrl-b s · then leave: Ctrl-b d" — which
+  reads as one and leaves the learner unsure which half registered. `Ctrl-b s`,
+  `tmux ls`, `Ctrl-b ;` and `muxa msg list` are steps in their own right now;
+  the learner's shell reports what it ran, so a step whose action is a command
+  can be detected rather than bolted onto the end of another cue. Splitting a
+  pane is one of them: the pane they split becomes claude, which is what turns
+  "a pane is an agent" from a sentence into something they did.
+
   The tour runs in a workspace of its own. It has its own `HOME` and a
   `checkout-service` tree — the files the scripted agents say they are reading,
   so `cat crates/checkout/src/auth.rs` answers — and every pane starts there,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   request and its status and stopped there, so the sender saw their own question
   marked `Completed` with the answer they came for nowhere on screen.
 
+- **Caller provenance is printed only when it is worth knowing.** Every
+  ordinary request is `matched`, and stamping `[via cli pane=%2 pid=3874566
+  matched]` on each of them turned a mailbox into a debug log. A `mismatched`
+  or `unverifiable` origin still says so.
+
 ### Added
 
 - **`muxa onboard --tour live` — the onboarding stops simulating muxa and
@@ -167,6 +172,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shared `/` skills with in-watch add/remove, and mailbox claim/reply. Remote
   collaboration stays owned by the selected node and travels over the existing
   exact-pane SSH relay behind an explicit capability gate.
+
+### Changed
+
+- **`scripts/onboard.sh` now runs the real `muxa onboard`.** It fetches the
+  release binary for the host into a temporary directory, verifies its
+  published SHA-256, runs the onboarding, and deletes it — a download, not an
+  install: no daemon, no config, no PATH entry. The embedded shell simulation
+  remains the fallback for `--no-download`, an unsupported platform, a missing
+  checksum tool, or no network, so the pipe-to-`sh` entry point keeps working
+  offline. The fallback was realigned to the real tour's step decomposition and
+  keys — the splits are one step, detach and reattach are two, pane movement
+  takes `→`, and the attention sort takes `Alt-T` (the macOS compose glyphs
+  `†`/`ˇ` included) rather than a stand-in `t`. `muxa onboard --emit
+  step-table` publishes the key each step waits for, derived by walking the
+  real gates, and `scripts/onboarding-parity.py` presses exactly those keys at
+  the fallback in CI so the two cannot drift apart again.
+
+### Fixed
+
+- **Onboarding no longer dead-ends on `Alt-T`, and arrow keys no longer quit
+  it.** The `Alt-T` gate was the tour's only step without an `Alt`-free path,
+  so a terminal that composes Option instead of sending Meta — the macOS
+  default — could never satisfy it. The gate now also accepts the compose
+  glyph (`†`, `ˇ`), and two missed attempts surface the terminal
+  setting from `docs/WATCH.md` plus `→` to move on. Separately, a lone
+  `ESC` byte that arrives in its own read is reported as `Esc`, so an arrow key
+  relayed through tmux or a slow pty could tear the tour down mid-step; both
+  the tour and the tmux track now confirm an `Esc` before quitting and
+  reassemble the split sequence. `scripts/onboard.sh` read one byte per key
+  and so quit on *every* arrow key; it now classifies the escape tail the same
+  way and accepts the real `Alt-T`.
 
 ## [0.8.35] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   real commands instead of a quiz. `scripts/live-tour-smoke.py` types those
   commands in CI and checks the tour keeps up.
 
+  Each invocation now allocates its own private PID-scoped directory, daemon,
+  and tmux socket. Concurrent tours cannot erase or reuse one another's state,
+  and failed tmux, muxa, or hook commands stop with their actual error instead
+  of leaving the learner at a step that can never advance.
+
   The sandbox is torn down on every exit path, including `Ctrl-C`. The old
   simulation remains the default (`--tour simulated`) until the live tour has
   replaced it outright.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,14 +62,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `checkout · 3 agents` instead of `muxa` and `bash`. None of it shells out to
   an agent CLI, and each transcript says so on its first line.
 
-  Fourteen steps, not nine, and one action each. Compressing them put two
+  Fifteen steps, not nine, and one action each. Compressing them put two
   instructions on a line — "see both: Ctrl-b s · then leave: Ctrl-b d" — which
   reads as one and leaves the learner unsure which half registered. `Ctrl-b s`,
   `tmux ls`, `Ctrl-b ;` and `muxa msg list` are steps in their own right now;
   the learner's shell reports what it ran, so a step whose action is a command
-  can be detected rather than bolted onto the end of another cue. Splitting a
-  pane is one of them: the pane they split becomes claude, which is what turns
-  "a pane is an agent" from a sentence into something they did.
+  can be detected rather than bolted onto the end of another cue.
+
+  The learner starts the agent themselves. Splitting a pane is one step and
+  typing `claude` in it is the next, because a pane that turns into an agent on
+  its own teaches that panes become agents by magic. `claude` resolves to a
+  shim on the sandbox `PATH`, so what comes up is the tour's screen and the
+  real CLI is never invoked — and the pane the learner ran it in is the pane
+  the hook registers, which is what turns "a pane is an agent" from a sentence
+  into something they did.
 
   The tour runs in a workspace of its own. It has its own `HOME` and a
   `checkout-service` tree — the files the scripted agents say they are reading,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `checkout · 3 agents` instead of `muxa` and `bash`. None of it shells out to
   an agent CLI, and each transcript says so on its first line.
 
+  The tour runs in a workspace of its own. It has its own `HOME` and a
+  `checkout-service` tree — the files the scripted agents say they are reading,
+  so `cat crates/checkout/src/auth.rs` answers — and every pane starts there,
+  so `ls` shows the practice project and `muxa watch` stops printing the
+  learner's real path as an agent's cwd. This is a convincing workspace rather
+  than a jail: `cd /` still works, because a real filesystem confinement needs
+  bubblewrap or a mount namespace and neither is available unprivileged on
+  every platform muxa runs on.
+
+  Codex's approval prompt answers. A prompt reading `[y] yes  [n] no` that
+  swallows the keystroke invites the learner to do the one thing the tour has
+  made impossible; pressing `y` now appends the tool output and fires the hook
+  a resuming agent fires, so the row in watch goes back to `working`.
+
 - **`scripts/muxa-sandbox.sh` — a throwaway muxa that cannot reach the real
   one.** The isolation the demo recordings had grown privately is now a
   supported command: `up` / `daemon` / `env` / `status` / `down` over a private

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the shell prompt while they are detached, instead of printed underneath a
   prompt bash had already drawn — which read as the shell having gone away.
 
+  Every step opens by saying what the last action did — `✓ second window
+  created, see both in the top row` — because a tour that only ever says what
+  to do next leaves the learner typing commands and guessing whether any of
+  them landed. tmux's own status row is left alone for the same reason: the
+  narration had been painted over the window list, so pressing `Ctrl-b c`
+  produced no visible result anywhere on screen.
+
 - **`scripts/muxa-sandbox.sh` — a throwaway muxa that cannot reach the real
   one.** The isolation the demo recordings had grown privately is now a
   supported command: `up` / `daemon` / `env` / `status` / `down` over a private

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nobody is attached to a status bar yet. `F2` switches the narration language
   mid-tour, as the simulation's footer did.
 
+  The scripted agents look like agents. Each pane tails a transcript the tour
+  appends to, so the session *grows* — a prompt, tool calls, and, when codex
+  goes to `waiting`, the approval prompt that explains why. `muxa watch`'s
+  inspector and preview both render the selected pane's live screen, so a fleet
+  parked on one static line makes those features look broken and makes the tour
+  assert what it should be showing. Windows are named after the Work rather
+  than after whatever is running in them, so the topology reads as
+  `checkout · 3 agents` instead of `muxa` and `bash`. None of it shells out to
+  an agent CLI, and each transcript says so on its first line.
+
 - **`scripts/muxa-sandbox.sh` — a throwaway muxa that cannot reach the real
   one.** The isolation the demo recordings had grown privately is now a
   supported command: `up` / `daemon` / `env` / `status` / `down` over a private

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--no-quiz` offers that from the first step; and skipping performs whatever
   the learner would have done, so Act II still has a session to put its agents
   in. The first step prints its instruction rather than painting it, because
-  nobody is attached to a status bar yet.
+  nobody is attached to a status bar yet. `F2` switches the narration language
+  mid-tour, as the simulation's footer did.
 
 - **`scripts/muxa-sandbox.sh` — a throwaway muxa that cannot reach the real
   one.** The isolation the demo recordings had grown privately is now a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`muxa onboard --tour live` — the onboarding stops simulating muxa and
+  becomes it.** Nine steps in two acts, against a sandbox on its own tmux
+  server: Act I is real `tmux new-session`, a real second window, a real detach
+  proving the work kept running, and a real reattach; Act II adds two scripted
+  agents to the learner's own window and walks them through real `muxa watch`,
+  `muxa attend`, `muxa msg send @claude` and `muxa msg inbox` over a real
+  mailbox. The states are produced by feeding `muxad` the same hook payloads
+  the agent CLIs send, so nothing on screen is drawn.
+
+  Narration goes through tmux's own status rows rather than a pane or a popup:
+  a narration pane would be split and zoomed by the very exercises Act I
+  teaches, and `display-popup` is modal and does not expand `#{}` formats.
+  Because the narration never owns the keyboard, no step can wait on a
+  keypress — each one polls real tmux and real muxa state and advances when the
+  learner has actually done the thing, which is why the tour is driven with
+  real commands instead of a quiz. `scripts/live-tour-smoke.py` types those
+  commands in CI and checks the tour keeps up.
+
+  The sandbox is torn down on every exit path, including `Ctrl-C`. The old
+  simulation remains the default (`--tour simulated`) until the live tour has
+  replaced it outright.
+
 - **`scripts/muxa-sandbox.sh` — a throwaway muxa that cannot reach the real
   one.** The isolation the demo recordings had grown privately is now a
   supported command: `up` / `daemon` / `env` / `status` / `down` over a private

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`muxa onboard --tour live` — the onboarding stops simulating muxa and
-  becomes it.** Nine steps in two acts, against a sandbox on its own tmux
+  becomes it.** Fifteen steps in two acts, against a sandbox on its own tmux
   server: Act I is real `tmux new-session`, a real second window, a real detach
   proving the work kept running, and a real reattach; Act II adds two scripted
   agents to the learner's own window and walks them through real `muxa watch`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   simulation remains the default (`--tour simulated`) until the live tour has
   replaced it outright.
 
+  No step is a dead end. The sandbox server starts with `-f /dev/null`, so a
+  learner who rebound their prefix is not told to press `Ctrl-b` and left
+  stranded; any step offers `F12` to move past it after 45 seconds, and
+  `--no-quiz` offers that from the first step; and skipping performs whatever
+  the learner would have done, so Act II still has a session to put its agents
+  in. The first step prints its instruction rather than painting it, because
+  nobody is attached to a status bar yet.
+
 - **`scripts/muxa-sandbox.sh` — a throwaway muxa that cannot reach the real
   one.** The isolation the demo recordings had grown privately is now a
   supported command: `up` / `daemon` / `env` / `status` / `down` over a private

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Codex's approval prompt answers. A prompt reading `[y] yes  [n] no` that
   swallows the keystroke invites the learner to do the one thing the tour has
   made impossible; pressing `y` now appends the tool output and fires the hook
-  a resuming agent fires, so the row in watch goes back to `working`.
+  a resuming agent fires, so the row in watch goes back to `working`. claude
+  answers the learner's question through the mailbox rather than only on its
+  own screen, straight away — a reply they can find with `muxa msg list` is
+  what a durable mailbox is for.
+
+  The steps say what their commands do: that `attend` goes to whichever agent
+  has been blocked longest and lands you in its pane, and that `Ctrl-b ;`
+  returns to the pane you were in before. The placeholder session is removed as
+  soon as the learner has one of their own, so the `tmux ls` that step 3 asks
+  for shows their session and not the tour's plumbing. And the step is part of
+  the shell prompt while they are detached, instead of printed underneath a
+  prompt bash had already drawn — which read as the shell having gone away.
 
 - **`scripts/muxa-sandbox.sh` — a throwaway muxa that cannot reach the real
   one.** The isolation the demo recordings had grown privately is now a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the learner's shell reports what it ran, so a step whose action is a command
   can be detected rather than bolted onto the end of another cue.
 
+  The fleet stays on screen. The learner's pane was zoomed so `muxa watch`
+  could have the whole screen, which hid the two agents that had just arrived —
+  the step confirmed an arrival the learner could not see, above an instruction
+  to look at the whole Work, over a blank pane. `main-vertical` gives them at
+  least 80 columns on the left and stacks claude and codex on the right, which
+  is both what watch needs and what the next four steps are about.
+
   The learner starts the agent themselves. Splitting a pane is one step and
   typing `claude` in it is the next, because a pane that turns into an agent on
   its own teaches that panes become agents by magic. `claude` resolves to a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`muxa msg send`, `reply`, and `cancel` print a one-line receipt instead of
+  the whole stored request.** They dumped every field of the record — each
+  timestamp, each `null` — which buries the two facts the caller wants (it went
+  through, and whether an answer is coming) under thirty lines of JSON. `--json`
+  still prints the record.
+
+- **`muxa msg list` and `muxa msg inbox` show the reply.** They printed the
+  request and its status and stopped there, so the sender saw their own question
+  marked `Completed` with the answer they came for nowhere on screen.
+
 ### Added
 
 - **`muxa onboard --tour live` — the onboarding stops simulating muxa and

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Korean is selected automatically for a Korean locale, can be requested with
 | `muxa work list/show/close [--workspace muxa]` | Inspect Work and its current Run binding, or explicitly close that Run window. |
 | `muxa agent start --host tmux --workspace muxa --work muxa-onboarding ...` | Add an allowlisted agent pane to one managed tmux Work window; also exposed as MCP `muxa_start_agent`. |
 | `muxa agent control (--pane %N\|--session pty-N) --action interrupt` | Interrupt or explicitly terminate one managed tmux pane or muxa-owned PTY agent session. |
+| `muxa onboard --tour live` | Nine live steps on a throwaway muxa: real tmux, real watch, real mailbox. Refuses to nest inside an existing tmux session. |
 | `muxa onboard [--lang auto\|en\|ko]` | Unified shell → tmux → Muxa fullscreen walkthrough. `F2` switches language, `--no-quiz` skips gates, and `--print` emits the combined guide. |
 | `muxa mcp` | MCP stdio server so a coding agent can orchestrate muxa — inspect agents, send prompts, capture panes, wait for changes (`claude mcp add --scope user muxa -- muxa mcp`, see [docs/MCP.md](docs/MCP.md)). |
 | `muxa init` | Interactive install/uninstall wizard. |

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -33,8 +33,8 @@ use muxa::adapters::{
     OpencodeAdapter,
 };
 use muxa::collaboration::{
-    AirArtifactReference, CollaborationClientKind, CollaborationOrigin, NewRequest, RequestKind,
-    RequestMailbox, RequestStatus, WorkMode,
+    AirArtifactReference, CollaborationClientKind, CollaborationOrigin, CollaborationOriginMatch,
+    NewRequest, RequestKind, RequestMailbox, RequestStatus, WorkMode,
 };
 use muxa::config::{IconSet, WatchConfig, WatchSortKey, WatchTheme};
 use muxa::ipc::Client;
@@ -1137,16 +1137,24 @@ fn print_collaboration_messages(
             } else {
                 format!("from {}", request.from.label())
             };
-            let provenance = request.provenance.as_ref().map_or_else(String::new, |p| {
-                let caller = p
-                    .observed_pane
-                    .as_deref()
-                    .map_or_else(|| "pane=?".into(), |pane| format!("pane={pane}"));
-                let pid = p
-                    .caller_pid
-                    .map_or_else(String::new, |pid| format!(" pid={pid}"));
-                format!("  [via {} {caller}{pid} {}]", p.client_kind, p.origin_match)
-            });
+            // Only when it is worth knowing. `matched` is every ordinary
+            // request, and printing the caller's pid and pane on each of them
+            // turns a mailbox into a debug log — which is what a first look at
+            // `muxa msg list` used to be.
+            let provenance = request
+                .provenance
+                .as_ref()
+                .filter(|p| p.origin_match != CollaborationOriginMatch::Matched)
+                .map_or_else(String::new, |p| {
+                    let caller = p
+                        .observed_pane
+                        .as_deref()
+                        .map_or_else(|| "pane=?".into(), |pane| format!("pane={pane}"));
+                    let pid = p
+                        .caller_pid
+                        .map_or_else(String::new, |pid| format!(" pid={pid}"));
+                    format!("  [via {} {caller}{pid} {}]", p.client_kind, p.origin_match)
+                });
             println!(
                 "{}  {:?}  {:?}  {}{}\n  {}",
                 request.id, request.status, request.kind, direction, provenance, request.body,

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -342,6 +342,9 @@ enum MsgCmd {
         /// Fire-and-forget message; do not expect a reply.
         #[arg(long)]
         no_reply: bool,
+        /// Print the stored request instead of a one-line receipt.
+        #[arg(long)]
+        json: bool,
     },
     /// Claim and print this agent's pending requests.
     Inbox {
@@ -366,6 +369,9 @@ enum MsgCmd {
         /// AIR 1 artifact reference as JSON. Repeat for multiple references.
         #[arg(long = "air-ref")]
         air_refs: Vec<String>,
+        /// Print the stored request instead of a one-line receipt.
+        #[arg(long)]
+        json: bool,
     },
     /// Wait for the structured reply to a sent request.
     Wait {
@@ -375,7 +381,12 @@ enum MsgCmd {
         timeout_secs: u64,
     },
     /// Cancel a request that the recipient has not claimed yet.
-    Cancel { request_id: String },
+    Cancel {
+        request_id: String,
+        /// Print the stored request instead of a one-line receipt.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -970,6 +981,7 @@ async fn cmd_msg(client: &Client, action: MsgCmd) -> Result<()> {
             paths,
             air_refs,
             no_reply,
+            json,
         } => {
             let kind = collaboration_request_kind(&kind)?;
             let air_artifacts = collaboration_air_references(&air_refs)?;
@@ -991,7 +1003,7 @@ async fn cmd_msg(client: &Client, action: MsgCmd) -> Result<()> {
                     },
                 )
                 .await?;
-            println!("{}", serde_json::to_string_pretty(&request)?);
+            print_collaboration_receipt(&request, json)?;
         }
         MsgCmd::Inbox { json } => {
             let requests = client.collaboration_inbox(&origin).await?;
@@ -1024,6 +1036,7 @@ async fn cmd_msg(client: &Client, action: MsgCmd) -> Result<()> {
             status,
             artifacts,
             air_refs,
+            json,
         } => {
             let air_artifacts = collaboration_air_references(&air_refs)?;
             let request = client
@@ -1036,15 +1049,15 @@ async fn cmd_msg(client: &Client, action: MsgCmd) -> Result<()> {
                     &air_artifacts,
                 )
                 .await?;
-            println!("{}", serde_json::to_string_pretty(&request)?);
+            print_collaboration_receipt(&request, json)?;
         }
         MsgCmd::Wait {
             request_id,
             timeout_secs,
         } => cmd_msg_wait(client, &origin, &request_id, timeout_secs).await?,
-        MsgCmd::Cancel { request_id } => {
+        MsgCmd::Cancel { request_id, json } => {
             let request = client.collaboration_cancel(&origin, &request_id).await?;
-            println!("{}", serde_json::to_string_pretty(&request)?);
+            print_collaboration_receipt(&request, json)?;
         }
     }
     Ok(())
@@ -1065,6 +1078,42 @@ async fn cmd_msg_wait(
     } else {
         anyhow::bail!("timed out waiting for {request_id}")
     }
+}
+
+/// What `send`, `reply`, and `cancel` say when they worked.
+///
+/// They used to print the whole stored request — every timestamp, every
+/// `null` — which buries the two facts the caller wants (it went through, and
+/// whether an answer is coming) under thirty lines of JSON. `--json` still
+/// gives the record for anything that wants to parse it.
+fn print_collaboration_receipt(
+    request: &muxa::collaboration::CollaborationRequest,
+    json: bool,
+) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(request)?);
+        return Ok(());
+    }
+    match request.status {
+        RequestStatus::Cancelled => println!("cancelled  {}", request.id),
+        // A reply on the request means this was `msg reply`, not `msg send`.
+        _ if request.reply.is_some() => {
+            println!("replied  {}  to {}", request.id, request.from.label());
+        }
+        _ => {
+            let awaiting = if request.expects_reply {
+                "awaiting reply"
+            } else {
+                "no reply expected"
+            };
+            println!(
+                "sent  {}  to {}  ({awaiting})",
+                request.id,
+                request.to.label()
+            );
+        }
+    }
+    Ok(())
 }
 
 fn print_collaboration_messages(
@@ -1102,6 +1151,14 @@ fn print_collaboration_messages(
                 "{}  {:?}  {:?}  {}{}\n  {}",
                 request.id, request.status, request.kind, direction, provenance, request.body,
             );
+            // Without this the sender sees their own question and a status, and
+            // the answer they were told to come here for is nowhere on screen.
+            if let Some(reply) = &request.reply {
+                println!("  <- {:?}: {}", reply.status, reply.body);
+                for artifact in &reply.artifacts {
+                    println!("     {artifact}");
+                }
+            }
         }
     }
     Ok(())

--- a/crates/muxa-cli/src/onboarding.rs
+++ b/crates/muxa-cli/src/onboarding.rs
@@ -5,6 +5,7 @@
 //! fullscreen terminal to a stable `muxa watch` mock with location-aware
 //! dialogs. `--print` remains available for scripts and accessibility.
 
+mod live;
 mod tmux;
 
 use anyhow::{Context, Result};
@@ -36,6 +37,23 @@ pub struct Args {
     /// Display language: auto, en, or ko. / 표시 언어: auto, en, ko.
     #[arg(long, value_enum, default_value_t)]
     pub lang: Language,
+    /// Which tour to run: the built-in simulation, or a throwaway muxa.
+    #[arg(long, value_enum, default_value_t)]
+    pub tour: Tour,
+}
+
+/// Which onboarding to run.
+///
+/// A value rather than a `--live` flag because `Args` is already at clippy's
+/// bool ceiling, and because the default is the thing that moves once the live
+/// tour covers both acts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+pub enum Tour {
+    /// Draw the scenario; change nothing, need nothing.
+    #[default]
+    Simulated,
+    /// Run the real muxa against a sandbox on its own tmux server.
+    Live,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
@@ -277,6 +295,9 @@ const SECTIONS: &[Section] = &[
 
 pub fn run(args: Args) -> Result<()> {
     apply_icon_preference();
+    if args.tour == Tour::Live && !args.print {
+        return live::run(args.lang.resolve());
+    }
     let mode = Mode::detect(args.print);
     let language = args.lang.resolve();
     match mode {

--- a/crates/muxa-cli/src/onboarding.rs
+++ b/crates/muxa-cli/src/onboarding.rs
@@ -296,7 +296,7 @@ const SECTIONS: &[Section] = &[
 pub fn run(args: Args) -> Result<()> {
     apply_icon_preference();
     if args.tour == Tour::Live && !args.print {
-        return live::run(args.lang.resolve());
+        return live::run(args.lang.resolve(), args.no_quiz);
     }
     let mode = Mode::detect(args.print);
     let language = args.lang.resolve();

--- a/crates/muxa-cli/src/onboarding.rs
+++ b/crates/muxa-cli/src/onboarding.rs
@@ -627,7 +627,7 @@ fn is_alt_chord(key: KeyEvent, letter: char) -> bool {
 /// nothing else in the same syscall, so an escape sequence split across reads —
 /// an arrow key relayed through tmux, or a slow pty — surfaces as a phantom
 /// quit. Wait this long before trusting `Esc`.
-const ESC_SEQUENCE_GRACE: Duration = Duration::from_millis(50);
+const ESC_SEQUENCE_GRACE: Duration = Duration::from_millis(100);
 
 /// Read one key, dropping the phantom `Esc` of a split escape sequence.
 pub(super) fn read_key_event() -> Result<Option<KeyEvent>> {

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -128,6 +128,14 @@ struct Sandbox {
     rcfile: PathBuf,
     /// What the shell prompt shows when nobody is attached to a status bar.
     cue: PathBuf,
+    /// Every command the learner runs, appended by their own shell.
+    ///
+    /// Without it a step whose action is a shell command — `tmux ls`,
+    /// `muxa msg list` — has nothing to detect, and the only way to teach one
+    /// was to bolt it onto the end of another step's cue. That is what put two
+    /// actions on one line and left the learner unsure which of them had
+    /// registered.
+    history: PathBuf,
     /// `HOME` for everything the learner runs, so `cd ~` lands here too.
     home: PathBuf,
     /// Where their shell starts, and what `ls` shows.
@@ -144,6 +152,7 @@ impl Sandbox {
         let config = dir.join("muxa-onboarding.src.toml");
         let rcfile = dir.join("muxa-onboarding.bashrc");
         let cue = dir.join("muxa-onboarding.cue");
+        let history = dir.join("muxa-onboarding.history");
         let home = dir.join("muxa-onboarding-home");
         let project = home.join("checkout-service");
         write_executable(&script, SANDBOX_SCRIPT).context("staging the sandbox script")?;
@@ -158,6 +167,7 @@ impl Sandbox {
             config,
             rcfile,
             cue,
+            history,
             home,
             project,
             tmux,
@@ -246,6 +256,11 @@ impl Sandbox {
         use std::fmt::Write as _;
 
         let mut body = String::from("unset PROMPT_COMMAND\n");
+        let _ = writeln!(
+            body,
+            "export PROMPT_COMMAND='history 1 | sed \"s/^ *[0-9]* *//\" >> {}'",
+            self.history.display()
+        );
         let _ = writeln!(
             body,
             "export PS1='$([ -z \"$TMUX\" ] && cat {} 2>/dev/null)muxa-onboarding $ '",
@@ -397,7 +412,13 @@ impl Sandbox {
 impl Drop for Sandbox {
     fn drop(&mut self) {
         let _ = self.script_command(&["down"]);
-        for path in [&self.script, &self.config, &self.rcfile, &self.cue] {
+        for path in [
+            &self.script,
+            &self.config,
+            &self.rcfile,
+            &self.cue,
+            &self.history,
+        ] {
             let _ = std::fs::remove_file(path);
         }
         // The agent transcripts are named deterministically, so they can be
@@ -487,6 +508,12 @@ impl Sandbox {
         }
         let _ = self.tmux_command(&["set", "-gu", option]);
         true
+    }
+
+    /// Has the learner run a command starting with this?
+    fn ran_command(&self, prefix: &str) -> bool {
+        std::fs::read_to_string(&self.history)
+            .is_ok_and(|log| log.lines().any(|line| line.trim().starts_with(prefix)))
     }
 
     fn skip_requested(&self) -> bool {
@@ -936,81 +963,119 @@ struct Fleet {
     codex_screen: Transcript,
 }
 
+/// The first screenful each agent shows, in the shape of the CLI it stands in
+/// for.
+fn write_opening_screens(claude: &Transcript, codex: &Transcript, language: UiLanguage) {
+    let claude_prompt = tr(
+        language,
+        "harden the checkout auth path",
+        "checkout 인증 경로를 강화해줘",
+    );
+    let codex_prompt = tr(
+        language,
+        "review the public-read boundary",
+        "public-read 경계를 검토해줘",
+    );
+
+    let mut opening = header(Cli::ClaudeCode, language);
+    opening.extend(prompt_line(claude_prompt));
+    opening.extend(turn(
+        Cli::ClaudeCode,
+        tr(
+            language,
+            "I'll start with the token handling in auth.rs.",
+            "auth.rs의 토큰 처리부터 보겠습니다.",
+        ),
+        "",
+    ));
+    opening.extend(turn(
+        Cli::ClaudeCode,
+        "Read(crates/checkout/src/auth.rs)",
+        tr(language, "Read 42 lines", "42줄 읽음"),
+    ));
+    opening.extend(turn(
+        Cli::ClaudeCode,
+        "Search(pattern: \"bearer\")",
+        tr(language, "Found 12 matches", "12건 일치"),
+    ));
+    opening.push(working(language));
+    opening.push(String::new());
+    opening.extend(composer(Cli::ClaudeCode, language));
+    claude.append(&opening);
+
+    let mut opening = header(Cli::Codex, language);
+    opening.extend(prompt_line(codex_prompt));
+    opening.extend(turn(
+        Cli::Codex,
+        "Read crates/api/src/public.rs",
+        tr(language, "3 routes listed", "route 3개 확인"),
+    ));
+    opening.push(working(language));
+    opening.push(String::new());
+    opening.extend(composer(Cli::Codex, language));
+    codex.append(&opening);
+}
+
 impl Sandbox {
     /// Two agents join whatever window the learner is sitting in.
     ///
     /// Joining *their* window rather than a prepared one is the point: the room
     /// they can address peers in is the window they are already in, and
     /// watching the panes arrive is what makes "a pane is an agent" land.
-    fn add_agents(&self, session: &str, language: UiLanguage) -> Result<Fleet> {
+    fn add_agents(
+        &self,
+        session: &str,
+        before_split: &[String],
+        language: UiLanguage,
+    ) -> Result<Fleet> {
         // Resolved through the session rather than the attached client: a
         // learner who skipped their way here may not be attached to anything,
         // and the agents still have to land in a real window.
         let target = format!("{session}:");
-        let learner = self.tmux_command(&["display-message", "-p", "-t", &target, "#{pane_id}"])?;
         let window =
             self.tmux_command(&["display-message", "-p", "-t", &target, "#{window_id}"])?;
-        if learner.is_empty() || window.is_empty() {
+        if window.is_empty() {
             bail!("could not find a window to put the agents in");
+        }
+
+        // The pane the learner just split off becomes claude, and the one they
+        // were sitting in stays theirs. Watching an agent move into the pane
+        // *they* made is what turns "a pane is an agent" from a sentence into
+        // something they did.
+        let panes: Vec<String> = self
+            .tmux_command(&["list-panes", "-t", &window, "-F", "#{pane_id}"])?
+            .lines()
+            .filter(|id| !id.is_empty())
+            .map(str::to_string)
+            .collect();
+        let fresh = panes
+            .iter()
+            .find(|id| !before_split.contains(id))
+            .cloned()
+            .unwrap_or_default();
+        let learner = panes
+            .iter()
+            .find(|id| **id != fresh)
+            .cloned()
+            .unwrap_or_default();
+        if learner.is_empty() {
+            bail!("could not tell your pane from the one you split off");
         }
 
         let dir = std::env::temp_dir();
         let claude_screen = Transcript::new(&dir, "claude")?;
         let codex_screen = Transcript::new(&dir, "codex")?;
+        write_opening_screens(&claude_screen, &codex_screen, language);
 
-        let claude_prompt = tr(
-            language,
-            "harden the checkout auth path",
-            "checkout 인증 경로를 강화해줘",
-        );
-        let codex_prompt = tr(
-            language,
-            "review the public-read boundary",
-            "public-read 경계를 검토해줘",
-        );
-
-        let mut opening = header(Cli::ClaudeCode, language);
-        opening.extend(prompt_line(claude_prompt));
-        opening.extend(turn(
-            Cli::ClaudeCode,
-            tr(
-                language,
-                "I'll start with the token handling in auth.rs.",
-                "auth.rs의 토큰 처리부터 보겠습니다.",
-            ),
-            "",
-        ));
-        opening.extend(turn(
-            Cli::ClaudeCode,
-            "Read(crates/checkout/src/auth.rs)",
-            tr(language, "Read 42 lines", "42줄 읽음"),
-        ));
-        opening.extend(turn(
-            Cli::ClaudeCode,
-            "Search(pattern: \"bearer\")",
-            tr(language, "Found 12 matches", "12건 일치"),
-        ));
-        opening.push(working(language));
-        opening.push(String::new());
-        opening.extend(composer(Cli::ClaudeCode, language));
-        claude_screen.append(&opening);
-
-        let mut opening = header(Cli::Codex, language);
-        opening.extend(prompt_line(codex_prompt));
-        opening.extend(turn(
-            Cli::Codex,
-            "Read crates/api/src/public.rs",
-            tr(language, "3 routes listed", "route 3개 확인"),
-        ));
-        opening.push(working(language));
-        opening.push(String::new());
-        opening.extend(composer(Cli::Codex, language));
-        codex_screen.append(&opening);
+        let approved = dir.join("muxa-onboarding-approved.txt");
+        let declined = dir.join("muxa-onboarding-declined.txt");
+        std::fs::write(&approved, approved_block(language).join("\n") + "\n")?;
+        std::fs::write(&declined, declined_block(language).join("\n") + "\n")?;
 
         // A window is a Work, and in a real fleet it is named after one.
         self.tmux_command(&["rename-window", "-t", &window, "checkout"])?;
-        // Whatever they made at step 2 is a Work too — an unstaffed one.
-        // Left called `bash` the fleet looks half-built rather than like a
+        // Whatever they made at step 2 is a Work too — an unstaffed one. Left
+        // called `bash`, the fleet looks half-built rather than like a
         // workspace with a job nobody has picked up yet.
         for other in self
             .tmux_quiet(&["list-windows", "-a", "-F", "#{window_id}"])
@@ -1022,12 +1087,22 @@ impl Sandbox {
             let _ = self.tmux_command(&["rename-window", "-t", &other, "release-checks"]);
         }
 
-        let approved = dir.join("muxa-onboarding-approved.txt");
-        let declined = dir.join("muxa-onboarding-declined.txt");
-        std::fs::write(&approved, approved_block(language).join("\n") + "\n")?;
-        std::fs::write(&declined, declined_block(language).join("\n") + "\n")?;
-
-        let claude = self.split(&window, &claude_screen.pane_command())?;
+        // `respawn-pane` keeps the pane id, so the hook that registers claude
+        // still lands on the pane the learner is looking at.
+        let claude = if fresh.is_empty() {
+            self.split(&window, &claude_screen.pane_command())?
+        } else {
+            self.tmux_command(&[
+                "respawn-pane",
+                "-k",
+                "-c",
+                &self.project.to_string_lossy(),
+                "-t",
+                &fresh,
+                &claude_screen.pane_command(),
+            ])?;
+            fresh
+        };
         let codex = self.split(
             &window,
             &codex_screen.answerable_pane_command(&dir, &approved, &declined)?,
@@ -1145,14 +1220,22 @@ enum Detect {
     SessionCreated,
     /// That session has more than the window it started with.
     SecondWindow,
+    /// They opened the session tree and closed it again — one gesture.
+    TreeModeClosed,
     /// Nobody is attached — they detached, and the work kept running.
     NoClient,
+    /// They ran a command starting with this.
+    TypedCommand(&'static str),
     /// Somebody is attached again.
     ClientAttached,
+    /// Their window has more than the pane it started with.
+    PaneSplit,
     /// Some pane on the sandbox server is running this command.
     PaneRunning(&'static str),
     /// The active pane is the one `muxa attend` should have jumped to.
     ActivePaneIsCodex,
+    /// They came back to their own pane.
+    ActivePaneIsLearner,
     /// The learner sent a request.
     SentMessage,
     /// The learner claimed what was waiting for them.
@@ -1177,8 +1260,14 @@ struct Step {
 /// terminal attached to it. Zoom, copy mode and pane-navigation drills are
 /// deliberately absent: they are tmux trivia, and the pane concept lands in Act
 /// II when the agents themselves arrive as panes.
+/// Fourteen steps in two acts, one action each.
+///
+/// An earlier pass fit this into nine by putting two actions on some cues —
+/// "see both: Ctrl-b s · then leave: Ctrl-b d". That reads as one instruction
+/// and leaves the learner unsure which half registered, which is the opposite
+/// of what a confirmation line is for. Fewer steps is not the goal; knowing
+/// where you are is.
 const STEPS: &[Step] = &[
-    // ---- Act I: tmux ------------------------------------------------------
     Step {
         achieved_en: "ready — you are at a plain shell, outside tmux",
         achieved_ko: "준비 완료 — 지금은 tmux 밖의 평범한 셸입니다",
@@ -1189,7 +1278,7 @@ const STEPS: &[Step] = &[
         detect: Detect::SessionCreated,
     },
     Step {
-        achieved_en: "✓ session created, and you are inside it — this bar is tmux's",
+        achieved_en: "✓ session created, and you are inside it — these rows are tmux's",
         achieved_ko: "✓ session을 만들고 들어왔습니다 — 이 줄들이 tmux입니다",
         title_en: "One window is one Work. Make a second one.",
         title_ko: "window 하나가 Work 하나입니다. 두 번째를 만들어 보세요.",
@@ -1198,62 +1287,102 @@ const STEPS: &[Step] = &[
         detect: Detect::SecondWindow,
     },
     Step {
-        achieved_en: "✓ second window created — see both in the top row",
+        achieved_en: "✓ second window created — the top row lists both",
         achieved_ko: "✓ 두 번째 window가 생겼습니다 — 맨 윗줄에 둘 다 보입니다",
+        title_en: "The tree is the readable view of that: sessions, and the windows in them.",
+        title_ko: "그걸 제대로 보는 화면이 tree입니다: session과 그 안의 window들.",
+        cue_en: "press   Ctrl-b   then   s      ·   q closes it",
+        cue_ko: "Ctrl-b 를 눌렀다 떼고   s      ·   q 로 닫습니다",
+        detect: Detect::TreeModeClosed,
+    },
+    Step {
+        achieved_en: "✓ you saw both windows in the tree",
+        achieved_ko: "✓ tree에서 window 두 개를 확인했습니다",
         title_en: "Now leave. Detaching removes you, not the work.",
         title_ko: "이제 나가 보세요. detach는 당신만 빠지고 작업은 그대로입니다.",
-        cue_en: "see both:   Ctrl-b s      ·   then leave:   Ctrl-b d",
-        cue_ko: "둘 다 보기:   Ctrl-b s      ·   그다음 나가기:   Ctrl-b d",
+        cue_en: "press   Ctrl-b   then   d",
+        cue_ko: "Ctrl-b 를 눌렀다 떼고   d",
         detect: Detect::NoClient,
     },
     Step {
-        achieved_en: "✓ detached — you are back at your shell, and the session kept running",
-        achieved_ko: "✓ detach했습니다 — 셸로 돌아왔고, session은 계속 돌고 있습니다",
-        title_en: "Still listed, still running. That is the whole reason muxa lives in tmux.",
-        title_ko: "여전히 목록에 있고 여전히 돌고 있습니다. muxa가 tmux에 사는 이유입니다.",
-        cue_en: "check:   tmux ls      ·   then:   tmux attach -t muxa-onboarding",
-        cue_ko: "확인:   tmux ls      ·   그다음:   tmux attach -t muxa-onboarding",
+        achieved_en: "✓ detached — you are back at your own shell",
+        achieved_ko: "✓ detach했습니다 — 당신의 셸로 돌아왔습니다",
+        title_en: "The session is still there. Ask tmux yourself.",
+        title_ko: "session은 여전히 있습니다. tmux에게 직접 물어보세요.",
+        cue_en: "type:   tmux ls",
+        cue_ko: "입력:   tmux ls",
+        detect: Detect::TypedCommand("tmux ls"),
+    },
+    Step {
+        achieved_en: "✓ still listed, still running — that is the whole reason muxa lives in tmux",
+        achieved_ko: "✓ 여전히 목록에 있고 여전히 돌고 있습니다 — muxa가 tmux에 사는 이유입니다",
+        title_en: "So going back is just attaching to it again.",
+        title_ko: "그러니 돌아가는 건 다시 붙기만 하면 됩니다.",
+        cue_en: "type:   tmux attach -t muxa-onboarding",
+        cue_ko: "입력:   tmux attach -t muxa-onboarding",
         detect: Detect::ClientAttached,
     },
-    // ---- Act II: muxa -----------------------------------------------------
     Step {
-        achieved_en: "✓ attached again — every window and pane exactly as you left it",
+        achieved_en: "✓ back in, with every window and pane as you left it",
         achieved_ko: "✓ 다시 들어왔습니다 — window도 pane도 떠날 때 그대로입니다",
-        title_en: "This window is the `checkout` Work now, with two agents in it. A pane is an agent.",
-        title_ko:
-            "이 window가 이제 `checkout` Work이고, 안에 agent가 둘 있습니다. pane 하나가 agent 하나입니다.",
-        cue_en: "run:   muxa watch             ·   q leaves it",
-        cue_ko: "입력:   muxa watch             ·   q로 나갑니다",
+        title_en: "A pane is an agent. Split this window and one will move in.",
+        title_ko: "pane 하나가 agent 하나입니다. 이 window를 나누면 거기에 agent가 들어옵니다.",
+        cue_en: "press   Ctrl-b   then   %      ·   \" splits top and bottom instead",
+        cue_ko: "Ctrl-b 를 눌렀다 떼고   %      ·   \" 는 상하로 나눕니다",
+        detect: Detect::PaneSplit,
+    },
+    Step {
+        achieved_en: "✓ the pane you just made is claude, and codex joined beside it",
+        achieved_ko: "✓ 방금 만든 pane이 claude가 됐고, 옆에 codex도 합류했습니다",
+        title_en: "This window is the `checkout` Work now. See all of it at once.",
+        title_ko: "이 window가 이제 `checkout` Work입니다. 전체를 한 번에 보세요.",
+        cue_en: "run:   muxa watch            ·   q leaves it",
+        cue_ko: "입력:   muxa watch            ·   q 로 나갑니다",
         detect: Detect::PaneRunning("muxa"),
     },
     Step {
-        achieved_en: "✓ watch showed the whole window at once — and codex just stopped",
-        achieved_ko: "✓ watch가 window 전체를 한 번에 보여줬습니다 — 그리고 codex가 방금 멈췄습니다",
-        title_en: "codex stopped and needs you. `attend` jumps to whichever agent has been blocked longest — you land in codex's pane.",
-        title_ko: "codex가 멈춰서 당신이 필요합니다. `attend`는 가장 오래 막힌 agent로 이동합니다 — codex의 pane에 도착합니다.",
-        cue_en: "leave watch with q, then run:   muxa attend",
-        cue_ko: "q로 watch를 나간 뒤 입력:   muxa attend",
+        achieved_en: "✓ watch showed the whole Work — and codex just stopped, waiting on you",
+        achieved_ko: "✓ watch가 Work 전체를 보여줬습니다 — 그리고 codex가 멈춰서 당신을 기다립니다",
+        title_en: "`attend` goes to whichever agent has been blocked longest — codex, here.",
+        title_ko: "`attend`는 가장 오래 막힌 agent로 갑니다 — 여기서는 codex입니다.",
+        cue_en: "run:   muxa attend",
+        cue_ko: "입력:   muxa attend",
         detect: Detect::ActivePaneIsCodex,
     },
     Step {
-        // attend left them sitting in codex's pane, which has no shell to
-        // type into. Getting back is a real tmux key, so the step teaches it
-        // rather than having the tour move the cursor on their behalf.
-        achieved_en: "✓ attend moved you to codex, the agent blocked longest",
-        achieved_ko: "✓ attend가 가장 오래 막힌 agent인 codex로 데려왔습니다",
-        title_en: "You are in codex's pane — press y to approve it if you like. `Ctrl-b ;` returns to the last pane you were in, which is your own shell.",
-        title_ko: "지금 codex의 pane입니다 — 원하면 y로 승인해 보세요. `Ctrl-b ;`는 직전에 있던 pane, 즉 당신의 셸로 돌아갑니다.",
-        cue_en: "back:   Ctrl-b ;   (or Ctrl-b o to cycle)   ·   then:   muxa msg send @claude \"how far along?\"",
-        cue_ko: "돌아가기:   Ctrl-b ;   (Ctrl-b o 로 순환)   ·   그다음:   muxa msg send @claude \"어디까지 됐나요?\"",
+        achieved_en: "✓ attend moved you into codex's pane — press y to approve it if you like",
+        achieved_ko: "✓ attend가 codex의 pane으로 데려왔습니다 — 원하면 y로 승인해 보세요",
+        title_en: "This pane has no shell of yours. `Ctrl-b ;` returns to the pane you were in.",
+        title_ko: "이 pane에는 당신의 셸이 없습니다. `Ctrl-b ;`는 직전에 있던 pane으로 돌아갑니다.",
+        cue_en: "press   Ctrl-b   then   ;      ·   Ctrl-b o cycles instead",
+        cue_ko: "Ctrl-b 를 눌렀다 떼고   ;      ·   Ctrl-b o 는 순서대로 순환합니다",
+        detect: Detect::ActivePaneIsLearner,
+    },
+    Step {
+        achieved_en: "✓ back in your own pane",
+        achieved_ko: "✓ 당신의 pane으로 돌아왔습니다",
+        title_en: "You can ask an agent something without attaching to it.",
+        title_ko: "attach하지 않고도 agent에게 물어볼 수 있습니다.",
+        cue_en: "run:   muxa msg send @claude \"how far along?\"",
+        cue_ko: "입력:   muxa msg send @claude \"어디까지 됐나요?\"",
         detect: Detect::SentMessage,
     },
     Step {
-        achieved_en: "✓ your question reached claude and it answered — and codex asked you something",
-        achieved_ko: "✓ 질문이 claude에게 닿았고 답이 왔습니다 — 그리고 codex가 당신에게 물어왔습니다",
-        title_en: "claude answered into your mailbox. `list` shows what you sent; `inbox` claims what was sent to you — codex just asked you something.",
-        title_ko: "claude가 mailbox로 답했습니다. `list`는 보낸 것, `inbox`는 받은 것을 가져옵니다 — codex가 방금 물어왔습니다.",
-        cue_en: "claude's answer:   muxa msg list      ·   codex's request:   muxa msg inbox",
-        cue_ko: "claude의 답장:   muxa msg list      ·   codex의 요청:   muxa msg inbox",
+        achieved_en: "✓ the message reached claude, and it answered into your mailbox",
+        achieved_ko: "✓ 메시지가 claude에게 닿았고, mailbox로 답이 왔습니다",
+        title_en: "`list` shows what you sent, and what came back.",
+        title_ko: "`list`는 보낸 것과 돌아온 답을 보여줍니다.",
+        cue_en: "run:   muxa msg list",
+        cue_ko: "입력:   muxa msg list",
+        detect: Detect::TypedCommand("muxa msg list"),
+    },
+    Step {
+        achieved_en: "✓ you read claude's reply — and codex has asked you something of its own",
+        achieved_ko: "✓ claude의 답장을 봤습니다 — 그리고 codex가 당신에게 물어왔습니다",
+        title_en: "`inbox` claims what was sent *to* you. Agents use muxa too.",
+        title_ko: "`inbox`는 당신에게 **온** 요청을 가져옵니다. agent도 muxa를 씁니다.",
+        cue_en: "run:   muxa msg inbox",
+        cue_ko: "입력:   muxa msg inbox",
         detect: Detect::ClaimedInbox,
     },
     Step {
@@ -1261,14 +1390,14 @@ const STEPS: &[Step] = &[
         achieved_ko: "✓ codex의 요청을 확인했습니다 — mailbox는 당신이 처리하는 곳입니다",
         title_en: "session is a workspace · window is a work · pane is an agent",
         title_ko: "session은 workspace · window는 work · pane은 agent",
-        cue_en: "press   Ctrl-b   then   d       ·   finishes and deletes the sandbox",
-        cue_ko: "Ctrl-b 를 눌렀다 떼고   d       ·   마치고 sandbox를 지웁니다",
+        cue_en: "press   Ctrl-b   then   d      ·   finishes and deletes the sandbox",
+        cue_ko: "Ctrl-b 를 눌렀다 떼고   d      ·   마치고 sandbox를 지웁니다",
         detect: Detect::NoClient,
     },
 ];
-
-/// The step Act II begins at, and so the point the agents arrive.
-const ACT_TWO_START: usize = 4;
+/// The step whose completion brings the agents in: the learner has just
+/// split a pane, and that pane becomes claude.
+const AGENTS_ARRIVE: usize = 7;
 
 // ---------------------------------------------------------------------------
 // Run
@@ -1279,6 +1408,10 @@ struct Tour<'a> {
     /// Mutable: `F2` switches it mid-tour, the way the simulation's footer did.
     language: UiLanguage,
     fleet: Option<Fleet>,
+    /// The tree opens and closes; the step is the whole gesture.
+    saw_tree: bool,
+    /// Panes present before the learner split, so the new one is identifiable.
+    before_split: Vec<String>,
     /// `--no-quiz` does not remove the steps — there is nothing to remove, the
     /// tour is the real thing — so it offers the way past from the start
     /// instead of after a wait.
@@ -1303,7 +1436,7 @@ impl Tour<'_> {
             .collect()
     }
 
-    fn satisfied(&self, detect: &Detect) -> bool {
+    fn satisfied(&mut self, detect: &Detect) -> bool {
         match detect {
             Detect::SessionCreated => !self.own_sessions().is_empty(),
             Detect::SecondWindow => {
@@ -1315,8 +1448,33 @@ impl Tour<'_> {
                     .count()
                     >= 2
             }
+            // Opened *and* closed: one gesture, so one step.
+            Detect::TreeModeClosed => {
+                // Across every pane, not `display-message` on "the current"
+                // one: run from outside a client that resolves to whichever
+                // pane tmux feels like, which is rarely the one the learner is
+                // looking at.
+                let in_tree = self
+                    .sandbox
+                    .tmux_quiet(&["list-panes", "-a", "-F", "#{pane_mode}"])
+                    .contains("tree");
+                if in_tree {
+                    self.saw_tree = true;
+                    return false;
+                }
+                self.saw_tree
+            }
             Detect::NoClient => self.clients().is_empty(),
+            Detect::TypedCommand(prefix) => self.sandbox.ran_command(prefix),
             Detect::ClientAttached => !self.clients().is_empty(),
+            Detect::PaneSplit => {
+                self.sandbox
+                    .tmux_quiet(&["list-panes", "-F", "#{pane_id}"])
+                    .lines()
+                    .filter(|id| !id.is_empty())
+                    .count()
+                    >= 2
+            }
             Detect::PaneRunning(command) => self
                 .sandbox
                 .tmux_quiet(&["list-panes", "-a", "-F", "#{pane_current_command}"])
@@ -1326,6 +1484,11 @@ impl Tour<'_> {
                 self.sandbox
                     .tmux_quiet(&["display-message", "-p", "#{pane_id}"])
                     == fleet.codex
+            }),
+            Detect::ActivePaneIsLearner => self.fleet.as_ref().is_some_and(|fleet| {
+                self.sandbox
+                    .tmux_quiet(&["display-message", "-p", "#{pane_id}"])
+                    == fleet.learner
             }),
             Detect::SentMessage => self.fleet.as_ref().is_some_and(|fleet| {
                 self.sandbox
@@ -1350,9 +1513,8 @@ impl Tour<'_> {
 
     /// What a skipped step would have done to the world.
     ///
-    /// Skipping has to leave the tour consistent, not just further along: Act II
-    /// cannot introduce agents into a session that was never created. Anything
-    /// the learner would have done that the tour can do for them, it does.
+    /// Skipping has to leave the tour consistent, not just further along: the
+    /// agents cannot move into a pane that was never split.
     fn perform(&self, index: usize) {
         match index {
             0 => {
@@ -1377,8 +1539,15 @@ impl Tour<'_> {
                     ]);
                 }
             }
-            // The rest are either about where the learner is looking, which the
-            // tour will not fake, or about state it has already produced.
+            6 => {
+                if let Some(session) = self.own_sessions().first() {
+                    let _ =
+                        self.sandbox
+                            .tmux_command(&["split-window", "-t", &format!("{session}:")]);
+                }
+            }
+            // The rest are about where the learner is looking, which the tour
+            // will not fake, or about state it has already produced.
             _ => {}
         }
     }
@@ -1387,7 +1556,7 @@ impl Tour<'_> {
     /// response to the learner.
     fn on_enter(&mut self, index: usize) -> Result<()> {
         // The placeholder only had to keep the server alive until the learner
-        // made a session of their own. Step 3 asks them to run `tmux ls`, and a
+        // made a session of their own. Step 5 asks them to run `tmux ls`, and a
         // mysterious `_sandbox` in that output is the tour's own plumbing
         // showing through the lesson.
         if index == 1 {
@@ -1396,20 +1565,34 @@ impl Tour<'_> {
                 let _ = self.sandbox.tmux_command(&["kill-session", "-t", &holder]);
             }
         }
-        if index == ACT_TWO_START {
+        // Their pane, recorded before the split so the new one can be told
+        // apart from it afterwards.
+        if index == AGENTS_ARRIVE - 1 {
+            self.before_split = self
+                .sandbox
+                .tmux_quiet(&["list-panes", "-F", "#{pane_id}"])
+                .lines()
+                .map(str::to_string)
+                .collect();
+        }
+        if index == AGENTS_ARRIVE {
             let session = self
                 .own_sessions()
                 .first()
                 .cloned()
                 .unwrap_or_else(|| "muxa-onboarding".to_string());
-            self.fleet = Some(self.sandbox.add_agents(&session, self.language)?);
+            self.fleet = Some(self.sandbox.add_agents(
+                &session,
+                &self.before_split,
+                self.language,
+            )?);
             return Ok(());
         }
         let Some(fleet) = self.fleet.as_ref() else {
             return Ok(());
         };
         match index {
-            5 => {
+            8 => {
                 // The row in watch flips to `waiting` because of the hook; the
                 // pane has to show *why*, or the state is a claim rather than
                 // something the learner can see for themselves.
@@ -1421,26 +1604,26 @@ impl Tour<'_> {
                     r#"{"session_id":"onboarding-codex","tool_name":"shell"}"#,
                 )
             }
-            7 => {
-                let body = tr(
-                    self.language,
-                    "the public-read boundary needs a decision before I continue",
-                    "public-read 경계는 계속하기 전에 결정이 필요합니다",
-                );
-                // Both beats land here, on the step *after* the one that asks
-                // for the message: claude answering before being asked read as
-                // the tour talking to itself.
+            11 => {
                 fleet
                     .claude_screen
                     .append(&incoming_question(self.language));
                 // And claude answers through muxa, not only on its own screen.
                 self.sandbox.reply_as_claude(fleet, self.language);
+                Ok(())
+            }
+            12 => {
+                let body = tr(
+                    self.language,
+                    "the public-read boundary needs a decision before I continue",
+                    "public-read 경계는 계속하기 전에 결정이 필요합니다",
+                );
                 fleet.codex_screen.append(&outgoing_request(self.language));
                 self.sandbox
                     .muxa_as(&fleet.codex, &["msg", "send", "@you", body, "--no-reply"])
                     .map(|_| ())
             }
-            8 => {
+            13 => {
                 fleet.claude_screen.append(&finished(self.language));
                 Ok(())
             }
@@ -1596,6 +1779,8 @@ pub(super) fn run(language: UiLanguage, no_quiz: bool) -> Result<()> {
             sandbox: &sandbox,
             language,
             fleet: None,
+            saw_tree: false,
+            before_split: Vec::new(),
             no_quiz,
         };
         tour.drive()?

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -1416,14 +1416,12 @@ struct Step {
     detect: Detect,
 }
 
-/// Nine steps in two acts.
+/// Fifteen steps in two acts, one action each.
 ///
 /// Act I keeps only the one tmux idea muxa is built on — a session outlives the
 /// terminal attached to it. Zoom, copy mode and pane-navigation drills are
 /// deliberately absent: they are tmux trivia, and the pane concept lands in Act
 /// II when the agents themselves arrive as panes.
-/// Fourteen steps in two acts, one action each.
-///
 /// An earlier pass fit this into nine by putting two actions on some cues —
 /// "see both: Ctrl-b s · then leave: Ctrl-b d". That reads as one instruction
 /// and leaves the learner unsure which half registered, which is the opposite

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -157,6 +157,10 @@ impl Sandbox {
         let project = home.join("checkout-service");
         write_executable(&script, SANDBOX_SCRIPT).context("staging the sandbox script")?;
         std::fs::write(&config, SANDBOX_CONFIG).context("staging the sandbox config")?;
+        // The shell appends to this. A run that died before its teardown — a
+        // crash, a SIGKILL — leaves commands behind that would satisfy this
+        // run's steps before the learner has typed anything.
+        std::fs::write(&history, "").context("clearing the command log")?;
         write_workspace(&project).context("staging the practice workspace")?;
 
         let tmux = which("tmux").context("tmux is required for the live tour")?;
@@ -427,7 +431,12 @@ impl Drop for Sandbox {
         for name in ["claude", "codex"] {
             let _ = std::fs::remove_file(dir.join(format!("muxa-onboarding-{name}.log")));
         }
-        for name in ["codex-pane.sh", "approved.txt", "declined.txt"] {
+        for name in [
+            "codex-pane.sh",
+            "approved.txt",
+            "declined.txt",
+            "claude.pane",
+        ] {
             let _ = std::fs::remove_file(dir.join(format!("muxa-onboarding-{name}")));
         }
         // Only ever the tour's own home — never anything the learner owns.
@@ -648,6 +657,13 @@ struct Transcript {
 }
 
 impl Transcript {
+    /// An existing transcript, left as it is.
+    fn open(dir: &Path, name: &str) -> Self {
+        Self {
+            path: dir.join(format!("muxa-onboarding-{name}.log")),
+        }
+    }
+
     fn new(dir: &Path, name: &str) -> Result<Self> {
         let path = dir.join(format!("muxa-onboarding-{name}.log"));
         std::fs::write(&path, "").with_context(|| format!("staging {name}'s transcript"))?;
@@ -669,6 +685,29 @@ impl Transcript {
     fn pane_command(&self) -> String {
         format!("exec tail -n +1 -f {}", self.path.display())
     }
+
+    /// A `claude` / `codex` the learner can start themselves.
+    ///
+    /// Having the agents appear on their own left the tour doing the one thing
+    /// it keeps telling them muxa does *for* them. Typing `claude` is what
+    /// starting an agent actually looks like, and the shim on the sandbox PATH
+    /// means the real CLI is never reached — the name resolves to this screen.
+    /// It records its pane so the tour knows where the agent landed.
+    fn launcher(&self, shim: &Path, name: &str, marker: &Path) -> Result<()> {
+        let body = format!(
+            r#"#!/usr/bin/env bash
+# Stands in for the {name} CLI inside `muxa onboard`. Never reaches the real
+# one: the sandbox PATH resolves the name here. Removed with the sandbox.
+printf '%s' "$TMUX_PANE" > {marker}
+exec tail -n +1 -f {log}
+"#,
+            name = name,
+            marker = marker.display(),
+            log = self.path.display(),
+        );
+        write_executable(&shim.join(name), &body)
+    }
+
     /// A pane that shows the transcript *and* answers its own approval prompt.
     ///
     /// A prompt reading `[y] yes  [n] no` that swallows the keystroke is worse
@@ -1017,11 +1056,38 @@ fn write_opening_screens(claude: &Transcript, codex: &Transcript, language: UiLa
 }
 
 impl Sandbox {
-    /// Two agents join whatever window the learner is sitting in.
+    /// Stage the screens and put `claude` on the learner's `PATH`, so starting
+    /// the agent is theirs to do rather than the tour's to perform.
+    fn prepare_agents(&self, language: UiLanguage) -> Result<()> {
+        let dir = std::env::temp_dir();
+        let claude_screen = Transcript::new(&dir, "claude")?;
+        let codex_screen = Transcript::new(&dir, "codex")?;
+        write_opening_screens(&claude_screen, &codex_screen, language);
+        // A marker left by an earlier tour would satisfy the step before the
+        // learner has typed anything.
+        let _ = std::fs::remove_file(dir.join("muxa-onboarding-claude.pane"));
+        claude_screen.launcher(
+            Path::new(&self.env_value("MUXA_SANDBOX_SHIM")),
+            "claude",
+            &dir.join("muxa-onboarding-claude.pane"),
+        )?;
+        Ok(())
+    }
+
+    /// Where the learner started claude, once they have.
+    fn started_pane() -> Option<String> {
+        std::fs::read_to_string(std::env::temp_dir().join("muxa-onboarding-claude.pane"))
+            .ok()
+            .map(|pane| pane.trim().to_string())
+            .filter(|pane| !pane.is_empty())
+    }
+
+    /// codex joins whatever window the learner started claude in.
     ///
     /// Joining *their* window rather than a prepared one is the point: the room
     /// they can address peers in is the window they are already in, and
-    /// watching the panes arrive is what makes "a pane is an agent" land.
+    /// watching a pane arrive beside their own is what makes "a pane is an
+    /// agent" land.
     fn add_agents(
         &self,
         session: &str,
@@ -1061,11 +1127,18 @@ impl Sandbox {
         if learner.is_empty() {
             bail!("could not tell your pane from the one you split off");
         }
+        // If they started claude in the pane this guessed was theirs, theirs is
+        // the other one.
+        let learner = match Self::started_pane() {
+            Some(started) if started == learner => fresh.clone(),
+            _ => learner,
+        };
 
+        // Already written by `prepare_agents`; opening them again would blank
+        // the screen the learner is looking at.
         let dir = std::env::temp_dir();
-        let claude_screen = Transcript::new(&dir, "claude")?;
-        let codex_screen = Transcript::new(&dir, "codex")?;
-        write_opening_screens(&claude_screen, &codex_screen, language);
+        let claude_screen = Transcript::open(&dir, "claude");
+        let codex_screen = Transcript::open(&dir, "codex");
 
         let approved = dir.join("muxa-onboarding-approved.txt");
         let declined = dir.join("muxa-onboarding-declined.txt");
@@ -1087,21 +1160,30 @@ impl Sandbox {
             let _ = self.tmux_command(&["rename-window", "-t", &other, "release-checks"]);
         }
 
-        // `respawn-pane` keeps the pane id, so the hook that registers claude
-        // still lands on the pane the learner is looking at.
-        let claude = if fresh.is_empty() {
-            self.split(&window, &claude_screen.pane_command())?
+        // claude is wherever the learner ran it. The fallback covers a skipped
+        // step, where nobody ran anything.
+        // Skipping past that step means nobody ran anything, so the pane they
+        // split — or failing that their own — is respawned into claude
+        // instead. `respawn-pane -k` keeps the pane id, so the hook still
+        // lands on the pane the learner is looking at.
+        let claude = if let Some(pane) = Self::started_pane() {
+            pane
         } else {
+            let pane = if fresh.is_empty() {
+                learner.clone()
+            } else {
+                fresh.clone()
+            };
             self.tmux_command(&[
                 "respawn-pane",
                 "-k",
                 "-c",
                 &self.project.to_string_lossy(),
                 "-t",
-                &fresh,
+                &pane,
                 &claude_screen.pane_command(),
             ])?;
-            fresh
+            pane
         };
         let codex = self.split(
             &window,
@@ -1230,6 +1312,8 @@ enum Detect {
     ClientAttached,
     /// Their window has more than the pane it started with.
     PaneSplit,
+    /// The learner started claude, in whichever pane they chose.
+    StartedClaude,
     /// Some pane on the sandbox server is running this command.
     PaneRunning(&'static str),
     /// The active pane is the one `muxa attend` should have jumped to.
@@ -1332,8 +1416,17 @@ const STEPS: &[Step] = &[
         detect: Detect::PaneSplit,
     },
     Step {
-        achieved_en: "✓ the pane you just made is claude, and codex joined beside it",
-        achieved_ko: "✓ 방금 만든 pane이 claude가 됐고, 옆에 codex도 합류했습니다",
+        achieved_en: "✓ split — you are in the new pane, at its own shell",
+        achieved_ko: "✓ 나눴습니다 — 지금 새 pane의 셸에 있습니다",
+        title_en: "Nothing makes a pane an agent except starting one in it.",
+        title_ko: "pane을 agent로 만드는 건 거기서 agent를 띄우는 것뿐입니다.",
+        cue_en: "type:   claude                 ·   the sandbox stands in for the real CLI",
+        cue_ko: "입력:   claude                 ·   sandbox가 실제 CLI를 대신합니다",
+        detect: Detect::StartedClaude,
+    },
+    Step {
+        achieved_en: "✓ claude took that pane, codex joined it, you are back in yours",
+        achieved_ko: "✓ claude가 그 pane을 차지하고 codex도 합류했습니다 — 당신은 자기 pane입니다",
         title_en: "This window is the `checkout` Work now. See all of it at once.",
         title_ko: "이 window가 이제 `checkout` Work입니다. 전체를 한 번에 보세요.",
         cue_en: "run:   muxa watch            ·   q leaves it",
@@ -1395,9 +1488,13 @@ const STEPS: &[Step] = &[
         detect: Detect::NoClient,
     },
 ];
-/// The step whose completion brings the agents in: the learner has just
-/// split a pane, and that pane becomes claude.
-const AGENTS_ARRIVE: usize = 7;
+/// The step that opens once the learner has started claude: the pane they ran
+/// it in becomes claude's, and codex lands beside it.
+const AGENTS_ARRIVE: usize = 8;
+
+/// The step that asks them to split — one before the one that asks for
+/// `claude`, which is one before the agents land.
+const SPLIT_STEP: usize = AGENTS_ARRIVE - 2;
 
 // ---------------------------------------------------------------------------
 // Run
@@ -1436,6 +1533,21 @@ impl Tour<'_> {
             .collect()
     }
 
+    /// The learner's current window, named explicitly.
+    ///
+    /// `list-panes` with no target picks whichever window tmux considers
+    /// current, and the tour runs outside any client — so after step 2 leaves a
+    /// second window behind, a bare `list-panes` can report the window the
+    /// learner is *not* in. That is a split that never registers.
+    fn session_target(&self) -> String {
+        let session = self
+            .own_sessions()
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "muxa-onboarding".to_string());
+        format!("{session}:")
+    }
+
     fn satisfied(&mut self, detect: &Detect) -> bool {
         match detect {
             Detect::SessionCreated => !self.own_sessions().is_empty(),
@@ -1469,12 +1581,19 @@ impl Tour<'_> {
             Detect::ClientAttached => !self.clients().is_empty(),
             Detect::PaneSplit => {
                 self.sandbox
-                    .tmux_quiet(&["list-panes", "-F", "#{pane_id}"])
+                    .tmux_quiet(&[
+                        "list-panes",
+                        "-t",
+                        &self.session_target(),
+                        "-F",
+                        "#{pane_id}",
+                    ])
                     .lines()
                     .filter(|id| !id.is_empty())
                     .count()
                     >= 2
             }
+            Detect::StartedClaude => Sandbox::started_pane().is_some(),
             Detect::PaneRunning(command) => self
                 .sandbox
                 .tmux_quiet(&["list-panes", "-a", "-F", "#{pane_current_command}"])
@@ -1539,7 +1658,7 @@ impl Tour<'_> {
                     ]);
                 }
             }
-            6 => {
+            SPLIT_STEP => {
                 if let Some(session) = self.own_sessions().first() {
                     let _ =
                         self.sandbox
@@ -1567,13 +1686,23 @@ impl Tour<'_> {
         }
         // Their pane, recorded before the split so the new one can be told
         // apart from it afterwards.
-        if index == AGENTS_ARRIVE - 1 {
+        if index == SPLIT_STEP {
             self.before_split = self
                 .sandbox
-                .tmux_quiet(&["list-panes", "-F", "#{pane_id}"])
+                .tmux_quiet(&[
+                    "list-panes",
+                    "-t",
+                    &self.session_target(),
+                    "-F",
+                    "#{pane_id}",
+                ])
                 .lines()
                 .map(str::to_string)
                 .collect();
+        }
+        // `claude` has to be on their PATH before the step that asks for it.
+        if index == AGENTS_ARRIVE - 1 {
+            return self.sandbox.prepare_agents(self.language);
         }
         if index == AGENTS_ARRIVE {
             let session = self
@@ -1592,7 +1721,7 @@ impl Tour<'_> {
             return Ok(());
         };
         match index {
-            8 => {
+            9 => {
                 // The row in watch flips to `waiting` because of the hook; the
                 // pane has to show *why*, or the state is a claim rather than
                 // something the learner can see for themselves.
@@ -1604,7 +1733,7 @@ impl Tour<'_> {
                     r#"{"session_id":"onboarding-codex","tool_name":"shell"}"#,
                 )
             }
-            11 => {
+            12 => {
                 fleet
                     .claude_screen
                     .append(&incoming_question(self.language));
@@ -1612,7 +1741,7 @@ impl Tour<'_> {
                 self.sandbox.reply_as_claude(fleet, self.language);
                 Ok(())
             }
-            12 => {
+            13 => {
                 let body = tr(
                     self.language,
                     "the public-read boundary needs a decision before I continue",
@@ -1623,7 +1752,7 @@ impl Tour<'_> {
                     .muxa_as(&fleet.codex, &["msg", "send", "@you", body, "--no-reply"])
                     .map(|_| ())
             }
-            13 => {
+            14 => {
                 fleet.claude_screen.append(&finished(self.language));
                 Ok(())
             }
@@ -1659,31 +1788,30 @@ impl Tour<'_> {
             },
         );
 
-        // The status bar only exists for someone attached to the server, and
-        // the first step is the one where they are not — they are at a bare
-        // shell being asked to create the session. Narrating only through tmux
-        // would leave that instruction invisible, which is the same dead end as
-        // a gate with no way past it, just earlier.
-        // Trailing newlines are stripped by the `$(...)` the prompt reads this
-        // through, which ran the instruction and the prompt together on one
-        // line. A trailing *space* survives, so the prompt starts its own line.
+        // The status bar only exists for someone attached to the server, and a
+        // few steps are the ones where they are not.
         //
-        // Coloured and ruled, because a plain paragraph above a shell prompt
-        // reads as output from the last command rather than as the thing to do
-        // next.
-        let rule = "─".repeat(64);
-        let _ = std::fs::write(
-            &self.sandbox.cue,
-            format!(
+        // Printed rather than left for the prompt to render: bash will not
+        // re-draw a prompt it has already put on screen — SIGWINCH redraws the
+        // *saved* prompt string rather than re-evaluating `PS1` — so a step
+        // change reached the learner only once they pressed a key. Ruled and
+        // coloured, because a plain paragraph above a shell prompt reads as the
+        // last command's output rather than as the thing to do next; and it
+        // ends with the prompt, so whatever they type next has one in front of
+        // it.
+        if self.clients().is_empty() {
+            let rule = "─".repeat(64);
+            print!(
                 "\n{DIM}{rule}{RESET}\n\
                  {BOLD}muxa onboarding · {}/{}{RESET}   {GREEN}{achieved}{RESET}\n\
                  {title}\n\
                  {YELLOW}{BOLD}{cue}{RESET}\n\
-                 {DIM}{rule}{RESET}\n ",
+                 {DIM}{rule}{RESET}\n muxa-onboarding $ ",
                 index + 1,
                 STEPS.len()
-            ),
-        );
+            );
+            let _ = std::io::stdout().flush();
+        }
     }
 
     fn drive(&mut self) -> Result<usize> {

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -126,6 +126,10 @@ struct Sandbox {
     script: PathBuf,
     config: PathBuf,
     rcfile: PathBuf,
+    /// `HOME` for everything the learner runs, so `cd ~` lands here too.
+    home: PathBuf,
+    /// Where their shell starts, and what `ls` shows.
+    project: PathBuf,
     tmux: PathBuf,
     exe: PathBuf,
     env: BTreeMap<String, String>,
@@ -137,8 +141,11 @@ impl Sandbox {
         let script = dir.join("muxa-onboarding-sandbox.sh");
         let config = dir.join("muxa-onboarding.src.toml");
         let rcfile = dir.join("muxa-onboarding.bashrc");
+        let home = dir.join("muxa-onboarding-home");
+        let project = home.join("checkout-service");
         write_executable(&script, SANDBOX_SCRIPT).context("staging the sandbox script")?;
         std::fs::write(&config, SANDBOX_CONFIG).context("staging the sandbox config")?;
+        write_workspace(&project).context("staging the practice workspace")?;
 
         let tmux = which("tmux").context("tmux is required for the live tour")?;
         let exe = std::env::current_exe().context("locating the running muxa binary")?;
@@ -147,6 +154,8 @@ impl Sandbox {
             script,
             config,
             rcfile,
+            home,
+            project,
             tmux,
             exe,
             env: BTreeMap::new(),
@@ -226,6 +235,10 @@ impl Sandbox {
         use std::fmt::Write as _;
 
         let mut body = String::from("unset PROMPT_COMMAND\nexport PS1='muxa-onboarding $ '\n");
+        // Every pane, not just the first: a window the learner opens at step 2
+        // would otherwise land back in their own home directory.
+        let _ = writeln!(body, "export HOME='{}'", self.home.display());
+        let _ = writeln!(body, "cd '{}' 2>/dev/null || true", self.project.display());
         for key in [
             "MUXA_SOCKET",
             "MUXA_CONFIG",
@@ -347,7 +360,25 @@ impl Drop for Sandbox {
         for name in ["claude", "codex"] {
             let _ = std::fs::remove_file(dir.join(format!("muxa-onboarding-{name}.log")));
         }
+        for name in ["codex-pane.sh", "approved.txt", "declined.txt"] {
+            let _ = std::fs::remove_file(dir.join(format!("muxa-onboarding-{name}")));
+        }
+        // Only ever the tour's own home — never anything the learner owns.
+        if self.home.starts_with(&dir) {
+            let _ = std::fs::remove_dir_all(&self.home);
+        }
     }
+}
+
+fn write_workspace(project: &Path) -> Result<()> {
+    for (relative, body) in WORKSPACE_FILES {
+        let path = project.join(relative);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, body)?;
+    }
+    Ok(())
 }
 
 fn write_executable(path: &Path, body: &str) -> Result<()> {
@@ -443,6 +474,77 @@ impl Sandbox {
 }
 
 // ---------------------------------------------------------------------------
+// The learner's workspace
+// ---------------------------------------------------------------------------
+
+/// A checkout service that does not exist, laid out where the tour can point
+/// at it.
+///
+/// Without this the learner's shell sits in whatever directory they launched
+/// from, so `ls` shows their own repository and `muxa watch` prints their real
+/// path in the inspector — the tour claiming to be a sandbox while showing
+/// them their own machine. The files are the ones the scripted agents say they
+/// are reading, so `cat crates/checkout/src/auth.rs` answers.
+///
+/// This is a convincing workspace, not a jail. `cd /` still works: a real
+/// filesystem confinement needs bubblewrap or a mount namespace, neither of
+/// which is available unprivileged on every platform muxa runs on.
+const WORKSPACE_FILES: &[(&str, &str)] = &[
+    (
+        "Cargo.toml",
+        "[workspace]\nresolver = \"2\"\nmembers = [\"crates/api\", \"crates/checkout\"]\n",
+    ),
+    (
+        "README.md",
+        "# checkout-service\n\nPayments and the public read API.\n\n\
+         - `crates/checkout` — auth, capture, refunds\n\
+         - `crates/api` — the public-read boundary\n",
+    ),
+    (
+        "crates/checkout/src/auth.rs",
+        "use crate::Session;\n\n\
+         /// Extracts the bearer token from an Authorization header.\n\
+         pub fn bearer_token(header: &str) -> Option<&str> {\n\
+         \x20   header.strip_prefix(\"Bearer \")\n\
+         }\n\n\
+         /// TODO: this stores the raw bearer token on the session.\n\
+         pub fn attach(session: &mut Session, bearer: &str) {\n\
+         \x20   session.bearer = bearer.to_string();\n\
+         }\n\n\
+         pub fn is_bearer(scheme: &str) -> bool {\n\
+         \x20   scheme.eq_ignore_ascii_case(\"bearer\")\n\
+         }\n",
+    ),
+    (
+        "crates/checkout/src/lib.rs",
+        "pub mod auth;\n\n\
+         pub struct Session {\n\
+         \x20   pub bearer: String,\n\
+         }\n",
+    ),
+    (
+        "crates/api/src/public.rs",
+        "/// Everything reachable without a session.\n\
+         ///\n\
+         /// Anything added here is public forever, so the boundary is reviewed\n\
+         /// before it moves.\n\
+         pub const PUBLIC_READ: &[&str] = &[\n\
+         \x20   \"/health\",\n\
+         \x20   \"/v1/catalog\",\n\
+         \x20   \"/v1/prices\",\n\
+         ];\n",
+    ),
+    ("crates/api/src/lib.rs", "pub mod public;\n"),
+    (
+        "tests/auth.rs",
+        "#[test]\n\
+         fn rejects_raw_bearer() {\n\
+         \x20   // pending: the regression test claude is writing\n\
+         }\n",
+    ),
+];
+
+// ---------------------------------------------------------------------------
 // Agent transcripts
 // ---------------------------------------------------------------------------
 
@@ -483,6 +585,50 @@ impl Transcript {
     /// and shows whatever arrives next.
     fn pane_command(&self) -> String {
         format!("exec tail -n +1 -f {}", self.path.display())
+    }
+    /// A pane that shows the transcript *and* answers its own approval prompt.
+    ///
+    /// A prompt reading `[y] yes  [n] no` that swallows the keystroke is worse
+    /// than no prompt: it invites the learner to do the one thing the tour has
+    /// made impossible. Pressing `y` here appends the tool output and fires the
+    /// hook a resuming agent fires, so the row in `muxa watch` goes back to
+    /// `working` — the real attend-and-clear loop rather than a picture of it.
+    fn answerable_pane_command(
+        &self,
+        dir: &Path,
+        approved: &Path,
+        declined: &Path,
+    ) -> Result<String> {
+        let runner = dir.join("muxa-onboarding-codex-pane.sh");
+        let body = format!(
+            r#"#!/usr/bin/env bash
+# codex's screen, plus the keypress that answers its approval prompt.
+# Written by `muxa onboard`; removed with the sandbox.
+log={log}
+tail -n +1 -f "$log" &
+while IFS= read -rsn1 key; do
+  case "$key" in
+    y|Y|a|A)
+      cat {approved} >> "$log"
+      # `pre_tool_use` is what a resuming agent sends, and what takes the row
+      # back out of `waiting` in watch.
+      muxa hook codex --event pre_tool_use \
+        <<< '{{"session_id":"onboarding-codex","tool_name":"shell"}}' \
+        >/dev/null 2>&1
+      break ;;
+    n|N)
+      cat {declined} >> "$log"
+      break ;;
+  esac
+done
+wait
+"#,
+            log = self.path.display(),
+            approved = approved.display(),
+            declined = declined.display(),
+        );
+        write_executable(&runner, &body)?;
+        Ok(format!("exec bash {}", runner.display()))
     }
 }
 
@@ -537,6 +683,29 @@ fn approval_block(language: UiLanguage) -> Vec<String> {
             tr(language, "yes", "예"),
             tr(language, "no", "아니오"),
             tr(language, "yes, and don't ask again", "예, 다시 묻지 않기"),
+        ),
+    ]
+}
+
+fn approved_block(language: UiLanguage) -> Vec<String> {
+    vec![
+        String::new(),
+        tool_line("ran      rg -n \"public_read\" --type rust   ·   3 matches"),
+        String::new(),
+        working(language),
+    ]
+}
+
+fn declined_block(language: UiLanguage) -> Vec<String> {
+    vec![
+        String::new(),
+        format!(
+            "  {DIM}✗ {}{RESET}",
+            tr(
+                language,
+                "declined — leaving it alone",
+                "거절됨 — 그대로 둡니다"
+            )
         ),
     ]
 }
@@ -680,8 +849,16 @@ impl Sandbox {
             let _ = self.tmux_command(&["rename-window", "-t", &other, "release-checks"]);
         }
 
+        let approved = dir.join("muxa-onboarding-approved.txt");
+        let declined = dir.join("muxa-onboarding-declined.txt");
+        std::fs::write(&approved, approved_block(language).join("\n") + "\n")?;
+        std::fs::write(&declined, declined_block(language).join("\n") + "\n")?;
+
         let claude = self.split(&window, &claude_screen.pane_command())?;
-        let codex = self.split(&window, &codex_screen.pane_command())?;
+        let codex = self.split(
+            &window,
+            &codex_screen.answerable_pane_command(&dir, &approved, &declined)?,
+        )?;
 
         // Zoomed so `muxa watch` gets the whole screen. The agent panes stay in
         // the window, and `muxa attend` unzooms to reach one — which
@@ -701,12 +878,19 @@ impl Sandbox {
     }
 
     fn split(&self, window: &str, command: &str) -> Result<String> {
+        // `-c` is not optional here. Invoked from outside any client,
+        // `split-window` takes this process's working directory — the repo the
+        // learner launched from — and `muxa watch` then prints that real path
+        // as the agent's cwd, in a tour that just told them nothing outside the
+        // sandbox is involved.
         let id = self.tmux_command(&[
             "split-window",
             "-d",
             "-P",
             "-F",
             "#{pane_id}",
+            "-c",
+            &self.project.to_string_lossy(),
             "-t",
             window,
             command,
@@ -1038,20 +1222,18 @@ impl Tour<'_> {
                     r#"{"session_id":"onboarding-codex","tool_name":"shell"}"#,
                 )
             }
-            6 => {
-                // The learner's question lands in claude's session, so claude's
-                // screen shows it arriving and being answered.
-                fleet
-                    .claude_screen
-                    .append(&incoming_question(self.language));
-                Ok(())
-            }
             7 => {
                 let body = tr(
                     self.language,
                     "the public-read boundary needs a decision before I continue",
                     "public-read 경계는 계속하기 전에 결정이 필요합니다",
                 );
+                // Both beats land here, on the step *after* the one that asks
+                // for the message: claude answering before being asked read as
+                // the tour talking to itself.
+                fleet
+                    .claude_screen
+                    .append(&incoming_question(self.language));
                 fleet.codex_screen.append(&outgoing_request(self.language));
                 self.sandbox
                     .muxa_as(&fleet.codex, &["msg", "send", "@you", body, "--no-reply"])

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -45,6 +45,19 @@ const POLL: Duration = Duration::from_millis(250);
 /// an abandoned terminal does not hold a sandbox open all afternoon.
 const STEP_TIMEOUT: Duration = Duration::from_secs(900);
 
+/// How long a step waits before it offers a way past itself.
+///
+/// Issue #76 was an onboarding with one gate and no way around it, and a live
+/// tour can strand someone just as easily — a terminal that swallows a key, a
+/// step that will not register. Long enough not to invite skipping, short
+/// enough that nobody sits there wondering.
+const SKIP_AFTER: Duration = Duration::from_secs(45);
+
+/// Set by the skip key, read by the poll loop. A tmux user option rather than a
+/// file: the narration already lives in tmux, and this keeps the escape hatch
+/// in the same place.
+const SKIP_OPTION: &str = "@muxa-onboarding-skip";
+
 const SANDBOX_CONFIG: &str = "\
 [discovery]
 enabled = false
@@ -153,6 +166,11 @@ impl Sandbox {
         }
         if args[0] == "up" {
             cmd.arg("--config").arg(&self.config);
+            // Without this the sandbox server reads the learner's own
+            // `~/.tmux.conf`. Somebody who rebound their prefix to `C-a` would
+            // then be told to press `Ctrl-b c`, and step 2 would be a dead end
+            // with no explanation — exactly the shape of issue #76.
+            cmd.args(["--tmux-config", "/dev/null"]);
             if let Some(dir) = self.exe.parent() {
                 cmd.arg("--extra-path").arg(dir);
             }
@@ -361,15 +379,30 @@ impl Sandbox {
         self.tmux_command(&["set", "-g", "status-position", "top"])?;
         self.tmux_command(&["set", "-g", "status-style", "bg=#0b1220,fg=#c9d1d9"])?;
         self.tmux_command(&["set", "-g", "status-interval", "2"])?;
+        // Root table, so it needs no prefix and cannot be confused with typing.
+        self.tmux_command(&["bind-key", "-n", "F12", "set", "-g", SKIP_OPTION, "1"])?;
         Ok(())
     }
 
-    fn narrate(&self, index: usize, total: usize, title: &str, cue: &str) {
+    fn skip_requested(&self) -> bool {
+        if self.tmux_quiet(&["show", "-gv", SKIP_OPTION]) != "1" {
+            return false;
+        }
+        let _ = self.tmux_command(&["set", "-gu", SKIP_OPTION]);
+        true
+    }
+
+    fn narrate(&self, index: usize, total: usize, title: &str, cue: &str, escape: Option<&str>) {
         let banner = format!(
             "#[align=centre bg=#1f6feb,fg=#0b1220,bold] muxa onboarding · {index}/{total} #[default]"
         );
         let title = format!("#[align=centre]{title}");
-        let cue = format!("#[align=centre fg=#d29922,bold]{cue}");
+        let cue = match escape {
+            Some(hint) => {
+                format!("#[align=centre fg=#d29922,bold]{cue}#[default]#[fg=#8b949e]    {hint}")
+            }
+            None => format!("#[align=centre fg=#d29922,bold]{cue}"),
+        };
         let _ = self.tmux_command(&["set", "-g", "status-format[0]", &banner]);
         let _ = self.tmux_command(&["set", "-g", "status-format[1]", &title]);
         let _ = self.tmux_command(&["set", "-g", "status-format[2]", &cue]);
@@ -398,17 +431,22 @@ impl Sandbox {
     /// Joining *their* window rather than a prepared one is the point: the room
     /// they can address peers in is the window they are already in, and
     /// watching the panes arrive is what makes "a pane is an agent" land.
-    fn add_agents(&self, language: UiLanguage) -> Result<Fleet> {
+    fn add_agents(&self, session: &str, language: UiLanguage) -> Result<Fleet> {
         let note = tr(
             language,
             "scripted agent — everything muxa does with it is real",
             "스크립트 agent — muxa가 하는 동작은 전부 진짜입니다",
         );
 
-        let learner = self.tmux_command(&["display-message", "-p", "#{pane_id}"])?;
-        let window = self.tmux_command(&["display-message", "-p", "#{window_id}"])?;
+        // Resolved through the session rather than the attached client: a
+        // learner who skipped their way here may not be attached to anything,
+        // and the agents still have to land in a real window.
+        let target = format!("{session}:");
+        let learner = self.tmux_command(&["display-message", "-p", "-t", &target, "#{pane_id}"])?;
+        let window =
+            self.tmux_command(&["display-message", "-p", "-t", &target, "#{window_id}"])?;
         if learner.is_empty() || window.is_empty() {
-            bail!("could not resolve the pane you are sitting in");
+            bail!("could not find a window to put the agents in");
         }
 
         let claude = self.split(
@@ -638,6 +676,10 @@ struct Tour<'a> {
     sandbox: &'a Sandbox,
     language: UiLanguage,
     fleet: Option<Fleet>,
+    /// `--no-quiz` does not remove the steps — there is nothing to remove, the
+    /// tour is the real thing — so it offers the way past from the start
+    /// instead of after a wait.
+    no_quiz: bool,
 }
 
 impl Tour<'_> {
@@ -703,6 +745,41 @@ impl Tour<'_> {
         }
     }
 
+    /// What a skipped step would have done to the world.
+    ///
+    /// Skipping has to leave the tour consistent, not just further along: Act II
+    /// cannot introduce agents into a session that was never created. Anything
+    /// the learner would have done that the tour can do for them, it does.
+    fn perform(&self, index: usize) {
+        match index {
+            0 => {
+                let _ = self.sandbox.tmux_command(&[
+                    "new-session",
+                    "-d",
+                    "-s",
+                    "muxa-onboarding",
+                    "-x",
+                    "200",
+                    "-y",
+                    "50",
+                ]);
+            }
+            1 => {
+                if let Some(session) = self.own_sessions().first() {
+                    let _ = self.sandbox.tmux_command(&[
+                        "new-window",
+                        "-d",
+                        "-t",
+                        &format!("{session}:"),
+                    ]);
+                }
+            }
+            // The rest are either about where the learner is looking, which the
+            // tour will not fake, or about state it has already produced.
+            _ => {}
+        }
+    }
+
     /// Fired as a step opens, so the world moves on its own rather than only in
     /// response to the learner.
     fn on_enter(&mut self, index: usize) -> Result<()> {
@@ -713,7 +790,12 @@ impl Tour<'_> {
             if !holder.is_empty() {
                 let _ = self.sandbox.tmux_command(&["kill-session", "-t", &holder]);
             }
-            self.fleet = Some(self.sandbox.add_agents(self.language)?);
+            let session = self
+                .own_sessions()
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "muxa-onboarding".to_string());
+            self.fleet = Some(self.sandbox.add_agents(&session, self.language)?);
             return Ok(());
         }
         let Some(fleet) = self.fleet.as_ref() else {
@@ -740,18 +822,38 @@ impl Tour<'_> {
         }
     }
 
-    fn narrate(&self, index: usize) {
+    fn narrate(&self, index: usize, escape: bool) {
         let step = &STEPS[index];
-        self.sandbox.narrate(
-            index + 1,
-            STEPS.len(),
-            tr(self.language, step.title_en, step.title_ko),
-            tr(self.language, step.cue_en, step.cue_ko),
-        );
+        let title = tr(self.language, step.title_en, step.title_ko);
+        let cue = tr(self.language, step.cue_en, step.cue_ko);
+        let hint = escape.then(|| {
+            tr(
+                self.language,
+                "stuck?  F12  skips this step",
+                "막혔나요?  F12  로 이 단계를 건너뜁니다",
+            )
+        });
+
+        self.sandbox
+            .narrate(index + 1, STEPS.len(), title, cue, hint);
+
+        // The status bar only exists for someone attached to the server, and
+        // the first step is the one where they are not — they are at a bare
+        // shell being asked to create the session. Narrating only through tmux
+        // would leave that instruction invisible, which is the same dead end as
+        // a gate with no way past it, just earlier.
+        if self.clients().is_empty() {
+            eprintln!();
+            eprintln!("  muxa onboarding · {}/{}", index + 1, STEPS.len());
+            eprintln!("  {title}");
+            eprintln!("  {cue}");
+            eprintln!();
+        }
     }
 
     fn drive(&mut self) -> Result<usize> {
-        self.narrate(0);
+        // Prints rather than paints: nobody is attached yet.
+        self.narrate(0, self.no_quiz);
 
         // The learner's own shell, in their own terminal. They are not attached
         // to anything yet — Act I is where they attach themselves, which is the
@@ -763,7 +865,8 @@ impl Tour<'_> {
             .context("starting your shell")?;
 
         let mut index = 0usize;
-        let mut deadline = Instant::now() + STEP_TIMEOUT;
+        let mut entered = Instant::now();
+        let mut offered_escape = self.no_quiz;
 
         while index < STEPS.len() {
             if INTERRUPTED.load(Ordering::SeqCst) {
@@ -772,17 +875,33 @@ impl Tour<'_> {
             if shell.try_wait().context("watching your shell")?.is_some() {
                 break;
             }
-            if Instant::now() > deadline {
+            if entered.elapsed() > STEP_TIMEOUT {
                 break;
             }
             if self.satisfied(&STEPS[index].detect) {
                 index += 1;
-                deadline = Instant::now() + STEP_TIMEOUT;
+                entered = Instant::now();
+                offered_escape = self.no_quiz;
                 if index < STEPS.len() {
                     self.on_enter(index)?;
-                    self.narrate(index);
+                    self.narrate(index, offered_escape);
                 }
                 continue;
+            }
+            if self.sandbox.skip_requested() {
+                self.perform(index);
+                index += 1;
+                entered = Instant::now();
+                offered_escape = self.no_quiz;
+                if index < STEPS.len() {
+                    self.on_enter(index)?;
+                    self.narrate(index, offered_escape);
+                }
+                continue;
+            }
+            if !offered_escape && entered.elapsed() > SKIP_AFTER {
+                offered_escape = true;
+                self.narrate(index, true);
             }
             std::thread::sleep(POLL);
         }
@@ -794,7 +913,7 @@ impl Tour<'_> {
     }
 }
 
-pub(super) fn run(language: UiLanguage) -> Result<()> {
+pub(super) fn run(language: UiLanguage, no_quiz: bool) -> Result<()> {
     preflight(language)?;
     trap_signals();
 
@@ -817,6 +936,7 @@ pub(super) fn run(language: UiLanguage) -> Result<()> {
             sandbox: &sandbox,
             language,
             fleet: None,
+            no_quiz,
         };
         tour.drive()?
         // `Drop` tears the sandbox down here, on every path including a panic.

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -126,6 +126,8 @@ struct Sandbox {
     script: PathBuf,
     config: PathBuf,
     rcfile: PathBuf,
+    /// What the shell prompt shows when nobody is attached to a status bar.
+    cue: PathBuf,
     /// `HOME` for everything the learner runs, so `cd ~` lands here too.
     home: PathBuf,
     /// Where their shell starts, and what `ls` shows.
@@ -141,6 +143,7 @@ impl Sandbox {
         let script = dir.join("muxa-onboarding-sandbox.sh");
         let config = dir.join("muxa-onboarding.src.toml");
         let rcfile = dir.join("muxa-onboarding.bashrc");
+        let cue = dir.join("muxa-onboarding.cue");
         let home = dir.join("muxa-onboarding-home");
         let project = home.join("checkout-service");
         write_executable(&script, SANDBOX_SCRIPT).context("staging the sandbox script")?;
@@ -154,6 +157,7 @@ impl Sandbox {
             script,
             config,
             rcfile,
+            cue,
             home,
             project,
             tmux,
@@ -231,10 +235,22 @@ impl Sandbox {
     /// The learner's shell. It carries the sandbox environment explicitly
     /// rather than relying on inheritance, and a bare prompt so the tour does
     /// not drag anyone's Starship setup into the recording of their own screen.
+    ///
+    /// The prompt also carries the current step. Printing it instead put the
+    /// instruction *below* the prompt bash had already drawn, so whatever the
+    /// learner typed next had nothing in front of it and the shell looked like
+    /// it had gone away. As part of the prompt it sits where every shell puts
+    /// context, and refreshes on every command — only outside tmux, since
+    /// inside the status bar already says it.
     fn write_rcfile(&self) -> Result<()> {
         use std::fmt::Write as _;
 
-        let mut body = String::from("unset PROMPT_COMMAND\nexport PS1='muxa-onboarding $ '\n");
+        let mut body = String::from("unset PROMPT_COMMAND\n");
+        let _ = writeln!(
+            body,
+            "export PS1='$([ -z \"$TMUX\" ] && cat {} 2>/dev/null)muxa-onboarding $ '",
+            self.cue.display()
+        );
         // Every pane, not just the first: a window the learner opens at step 2
         // would otherwise land back in their own home directory.
         let _ = writeln!(body, "export HOME='{}'", self.home.display());
@@ -326,6 +342,36 @@ impl Sandbox {
     /// the tour teaches arrive through the real pipeline rather than being
     /// drawn. Only valid once the daemon is up — events sent before it starts
     /// are simply lost.
+    /// Answer whatever the learner just asked claude.
+    ///
+    /// Their request is real and sits in claude's mailbox; leaving it there
+    /// would teach that messages go nowhere. A reply they can find with
+    /// `muxa msg list` is the point of a durable mailbox — a line in a
+    /// transcript is a drawing of one. Best-effort: a flourish should not stop
+    /// the tour.
+    fn reply_as_claude(&self, fleet: &Fleet, language: UiLanguage) {
+        let Ok(raw) = self.muxa_as(&fleet.claude, &["msg", "inbox", "--json"]) else {
+            return;
+        };
+        let Ok(requests) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            return;
+        };
+        let Some(id) = requests
+            .as_array()
+            .and_then(|items| items.first())
+            .and_then(|item| item.get("id"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            return;
+        };
+        let body = tr(
+            language,
+            "auth path is covered; writing the regression test now",
+            "인증 경로는 끝났고, 지금 회귀 테스트를 쓰는 중입니다",
+        );
+        let _ = self.muxa_as(&fleet.claude, &["msg", "reply", id, body]);
+    }
+
     fn hook(&self, pane: &str, kind: &str, event: &str, body: &str) -> Result<()> {
         let mut cmd = Command::new(&self.exe);
         cmd.args(["hook", kind, "--event", event]);
@@ -351,7 +397,7 @@ impl Sandbox {
 impl Drop for Sandbox {
     fn drop(&mut self) {
         let _ = self.script_command(&["down"]);
-        for path in [&self.script, &self.config, &self.rcfile] {
+        for path in [&self.script, &self.config, &self.rcfile, &self.cue] {
             let _ = std::fs::remove_file(path);
         }
         // The agent transcripts are named deterministically, so they can be
@@ -1040,8 +1086,8 @@ const STEPS: &[Step] = &[
         detect: Detect::PaneRunning("muxa"),
     },
     Step {
-        title_en: "codex stopped and is waiting on you. State is how you find that.",
-        title_ko: "codex가 멈춰서 당신을 기다립니다. 그걸 찾는 방법이 state입니다.",
+        title_en: "codex stopped and needs you. `attend` jumps to whichever agent has been blocked longest — you land in codex's pane.",
+        title_ko: "codex가 멈춰서 당신이 필요합니다. `attend`는 가장 오래 막힌 agent로 이동합니다 — codex의 pane에 도착합니다.",
         cue_en: "leave watch with q, then run:   muxa attend",
         cue_ko: "q로 watch를 나간 뒤 입력:   muxa attend",
         detect: Detect::ActivePaneIsCodex,
@@ -1050,10 +1096,10 @@ const STEPS: &[Step] = &[
         // attend left them sitting in codex's pane, which has no shell to
         // type into. Getting back is a real tmux key, so the step teaches it
         // rather than having the tour move the cursor on their behalf.
-        title_en: "That is codex's own pane. Go back to yours, and ask from there.",
-        title_ko: "여기는 codex의 pane입니다. 당신 pane으로 돌아가서 물어보세요.",
-        cue_en: "press   Ctrl-b   then   ;      then run:   muxa msg send @claude \"how far along?\"",
-        cue_ko: "Ctrl-b 를 눌렀다 떼고   ;      그 뒤 입력:   muxa msg send @claude \"어디까지 됐나요?\"",
+        title_en: "You are in codex's pane — press y to approve it if you like. `Ctrl-b ;` returns to the last pane you were in, which is your own shell.",
+        title_ko: "지금 codex의 pane입니다 — 원하면 y로 승인해 보세요. `Ctrl-b ;`는 직전에 있던 pane, 즉 당신의 셸로 돌아갑니다.",
+        cue_en: "back with   Ctrl-b ;   then run:   muxa msg send @claude \"how far along?\"",
+        cue_ko: "Ctrl-b ; 로 돌아간 뒤 입력:   muxa msg send @claude \"어디까지 됐나요?\"",
         detect: Detect::SentMessage,
     },
     Step {
@@ -1191,13 +1237,17 @@ impl Tour<'_> {
     /// Fired as a step opens, so the world moves on its own rather than only in
     /// response to the learner.
     fn on_enter(&mut self, index: usize) -> Result<()> {
-        if index == ACT_TWO_START {
-            // The placeholder has done its job; left alive it shows up in watch
-            // as a session with no agents in it.
+        // The placeholder only had to keep the server alive until the learner
+        // made a session of their own. Step 3 asks them to run `tmux ls`, and a
+        // mysterious `_sandbox` in that output is the tour's own plumbing
+        // showing through the lesson.
+        if index == 1 {
             let holder = self.sandbox.env_value("MUXA_SANDBOX_HOLDER");
             if !holder.is_empty() {
                 let _ = self.sandbox.tmux_command(&["kill-session", "-t", &holder]);
             }
+        }
+        if index == ACT_TWO_START {
             let session = self
                 .own_sessions()
                 .first()
@@ -1234,6 +1284,8 @@ impl Tour<'_> {
                 fleet
                     .claude_screen
                     .append(&incoming_question(self.language));
+                // And claude answers through muxa, not only on its own screen.
+                self.sandbox.reply_as_claude(fleet, self.language);
                 fleet.codex_screen.append(&outgoing_request(self.language));
                 self.sandbox
                     .muxa_as(&fleet.codex, &["msg", "send", "@you", body, "--no-reply"])
@@ -1278,13 +1330,14 @@ impl Tour<'_> {
         // shell being asked to create the session. Narrating only through tmux
         // would leave that instruction invisible, which is the same dead end as
         // a gate with no way past it, just earlier.
-        if self.clients().is_empty() {
-            eprintln!();
-            eprintln!("  muxa onboarding · {}/{}", index + 1, STEPS.len());
-            eprintln!("  {title}");
-            eprintln!("  {cue}");
-            eprintln!();
-        }
+        let _ = std::fs::write(
+            &self.sandbox.cue,
+            format!(
+                "\n  muxa onboarding · {}/{}\n  {title}\n  {cue}\n\n",
+                index + 1,
+                STEPS.len()
+            ),
+        );
     }
 
     fn drive(&mut self) -> Result<usize> {

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -865,8 +865,14 @@ fn display_width(text: &str) -> usize {
         .sum()
 }
 
+/// How wide an agent's pane has to be for its own frames to render.
+///
+/// The layout reads this, so narrowing the mock screens widens the learner's
+/// pane rather than leaving a box clipped down the middle.
+const AGENT_FRAME_COLUMNS: usize = 60;
+
 fn composer(cli: Cli, language: UiLanguage) -> Vec<String> {
-    let width: usize = 58;
+    let width: usize = AGENT_FRAME_COLUMNS - 2;
     // Each CLI's own idle hint. Inviting the learner to type here would be a
     // lie — they talk to these agents through `muxa msg`, not this box.
     let hint = match cli {
@@ -1082,6 +1088,53 @@ impl Sandbox {
             .filter(|pane| !pane.is_empty())
     }
 
+    /// Learner on the left, agents stacked on the right.
+    ///
+    /// Laid out rather than zoomed. Zooming the learner's pane gave
+    /// `muxa watch` the whole screen and hid the two agents that had just
+    /// arrived — so the step confirmed an arrival the learner could not see,
+    /// above an instruction to look at the whole Work, over a blank screen.
+    /// Half the width is still plenty for watch, and the fleet is what the
+    /// next four steps are about.
+    fn lay_out_fleet(&self, window: &str, learner: &str) -> Result<()> {
+        // `main-vertical` makes the first pane the wide one, and the learner's
+        // is first only because it predates the split. Not worth assuming.
+        let first = self
+            .tmux_command(&["list-panes", "-t", window, "-F", "#{pane_id}"])?
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        if !first.is_empty() && first != learner {
+            let _ = self.tmux_command(&["swap-pane", "-s", &first, "-t", learner]);
+        }
+        // A column count rather than `50%`, which older tmux rejects here.
+        // Half each suits a wide terminal. On a narrow one, half would put the
+        // agents below the width their own frames need, so they keep that and
+        // the learner takes what is left — down to a floor, because a pane too
+        // narrow for `muxa watch` is its own kind of broken.
+        let width = self
+            .tmux_command(&["display-message", "-p", "-t", window, "#{window_width}"])?
+            .trim()
+            .parse::<usize>()
+            .unwrap_or(160);
+        let main = (width / 2)
+            .min(width.saturating_sub(AGENT_FRAME_COLUMNS + 1))
+            .max(60)
+            .min(width.saturating_sub(20))
+            .max(20);
+        let _ = self.tmux_command(&[
+            "set-window-option",
+            "-t",
+            window,
+            "main-pane-width",
+            &main.to_string(),
+        ]);
+        let _ = self.tmux_command(&["select-layout", "-t", window, "main-vertical"]);
+        self.tmux_command(&["select-pane", "-t", learner])?;
+        Ok(())
+    }
+
     /// codex joins whatever window the learner started claude in.
     ///
     /// Joining *their* window rather than a prepared one is the point: the room
@@ -1190,11 +1243,7 @@ impl Sandbox {
             &codex_screen.answerable_pane_command(&dir, &approved, &declined)?,
         )?;
 
-        // Zoomed so `muxa watch` gets the whole screen. The agent panes stay in
-        // the window, and `muxa attend` unzooms to reach one — which
-        // demonstrates attend better than any description of it.
-        self.tmux_command(&["select-pane", "-t", &learner])?;
-        self.tmux_command(&["resize-pane", "-Z", "-t", &learner])?;
+        self.lay_out_fleet(&window, &learner)?;
 
         let fleet = Fleet {
             learner,
@@ -1425,8 +1474,8 @@ const STEPS: &[Step] = &[
         detect: Detect::StartedClaude,
     },
     Step {
-        achieved_en: "✓ claude took that pane, codex joined it, you are back in yours",
-        achieved_ko: "✓ claude가 그 pane을 차지하고 codex도 합류했습니다 — 당신은 자기 pane입니다",
+        achieved_en: "✓ that pane is claude now, codex joined it, and your cursor is back in yours",
+        achieved_ko: "✓ 그 pane이 claude가 됐고 codex도 합류했습니다 — 커서는 당신 pane에 있습니다",
         title_en: "This window is the `checkout` Work now. See all of it at once.",
         title_ko: "이 window가 이제 `checkout` Work입니다. 전체를 한 번에 보세요.",
         cue_en: "run:   muxa watch            ·   q leaves it",
@@ -1472,8 +1521,8 @@ const STEPS: &[Step] = &[
     Step {
         achieved_en: "✓ you read claude's reply — and codex has asked you something of its own",
         achieved_ko: "✓ claude의 답장을 봤습니다 — 그리고 codex가 당신에게 물어왔습니다",
-        title_en: "`inbox` claims what was sent *to* you. Agents use muxa too.",
-        title_ko: "`inbox`는 당신에게 **온** 요청을 가져옵니다. agent도 muxa를 씁니다.",
+        title_en: "`inbox` claims the requests addressed to you. Agents use muxa too.",
+        title_ko: "`inbox`는 당신 앞으로 온 요청을 가져옵니다. agent도 muxa를 씁니다.",
         cue_en: "run:   muxa msg inbox",
         cue_ko: "입력:   muxa msg inbox",
         detect: Detect::ClaimedInbox,

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -341,6 +341,12 @@ impl Drop for Sandbox {
         for path in [&self.script, &self.config, &self.rcfile] {
             let _ = std::fs::remove_file(path);
         }
+        // The agent transcripts are named deterministically, so they can be
+        // cleaned from here without threading the `Fleet` back through.
+        let dir = std::env::temp_dir();
+        for name in ["claude", "codex"] {
+            let _ = std::fs::remove_file(dir.join(format!("muxa-onboarding-{name}.log")));
+        }
     }
 }
 
@@ -382,6 +388,11 @@ impl Sandbox {
         self.tmux_command(&["set", "-g", "status-position", "top"])?;
         self.tmux_command(&["set", "-g", "status-style", "bg=#0b1220,fg=#c9d1d9"])?;
         self.tmux_command(&["set", "-g", "status-interval", "2"])?;
+        // tmux renames a window after whatever is running in it, which turns
+        // the topology into a list of processes — `bash`, and then `muxa` the
+        // moment they start watch. A window is a Work, and a Work keeps its
+        // name.
+        self.tmux_command(&["set", "-g", "automatic-rename", "off"])?;
         // Root table, so they need no prefix and cannot be confused with typing.
         self.tmux_command(&["bind-key", "-n", "F12", "set", "-g", SKIP_OPTION, "1"])?;
         self.tmux_command(&["bind-key", "-n", "F2", "set", "-g", LANGUAGE_OPTION, "1"])?;
@@ -432,6 +443,163 @@ impl Sandbox {
 }
 
 // ---------------------------------------------------------------------------
+// Agent transcripts
+// ---------------------------------------------------------------------------
+
+/// One scripted agent's screen.
+///
+/// The pane runs `tail -f` over this file and the tour appends to it, so the
+/// session *grows* the way a real one does. A painted frame would have been
+/// less code, but `muxa watch`'s inspector and preview both render the selected
+/// pane's live screen — a fleet parked on a single static line makes those
+/// features look broken, and makes the tour's claim that this is what the work
+/// looks like ring hollow.
+///
+/// Nothing here shells out to an agent CLI. The transcript is a fiction; what
+/// muxa does around it is not, and the tour says so rather than letting anyone
+/// believe they watched Claude answer.
+struct Transcript {
+    path: PathBuf,
+}
+
+impl Transcript {
+    fn new(dir: &Path, name: &str) -> Result<Self> {
+        let path = dir.join(format!("muxa-onboarding-{name}.log"));
+        std::fs::write(&path, "").with_context(|| format!("staging {name}'s transcript"))?;
+        Ok(Self { path })
+    }
+
+    fn append(&self, lines: &[String]) {
+        use std::io::Write as _;
+        let Ok(mut file) = std::fs::OpenOptions::new().append(true).open(&self.path) else {
+            return;
+        };
+        for line in lines {
+            let _ = writeln!(file, "{line}");
+        }
+    }
+
+    /// `tail` rather than `cat`: it never reaches EOF, so the pane stays open
+    /// and shows whatever arrives next.
+    fn pane_command(&self) -> String {
+        format!("exec tail -n +1 -f {}", self.path.display())
+    }
+}
+
+const DIM: &str = "\u{1b}[2m";
+const BOLD: &str = "\u{1b}[1m";
+const RESET: &str = "\u{1b}[0m";
+const GREEN: &str = "\u{1b}[1;32m";
+const YELLOW: &str = "\u{1b}[1;33m";
+const BLUE: &str = "\u{1b}[1;34m";
+const MAGENTA: &str = "\u{1b}[1;35m";
+const CYAN: &str = "\u{1b}[1;36m";
+
+/// Matches `docs/demo-paint.sh` so the tour and the recordings show the same
+/// agent, rather than two different ideas of one.
+fn header(colour: &str, name: &str, language: UiLanguage) -> Vec<String> {
+    vec![
+        format!(
+            "{DIM}⟨{}⟩{RESET}",
+            tr(
+                language,
+                "simulated session — no agent CLI is running",
+                "시뮬레이션 세션 — 실제 agent CLI는 실행되지 않습니다",
+            )
+        ),
+        String::new(),
+        format!("{colour}●{RESET} {BOLD}{name}{RESET}"),
+        String::new(),
+    ]
+}
+
+fn prompt_line(text: &str) -> Vec<String> {
+    vec![format!("{GREEN}›{RESET} {text}"), String::new()]
+}
+
+fn tool_line(text: &str) -> String {
+    format!("  {DIM}⚙{RESET} {text}")
+}
+
+/// What codex's pane shows once it is blocked. Mirrors the `approval` frame in
+/// `docs/demo-paint.sh`.
+fn approval_block(language: UiLanguage) -> Vec<String> {
+    vec![
+        String::new(),
+        format!(
+            "  {YELLOW}⏸  {}{RESET}",
+            tr(language, "Approval required", "승인이 필요합니다")
+        ),
+        format!("     {BOLD}$ rg -n \"public_read\" --type rust{RESET}"),
+        String::new(),
+        format!(
+            "     {GREEN}[y]{RESET} {}   {YELLOW}[n]{RESET} {}   {DIM}[a]{RESET} {}",
+            tr(language, "yes", "예"),
+            tr(language, "no", "아니오"),
+            tr(language, "yes, and don't ask again", "예, 다시 묻지 않기"),
+        ),
+    ]
+}
+
+fn incoming_question(language: UiLanguage) -> Vec<String> {
+    vec![
+        String::new(),
+        format!(
+            "  {DIM}✉ {}{RESET}",
+            tr(language, "question from you", "당신이 보낸 질문")
+        ),
+        format!(
+            "     {}",
+            tr(language, "how far along?", "어디까지 됐나요?")
+        ),
+        String::new(),
+        format!(
+            "  {GREEN}›{RESET} {}",
+            tr(
+                language,
+                "auth path is covered; writing the regression test now",
+                "인증 경로는 끝났고, 지금 회귀 테스트를 쓰는 중입니다",
+            )
+        ),
+    ]
+}
+
+fn outgoing_request(language: UiLanguage) -> Vec<String> {
+    vec![
+        String::new(),
+        format!(
+            "  {DIM}✉ {}{RESET}",
+            tr(
+                language,
+                "asked you for a decision",
+                "당신에게 결정을 요청했습니다"
+            )
+        ),
+        format!(
+            "     {}",
+            tr(
+                language,
+                "the public-read boundary needs a decision before I continue",
+                "public-read 경계는 계속하기 전에 결정이 필요합니다",
+            )
+        ),
+    ]
+}
+
+fn finished(language: UiLanguage) -> Vec<String> {
+    vec![
+        String::new(),
+        format!("  {DIM}⚙{RESET} test     checkout::auth::rejects_raw_bearer  ok"),
+        String::new(),
+        format!("  {GREEN}✓ {}{RESET}", tr(language, "done", "완료")),
+    ]
+}
+
+fn working(language: UiLanguage) -> String {
+    format!("  {BLUE}▶ {}{RESET}", tr(language, "working…", "작업 중…"))
+}
+
+// ---------------------------------------------------------------------------
 // Fixture
 // ---------------------------------------------------------------------------
 
@@ -445,6 +613,8 @@ struct Fleet {
     learner: String,
     claude: String,
     codex: String,
+    claude_screen: Transcript,
+    codex_screen: Transcript,
 }
 
 impl Sandbox {
@@ -454,12 +624,6 @@ impl Sandbox {
     /// they can address peers in is the window they are already in, and
     /// watching the panes arrive is what makes "a pane is an agent" land.
     fn add_agents(&self, session: &str, language: UiLanguage) -> Result<Fleet> {
-        let note = tr(
-            language,
-            "scripted agent — everything muxa does with it is real",
-            "스크립트 agent — muxa가 하는 동작은 전부 진짜입니다",
-        );
-
         // Resolved through the session rather than the attached client: a
         // learner who skipped their way here may not be attached to anything,
         // and the agents still have to land in a real window.
@@ -471,18 +635,53 @@ impl Sandbox {
             bail!("could not find a window to put the agents in");
         }
 
-        let claude = self.split(
-            &window,
-            &format!(
-                "printf '\\033[1;36m▸ claude\\033[0m  {note}\\n\\n  harden the checkout auth path\\n'; exec cat"
-            ),
-        )?;
-        let codex = self.split(
-            &window,
-            &format!(
-                "printf '\\033[1;35m▸ codex\\033[0m  {note}\\n\\n  review the public-read boundary\\n'; exec cat"
-            ),
-        )?;
+        let dir = std::env::temp_dir();
+        let claude_screen = Transcript::new(&dir, "claude")?;
+        let codex_screen = Transcript::new(&dir, "codex")?;
+
+        let claude_prompt = tr(
+            language,
+            "harden the checkout auth path",
+            "checkout 인증 경로를 강화해줘",
+        );
+        let codex_prompt = tr(
+            language,
+            "review the public-read boundary",
+            "public-read 경계를 검토해줘",
+        );
+
+        let mut opening = header(MAGENTA, "claude", language);
+        opening.extend(prompt_line(claude_prompt));
+        opening.push(tool_line("read     crates/checkout/src/auth.rs"));
+        opening.push(tool_line("grep     \"bearer\"  ·  12 matches"));
+        opening.push(String::new());
+        opening.push(working(language));
+        claude_screen.append(&opening);
+
+        let mut opening = header(CYAN, "codex", language);
+        opening.extend(prompt_line(codex_prompt));
+        opening.push(tool_line("read     crates/api/src/public.rs"));
+        opening.push(String::new());
+        opening.push(working(language));
+        codex_screen.append(&opening);
+
+        // A window is a Work, and in a real fleet it is named after one.
+        self.tmux_command(&["rename-window", "-t", &window, "checkout"])?;
+        // Whatever they made at step 2 is a Work too — an unstaffed one.
+        // Left called `bash` the fleet looks half-built rather than like a
+        // workspace with a job nobody has picked up yet.
+        for other in self
+            .tmux_quiet(&["list-windows", "-a", "-F", "#{window_id}"])
+            .lines()
+            .filter(|id| !id.is_empty() && *id != window)
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+        {
+            let _ = self.tmux_command(&["rename-window", "-t", &other, "release-checks"]);
+        }
+
+        let claude = self.split(&window, &claude_screen.pane_command())?;
+        let codex = self.split(&window, &codex_screen.pane_command())?;
 
         // Zoomed so `muxa watch` gets the whole screen. The agent panes stay in
         // the window, and `muxa attend` unzooms to reach one — which
@@ -494,6 +693,8 @@ impl Sandbox {
             learner,
             claude,
             codex,
+            claude_screen,
+            codex_screen,
         };
         self.seed_fleet(&fleet)?;
         Ok(fleet)
@@ -647,9 +848,9 @@ const STEPS: &[Step] = &[
     },
     // ---- Act II: muxa -----------------------------------------------------
     Step {
-        title_en: "Two agents just joined this window. A pane is an agent. See them all at once.",
+        title_en: "This window is the `checkout` Work now, with two agents in it. A pane is an agent.",
         title_ko:
-            "이 window에 agent 둘이 합류했습니다. pane 하나가 agent 하나입니다. 한눈에 보세요.",
+            "이 window가 이제 `checkout` Work이고, 안에 agent가 둘 있습니다. pane 하나가 agent 하나입니다.",
         cue_en: "run:   muxa watch             ·   q leaves it",
         cue_ko: "입력:   muxa watch             ·   q로 나갑니다",
         detect: Detect::PaneRunning("muxa"),
@@ -825,21 +1026,40 @@ impl Tour<'_> {
             return Ok(());
         };
         match index {
-            5 => self.sandbox.hook(
-                &fleet.codex,
-                "codex",
-                "permission_request",
-                r#"{"session_id":"onboarding-codex","tool_name":"shell"}"#,
-            ),
+            5 => {
+                // The row in watch flips to `waiting` because of the hook; the
+                // pane has to show *why*, or the state is a claim rather than
+                // something the learner can see for themselves.
+                fleet.codex_screen.append(&approval_block(self.language));
+                self.sandbox.hook(
+                    &fleet.codex,
+                    "codex",
+                    "permission_request",
+                    r#"{"session_id":"onboarding-codex","tool_name":"shell"}"#,
+                )
+            }
+            6 => {
+                // The learner's question lands in claude's session, so claude's
+                // screen shows it arriving and being answered.
+                fleet
+                    .claude_screen
+                    .append(&incoming_question(self.language));
+                Ok(())
+            }
             7 => {
                 let body = tr(
                     self.language,
                     "the public-read boundary needs a decision before I continue",
                     "public-read 경계는 계속하기 전에 결정이 필요합니다",
                 );
+                fleet.codex_screen.append(&outgoing_request(self.language));
                 self.sandbox
                     .muxa_as(&fleet.codex, &["msg", "send", "@you", body, "--no-reply"])
                     .map(|_| ())
+            }
+            8 => {
+                fleet.claude_screen.append(&finished(self.language));
+                Ok(())
             }
             _ => Ok(()),
         }

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -461,7 +461,11 @@ fn muxad_beside(exe: &Path) -> Option<PathBuf> {
 
 impl Sandbox {
     fn prepare_status(&self) -> Result<()> {
-        self.tmux_command(&["set", "-g", "status", "3"])?;
+        // Four rows, and row 0 is left as tmux's own window list.
+        // Overwriting it meant a learner who pressed `Ctrl-b c` had no way
+        // to see the window they had just made — the tour was hiding its
+        // own evidence.
+        self.tmux_command(&["set", "-g", "status", "4"])?;
         self.tmux_command(&["set", "-g", "status-position", "top"])?;
         self.tmux_command(&["set", "-g", "status-style", "bg=#0b1220,fg=#c9d1d9"])?;
         self.tmux_command(&["set", "-g", "status-interval", "2"])?;
@@ -493,18 +497,23 @@ impl Sandbox {
         self.consume_flag(LANGUAGE_OPTION)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn narrate(
         &self,
         index: usize,
         total: usize,
+        achieved: &str,
         title: &str,
         cue: &str,
         escape: Option<&str>,
         other_language: &str,
     ) {
+        // What just happened comes first. A tour that only ever says what to do
+        // next leaves the learner typing commands and guessing whether any of
+        // them landed.
         let banner = format!(
             "#[align=centre bg=#1f6feb,fg=#0b1220,bold] muxa onboarding · {index}/{total} \
-             #[default]#[fg=#8b949e]  F2 {other_language}"
+             #[default]  #[fg=#3fb950]{achieved}#[default]#[fg=#8b949e]    F2 {other_language}"
         );
         let title = format!("#[align=centre]{title}");
         let cue = match escape {
@@ -513,9 +522,10 @@ impl Sandbox {
             }
             None => format!("#[align=centre fg=#d29922,bold]{cue}"),
         };
-        let _ = self.tmux_command(&["set", "-g", "status-format[0]", &banner]);
-        let _ = self.tmux_command(&["set", "-g", "status-format[1]", &title]);
-        let _ = self.tmux_command(&["set", "-g", "status-format[2]", &cue]);
+        // Row 0 stays tmux's own window list.
+        let _ = self.tmux_command(&["set", "-g", "status-format[1]", &banner]);
+        let _ = self.tmux_command(&["set", "-g", "status-format[2]", &title]);
+        let _ = self.tmux_command(&["set", "-g", "status-format[3]", &cue]);
     }
 }
 
@@ -1033,6 +1043,10 @@ enum Detect {
 }
 
 struct Step {
+    /// What the learner's last action actually did. Shown as this step opens,
+    /// because "did that work?" is the question they are holding.
+    achieved_en: &'static str,
+    achieved_ko: &'static str,
     title_en: &'static str,
     title_ko: &'static str,
     cue_en: &'static str,
@@ -1049,6 +1063,8 @@ struct Step {
 const STEPS: &[Step] = &[
     // ---- Act I: tmux ------------------------------------------------------
     Step {
+        achieved_en: "ready — you are at a plain shell, outside tmux",
+        achieved_ko: "준비 완료 — 지금은 tmux 밖의 평범한 셸입니다",
         title_en: "A tmux session is a workspace that keeps running without you.",
         title_ko: "tmux session은 당신 없이도 계속 도는 작업 공간입니다.",
         cue_en: "type:   tmux new-session -s muxa-onboarding",
@@ -1056,6 +1072,8 @@ const STEPS: &[Step] = &[
         detect: Detect::SessionCreated,
     },
     Step {
+        achieved_en: "✓ session created, and you are inside it — this bar is tmux's",
+        achieved_ko: "✓ session을 만들고 들어왔습니다 — 이 줄들이 tmux입니다",
         title_en: "One window is one Work. Make a second one.",
         title_ko: "window 하나가 Work 하나입니다. 두 번째를 만들어 보세요.",
         cue_en: "press   Ctrl-b   then   c",
@@ -1063,6 +1081,8 @@ const STEPS: &[Step] = &[
         detect: Detect::SecondWindow,
     },
     Step {
+        achieved_en: "✓ second window created — see both in the top row",
+        achieved_ko: "✓ 두 번째 window가 생겼습니다 — 맨 윗줄에 둘 다 보입니다",
         title_en: "Now leave. Detaching removes you, not the work.",
         title_ko: "이제 나가 보세요. detach는 당신만 빠지고 작업은 그대로입니다.",
         cue_en: "press   Ctrl-b   then   d       ·   then try:   tmux ls",
@@ -1070,6 +1090,8 @@ const STEPS: &[Step] = &[
         detect: Detect::NoClient,
     },
     Step {
+        achieved_en: "✓ detached — you are back at your shell, and the session kept running",
+        achieved_ko: "✓ detach했습니다 — 셸로 돌아왔고, session은 계속 돌고 있습니다",
         title_en: "Still listed, still running. That is the whole reason muxa lives in tmux.",
         title_ko: "여전히 목록에 있고 여전히 돌고 있습니다. muxa가 tmux에 사는 이유입니다.",
         cue_en: "type:   tmux attach -t muxa-onboarding",
@@ -1078,6 +1100,8 @@ const STEPS: &[Step] = &[
     },
     // ---- Act II: muxa -----------------------------------------------------
     Step {
+        achieved_en: "✓ attached again — every window and pane exactly as you left it",
+        achieved_ko: "✓ 다시 들어왔습니다 — window도 pane도 떠날 때 그대로입니다",
         title_en: "This window is the `checkout` Work now, with two agents in it. A pane is an agent.",
         title_ko:
             "이 window가 이제 `checkout` Work이고, 안에 agent가 둘 있습니다. pane 하나가 agent 하나입니다.",
@@ -1086,6 +1110,8 @@ const STEPS: &[Step] = &[
         detect: Detect::PaneRunning("muxa"),
     },
     Step {
+        achieved_en: "✓ watch showed the whole window at once — and codex just stopped",
+        achieved_ko: "✓ watch가 window 전체를 한 번에 보여줬습니다 — 그리고 codex가 방금 멈췄습니다",
         title_en: "codex stopped and needs you. `attend` jumps to whichever agent has been blocked longest — you land in codex's pane.",
         title_ko: "codex가 멈춰서 당신이 필요합니다. `attend`는 가장 오래 막힌 agent로 이동합니다 — codex의 pane에 도착합니다.",
         cue_en: "leave watch with q, then run:   muxa attend",
@@ -1096,6 +1122,8 @@ const STEPS: &[Step] = &[
         // attend left them sitting in codex's pane, which has no shell to
         // type into. Getting back is a real tmux key, so the step teaches it
         // rather than having the tour move the cursor on their behalf.
+        achieved_en: "✓ attend moved you to codex, the agent blocked longest",
+        achieved_ko: "✓ attend가 가장 오래 막힌 agent인 codex로 데려왔습니다",
         title_en: "You are in codex's pane — press y to approve it if you like. `Ctrl-b ;` returns to the last pane you were in, which is your own shell.",
         title_ko: "지금 codex의 pane입니다 — 원하면 y로 승인해 보세요. `Ctrl-b ;`는 직전에 있던 pane, 즉 당신의 셸로 돌아갑니다.",
         cue_en: "back with   Ctrl-b ;   then run:   muxa msg send @claude \"how far along?\"",
@@ -1103,6 +1131,8 @@ const STEPS: &[Step] = &[
         detect: Detect::SentMessage,
     },
     Step {
+        achieved_en: "✓ your question reached claude and it answered — and codex asked you something",
+        achieved_ko: "✓ 질문이 claude에게 닿았고 답이 왔습니다 — 그리고 codex가 당신에게 물어왔습니다",
         title_en: "Agents use muxa too — codex just sent you a request of its own.",
         title_ko: "agent도 muxa를 씁니다 — codex가 방금 당신에게 요청을 보냈습니다.",
         cue_en: "run:   muxa msg inbox",
@@ -1110,6 +1140,8 @@ const STEPS: &[Step] = &[
         detect: Detect::ClaimedInbox,
     },
     Step {
+        achieved_en: "✓ you claimed codex's request — the mailbox is yours to work through",
+        achieved_ko: "✓ codex의 요청을 확인했습니다 — mailbox는 당신이 처리하는 곳입니다",
         title_en: "session is a workspace · window is a work · pane is an agent",
         title_ko: "session은 workspace · window는 work · pane은 agent",
         cue_en: "press   Ctrl-b   then   d       ·   finishes and deletes the sandbox",
@@ -1301,6 +1333,7 @@ impl Tour<'_> {
 
     fn narrate(&self, index: usize, escape: bool) {
         let step = &STEPS[index];
+        let achieved = tr(self.language, step.achieved_en, step.achieved_ko);
         let title = tr(self.language, step.title_en, step.title_ko);
         let cue = tr(self.language, step.cue_en, step.cue_ko);
         let hint = escape.then(|| {
@@ -1314,6 +1347,7 @@ impl Tour<'_> {
         self.sandbox.narrate(
             index + 1,
             STEPS.len(),
+            achieved,
             title,
             cue,
             hint,
@@ -1333,7 +1367,7 @@ impl Tour<'_> {
         let _ = std::fs::write(
             &self.sandbox.cue,
             format!(
-                "\n  muxa onboarding · {}/{}\n  {title}\n  {cue}\n\n",
+                "\n  muxa onboarding · {}/{}   {achieved}\n  {title}\n  {cue}\n\n",
                 index + 1,
                 STEPS.len()
             ),

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -512,15 +512,15 @@ impl Sandbox {
         // next leaves the learner typing commands and guessing whether any of
         // them landed.
         let banner = format!(
-            "#[align=centre bg=#1f6feb,fg=#0b1220,bold] muxa onboarding · {index}/{total} \
+            "#[align=left bg=#1f6feb,fg=#0b1220,bold] muxa onboarding · {index}/{total} \
              #[default]  #[fg=#3fb950]{achieved}#[default]#[fg=#8b949e]    F2 {other_language}"
         );
-        let title = format!("#[align=centre]{title}");
+        let title = format!("#[align=left]  {title}");
         let cue = match escape {
             Some(hint) => {
-                format!("#[align=centre fg=#d29922,bold]{cue}#[default]#[fg=#8b949e]    {hint}")
+                format!("#[align=left fg=#d29922,bold]  {cue}#[default]#[fg=#8b949e]    {hint}")
             }
-            None => format!("#[align=centre fg=#d29922,bold]{cue}"),
+            None => format!("#[align=left fg=#d29922,bold]  {cue}"),
         };
         // Row 0 stays tmux's own window list.
         let _ = self.tmux_command(&["set", "-g", "status-format[1]", &banner]);
@@ -697,9 +697,55 @@ const BLUE: &str = "\u{1b}[1;34m";
 const MAGENTA: &str = "\u{1b}[1;35m";
 const CYAN: &str = "\u{1b}[1;36m";
 
-/// Matches `docs/demo-paint.sh` so the tour and the recordings show the same
-/// agent, rather than two different ideas of one.
-fn header(colour: &str, name: &str, language: UiLanguage) -> Vec<String> {
+/// The shape of the CLI a pane is standing in for.
+///
+/// A generic "agent frame" is what made the first version read as a mock: the
+/// learner knows what these two look like, and a screen that matches nothing
+/// they recognise is a screen they discount. Claude Code marks its turns with
+/// `⏺` and folds tool results under `⎿`; Codex prefixes its own with `•` and
+/// `└`. Close enough to be recognised, never close enough to be mistaken for a
+/// real session — the first line says so outright.
+#[derive(Clone, Copy)]
+enum Cli {
+    ClaudeCode,
+    Codex,
+}
+
+impl Cli {
+    fn colour(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => MAGENTA,
+            Self::Codex => CYAN,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "claude",
+            Self::Codex => "codex",
+        }
+    }
+
+    /// The glyph each CLI puts in front of its own turns.
+    fn turn(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "⏺",
+            Self::Codex => "•",
+        }
+    }
+
+    /// And in front of the result folded underneath.
+    fn result(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "⎿ ",
+            Self::Codex => "└ ",
+        }
+    }
+}
+
+fn header(cli: Cli, language: UiLanguage) -> Vec<String> {
+    let colour = cli.colour();
+    let name = cli.name();
     vec![
         format!(
             "{DIM}⟨{}⟩{RESET}",
@@ -710,17 +756,67 @@ fn header(colour: &str, name: &str, language: UiLanguage) -> Vec<String> {
             )
         ),
         String::new(),
-        format!("{colour}●{RESET} {BOLD}{name}{RESET}"),
+        format!("{colour}▐{RESET} {BOLD}{name}{RESET} {DIM}· ~/checkout-service{RESET}"),
         String::new(),
     ]
 }
 
 fn prompt_line(text: &str) -> Vec<String> {
-    vec![format!("{GREEN}›{RESET} {text}"), String::new()]
+    vec![format!("{GREEN}>{RESET} {text}"), String::new()]
 }
 
-fn tool_line(text: &str) -> String {
-    format!("  {DIM}⚙{RESET} {text}")
+/// One turn: what the agent did, and what came back.
+fn turn(cli: Cli, action: &str, result: &str) -> Vec<String> {
+    let mut lines = vec![format!("{}{}{RESET} {action}", cli.colour(), cli.turn())];
+    if !result.is_empty() {
+        lines.push(format!("  {DIM}{}{result}{RESET}", cli.result()));
+    }
+    lines.push(String::new());
+    lines
+}
+
+/// The input box Claude Code and Codex both park at the bottom of the screen.
+/// Without it the pane reads as a log rather than as a session waiting on you.
+/// Columns a string occupies in a terminal.
+///
+/// Padding by character count leaves the box's right edge ragged the moment any
+/// CJK text is in it, because those glyphs are two cells wide. Close enough for
+/// a fixed-width box without taking a dependency for it.
+fn display_width(text: &str) -> usize {
+    text.chars()
+        .map(|ch| match ch as u32 {
+            0x1100..=0x115F
+            | 0x2E80..=0xA4CF
+            | 0xAC00..=0xD7A3
+            | 0xF900..=0xFAFF
+            | 0xFE30..=0xFE6F
+            | 0xFF00..=0xFF60
+            | 0xFFE0..=0xFFE6
+            | 0x1F300..=0x1F64F
+            | 0x20000..=0x3FFFD => 2,
+            _ => 1,
+        })
+        .sum()
+}
+
+fn composer(cli: Cli, language: UiLanguage) -> Vec<String> {
+    let width: usize = 58;
+    // Each CLI's own idle hint. Inviting the learner to type here would be a
+    // lie — they talk to these agents through `muxa msg`, not this box.
+    let hint = match cli {
+        Cli::ClaudeCode => tr(language, "? for shortcuts", "? 로 단축키 보기"),
+        Cli::Codex => tr(language, "Ctrl+C to quit", "Ctrl+C 로 종료"),
+    };
+    let padding = (width - 4).saturating_sub(display_width(hint));
+    vec![
+        format!("{DIM}╭{}╮{RESET}", "─".repeat(width)),
+        format!(
+            "{DIM}│{RESET} {}>{RESET}  {DIM}{hint}{}{RESET}{DIM}│{RESET}",
+            cli.colour(),
+            " ".repeat(padding),
+        ),
+        format!("{DIM}╰{}╯{RESET}", "─".repeat(width)),
+    ]
 }
 
 /// What codex's pane shows once it is blocked. Mirrors the `approval` frame in
@@ -744,12 +840,14 @@ fn approval_block(language: UiLanguage) -> Vec<String> {
 }
 
 fn approved_block(language: UiLanguage) -> Vec<String> {
-    vec![
-        String::new(),
-        tool_line("ran      rg -n \"public_read\" --type rust   ·   3 matches"),
-        String::new(),
-        working(language),
-    ]
+    let mut lines = turn(
+        Cli::Codex,
+        "Ran rg -n \"public_read\" --type rust",
+        tr(language, "3 matches", "3건 일치"),
+    );
+    lines.push(working(language));
+    lines.push(String::new());
+    lines
 }
 
 fn declined_block(language: UiLanguage) -> Vec<String> {
@@ -767,57 +865,53 @@ fn declined_block(language: UiLanguage) -> Vec<String> {
 }
 
 fn incoming_question(language: UiLanguage) -> Vec<String> {
-    vec![
-        String::new(),
-        format!(
-            "  {DIM}✉ {}{RESET}",
-            tr(language, "question from you", "당신이 보낸 질문")
+    let mut lines = turn(
+        Cli::ClaudeCode,
+        &format!(
+            "muxa_inbox()  {DIM}·  {}{RESET}",
+            tr(language, "1 request", "요청 1건")
         ),
-        format!(
-            "     {}",
-            tr(language, "how far along?", "어디까지 됐나요?")
+        tr(language, "how far along?", "어디까지 됐나요?"),
+    );
+    lines.extend(turn(
+        Cli::ClaudeCode,
+        tr(
+            language,
+            "Replied: auth path is covered; writing the regression test now",
+            "답장함: 인증 경로는 끝났고, 지금 회귀 테스트를 쓰는 중입니다",
         ),
-        String::new(),
-        format!(
-            "  {GREEN}›{RESET} {}",
-            tr(
-                language,
-                "auth path is covered; writing the regression test now",
-                "인증 경로는 끝났고, 지금 회귀 테스트를 쓰는 중입니다",
-            )
-        ),
-    ]
+        "",
+    ));
+    lines
 }
 
 fn outgoing_request(language: UiLanguage) -> Vec<String> {
-    vec![
-        String::new(),
-        format!(
-            "  {DIM}✉ {}{RESET}",
-            tr(
-                language,
-                "asked you for a decision",
-                "당신에게 결정을 요청했습니다"
-            )
+    turn(
+        Cli::Codex,
+        &format!(
+            "muxa_send_message(to: \"you\")  {DIM}·  {}{RESET}",
+            tr(language, "waiting on a decision", "결정 대기 중")
         ),
-        format!(
-            "     {}",
-            tr(
-                language,
-                "the public-read boundary needs a decision before I continue",
-                "public-read 경계는 계속하기 전에 결정이 필요합니다",
-            )
+        tr(
+            language,
+            "the public-read boundary needs a decision before I continue",
+            "public-read 경계는 계속하기 전에 결정이 필요합니다",
         ),
-    ]
+    )
 }
 
 fn finished(language: UiLanguage) -> Vec<String> {
-    vec![
-        String::new(),
-        format!("  {DIM}⚙{RESET} test     checkout::auth::rejects_raw_bearer  ok"),
-        String::new(),
-        format!("  {GREEN}✓ {}{RESET}", tr(language, "done", "완료")),
-    ]
+    let mut lines = turn(
+        Cli::ClaudeCode,
+        "Bash(cargo test -p checkout auth)",
+        tr(language, "1 passed", "1건 통과"),
+    );
+    lines.push(format!(
+        "{GREEN}⏺{RESET} {}",
+        tr(language, "Done.", "완료했습니다.")
+    ));
+    lines.push(String::new());
+    lines
 }
 
 fn working(language: UiLanguage) -> String {
@@ -875,19 +969,42 @@ impl Sandbox {
             "public-read 경계를 검토해줘",
         );
 
-        let mut opening = header(MAGENTA, "claude", language);
+        let mut opening = header(Cli::ClaudeCode, language);
         opening.extend(prompt_line(claude_prompt));
-        opening.push(tool_line("read     crates/checkout/src/auth.rs"));
-        opening.push(tool_line("grep     \"bearer\"  ·  12 matches"));
-        opening.push(String::new());
+        opening.extend(turn(
+            Cli::ClaudeCode,
+            tr(
+                language,
+                "I'll start with the token handling in auth.rs.",
+                "auth.rs의 토큰 처리부터 보겠습니다.",
+            ),
+            "",
+        ));
+        opening.extend(turn(
+            Cli::ClaudeCode,
+            "Read(crates/checkout/src/auth.rs)",
+            tr(language, "Read 42 lines", "42줄 읽음"),
+        ));
+        opening.extend(turn(
+            Cli::ClaudeCode,
+            "Search(pattern: \"bearer\")",
+            tr(language, "Found 12 matches", "12건 일치"),
+        ));
         opening.push(working(language));
+        opening.push(String::new());
+        opening.extend(composer(Cli::ClaudeCode, language));
         claude_screen.append(&opening);
 
-        let mut opening = header(CYAN, "codex", language);
+        let mut opening = header(Cli::Codex, language);
         opening.extend(prompt_line(codex_prompt));
-        opening.push(tool_line("read     crates/api/src/public.rs"));
-        opening.push(String::new());
+        opening.extend(turn(
+            Cli::Codex,
+            "Read crates/api/src/public.rs",
+            tr(language, "3 routes listed", "route 3개 확인"),
+        ));
         opening.push(working(language));
+        opening.push(String::new());
+        opening.extend(composer(Cli::Codex, language));
         codex_screen.append(&opening);
 
         // A window is a Work, and in a real fleet it is named after one.
@@ -1085,8 +1202,8 @@ const STEPS: &[Step] = &[
         achieved_ko: "✓ 두 번째 window가 생겼습니다 — 맨 윗줄에 둘 다 보입니다",
         title_en: "Now leave. Detaching removes you, not the work.",
         title_ko: "이제 나가 보세요. detach는 당신만 빠지고 작업은 그대로입니다.",
-        cue_en: "press   Ctrl-b   then   d       ·   then try:   tmux ls",
-        cue_ko: "Ctrl-b 를 눌렀다 떼고   d       ·   그다음:   tmux ls",
+        cue_en: "see both:   Ctrl-b s      ·   then leave:   Ctrl-b d",
+        cue_ko: "둘 다 보기:   Ctrl-b s      ·   그다음 나가기:   Ctrl-b d",
         detect: Detect::NoClient,
     },
     Step {
@@ -1094,8 +1211,8 @@ const STEPS: &[Step] = &[
         achieved_ko: "✓ detach했습니다 — 셸로 돌아왔고, session은 계속 돌고 있습니다",
         title_en: "Still listed, still running. That is the whole reason muxa lives in tmux.",
         title_ko: "여전히 목록에 있고 여전히 돌고 있습니다. muxa가 tmux에 사는 이유입니다.",
-        cue_en: "type:   tmux attach -t muxa-onboarding",
-        cue_ko: "입력:   tmux attach -t muxa-onboarding",
+        cue_en: "check:   tmux ls      ·   then:   tmux attach -t muxa-onboarding",
+        cue_ko: "확인:   tmux ls      ·   그다음:   tmux attach -t muxa-onboarding",
         detect: Detect::ClientAttached,
     },
     // ---- Act II: muxa -----------------------------------------------------
@@ -1126,17 +1243,17 @@ const STEPS: &[Step] = &[
         achieved_ko: "✓ attend가 가장 오래 막힌 agent인 codex로 데려왔습니다",
         title_en: "You are in codex's pane — press y to approve it if you like. `Ctrl-b ;` returns to the last pane you were in, which is your own shell.",
         title_ko: "지금 codex의 pane입니다 — 원하면 y로 승인해 보세요. `Ctrl-b ;`는 직전에 있던 pane, 즉 당신의 셸로 돌아갑니다.",
-        cue_en: "back with   Ctrl-b ;   then run:   muxa msg send @claude \"how far along?\"",
-        cue_ko: "Ctrl-b ; 로 돌아간 뒤 입력:   muxa msg send @claude \"어디까지 됐나요?\"",
+        cue_en: "back:   Ctrl-b ;   (or Ctrl-b o to cycle)   ·   then:   muxa msg send @claude \"how far along?\"",
+        cue_ko: "돌아가기:   Ctrl-b ;   (Ctrl-b o 로 순환)   ·   그다음:   muxa msg send @claude \"어디까지 됐나요?\"",
         detect: Detect::SentMessage,
     },
     Step {
         achieved_en: "✓ your question reached claude and it answered — and codex asked you something",
         achieved_ko: "✓ 질문이 claude에게 닿았고 답이 왔습니다 — 그리고 codex가 당신에게 물어왔습니다",
-        title_en: "Agents use muxa too — codex just sent you a request of its own.",
-        title_ko: "agent도 muxa를 씁니다 — codex가 방금 당신에게 요청을 보냈습니다.",
-        cue_en: "run:   muxa msg inbox",
-        cue_ko: "입력:   muxa msg inbox",
+        title_en: "claude answered into your mailbox. `list` shows what you sent; `inbox` claims what was sent to you — codex just asked you something.",
+        title_ko: "claude가 mailbox로 답했습니다. `list`는 보낸 것, `inbox`는 받은 것을 가져옵니다 — codex가 방금 물어왔습니다.",
+        cue_en: "claude's answer:   muxa msg list      ·   codex's request:   muxa msg inbox",
+        cue_ko: "claude의 답장:   muxa msg list      ·   codex의 요청:   muxa msg inbox",
         detect: Detect::ClaimedInbox,
     },
     Step {
@@ -1364,10 +1481,22 @@ impl Tour<'_> {
         // shell being asked to create the session. Narrating only through tmux
         // would leave that instruction invisible, which is the same dead end as
         // a gate with no way past it, just earlier.
+        // Trailing newlines are stripped by the `$(...)` the prompt reads this
+        // through, which ran the instruction and the prompt together on one
+        // line. A trailing *space* survives, so the prompt starts its own line.
+        //
+        // Coloured and ruled, because a plain paragraph above a shell prompt
+        // reads as output from the last command rather than as the thing to do
+        // next.
+        let rule = "─".repeat(64);
         let _ = std::fs::write(
             &self.sandbox.cue,
             format!(
-                "\n  muxa onboarding · {}/{}   {achieved}\n  {title}\n  {cue}\n\n",
+                "\n{DIM}{rule}{RESET}\n\
+                 {BOLD}muxa onboarding · {}/{}{RESET}   {GREEN}{achieved}{RESET}\n\
+                 {title}\n\
+                 {YELLOW}{BOLD}{cue}{RESET}\n\
+                 {DIM}{rule}{RESET}\n ",
                 index + 1,
                 STEPS.len()
             ),

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -25,6 +25,7 @@
 use anyhow::{bail, Context, Result};
 use std::collections::BTreeMap;
 use std::io::Write;
+use std::os::unix::fs::DirBuilderExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -38,7 +39,7 @@ use super::{tr, UiLanguage};
 /// `scripts/sandbox-smoke.sh`.
 const SANDBOX_SCRIPT: &str = include_str!("../../../../scripts/muxa-sandbox.sh");
 
-const SANDBOX_NAME: &str = "muxa-onboarding";
+const SANDBOX_NAME_PREFIX: &str = "muxa-onboarding";
 const POLL: Duration = Duration::from_millis(250);
 
 /// Long enough that nobody reading the screen feels rushed, short enough that
@@ -85,8 +86,9 @@ static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 /// handler keeps the workspace's `unsafe_code = "forbid"` intact; the teardown
 /// itself happens on the main thread once the poll loop sees the flag.
 ///
-/// SIGKILL cannot be caught. The next `up` clears whatever it leaves behind,
-/// and `muxa-sandbox.sh status --name muxa-onboarding` names it meanwhile.
+/// SIGKILL cannot be caught. Each run has a PID-scoped directory and sandbox,
+/// so even an unclean exit cannot make a later or concurrent tour adopt its
+/// daemon, tmux server, command history, or scripted-agent transcripts.
 fn trap_signals() {
     std::thread::spawn(|| {
         let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
@@ -123,6 +125,8 @@ fn trap_signals() {
 /// including on a panic, which is the path that would otherwise leave a daemon
 /// and a tmux server behind on someone's machine.
 struct Sandbox {
+    name: String,
+    dir: PathBuf,
     script: PathBuf,
     config: PathBuf,
     rcfile: PathBuf,
@@ -147,26 +151,20 @@ struct Sandbox {
 
 impl Sandbox {
     fn create() -> Result<Self> {
-        let dir = std::env::temp_dir();
-        let script = dir.join("muxa-onboarding-sandbox.sh");
-        let config = dir.join("muxa-onboarding.src.toml");
-        let rcfile = dir.join("muxa-onboarding.bashrc");
-        let cue = dir.join("muxa-onboarding.cue");
-        let history = dir.join("muxa-onboarding.history");
-        let home = dir.join("muxa-onboarding-home");
-        let project = home.join("checkout-service");
-        write_executable(&script, SANDBOX_SCRIPT).context("staging the sandbox script")?;
-        std::fs::write(&config, SANDBOX_CONFIG).context("staging the sandbox config")?;
-        // The shell appends to this. A run that died before its teardown — a
-        // crash, a SIGKILL — leaves commands behind that would satisfy this
-        // run's steps before the learner has typed anything.
-        std::fs::write(&history, "").context("clearing the command log")?;
-        write_workspace(&project).context("staging the practice workspace")?;
-
         let tmux = which("tmux").context("tmux is required for the live tour")?;
         let exe = std::env::current_exe().context("locating the running muxa binary")?;
+        let (name, dir) = allocate_tour_dir()?;
+        let script = dir.join("sandbox.sh");
+        let config = dir.join("config.src.toml");
+        let rcfile = dir.join("bashrc");
+        let cue = dir.join("cue");
+        let history = dir.join("history");
+        let home = dir.join("home");
+        let project = home.join("checkout-service");
 
         let mut sandbox = Self {
+            name,
+            dir,
             script,
             config,
             rcfile,
@@ -178,6 +176,16 @@ impl Sandbox {
             exe,
             env: BTreeMap::new(),
         };
+        // Construct the owner before staging anything: if a later write or
+        // command fails, normal local-drop cleanup removes this run's unique
+        // directory and sandbox instead of leaving a half-built fixture.
+        write_executable(&sandbox.script, SANDBOX_SCRIPT).context("staging the sandbox script")?;
+        std::fs::write(&sandbox.config, SANDBOX_CONFIG).context("staging the sandbox config")?;
+        // The shell appends to this. A run that died before its teardown — a
+        // crash, a SIGKILL — leaves commands behind that would satisfy this
+        // run's steps before the learner has typed anything.
+        std::fs::write(&sandbox.history, "").context("clearing the command log")?;
+        write_workspace(&sandbox.project).context("staging the practice workspace")?;
         sandbox.script_command(&["up"])?;
         sandbox.env = sandbox.read_env()?;
         sandbox.write_rcfile()?;
@@ -188,7 +196,7 @@ impl Sandbox {
     fn script_command(&self, args: &[&str]) -> Result<String> {
         let mut cmd = Command::new("bash");
         cmd.arg(&self.script).arg(args[0]);
-        cmd.args(["--name", SANDBOX_NAME]);
+        cmd.args(["--name", &self.name]);
         cmd.arg("--tmux").arg(&self.tmux);
         cmd.arg("--muxa").arg(&self.exe);
         if let Some(muxad) = muxad_beside(&self.exe) {
@@ -327,11 +335,20 @@ impl Sandbox {
     }
 
     fn tmux_command(&self, args: &[&str]) -> Result<String> {
+        let socket = self.env_value("MUXA_TMUX_SOCKET");
         let out = Command::new(&self.tmux)
-            .args(["-u", "-L", SANDBOX_NAME])
+            .args(["-u", "-S", &socket])
             .args(args)
             .output()
             .context("running tmux against the sandbox")?;
+        if !out.status.success() {
+            bail!(
+                "tmux {} failed ({}):\n{}",
+                args.join(" "),
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
         Ok(String::from_utf8_lossy(&out.stdout).trim_end().to_string())
     }
 
@@ -354,43 +371,47 @@ impl Sandbox {
         cmd.env("TMUX", self.env_value("MUXA_SANDBOX_TMUX_ENV"));
         cmd.env("TMUX_PANE", pane);
         let out = cmd.output().context("running muxa against the sandbox")?;
+        if !out.status.success() {
+            bail!(
+                "muxa {} failed ({}):\n{}",
+                args.join(" "),
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
         Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    }
+
+    /// Answer whatever the learner just asked claude.
+    ///
+    /// Their request is real and sits in claude's mailbox; leaving it there
+    /// would teach that messages go nowhere. A reply they can find with
+    /// `muxa msg list` is the point of a durable mailbox — a line in a
+    /// transcript is a drawing of one. Failure is fatal because the next step
+    /// explicitly asks the learner to read this reply.
+    fn reply_as_claude(&self, fleet: &Fleet, language: UiLanguage) -> Result<()> {
+        let raw = self.muxa_as(&fleet.claude, &["msg", "inbox", "--json"])?;
+        let requests = serde_json::from_str::<serde_json::Value>(&raw)
+            .context("reading claude's live-tour inbox")?;
+        let id = requests
+            .as_array()
+            .and_then(|items| items.first())
+            .and_then(|item| item.get("id"))
+            .and_then(serde_json::Value::as_str)
+            .context("claude's live-tour inbox had no request to answer")?;
+        let body = tr(
+            language,
+            "auth path is covered; writing the regression test now",
+            "인증 경로는 끝났고, 지금 회귀 테스트를 쓰는 중입니다",
+        );
+        self.muxa_as(&fleet.claude, &["msg", "reply", id, body])?;
+        Ok(())
     }
 
     /// Feed the daemon the payload a real agent CLI would send, so the states
     /// the tour teaches arrive through the real pipeline rather than being
     /// drawn. Only valid once the daemon is up — events sent before it starts
     /// are simply lost.
-    /// Answer whatever the learner just asked claude.
-    ///
-    /// Their request is real and sits in claude's mailbox; leaving it there
-    /// would teach that messages go nowhere. A reply they can find with
-    /// `muxa msg list` is the point of a durable mailbox — a line in a
-    /// transcript is a drawing of one. Best-effort: a flourish should not stop
-    /// the tour.
-    fn reply_as_claude(&self, fleet: &Fleet, language: UiLanguage) {
-        let Ok(raw) = self.muxa_as(&fleet.claude, &["msg", "inbox", "--json"]) else {
-            return;
-        };
-        let Ok(requests) = serde_json::from_str::<serde_json::Value>(&raw) else {
-            return;
-        };
-        let Some(id) = requests
-            .as_array()
-            .and_then(|items| items.first())
-            .and_then(|item| item.get("id"))
-            .and_then(serde_json::Value::as_str)
-        else {
-            return;
-        };
-        let body = tr(
-            language,
-            "auth path is covered; writing the regression test now",
-            "인증 경로는 끝났고, 지금 회귀 테스트를 쓰는 중입니다",
-        );
-        let _ = self.muxa_as(&fleet.claude, &["msg", "reply", id, body]);
-    }
-
     fn hook(&self, pane: &str, kind: &str, event: &str, body: &str) -> Result<()> {
         let mut cmd = Command::new(&self.exe);
         cmd.args(["hook", kind, "--event", event]);
@@ -401,14 +422,21 @@ impl Sandbox {
         cmd.env("TMUX_PANE", pane);
         cmd.stdin(Stdio::piped())
             .stdout(Stdio::null())
-            .stderr(Stdio::null());
+            .stderr(Stdio::piped());
         let mut child = cmd.spawn().context("spawning a hook")?;
         child
             .stdin
             .as_mut()
             .context("hook stdin")?
             .write_all(body.as_bytes())?;
-        child.wait().context("waiting for a hook")?;
+        let output = child.wait_with_output().context("waiting for a hook")?;
+        if !output.status.success() {
+            bail!(
+                "muxa hook {kind} --event {event} failed ({}):\n{}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
         Ok(())
     }
 }
@@ -416,34 +444,34 @@ impl Sandbox {
 impl Drop for Sandbox {
     fn drop(&mut self) {
         let _ = self.script_command(&["down"]);
-        for path in [
-            &self.script,
-            &self.config,
-            &self.rcfile,
-            &self.cue,
-            &self.history,
-        ] {
-            let _ = std::fs::remove_file(path);
-        }
-        // The agent transcripts are named deterministically, so they can be
-        // cleaned from here without threading the `Fleet` back through.
-        let dir = std::env::temp_dir();
-        for name in ["claude", "codex"] {
-            let _ = std::fs::remove_file(dir.join(format!("muxa-onboarding-{name}.log")));
-        }
-        for name in [
-            "codex-pane.sh",
-            "approved.txt",
-            "declined.txt",
-            "claude.pane",
-        ] {
-            let _ = std::fs::remove_file(dir.join(format!("muxa-onboarding-{name}")));
-        }
-        // Only ever the tour's own home — never anything the learner owns.
-        if self.home.starts_with(&dir) {
-            let _ = std::fs::remove_dir_all(&self.home);
+        let temp = std::env::temp_dir();
+        // Exact equality to the directory this instance allocated, plus the
+        // validated prefix, keeps recursive cleanup away from every caller path.
+        if self.name.starts_with(SANDBOX_NAME_PREFIX) && self.dir == temp.join(&self.name) {
+            let _ = std::fs::remove_dir_all(&self.dir);
         }
     }
+}
+
+fn allocate_tour_dir() -> Result<(String, PathBuf)> {
+    let temp = std::env::temp_dir();
+    let pid = std::process::id();
+    for attempt in 0..100_u8 {
+        let name = if attempt == 0 {
+            format!("{SANDBOX_NAME_PREFIX}-{pid}")
+        } else {
+            format!("{SANDBOX_NAME_PREFIX}-{pid}-{attempt}")
+        };
+        let dir = temp.join(&name);
+        let mut builder = std::fs::DirBuilder::new();
+        builder.mode(0o700);
+        match builder.create(&dir) {
+            Ok(()) => return Ok((name, dir)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error).context("creating the live-tour directory"),
+        }
+    }
+    bail!("could not allocate a unique live-tour directory")
 }
 
 fn write_workspace(project: &Path) -> Result<()> {
@@ -511,12 +539,12 @@ impl Sandbox {
     }
 
     /// Reads the flag and clears it, so one keypress is one request.
-    fn consume_flag(&self, option: &str) -> bool {
-        if self.tmux_quiet(&["show", "-gv", option]) != "1" {
-            return false;
+    fn consume_flag(&self, option: &str) -> Result<bool> {
+        if self.tmux_command(&["show", "-gvq", option])? != "1" {
+            return Ok(false);
         }
-        let _ = self.tmux_command(&["set", "-gu", option]);
-        true
+        self.tmux_command(&["set", "-gu", option])?;
+        Ok(true)
     }
 
     /// Has the learner run a command starting with this?
@@ -525,11 +553,11 @@ impl Sandbox {
             .is_ok_and(|log| log.lines().any(|line| line.trim().starts_with(prefix)))
     }
 
-    fn skip_requested(&self) -> bool {
+    fn skip_requested(&self) -> Result<bool> {
         self.consume_flag(SKIP_OPTION)
     }
 
-    fn language_toggled(&self) -> bool {
+    fn language_toggled(&self) -> Result<bool> {
         self.consume_flag(LANGUAGE_OPTION)
     }
 
@@ -543,7 +571,7 @@ impl Sandbox {
         cue: &str,
         escape: Option<&str>,
         other_language: &str,
-    ) {
+    ) -> Result<()> {
         // What just happened comes first. A tour that only ever says what to do
         // next leaves the learner typing commands and guessing whether any of
         // them landed.
@@ -559,9 +587,10 @@ impl Sandbox {
             None => format!("#[align=left fg=#d29922,bold]  {cue}"),
         };
         // Row 0 stays tmux's own window list.
-        let _ = self.tmux_command(&["set", "-g", "status-format[1]", &banner]);
-        let _ = self.tmux_command(&["set", "-g", "status-format[2]", &title]);
-        let _ = self.tmux_command(&["set", "-g", "status-format[3]", &cue]);
+        self.tmux_command(&["set", "-g", "status-format[1]", &banner])?;
+        self.tmux_command(&["set", "-g", "status-format[2]", &title])?;
+        self.tmux_command(&["set", "-g", "status-format[3]", &cue])?;
+        Ok(())
     }
 }
 
@@ -1065,24 +1094,21 @@ impl Sandbox {
     /// Stage the screens and put `claude` on the learner's `PATH`, so starting
     /// the agent is theirs to do rather than the tour's to perform.
     fn prepare_agents(&self, language: UiLanguage) -> Result<()> {
-        let dir = std::env::temp_dir();
-        let claude_screen = Transcript::new(&dir, "claude")?;
-        let codex_screen = Transcript::new(&dir, "codex")?;
+        let claude_screen = Transcript::new(&self.dir, "claude")?;
+        let codex_screen = Transcript::new(&self.dir, "codex")?;
         write_opening_screens(&claude_screen, &codex_screen, language);
-        // A marker left by an earlier tour would satisfy the step before the
-        // learner has typed anything.
-        let _ = std::fs::remove_file(dir.join("muxa-onboarding-claude.pane"));
+        let marker = self.dir.join("muxa-onboarding-claude.pane");
         claude_screen.launcher(
             Path::new(&self.env_value("MUXA_SANDBOX_SHIM")),
             "claude",
-            &dir.join("muxa-onboarding-claude.pane"),
+            &marker,
         )?;
         Ok(())
     }
 
     /// Where the learner started claude, once they have.
-    fn started_pane() -> Option<String> {
-        std::fs::read_to_string(std::env::temp_dir().join("muxa-onboarding-claude.pane"))
+    fn started_pane(&self) -> Option<String> {
+        std::fs::read_to_string(self.dir.join("muxa-onboarding-claude.pane"))
             .ok()
             .map(|pane| pane.trim().to_string())
             .filter(|pane| !pane.is_empty())
@@ -1106,7 +1132,7 @@ impl Sandbox {
             .unwrap_or_default()
             .to_string();
         if !first.is_empty() && first != learner {
-            let _ = self.tmux_command(&["swap-pane", "-s", &first, "-t", learner]);
+            self.tmux_command(&["swap-pane", "-s", &first, "-t", learner])?;
         }
         // A column count rather than `50%`, which older tmux rejects here.
         // Half each suits a wide terminal. On a narrow one, half would put the
@@ -1123,14 +1149,14 @@ impl Sandbox {
             .max(60)
             .min(width.saturating_sub(20))
             .max(20);
-        let _ = self.tmux_command(&[
+        self.tmux_command(&[
             "set-window-option",
             "-t",
             window,
             "main-pane-width",
             &main.to_string(),
-        ]);
-        let _ = self.tmux_command(&["select-layout", "-t", window, "main-vertical"]);
+        ])?;
+        self.tmux_command(&["select-layout", "-t", window, "main-vertical"])?;
         self.tmux_command(&["select-pane", "-t", learner])?;
         Ok(())
     }
@@ -1182,19 +1208,18 @@ impl Sandbox {
         }
         // If they started claude in the pane this guessed was theirs, theirs is
         // the other one.
-        let learner = match Self::started_pane() {
+        let learner = match self.started_pane() {
             Some(started) if started == learner => fresh.clone(),
             _ => learner,
         };
 
         // Already written by `prepare_agents`; opening them again would blank
         // the screen the learner is looking at.
-        let dir = std::env::temp_dir();
-        let claude_screen = Transcript::open(&dir, "claude");
-        let codex_screen = Transcript::open(&dir, "codex");
+        let claude_screen = Transcript::open(&self.dir, "claude");
+        let codex_screen = Transcript::open(&self.dir, "codex");
 
-        let approved = dir.join("muxa-onboarding-approved.txt");
-        let declined = dir.join("muxa-onboarding-declined.txt");
+        let approved = self.dir.join("muxa-onboarding-approved.txt");
+        let declined = self.dir.join("muxa-onboarding-declined.txt");
         std::fs::write(&approved, approved_block(language).join("\n") + "\n")?;
         std::fs::write(&declined, declined_block(language).join("\n") + "\n")?;
 
@@ -1210,7 +1235,7 @@ impl Sandbox {
             .map(str::to_string)
             .collect::<Vec<_>>()
         {
-            let _ = self.tmux_command(&["rename-window", "-t", &other, "release-checks"]);
+            self.tmux_command(&["rename-window", "-t", &other, "release-checks"])?;
         }
 
         // claude is wherever the learner ran it. The fallback covers a skipped
@@ -1219,7 +1244,7 @@ impl Sandbox {
         // split — or failing that their own — is respawned into claude
         // instead. `respawn-pane -k` keeps the pane id, so the hook still
         // lands on the pane the learner is looking at.
-        let claude = if let Some(pane) = Self::started_pane() {
+        let claude = if let Some(pane) = self.started_pane() {
             pane
         } else {
             let pane = if fresh.is_empty() {
@@ -1240,7 +1265,7 @@ impl Sandbox {
         };
         let codex = self.split(
             &window,
-            &codex_screen.answerable_pane_command(&dir, &approved, &declined)?,
+            &codex_screen.answerable_pane_command(&self.dir, &approved, &declined)?,
         )?;
 
         self.lay_out_fleet(&window, &learner)?;
@@ -1312,10 +1337,14 @@ impl Sandbox {
 
         // Aliases are what make `muxa msg send @claude` teachable; without them
         // the learner would have to name a peer by raw pane id.
+        // `session_start` classifies the learner pane through the Claude
+        // adapter, so automatic pane handles may provision `claude` there
+        // before the scripted peer arrives. Move the learner to `you` first;
+        // that releases the room-local namespace before assigning peer names.
         for (pane, alias) in [
+            (&fleet.learner, "you"),
             (&fleet.claude, "claude"),
             (&fleet.codex, "codex"),
-            (&fleet.learner, "you"),
         ] {
             self.muxa_as(pane, &["identity", "set", "--alias", alias])?;
         }
@@ -1642,7 +1671,7 @@ impl Tour<'_> {
                     .count()
                     >= 2
             }
-            Detect::StartedClaude => Sandbox::started_pane().is_some(),
+            Detect::StartedClaude => self.sandbox.started_pane().is_some(),
             Detect::PaneRunning(command) => self
                 .sandbox
                 .tmux_quiet(&["list-panes", "-a", "-F", "#{pane_current_command}"])
@@ -1683,10 +1712,10 @@ impl Tour<'_> {
     ///
     /// Skipping has to leave the tour consistent, not just further along: the
     /// agents cannot move into a pane that was never split.
-    fn perform(&self, index: usize) {
+    fn perform(&self, index: usize) -> Result<()> {
         match index {
             0 => {
-                let _ = self.sandbox.tmux_command(&[
+                self.sandbox.tmux_command(&[
                     "new-session",
                     "-d",
                     "-s",
@@ -1695,29 +1724,40 @@ impl Tour<'_> {
                     "200",
                     "-y",
                     "50",
-                ]);
+                ])?;
             }
             1 => {
                 if let Some(session) = self.own_sessions().first() {
-                    let _ = self.sandbox.tmux_command(&[
+                    self.sandbox.tmux_command(&[
                         "new-window",
                         "-d",
                         "-t",
                         &format!("{session}:"),
-                    ]);
+                    ])?;
                 }
             }
             SPLIT_STEP => {
                 if let Some(session) = self.own_sessions().first() {
-                    let _ =
-                        self.sandbox
-                            .tmux_command(&["split-window", "-t", &format!("{session}:")]);
+                    self.sandbox
+                        .tmux_command(&["split-window", "-t", &format!("{session}:")])?;
+                }
+            }
+            11 => {
+                // Entering the next step makes scripted claude answer the
+                // learner's request. A skipped send still needs to create that
+                // request, or the escape hatch exits on an empty inbox instead
+                // of leaving the later mailbox steps coherent.
+                if let Some(fleet) = self.fleet.as_ref() {
+                    let body = tr(self.language, "how far along?", "어디까지 됐나요?");
+                    self.sandbox
+                        .muxa_as(&fleet.learner, &["msg", "send", "@claude", body])?;
                 }
             }
             // The rest are about where the learner is looking, which the tour
             // will not fake, or about state it has already produced.
             _ => {}
         }
+        Ok(())
     }
 
     /// Fired as a step opens, so the world moves on its own rather than only in
@@ -1730,7 +1770,8 @@ impl Tour<'_> {
         if index == 1 {
             let holder = self.sandbox.env_value("MUXA_SANDBOX_HOLDER");
             if !holder.is_empty() {
-                let _ = self.sandbox.tmux_command(&["kill-session", "-t", &holder]);
+                self.sandbox
+                    .tmux_command(&["kill-session", "-t", &holder])?;
             }
         }
         // Their pane, recorded before the split so the new one can be told
@@ -1738,13 +1779,13 @@ impl Tour<'_> {
         if index == SPLIT_STEP {
             self.before_split = self
                 .sandbox
-                .tmux_quiet(&[
+                .tmux_command(&[
                     "list-panes",
                     "-t",
                     &self.session_target(),
                     "-F",
                     "#{pane_id}",
-                ])
+                ])?
                 .lines()
                 .map(str::to_string)
                 .collect();
@@ -1787,8 +1828,7 @@ impl Tour<'_> {
                     .claude_screen
                     .append(&incoming_question(self.language));
                 // And claude answers through muxa, not only on its own screen.
-                self.sandbox.reply_as_claude(fleet, self.language);
-                Ok(())
+                self.sandbox.reply_as_claude(fleet, self.language)
             }
             13 => {
                 let body = tr(
@@ -1809,7 +1849,7 @@ impl Tour<'_> {
         }
     }
 
-    fn narrate(&self, index: usize, escape: bool) {
+    fn narrate(&self, index: usize, escape: bool) -> Result<()> {
         let step = &STEPS[index];
         let achieved = tr(self.language, step.achieved_en, step.achieved_ko);
         let title = tr(self.language, step.title_en, step.title_ko);
@@ -1835,7 +1875,7 @@ impl Tour<'_> {
                 UiLanguage::En => "한국어",
                 UiLanguage::Ko => "English",
             },
-        );
+        )?;
 
         // The status bar only exists for someone attached to the server, and a
         // few steps are the ones where they are not.
@@ -1859,13 +1899,16 @@ impl Tour<'_> {
                 index + 1,
                 STEPS.len()
             );
-            let _ = std::io::stdout().flush();
+            std::io::stdout()
+                .flush()
+                .context("printing live-tour narration")?;
         }
+        Ok(())
     }
 
     fn drive(&mut self) -> Result<usize> {
         // Prints rather than paints: nobody is attached yet.
-        self.narrate(0, self.no_quiz);
+        self.narrate(0, self.no_quiz)?;
 
         // The learner's own shell, in their own terminal. They are not attached
         // to anything yet — Act I is where they attach themselves, which is the
@@ -1896,32 +1939,32 @@ impl Tour<'_> {
                 offered_escape = self.no_quiz;
                 if index < STEPS.len() {
                     self.on_enter(index)?;
-                    self.narrate(index, offered_escape);
+                    self.narrate(index, offered_escape)?;
                 }
                 continue;
             }
-            if self.sandbox.language_toggled() {
+            if self.sandbox.language_toggled()? {
                 self.language = match self.language {
                     UiLanguage::En => UiLanguage::Ko,
                     UiLanguage::Ko => UiLanguage::En,
                 };
-                self.narrate(index, offered_escape);
+                self.narrate(index, offered_escape)?;
                 continue;
             }
-            if self.sandbox.skip_requested() {
-                self.perform(index);
+            if self.sandbox.skip_requested()? {
+                self.perform(index)?;
                 index += 1;
                 entered = Instant::now();
                 offered_escape = self.no_quiz;
                 if index < STEPS.len() {
                     self.on_enter(index)?;
-                    self.narrate(index, offered_escape);
+                    self.narrate(index, offered_escape)?;
                 }
                 continue;
             }
             if !offered_escape && entered.elapsed() > SKIP_AFTER {
                 offered_escape = true;
-                self.narrate(index, true);
+                self.narrate(index, true)?;
             }
             std::thread::sleep(POLL);
         }

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -58,6 +58,9 @@ const SKIP_AFTER: Duration = Duration::from_secs(45);
 /// in the same place.
 const SKIP_OPTION: &str = "@muxa-onboarding-skip";
 
+/// Same mechanism for the language toggle the simulation had on `F2`.
+const LANGUAGE_OPTION: &str = "@muxa-onboarding-language";
+
 const SANDBOX_CONFIG: &str = "\
 [discovery]
 enabled = false
@@ -379,22 +382,41 @@ impl Sandbox {
         self.tmux_command(&["set", "-g", "status-position", "top"])?;
         self.tmux_command(&["set", "-g", "status-style", "bg=#0b1220,fg=#c9d1d9"])?;
         self.tmux_command(&["set", "-g", "status-interval", "2"])?;
-        // Root table, so it needs no prefix and cannot be confused with typing.
+        // Root table, so they need no prefix and cannot be confused with typing.
         self.tmux_command(&["bind-key", "-n", "F12", "set", "-g", SKIP_OPTION, "1"])?;
+        self.tmux_command(&["bind-key", "-n", "F2", "set", "-g", LANGUAGE_OPTION, "1"])?;
         Ok(())
     }
 
-    fn skip_requested(&self) -> bool {
-        if self.tmux_quiet(&["show", "-gv", SKIP_OPTION]) != "1" {
+    /// Reads the flag and clears it, so one keypress is one request.
+    fn consume_flag(&self, option: &str) -> bool {
+        if self.tmux_quiet(&["show", "-gv", option]) != "1" {
             return false;
         }
-        let _ = self.tmux_command(&["set", "-gu", SKIP_OPTION]);
+        let _ = self.tmux_command(&["set", "-gu", option]);
         true
     }
 
-    fn narrate(&self, index: usize, total: usize, title: &str, cue: &str, escape: Option<&str>) {
+    fn skip_requested(&self) -> bool {
+        self.consume_flag(SKIP_OPTION)
+    }
+
+    fn language_toggled(&self) -> bool {
+        self.consume_flag(LANGUAGE_OPTION)
+    }
+
+    fn narrate(
+        &self,
+        index: usize,
+        total: usize,
+        title: &str,
+        cue: &str,
+        escape: Option<&str>,
+        other_language: &str,
+    ) {
         let banner = format!(
-            "#[align=centre bg=#1f6feb,fg=#0b1220,bold] muxa onboarding · {index}/{total} #[default]"
+            "#[align=centre bg=#1f6feb,fg=#0b1220,bold] muxa onboarding · {index}/{total} \
+             #[default]#[fg=#8b949e]  F2 {other_language}"
         );
         let title = format!("#[align=centre]{title}");
         let cue = match escape {
@@ -674,6 +696,7 @@ const ACT_TWO_START: usize = 4;
 
 struct Tour<'a> {
     sandbox: &'a Sandbox,
+    /// Mutable: `F2` switches it mid-tour, the way the simulation's footer did.
     language: UiLanguage,
     fleet: Option<Fleet>,
     /// `--no-quiz` does not remove the steps — there is nothing to remove, the
@@ -834,8 +857,19 @@ impl Tour<'_> {
             )
         });
 
-        self.sandbox
-            .narrate(index + 1, STEPS.len(), title, cue, hint);
+        self.sandbox.narrate(
+            index + 1,
+            STEPS.len(),
+            title,
+            cue,
+            hint,
+            // Named in the language it switches *to*, so it reads as an offer
+            // rather than a label for where you already are.
+            match self.language {
+                UiLanguage::En => "한국어",
+                UiLanguage::Ko => "English",
+            },
+        );
 
         // The status bar only exists for someone attached to the server, and
         // the first step is the one where they are not — they are at a bare
@@ -886,6 +920,14 @@ impl Tour<'_> {
                     self.on_enter(index)?;
                     self.narrate(index, offered_escape);
                 }
+                continue;
+            }
+            if self.sandbox.language_toggled() {
+                self.language = match self.language {
+                    UiLanguage::En => UiLanguage::Ko,
+                    UiLanguage::Ko => UiLanguage::En,
+                };
+                self.narrate(index, offered_escape);
                 continue;
             }
             if self.sandbox.skip_requested() {

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -1,0 +1,883 @@
+//! The live tour: onboarding stops simulating muxa and becomes it.
+//!
+//! Everything the learner sees is real — a real tmux server, a real `muxad`, a
+//! real `muxa watch` over a real mailbox. Only the agents are scripted, and the
+//! tour says so on screen rather than hoping nobody notices.
+//!
+//! Three decisions shape the whole module.
+//!
+//! **The sandbox.** `scripts/muxa-sandbox.sh`, embedded so it ships with every
+//! install, redirects every muxa surface at once — socket, config, data
+//! directory, tmux server, and `tmux` on `PATH`. Nothing here can reach the
+//! fleet the learner actually runs.
+//!
+//! **Narration through tmux's own status bar.** The alternatives fight the
+//! lesson: a narration *pane* gets split and zoomed by the very exercises the
+//! tour teaches, and `display-popup` is modal — it covers the watch the learner
+//! is meant to be reading, and does not expand `#{}` formats. Status rows
+//! survive every pane operation, expand formats, and are themselves real tmux.
+//!
+//! **Observation, not interception.** Because the narration never owns the
+//! keyboard, no step can wait on a keypress. Each one polls real tmux and real
+//! muxa state and advances when the learner has actually done the thing, which
+//! is what lets the tour be driven with real commands instead of a quiz.
+
+use anyhow::{bail, Context, Result};
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use super::{tr, UiLanguage};
+
+/// Embedded rather than located on disk: a release tarball, a `cargo install`
+/// and a brew bottle all ship the binary and none of them ship the repository.
+/// `scripts/muxa-sandbox.sh` stays the single source, tested by
+/// `scripts/sandbox-smoke.sh`.
+const SANDBOX_SCRIPT: &str = include_str!("../../../../scripts/muxa-sandbox.sh");
+
+const SANDBOX_NAME: &str = "muxa-onboarding";
+const POLL: Duration = Duration::from_millis(250);
+
+/// Long enough that nobody reading the screen feels rushed, short enough that
+/// an abandoned terminal does not hold a sandbox open all afternoon.
+const STEP_TIMEOUT: Duration = Duration::from_secs(900);
+
+const SANDBOX_CONFIG: &str = "\
+[discovery]
+enabled = false
+
+[collaboration]
+enabled = true
+# The tour must never type into a pane the learner is reading.
+wake = 'never'
+scope = 'host'
+
+[watch]
+view = 'window'
+sort = ['state']
+";
+
+/// Set by the signal handler, read by the poll loop.
+static INTERRUPTED: AtomicBool = AtomicBool::new(false);
+
+/// Without this, Ctrl-C tears the process down without running `Drop`, and the
+/// learner is left with a daemon and a tmux server they did not ask for and
+/// have no idea how to find. Watching on a thread rather than installing a raw
+/// handler keeps the workspace's `unsafe_code = "forbid"` intact; the teardown
+/// itself happens on the main thread once the poll loop sees the flag.
+///
+/// SIGKILL cannot be caught. The next `up` clears whatever it leaves behind,
+/// and `muxa-sandbox.sh status --name muxa-onboarding` names it meanwhile.
+fn trap_signals() {
+    std::thread::spawn(|| {
+        let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        else {
+            return;
+        };
+        runtime.block_on(async {
+            use tokio::signal::unix::{signal, SignalKind};
+
+            let (Ok(mut interrupt), Ok(mut terminate), Ok(mut hangup)) = (
+                signal(SignalKind::interrupt()),
+                signal(SignalKind::terminate()),
+                signal(SignalKind::hangup()),
+            ) else {
+                return;
+            };
+            tokio::select! {
+                _ = interrupt.recv() => {}
+                _ = terminate.recv() => {}
+                _ = hangup.recv() => {}
+            }
+            INTERRUPTED.store(true, Ordering::SeqCst);
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox
+// ---------------------------------------------------------------------------
+
+/// Owns the sandbox while it is alive and takes it down on the way out —
+/// including on a panic, which is the path that would otherwise leave a daemon
+/// and a tmux server behind on someone's machine.
+struct Sandbox {
+    script: PathBuf,
+    config: PathBuf,
+    rcfile: PathBuf,
+    tmux: PathBuf,
+    exe: PathBuf,
+    env: BTreeMap<String, String>,
+}
+
+impl Sandbox {
+    fn create() -> Result<Self> {
+        let dir = std::env::temp_dir();
+        let script = dir.join("muxa-onboarding-sandbox.sh");
+        let config = dir.join("muxa-onboarding.src.toml");
+        let rcfile = dir.join("muxa-onboarding.bashrc");
+        write_executable(&script, SANDBOX_SCRIPT).context("staging the sandbox script")?;
+        std::fs::write(&config, SANDBOX_CONFIG).context("staging the sandbox config")?;
+
+        let tmux = which("tmux").context("tmux is required for the live tour")?;
+        let exe = std::env::current_exe().context("locating the running muxa binary")?;
+
+        let mut sandbox = Self {
+            script,
+            config,
+            rcfile,
+            tmux,
+            exe,
+            env: BTreeMap::new(),
+        };
+        sandbox.script_command(&["up"])?;
+        sandbox.env = sandbox.read_env()?;
+        sandbox.write_rcfile()?;
+        sandbox.prepare_shell()?;
+        Ok(sandbox)
+    }
+
+    fn script_command(&self, args: &[&str]) -> Result<String> {
+        let mut cmd = Command::new("bash");
+        cmd.arg(&self.script).arg(args[0]);
+        cmd.args(["--name", SANDBOX_NAME]);
+        cmd.arg("--tmux").arg(&self.tmux);
+        cmd.arg("--muxa").arg(&self.exe);
+        if let Some(muxad) = muxad_beside(&self.exe) {
+            cmd.arg("--muxad").arg(muxad);
+        }
+        if args[0] == "up" {
+            cmd.arg("--config").arg(&self.config);
+            if let Some(dir) = self.exe.parent() {
+                cmd.arg("--extra-path").arg(dir);
+            }
+        }
+        cmd.args(&args[1..]);
+        let out = cmd.output().context("running the sandbox script")?;
+        if !out.status.success() {
+            bail!(
+                "sandbox {} failed:\n{}",
+                args[0],
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    }
+
+    fn read_env(&self) -> Result<BTreeMap<String, String>> {
+        let raw = self.script_command(&["env"])?;
+        let mut env = BTreeMap::new();
+        for line in raw.lines() {
+            let Some(rest) = line.strip_prefix("export ") else {
+                continue;
+            };
+            let Some((key, value)) = rest.split_once('=') else {
+                continue;
+            };
+            // `env` single-quotes every value, and appends an unexpanded
+            // `:"$PATH"` that only a shell should resolve.
+            let value = value
+                .split(":\"$PATH\"")
+                .next()
+                .unwrap_or_default()
+                .trim_matches('\'');
+            env.insert(key.to_string(), value.to_string());
+        }
+        if !env.contains_key("MUXA_SOCKET") {
+            bail!("the sandbox did not report its environment");
+        }
+        Ok(env)
+    }
+
+    fn env_value(&self, key: &str) -> String {
+        self.env.get(key).cloned().unwrap_or_default()
+    }
+
+    /// The learner's shell. It carries the sandbox environment explicitly
+    /// rather than relying on inheritance, and a bare prompt so the tour does
+    /// not drag anyone's Starship setup into the recording of their own screen.
+    fn write_rcfile(&self) -> Result<()> {
+        use std::fmt::Write as _;
+
+        let mut body = String::from("unset PROMPT_COMMAND\nexport PS1='muxa-onboarding $ '\n");
+        for key in [
+            "MUXA_SOCKET",
+            "MUXA_CONFIG",
+            "XDG_DATA_HOME",
+            "MUXA_TMUX_SOCKET",
+        ] {
+            let _ = writeln!(body, "export {key}='{}'", self.env_value(key));
+        }
+        let _ = writeln!(
+            body,
+            "export PATH='{}':\"$PATH\"",
+            self.env_value("MUXA_SANDBOX_SHIM")
+        );
+        if let Some(dir) = self.exe.parent() {
+            let _ = writeln!(body, "export PATH='{}':\"$PATH\"", dir.display());
+        }
+        std::fs::write(&self.rcfile, body).context("staging the learner's shell profile")?;
+        Ok(())
+    }
+
+    /// Make every pane the learner opens use the tour's shell.
+    ///
+    /// The rcfile only covers the shell this process starts. The moment they
+    /// run `tmux new-session`, tmux opens their *login* shell instead — which
+    /// never reads that file, and which does read their own dotfiles against a
+    /// redirected `XDG_DATA_HOME`, so a plugin manager greets the learner with
+    /// an installation error on step one. Pinning `default-command` fixes the
+    /// prompt, the `PATH`, and that first impression in one line.
+    ///
+    /// `PATH` goes into the server environment as well, for anything that ends
+    /// up running outside a login shell.
+    fn prepare_shell(&self) -> Result<()> {
+        let mut path = self.env_value("MUXA_SANDBOX_SHIM");
+        if let Some(dir) = self.exe.parent() {
+            path.push(':');
+            path.push_str(&dir.to_string_lossy());
+        }
+        if let Some(inherited) = std::env::var_os("PATH") {
+            path.push(':');
+            path.push_str(&inherited.to_string_lossy());
+        }
+        self.tmux_command(&["set-environment", "-g", "PATH", &path])?;
+        // Panes created with an explicit command — the agents — are unaffected.
+        self.tmux_command(&[
+            "set-option",
+            "-g",
+            "default-command",
+            &format!("bash --rcfile {}", self.rcfile.display()),
+        ])?;
+        Ok(())
+    }
+
+    fn tmux_command(&self, args: &[&str]) -> Result<String> {
+        let out = Command::new(&self.tmux)
+            .args(["-u", "-L", SANDBOX_NAME])
+            .args(args)
+            .output()
+            .context("running tmux against the sandbox")?;
+        Ok(String::from_utf8_lossy(&out.stdout).trim_end().to_string())
+    }
+
+    /// Best-effort tmux, for the many polls whose failure is not interesting —
+    /// asking about a session that has already gone away, mostly.
+    fn tmux_quiet(&self, args: &[&str]) -> String {
+        self.tmux_command(args).unwrap_or_default()
+    }
+
+    /// muxa, speaking as one of the sandbox's panes. Every collaboration call
+    /// needs this: the daemon refuses an origin it cannot correlate to a
+    /// tracked pane, and an unstamped call would carry the learner's *real*
+    /// `$TMUX_PANE` instead.
+    fn muxa_as(&self, pane: &str, args: &[&str]) -> Result<String> {
+        let mut cmd = Command::new(&self.exe);
+        cmd.args(args);
+        for (key, value) in &self.env {
+            cmd.env(key, value);
+        }
+        cmd.env("TMUX", self.env_value("MUXA_SANDBOX_TMUX_ENV"));
+        cmd.env("TMUX_PANE", pane);
+        let out = cmd.output().context("running muxa against the sandbox")?;
+        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    }
+
+    /// Feed the daemon the payload a real agent CLI would send, so the states
+    /// the tour teaches arrive through the real pipeline rather than being
+    /// drawn. Only valid once the daemon is up — events sent before it starts
+    /// are simply lost.
+    fn hook(&self, pane: &str, kind: &str, event: &str, body: &str) -> Result<()> {
+        let mut cmd = Command::new(&self.exe);
+        cmd.args(["hook", kind, "--event", event]);
+        for (key, value) in &self.env {
+            cmd.env(key, value);
+        }
+        cmd.env("TMUX", self.env_value("MUXA_SANDBOX_TMUX_ENV"));
+        cmd.env("TMUX_PANE", pane);
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut child = cmd.spawn().context("spawning a hook")?;
+        child
+            .stdin
+            .as_mut()
+            .context("hook stdin")?
+            .write_all(body.as_bytes())?;
+        child.wait().context("waiting for a hook")?;
+        Ok(())
+    }
+}
+
+impl Drop for Sandbox {
+    fn drop(&mut self) {
+        let _ = self.script_command(&["down"]);
+        for path in [&self.script, &self.config, &self.rcfile] {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+fn write_executable(path: &Path, body: &str) -> Result<()> {
+    std::fs::write(path, body)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(())
+}
+
+fn which(binary: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(binary))
+        .find(|candidate| candidate.is_file())
+}
+
+/// `muxad` normally sits beside `muxa`; the `PATH` fallback covers a
+/// development tree where only one of them is on it.
+fn muxad_beside(exe: &Path) -> Option<PathBuf> {
+    let sibling = exe.parent()?.join("muxad");
+    if sibling.is_file() {
+        Some(sibling)
+    } else {
+        which("muxad")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Narration
+// ---------------------------------------------------------------------------
+
+impl Sandbox {
+    fn prepare_status(&self) -> Result<()> {
+        self.tmux_command(&["set", "-g", "status", "3"])?;
+        self.tmux_command(&["set", "-g", "status-position", "top"])?;
+        self.tmux_command(&["set", "-g", "status-style", "bg=#0b1220,fg=#c9d1d9"])?;
+        self.tmux_command(&["set", "-g", "status-interval", "2"])?;
+        Ok(())
+    }
+
+    fn narrate(&self, index: usize, total: usize, title: &str, cue: &str) {
+        let banner = format!(
+            "#[align=centre bg=#1f6feb,fg=#0b1220,bold] muxa onboarding · {index}/{total} #[default]"
+        );
+        let title = format!("#[align=centre]{title}");
+        let cue = format!("#[align=centre fg=#d29922,bold]{cue}");
+        let _ = self.tmux_command(&["set", "-g", "status-format[0]", &banner]);
+        let _ = self.tmux_command(&["set", "-g", "status-format[1]", &title]);
+        let _ = self.tmux_command(&["set", "-g", "status-format[2]", &cue]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+/// The learner's pane and the two scripted agents.
+///
+/// All three live in one window on purpose. A collaboration room *is* a tmux
+/// window — `@alias` targets resolve inside it and nowhere else — so putting
+/// the learner anywhere else would force them to address peers by raw pane id,
+/// which teaches the wrong thing about the model.
+struct Fleet {
+    learner: String,
+    claude: String,
+    codex: String,
+}
+
+impl Sandbox {
+    /// Two agents join whatever window the learner is sitting in.
+    ///
+    /// Joining *their* window rather than a prepared one is the point: the room
+    /// they can address peers in is the window they are already in, and
+    /// watching the panes arrive is what makes "a pane is an agent" land.
+    fn add_agents(&self, language: UiLanguage) -> Result<Fleet> {
+        let note = tr(
+            language,
+            "scripted agent — everything muxa does with it is real",
+            "스크립트 agent — muxa가 하는 동작은 전부 진짜입니다",
+        );
+
+        let learner = self.tmux_command(&["display-message", "-p", "#{pane_id}"])?;
+        let window = self.tmux_command(&["display-message", "-p", "#{window_id}"])?;
+        if learner.is_empty() || window.is_empty() {
+            bail!("could not resolve the pane you are sitting in");
+        }
+
+        let claude = self.split(
+            &window,
+            &format!(
+                "printf '\\033[1;36m▸ claude\\033[0m  {note}\\n\\n  harden the checkout auth path\\n'; exec cat"
+            ),
+        )?;
+        let codex = self.split(
+            &window,
+            &format!(
+                "printf '\\033[1;35m▸ codex\\033[0m  {note}\\n\\n  review the public-read boundary\\n'; exec cat"
+            ),
+        )?;
+
+        // Zoomed so `muxa watch` gets the whole screen. The agent panes stay in
+        // the window, and `muxa attend` unzooms to reach one — which
+        // demonstrates attend better than any description of it.
+        self.tmux_command(&["select-pane", "-t", &learner])?;
+        self.tmux_command(&["resize-pane", "-Z", "-t", &learner])?;
+
+        let fleet = Fleet {
+            learner,
+            claude,
+            codex,
+        };
+        self.seed_fleet(&fleet)?;
+        Ok(fleet)
+    }
+
+    fn split(&self, window: &str, command: &str) -> Result<String> {
+        let id = self.tmux_command(&[
+            "split-window",
+            "-d",
+            "-P",
+            "-F",
+            "#{pane_id}",
+            "-t",
+            window,
+            command,
+        ])?;
+        if id.is_empty() {
+            bail!("could not create an agent pane");
+        }
+        Ok(id)
+    }
+
+    /// Hooks, not fabricated rows: the daemon has to be listening for these, so
+    /// they run well after `daemon`, and the states they produce arrive through
+    /// the same pipeline a real agent CLI uses.
+    fn seed_fleet(&self, fleet: &Fleet) -> Result<()> {
+        self.hook(
+            &fleet.learner,
+            "claude",
+            "session_start",
+            r#"{"session_id":"onboarding-you"}"#,
+        )?;
+        self.hook(
+            &fleet.claude,
+            "claude",
+            "user_prompt_submit",
+            r#"{"session_id":"onboarding-claude","prompt":"harden the checkout auth path"}"#,
+        )?;
+        self.hook(
+            &fleet.codex,
+            "codex",
+            "user_prompt_submit",
+            r#"{"session_id":"onboarding-codex","prompt":"review the public-read boundary"}"#,
+        )?;
+        // The daemon ingests hooks asynchronously, and both `identity` and `msg`
+        // refuse an origin it has not correlated yet. Setting the aliases
+        // immediately looks like it works and leaves the tour unable to advance
+        // past `muxa msg send @claude`, so wait for the panes to actually land.
+        if !self.wait_until_tracked(fleet) {
+            bail!("the daemon did not pick up the tour's panes");
+        }
+
+        // Aliases are what make `muxa msg send @claude` teachable; without them
+        // the learner would have to name a peer by raw pane id.
+        for (pane, alias) in [
+            (&fleet.claude, "claude"),
+            (&fleet.codex, "codex"),
+            (&fleet.learner, "you"),
+        ] {
+            self.muxa_as(pane, &["identity", "set", "--alias", alias])?;
+        }
+        Ok(())
+    }
+
+    fn wait_until_tracked(&self, fleet: &Fleet) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while Instant::now() < deadline {
+            let all_known = [&fleet.learner, &fleet.claude, &fleet.codex]
+                .iter()
+                .all(|pane| {
+                    self.muxa_as(pane, &["peers"])
+                        .is_ok_and(|out| out.contains("self"))
+                });
+            if all_known {
+                return true;
+            }
+            std::thread::sleep(POLL);
+        }
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Steps
+// ---------------------------------------------------------------------------
+
+/// What a step is waiting for. Every variant reads real tmux or real muxa
+/// state; none of them reads a keystroke.
+enum Detect {
+    /// The learner made a session of their own.
+    SessionCreated,
+    /// That session has more than the window it started with.
+    SecondWindow,
+    /// Nobody is attached — they detached, and the work kept running.
+    NoClient,
+    /// Somebody is attached again.
+    ClientAttached,
+    /// Some pane on the sandbox server is running this command.
+    PaneRunning(&'static str),
+    /// The active pane is the one `muxa attend` should have jumped to.
+    ActivePaneIsCodex,
+    /// The learner sent a request.
+    SentMessage,
+    /// The learner claimed what was waiting for them.
+    ClaimedInbox,
+}
+
+struct Step {
+    title_en: &'static str,
+    title_ko: &'static str,
+    cue_en: &'static str,
+    cue_ko: &'static str,
+    detect: Detect,
+}
+
+/// Nine steps in two acts.
+///
+/// Act I keeps only the one tmux idea muxa is built on — a session outlives the
+/// terminal attached to it. Zoom, copy mode and pane-navigation drills are
+/// deliberately absent: they are tmux trivia, and the pane concept lands in Act
+/// II when the agents themselves arrive as panes.
+const STEPS: &[Step] = &[
+    // ---- Act I: tmux ------------------------------------------------------
+    Step {
+        title_en: "A tmux session is a workspace that keeps running without you.",
+        title_ko: "tmux session은 당신 없이도 계속 도는 작업 공간입니다.",
+        cue_en: "type:   tmux new-session -s muxa-onboarding",
+        cue_ko: "입력:   tmux new-session -s muxa-onboarding",
+        detect: Detect::SessionCreated,
+    },
+    Step {
+        title_en: "One window is one Work. Make a second one.",
+        title_ko: "window 하나가 Work 하나입니다. 두 번째를 만들어 보세요.",
+        cue_en: "press   Ctrl-b   then   c",
+        cue_ko: "Ctrl-b 를 눌렀다 떼고   c",
+        detect: Detect::SecondWindow,
+    },
+    Step {
+        title_en: "Now leave. Detaching removes you, not the work.",
+        title_ko: "이제 나가 보세요. detach는 당신만 빠지고 작업은 그대로입니다.",
+        cue_en: "press   Ctrl-b   then   d       ·   then try:   tmux ls",
+        cue_ko: "Ctrl-b 를 눌렀다 떼고   d       ·   그다음:   tmux ls",
+        detect: Detect::NoClient,
+    },
+    Step {
+        title_en: "Still listed, still running. That is the whole reason muxa lives in tmux.",
+        title_ko: "여전히 목록에 있고 여전히 돌고 있습니다. muxa가 tmux에 사는 이유입니다.",
+        cue_en: "type:   tmux attach -t muxa-onboarding",
+        cue_ko: "입력:   tmux attach -t muxa-onboarding",
+        detect: Detect::ClientAttached,
+    },
+    // ---- Act II: muxa -----------------------------------------------------
+    Step {
+        title_en: "Two agents just joined this window. A pane is an agent. See them all at once.",
+        title_ko:
+            "이 window에 agent 둘이 합류했습니다. pane 하나가 agent 하나입니다. 한눈에 보세요.",
+        cue_en: "run:   muxa watch             ·   q leaves it",
+        cue_ko: "입력:   muxa watch             ·   q로 나갑니다",
+        detect: Detect::PaneRunning("muxa"),
+    },
+    Step {
+        title_en: "codex stopped and is waiting on you. State is how you find that.",
+        title_ko: "codex가 멈춰서 당신을 기다립니다. 그걸 찾는 방법이 state입니다.",
+        cue_en: "leave watch with q, then run:   muxa attend",
+        cue_ko: "q로 watch를 나간 뒤 입력:   muxa attend",
+        detect: Detect::ActivePaneIsCodex,
+    },
+    Step {
+        // attend left them sitting in codex's pane, which has no shell to
+        // type into. Getting back is a real tmux key, so the step teaches it
+        // rather than having the tour move the cursor on their behalf.
+        title_en: "That is codex's own pane. Go back to yours, and ask from there.",
+        title_ko: "여기는 codex의 pane입니다. 당신 pane으로 돌아가서 물어보세요.",
+        cue_en: "press   Ctrl-b   then   ;      then run:   muxa msg send @claude \"how far along?\"",
+        cue_ko: "Ctrl-b 를 눌렀다 떼고   ;      그 뒤 입력:   muxa msg send @claude \"어디까지 됐나요?\"",
+        detect: Detect::SentMessage,
+    },
+    Step {
+        title_en: "Agents use muxa too — codex just sent you a request of its own.",
+        title_ko: "agent도 muxa를 씁니다 — codex가 방금 당신에게 요청을 보냈습니다.",
+        cue_en: "run:   muxa msg inbox",
+        cue_ko: "입력:   muxa msg inbox",
+        detect: Detect::ClaimedInbox,
+    },
+    Step {
+        title_en: "session is a workspace · window is a work · pane is an agent",
+        title_ko: "session은 workspace · window는 work · pane은 agent",
+        cue_en: "press   Ctrl-b   then   d       ·   finishes and deletes the sandbox",
+        cue_ko: "Ctrl-b 를 눌렀다 떼고   d       ·   마치고 sandbox를 지웁니다",
+        detect: Detect::NoClient,
+    },
+];
+
+/// The step Act II begins at, and so the point the agents arrive.
+const ACT_TWO_START: usize = 4;
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+struct Tour<'a> {
+    sandbox: &'a Sandbox,
+    language: UiLanguage,
+    fleet: Option<Fleet>,
+}
+
+impl Tour<'_> {
+    fn clients(&self) -> String {
+        self.sandbox
+            .tmux_quiet(&["list-clients", "-F", "#{client_name}"])
+    }
+
+    /// Sessions the learner made, as opposed to the placeholder that kept the
+    /// server alive before they had one.
+    fn own_sessions(&self) -> Vec<String> {
+        let holder = self.sandbox.env_value("MUXA_SANDBOX_HOLDER");
+        self.sandbox
+            .tmux_quiet(&["list-sessions", "-F", "#{session_name}"])
+            .lines()
+            .filter(|name| !name.is_empty() && *name != holder)
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn satisfied(&self, detect: &Detect) -> bool {
+        match detect {
+            Detect::SessionCreated => !self.own_sessions().is_empty(),
+            Detect::SecondWindow => {
+                let holder = self.sandbox.env_value("MUXA_SANDBOX_HOLDER");
+                self.sandbox
+                    .tmux_quiet(&["list-windows", "-a", "-F", "#{session_name}"])
+                    .lines()
+                    .filter(|name| !name.is_empty() && *name != holder)
+                    .count()
+                    >= 2
+            }
+            Detect::NoClient => self.clients().is_empty(),
+            Detect::ClientAttached => !self.clients().is_empty(),
+            Detect::PaneRunning(command) => self
+                .sandbox
+                .tmux_quiet(&["list-panes", "-a", "-F", "#{pane_current_command}"])
+                .lines()
+                .any(|line| line.trim() == *command),
+            Detect::ActivePaneIsCodex => self.fleet.as_ref().is_some_and(|fleet| {
+                self.sandbox
+                    .tmux_quiet(&["display-message", "-p", "#{pane_id}"])
+                    == fleet.codex
+            }),
+            Detect::SentMessage => self.fleet.as_ref().is_some_and(|fleet| {
+                self.sandbox
+                    .muxa_as(
+                        &fleet.learner,
+                        &["msg", "list", "--mailbox", "sent", "--json"],
+                    )
+                    .is_ok_and(|out| out.contains("\"id\""))
+            }),
+            // A claimed `--no-reply` request leaves `queued` behind, and that is
+            // the only transition this step needs to see.
+            Detect::ClaimedInbox => self.fleet.as_ref().is_some_and(|fleet| {
+                self.sandbox
+                    .muxa_as(
+                        &fleet.learner,
+                        &["msg", "list", "--mailbox", "incoming", "--json"],
+                    )
+                    .is_ok_and(|out| out.contains("\"status\"") && !out.contains("\"queued\""))
+            }),
+        }
+    }
+
+    /// Fired as a step opens, so the world moves on its own rather than only in
+    /// response to the learner.
+    fn on_enter(&mut self, index: usize) -> Result<()> {
+        if index == ACT_TWO_START {
+            // The placeholder has done its job; left alive it shows up in watch
+            // as a session with no agents in it.
+            let holder = self.sandbox.env_value("MUXA_SANDBOX_HOLDER");
+            if !holder.is_empty() {
+                let _ = self.sandbox.tmux_command(&["kill-session", "-t", &holder]);
+            }
+            self.fleet = Some(self.sandbox.add_agents(self.language)?);
+            return Ok(());
+        }
+        let Some(fleet) = self.fleet.as_ref() else {
+            return Ok(());
+        };
+        match index {
+            5 => self.sandbox.hook(
+                &fleet.codex,
+                "codex",
+                "permission_request",
+                r#"{"session_id":"onboarding-codex","tool_name":"shell"}"#,
+            ),
+            7 => {
+                let body = tr(
+                    self.language,
+                    "the public-read boundary needs a decision before I continue",
+                    "public-read 경계는 계속하기 전에 결정이 필요합니다",
+                );
+                self.sandbox
+                    .muxa_as(&fleet.codex, &["msg", "send", "@you", body, "--no-reply"])
+                    .map(|_| ())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn narrate(&self, index: usize) {
+        let step = &STEPS[index];
+        self.sandbox.narrate(
+            index + 1,
+            STEPS.len(),
+            tr(self.language, step.title_en, step.title_ko),
+            tr(self.language, step.cue_en, step.cue_ko),
+        );
+    }
+
+    fn drive(&mut self) -> Result<usize> {
+        self.narrate(0);
+
+        // The learner's own shell, in their own terminal. They are not attached
+        // to anything yet — Act I is where they attach themselves, which is the
+        // lesson. The tour polls alongside rather than taking the keyboard.
+        let mut shell = Command::new("bash")
+            .arg("--rcfile")
+            .arg(&self.sandbox.rcfile)
+            .spawn()
+            .context("starting your shell")?;
+
+        let mut index = 0usize;
+        let mut deadline = Instant::now() + STEP_TIMEOUT;
+
+        while index < STEPS.len() {
+            if INTERRUPTED.load(Ordering::SeqCst) {
+                break;
+            }
+            if shell.try_wait().context("watching your shell")?.is_some() {
+                break;
+            }
+            if Instant::now() > deadline {
+                break;
+            }
+            if self.satisfied(&STEPS[index].detect) {
+                index += 1;
+                deadline = Instant::now() + STEP_TIMEOUT;
+                if index < STEPS.len() {
+                    self.on_enter(index)?;
+                    self.narrate(index);
+                }
+                continue;
+            }
+            std::thread::sleep(POLL);
+        }
+
+        let _ = self.sandbox.tmux_command(&["kill-server"]);
+        let _ = shell.kill();
+        let _ = shell.wait();
+        Ok(index)
+    }
+}
+
+pub(super) fn run(language: UiLanguage) -> Result<()> {
+    preflight(language)?;
+    trap_signals();
+
+    eprintln!(
+        "{}",
+        tr(
+            language,
+            "Building a throwaway muxa — its own tmux server, its own daemon. Nothing is installed.",
+            "일회용 muxa를 만듭니다 — 전용 tmux 서버, 전용 daemon. 설치는 없습니다.",
+        )
+    );
+
+    let completed = {
+        let sandbox = Sandbox::create()?;
+        // The daemon comes up before the learner has anything, because a hook
+        // sent while it is down is dropped rather than queued.
+        sandbox.script_command(&["daemon"])?;
+        sandbox.prepare_status()?;
+        let mut tour = Tour {
+            sandbox: &sandbox,
+            language,
+            fleet: None,
+        };
+        tour.drive()?
+        // `Drop` tears the sandbox down here, on every path including a panic.
+    };
+
+    summary(language, completed);
+    Ok(())
+}
+
+fn preflight(language: UiLanguage) -> Result<()> {
+    if std::env::var_os("TMUX").is_some() {
+        bail!(tr(
+            language,
+            "The live tour runs its own tmux server, and nesting it inside yours makes the prefix ambiguous.\nDetach with your prefix + d, or open a terminal outside tmux, then run this again.",
+            "라이브 tour는 자체 tmux 서버를 띄웁니다. 지금 tmux 안이라 prefix가 모호해집니다.\nprefix + d로 detach하거나 tmux 밖 터미널에서 다시 실행하세요.",
+        ));
+    }
+    if which("tmux").is_none() {
+        bail!(tr(
+            language,
+            "The live tour needs tmux. Install it, or run `muxa onboard --print` for the written guide.",
+            "라이브 tour에는 tmux가 필요합니다. 설치하거나 `muxa onboard --print`로 문서 가이드를 보세요.",
+        ));
+    }
+    Ok(())
+}
+
+fn summary(language: UiLanguage, completed: usize) {
+    println!();
+    println!(
+        "{}",
+        if completed >= STEPS.len() {
+            tr(
+                language,
+                "Done. The sandbox is gone — no daemon, no config, nothing left on disk.",
+                "끝났습니다. sandbox는 사라졌습니다 — daemon도 config도 남지 않았습니다.",
+            )
+        } else {
+            tr(
+                language,
+                "Stopped early. The sandbox is gone — no daemon, no config, nothing left on disk.",
+                "중간에 종료했습니다. sandbox는 사라졌습니다 — daemon도 config도 남지 않았습니다.",
+            )
+        }
+    );
+    println!();
+    println!(
+        "{}",
+        tr(
+            language,
+            "The same commands work on your own fleet:",
+            "직접 쓰실 때도 같은 명령입니다:",
+        )
+    );
+    for line in [
+        "  tmux new-session -s <work>",
+        "  muxa watch",
+        "  muxa attend",
+        "  muxa msg send @<alias> \"…\"",
+        "  muxa msg inbox",
+    ] {
+        println!("{line}");
+    }
+}

--- a/docs/COLLABORATION.ko.md
+++ b/docs/COLLABORATION.ko.md
@@ -175,6 +175,10 @@ muxa msg list --mailbox incoming --json
 muxa msg cancel req_...
 ```
 
+`send`, `reply`, `cancel`은 한 줄 영수증만 출력하고, `list`와 `inbox`는 각
+요청과 (도착했다면) 그 답장을 함께 보여줍니다. 저장된 레코드 전체가 필요하면
+`--json`을 붙이세요.
+
 tracked agent pane에서 `prefix+s`로 `muxa watch`를 열면 같은 lifecycle을 TUI로
 사용할 수 있습니다. `m`은 선택한 room peer에게 요청을 보내고, `b`는 claim 없는
 mailbox 이력을 열며, `i`는 inbox를 claim하고 `e`는 응답합니다. `muxa dashboard`는

--- a/docs/COLLABORATION.md
+++ b/docs/COLLABORATION.md
@@ -145,6 +145,10 @@ muxa msg list --mailbox sent
 muxa msg cancel req_... # queued requests only
 ```
 
+`send`, `reply`, and `cancel` print a one-line receipt; `list` and `inbox`
+print each request followed by its reply, when one has come back. Add `--json`
+to any of them for the stored record instead.
+
 The same lifecycle is available interactively in `muxa watch`: `m` sends to the
 selected room peer, `b` opens non-claiming mailbox history, `i` claims the
 inbox, and `e` replies. `muxa dashboard` provides the richer workspace-card form

--- a/docs/demo-README.md
+++ b/docs/demo-README.md
@@ -13,6 +13,7 @@ new keybinds, layout shifts, a renamed subcommand, a new panel.
 | `docs/demo-onboard.tape`  | Unified shell → tmux → Muxa fullscreen walkthrough; no fixture or daemon needed.           |
 | `scripts/muxa-sandbox.sh` | The isolation itself: private socket, config, data dir, tmux server, and the `tmux` PATH shim. `up` / `daemon` / `env` / `status` / `down`. |
 | `scripts/sandbox-smoke.sh`| Lifecycle test for the sandbox — proves `down` returns the machine to clean from every state, including the ones a crash leaves. |
+| `scripts/live-tour-smoke.py`| Types a learner's commands at `muxa onboard --tour live` and checks each of the nine steps advances. |
 | `docs/demo-setup.sh`      | The fixture layered on the sandbox: the seeded fleet, the mailbox, the ask history, and the painted panes. |
 | `docs/demo-paint.sh`      | Emits one agent's screen — `demo-paint.sh <agent> <state> <prompt> [tool]...` — so panes hold a believable frame instead of a bare `cat`. |
 | `docs/demo-teardown.sh`   | Removes all of it — delegates to the sandbox, then clears the fixture-only files. Safe at any time, including after a half-finished render. |

--- a/scripts/live-tour-smoke.py
+++ b/scripts/live-tour-smoke.py
@@ -116,6 +116,10 @@ def cue() -> str:
     return tmux("show", "-g", "status-format[2]").stdout
 
 
+def title_row() -> str:
+    return tmux("show", "-g", "status-format[1]").stdout.strip()
+
+
 def wait_step(terminal: Terminal, target: int, timeout: float = 60) -> bool:
     end = time.time() + timeout
     while time.time() < end:
@@ -178,6 +182,17 @@ def escape_hatch(muxa: str, args, report: "Report") -> int:
         # that it is a plain command.
         terminal.type(b"tmux new-session -s muxa-onboarding\r", 4)
         report.check("step 1 done for real", wait_step(terminal, 2), f"step={step()}")
+
+        # F2 was the simulation's language switch; losing it in the live tour
+        # would be a regression for anyone who starts in the wrong one.
+        before = title_row()
+        terminal.type(b"\x1bOQ", 2)  # F2
+        after = title_row()
+        report.check("F2 switches the narration language", before != after and after != "",
+                     f"{before!r} -> {after!r}")
+        terminal.type(b"\x1bOQ", 2)
+        report.check("F2 switches it back", title_row() == before,
+                     f"{title_row()!r} != {before!r}")
 
         target = 3
         while target <= len(STEPS_TOTAL):

--- a/scripts/live-tour-smoke.py
+++ b/scripts/live-tour-smoke.py
@@ -28,7 +28,7 @@ import time
 
 SANDBOX = "muxa-onboarding"
 STEP_MARK = re.compile(r"onboarding · (\d+)/(\d+)")
-STEPS_TOTAL = range(9)
+TOTAL_STEPS = 14
 
 
 class Terminal:
@@ -189,8 +189,8 @@ def escape_hatch(muxa: str, args, report: "Report") -> int:
     cannot repeat that: `--no-quiz` offers the way past from the first step, and
     F12 walks the whole tour without the learner doing any of it.
 
-    Skipping has to leave the world consistent too — Act II introduces agents,
-    and there has to be a session for them to arrive in."""
+    Skipping has to leave the world consistent too — the agents move into a pane
+    the learner split, and there has to be one for them to move into."""
     print("escape hatch")
     terminal = Terminal(muxa, args.lang, no_quiz=True)
     try:
@@ -209,32 +209,24 @@ def escape_hatch(muxa: str, args, report: "Report") -> int:
         terminal.type(b"tmux new-session -s muxa-onboarding\r", 4)
         report.check("step 1 done for real", wait_step(terminal, 2), f"step={step()}")
 
-        # F2 was the simulation's language switch; losing it in the live tour
-        # would be a regression for anyone who starts in the wrong one.
-        before = title_row()
-        terminal.type(b"\x1bOQ", 2)  # F2
-        after = title_row()
-        report.check("F2 switches the narration language", before != after and after != "",
-                     f"{before!r} -> {after!r}")
-        terminal.type(b"\x1bOQ", 2)
-        report.check("F2 switches it back", title_row() == before,
-                     f"{title_row()!r} != {before!r}")
-
         target = 3
-        while target <= len(STEPS_TOTAL):
+        while target <= TOTAL_STEPS:
             terminal.type(b"\x1b[24~", 1.5)  # F12
-            if not report.check(f"F12 reaches step {target} or past it",
-                                wait_past(terminal, target, 45), f"step={step()}"):
+            if not report.check(
+                f"F12 reaches step {target} or past it",
+                wait_past(terminal, target, 45),
+                f"step={step()}",
+            ):
                 break
             reached = step() or target
-            if reached >= 5 and target < 5:
-                # The agents joined a session the learner never made themselves.
+            if reached >= 8 and target < 8:
                 panes = tmux("list-panes", "-a", "-F", "#{pane_id}").stdout.split()
-                report.check("the agents still had a window to arrive in", len(panes) >= 3,
-                             str(panes))
+                report.check(
+                    "the agents still had a pane to move into", len(panes) >= 3, str(panes)
+                )
             target = reached + 1
 
-        terminal.type(b"\x1b[24~", 2)  # F12 past the last step
+        terminal.type(b"\x1b[24~", 2)
         for _ in range(10):
             if terminal.finished():
                 break
@@ -271,109 +263,106 @@ def main() -> int:
 
     terminal = Terminal(muxa, args.lang)
     try:
-        # Sandbox up, daemon up, the learner's shell.
         terminal.pump(12)
 
         print("act I — tmux")
-        report.check("step 1 is showing", step() == 1, f"step={step()}")
-        report.check("the cue asks for tmux new-session", "tmux new-session" in cue(), cue())
+        report.check("1  the first step is showing", step() == 1, f"step={step()}")
+        report.check("1  the cue asks for tmux new-session", "tmux new-session" in cue(), cue())
         report.check(
-            "tmux's own status row is left alone",
-            "status-format[0]" in tmux("show", "-g", "status-format[0]").stdout
-            and "window-status" in tmux("show", "-g", "status-format[0]").stdout,
+            "1  tmux's own status row is left alone",
+            "window-status" in tmux("show", "-g", "status-format[0]").stdout,
             tmux("show", "-g", "status-format[0]").stdout[:120],
         )
 
         terminal.type(b"tmux new-session -s muxa-onboarding\r", 4)
-        report.check("creating a session advances", wait_step(terminal, 2), f"step={step()}")
+        report.check("2  creating a session", wait_step(terminal, 2), f"step={step()}")
+        report.check("2  the step confirms what just happened", "✓" in banner(), banner())
 
-        terminal.type(b"\x02c", 3)  # Ctrl-b c
-        report.check("a second window advances", wait_step(terminal, 3), f"step={step()}")
-        # "Did that work?" is the question the learner is holding at every step.
-        report.check("the step confirms what the last action did", "✓" in banner(), banner())
+        terminal.type(b"\x02c", 3)
+        report.check("3  a second window", wait_step(terminal, 3), f"step={step()}")
 
-        terminal.type(b"\x02d", 3)  # Ctrl-b d
-        report.check("detaching advances", wait_step(terminal, 4), f"step={step()}")
+        terminal.type(b"\x02s", 2)
+        terminal.type(b"q", 2)
+        report.check("4  opening and closing the tree", wait_step(terminal, 4), f"step={step()}")
 
-        # Step 3 tells them to run `tmux ls`; the tour's own placeholder session
-        # showing up in that output is plumbing leaking through the lesson.
+        terminal.type(b"\x02d", 3)
+        report.check("5  detaching", wait_step(terminal, 5), f"step={step()}")
         sessions = tmux("list-sessions", "-F", "#{session_name}").stdout.split()
-        report.check("the placeholder session is not in `tmux ls`",
-                     "_sandbox" not in sessions, str(sessions))
+        report.check(
+            "5  the placeholder session is not in `tmux ls`",
+            "_sandbox" not in sessions,
+            str(sessions),
+        )
+
+        terminal.type(b"tmux ls\r", 3)
+        report.check("6  running tmux ls", wait_step(terminal, 6), f"step={step()}")
 
         terminal.type(b"tmux attach -t muxa-onboarding\r", 4)
-        report.check("reattaching advances", wait_step(terminal, 5), f"step={step()}")
+        report.check("7  reattaching", wait_step(terminal, 7), f"step={step()}")
+
+        terminal.type(b"\x02%", 3)
+        report.check("8  splitting a pane", wait_step(terminal, 8), f"step={step()}")
 
         print("act II — muxa")
         panes = tmux("list-panes", "-a", "-F", "#{pane_id}").stdout.split()
-        report.check("two agents joined the learner's window", len(panes) >= 3, str(panes))
-
-        # The tour claims to be a sandbox. If `ls` shows the learner their own
-        # repository, or watch prints their real path, it is not one.
+        report.check(
+            "8  the split pane became an agent, and a second joined",
+            len(panes) >= 3,
+            str(panes),
+        )
         paths = tmux("list-panes", "-a", "-F", "#{pane_current_path}").stdout.split()
         report.check(
-            "nothing runs outside the sandbox workspace",
-            paths and all(p.startswith("/tmp/muxa-onboarding-home") for p in paths),
+            "8  nothing runs outside the sandbox workspace",
+            bool(paths) and all(p.startswith("/tmp/muxa-onboarding-home") for p in paths),
             str(paths),
         )
         report.check(
-            "the windows are named after Works, not processes",
+            "8  the windows are named after Works, not processes",
             set(tmux("list-windows", "-a", "-F", "#{window_name}").stdout.split())
             == {"checkout", "release-checks"},
             tmux("list-windows", "-a", "-F", "#{window_name}").stdout.split(),
         )
 
         terminal.type(b"muxa watch\r", 4)
-        report.check("running watch advances", wait_step(terminal, 6), f"step={step()}")
+        report.check("9  running watch", wait_step(terminal, 9), f"step={step()}")
 
-        # A cue that names a command without saying what it does leaves the
-        # learner running things blind.
         explains_attend = {"en": "blocked longest", "ko": "가장 오래 막힌"}[args.lang]
-        report.check("the attend step says what attend does",
-                     explains_attend in title_text(), title_text())
-
+        report.check(
+            "9  the step says what attend does", explains_attend in title_text(), title_text()
+        )
         terminal.type(b"q", 2)
         terminal.type(b"muxa attend\r", 4)
-        report.check("attend advances", wait_step(terminal, 7), f"step={step()}")
-        explains_return = {"en": "last pane you were in", "ko": "직전에 있던 pane"}[args.lang]
-        report.check("the return step says what Ctrl-b ; does",
-                     explains_return in title_text(), title_text())
+        report.check("10  attend", wait_step(terminal, 10), f"step={step()}")
 
-        # attend put the learner in codex's pane, which is the point of it —
-        # and that pane has no shell. Step 7 teaches `Ctrl-b ;` to get back, so
-        # type exactly that rather than repositioning the cursor out of band,
-        # or the test stops covering the step it claims to.
-        terminal.type(b"\x02;", 2)
+        explains_return = {"en": "pane you were in", "ko": "직전에 있던 pane"}[args.lang]
+        report.check(
+            "10  the step says what Ctrl-b ; does", explains_return in title_text(), title_text()
+        )
+        terminal.type(b"\x02;", 3)
+        report.check("11  back in your own pane", wait_step(terminal, 11), f"step={step()}")
 
         terminal.type(b'muxa msg send @claude "how far along?"\r', 4)
-        report.check("messaging a peer advances", wait_step(terminal, 8), f"step={step()}")
+        report.check("12  messaging a peer", wait_step(terminal, 12), f"step={step()}")
 
-        # claude answers through the mailbox, not just on its own screen, and
-        # before the learner runs anything to fetch it.
         sent = sandbox_muxa(muxa, "msg", "list", "--mailbox", "sent", "--json")
         report.check(
-            "claude replied through muxa on its own",
-            '"completed"' in sent,
-            sent[-300:],
+            "12  claude replied through muxa on its own", '"completed"' in sent, sent[-300:]
         )
 
-        terminal.type(b"muxa msg inbox\r", 4)
-        report.check("claiming the inbox advances", wait_step(terminal, 9), f"step={step()}")
+        terminal.type(b"muxa msg list\r", 4)
+        report.check("13  reading the mailbox", wait_step(terminal, 13), f"step={step()}")
 
-        terminal.type(b"\x02d", 4)  # Ctrl-b d finishes the tour
+        terminal.type(b"muxa msg inbox\r", 4)
+        report.check("14  claiming the inbox", wait_step(terminal, 14), f"step={step()}")
+
+        terminal.type(b"\x02d", 4)
         for _ in range(12):
             if terminal.finished():
                 break
             terminal.pump(2)
         report.check("the tour exits on its own", terminal.finished())
-        # Both languages, because the summary is the only place the tour tells
-        # the learner nothing was left on their machine.
         gone = {"en": "sandbox is gone", "ko": "sandbox는 사라졌습니다"}[args.lang]
-        report.check(
-            "it says the sandbox is gone",
-            gone in terminal.text(),
-            terminal.text()[-300:],
-        )
+        report.check("it says the sandbox is gone", gone in terminal.text(), terminal.text()[-300:])
     finally:
         terminal.kill()
 

--- a/scripts/live-tour-smoke.py
+++ b/scripts/live-tour-smoke.py
@@ -346,6 +346,27 @@ def main() -> int:
             len(panes) >= 3,
             str(panes),
         )
+        # The step says the agents arrived and the next one says to look at the
+        # whole Work. Zooming the learner's pane hid both and left that claim
+        # sitting above a blank screen.
+        report.check(
+            "9  the fleet is visible, not hidden behind a zoom",
+            tmux("display-message", "-p", "#{window_zoomed_flag}").stdout.strip() == "0",
+            tmux("display-message", "-p", "#{window_zoomed_flag}").stdout,
+        )
+        # The learner's pane has to fit `muxa watch` and the agents' have to fit
+        # their own frames; on a 200-column window both sides clear that easily,
+        # and the point of the check is that neither was starved to zero.
+        visible = [
+            int(w) for w in tmux(
+                "list-panes", "-t", "muxa-onboarding:", "-F", "#{pane_width}"
+            ).stdout.split()
+        ]
+        report.check(
+            "9  and every pane has room to render",
+            len(visible) >= 3 and min(visible) >= 60,
+            str(visible),
+        )
         paths = tmux("list-panes", "-a", "-F", "#{pane_current_path}").stdout.split()
         report.check(
             "9  nothing runs outside the sandbox workspace",

--- a/scripts/live-tour-smoke.py
+++ b/scripts/live-tour-smoke.py
@@ -26,7 +26,8 @@ import sys
 import termios
 import time
 
-SANDBOX = "muxa-onboarding"
+SANDBOX_PREFIX = "muxa-onboarding"
+SANDBOX = ""
 STEP_MARK = re.compile(r"onboarding · (\d+)/(\d+)")
 TOTAL_STEPS = 15
 
@@ -35,6 +36,7 @@ class Terminal:
     """A pty with a `muxa onboard --tour live` running in it."""
 
     def __init__(self, muxa: str, lang: str, no_quiz: bool = False) -> None:
+        global SANDBOX
         self.buffer = b""
         self.exited = False
         self.pid, self.fd = pty.fork()
@@ -48,6 +50,10 @@ class Terminal:
                 argv.append("--no-quiz")
             os.execv(muxa, argv)
             os._exit(127)
+        # The live tour scopes every artifact to the muxa process PID. Keep the
+        # driver on that same namespace so parallel smoke jobs cannot observe
+        # or tear down one another's tmux server and daemon.
+        SANDBOX = f"{SANDBOX_PREFIX}-{self.pid}"
         fcntl.ioctl(self.fd, termios.TIOCSWINSZ, struct.pack("HHHH", 50, 200, 0, 0))
         os.set_blocking(self.fd, False)
 
@@ -102,8 +108,9 @@ class Terminal:
 
 
 def tmux(*args: str) -> subprocess.CompletedProcess:
+    socket = f"/tmp/{SANDBOX}-sandbox/tmux.sock"
     return subprocess.run(
-        ["tmux", "-L", SANDBOX, *args], capture_output=True, text=True, timeout=10
+        ["tmux", "-S", socket, *args], capture_output=True, text=True, timeout=10
     )
 
 
@@ -165,6 +172,8 @@ def wait_step(terminal: Terminal, target: int, timeout: float = 60) -> bool:
     while time.time() < end:
         if step() == target:
             return True
+        if terminal.finished():
+            return False
         terminal.pump(0.4)
     return False
 
@@ -178,6 +187,8 @@ def wait_past(terminal: Terminal, target: int, timeout: float = 60) -> bool:
         current = step()
         if current is not None and current >= target:
             return True
+        if terminal.finished():
+            return False
         terminal.pump(0.4)
     current = step()
     return current is not None and current >= target
@@ -229,7 +240,7 @@ def escape_hatch(muxa: str, args, report: "Report") -> int:
             if not report.check(
                 f"F12 reaches step {target} or past it",
                 wait_past(terminal, target, 45),
-                f"step={step()}",
+                f"step={step()}\n{terminal.text()[-800:]}",
             ):
                 break
             reached = step() or target
@@ -251,7 +262,9 @@ def escape_hatch(muxa: str, args, report: "Report") -> int:
 
     report.check("no tmux server survives", tmux("list-sessions").returncode != 0)
     strays = subprocess.run(
-        ["pgrep", "-f", f"{SANDBOX}-config"], capture_output=True, text=True
+        ["pgrep", "-f", f"/tmp/{SANDBOX}-sandbox/config[.]toml"],
+        capture_output=True,
+        text=True,
     ).stdout.strip()
     report.check("no daemon survives", strays == "", strays)
     print(f"\n{report.passes} passed, {len(report.failures)} failed")
@@ -338,7 +351,11 @@ def main() -> int:
             which,
         )
         terminal.type(b"claude\r", 4)
-        report.check("9  starting claude", wait_step(terminal, 9), f"step={step()}")
+        report.check(
+            "9  starting claude",
+            wait_step(terminal, 9),
+            f"step={step()}\n{terminal.text()[-800:]}",
+        )
 
         panes = tmux("list-panes", "-a", "-F", "#{pane_id}").stdout.split()
         report.check(
@@ -370,7 +387,7 @@ def main() -> int:
         paths = tmux("list-panes", "-a", "-F", "#{pane_current_path}").stdout.split()
         report.check(
             "9  nothing runs outside the sandbox workspace",
-            bool(paths) and all(p.startswith("/tmp/muxa-onboarding-home") for p in paths),
+            bool(paths) and all(p.startswith(f"/tmp/{SANDBOX}/home") for p in paths),
             str(paths),
         )
         report.check(
@@ -437,7 +454,9 @@ def main() -> int:
     print("nothing left behind")
     report.check("no tmux server survives", tmux("list-sessions").returncode != 0)
     strays = subprocess.run(
-        ["pgrep", "-f", f"{SANDBOX}-config"], capture_output=True, text=True
+        ["pgrep", "-f", f"/tmp/{SANDBOX}-sandbox/config[.]toml"],
+        capture_output=True,
+        text=True,
     ).stdout.strip()
     report.check("no daemon survives", strays == "", strays)
 

--- a/scripts/live-tour-smoke.py
+++ b/scripts/live-tour-smoke.py
@@ -28,7 +28,7 @@ import time
 
 SANDBOX = "muxa-onboarding"
 STEP_MARK = re.compile(r"onboarding · (\d+)/(\d+)")
-TOTAL_STEPS = 14
+TOTAL_STEPS = 15
 
 
 class Terminal:
@@ -126,9 +126,9 @@ def title_text() -> str:
     return tmux("show", "-g", "status-format[2]").stdout
 
 
-def sandbox_muxa(muxa: str, *args: str) -> str:
-    """Run muxa as the learner's pane, which is the only origin the daemon
-    accepts for a mailbox query."""
+def sandbox_env() -> dict[str, str]:
+    """The environment a pane inside the tour runs with. PATH keeps only the
+    sandbox prefix, so a lookup here proves what the *learner* would resolve."""
     env = dict(os.environ)
     for line in subprocess.run(
         ["bash", "scripts/muxa-sandbox.sh", "env", "--name", SANDBOX],
@@ -139,7 +139,21 @@ def sandbox_muxa(muxa: str, *args: str) -> str:
             env[key] = value.split(':"$PATH"')[0].strip("'")
     env["TMUX"] = env.get("MUXA_SANDBOX_TMUX_ENV", "")
     env["TMUX_PANE"] = tmux("display-message", "-p", "#{pane_id}").stdout.strip()
-    return subprocess.run([muxa, *args], capture_output=True, text=True, env=env).stdout
+    return env
+
+
+def sandbox_run(*args: str) -> str:
+    return subprocess.run(
+        args, capture_output=True, text=True, env=sandbox_env()
+    ).stdout.strip()
+
+
+def sandbox_muxa(muxa: str, *args: str) -> str:
+    """Run muxa as the learner's pane, which is the only origin the daemon
+    accepts for a mailbox query."""
+    return subprocess.run(
+        [muxa, *args], capture_output=True, text=True, env=sandbox_env()
+    ).stdout
 
 
 def title_row() -> str:
@@ -287,6 +301,16 @@ def main() -> int:
 
         terminal.type(b"\x02d", 3)
         report.check("5  detaching", wait_step(terminal, 5), f"step={step()}")
+        # Nobody is attached, so there is no status bar to carry the cue — and
+        # bash will not re-evaluate a prompt it has already drawn. The step has
+        # to print itself, or it stays invisible until the learner presses a
+        # key to find out what they were supposed to press.
+        terminal.pump(1)
+        report.check(
+            "5  the cue is on screen without a keypress",
+            "tmux ls" in terminal.text(),
+            terminal.text()[-400:],
+        )
         sessions = tmux("list-sessions", "-F", "#{session_name}").stdout.split()
         report.check(
             "5  the placeholder session is not in `tmux ls`",
@@ -304,56 +328,79 @@ def main() -> int:
         report.check("8  splitting a pane", wait_step(terminal, 8), f"step={step()}")
 
         print("act II — muxa")
+        # The learner starts the agent themselves. `claude` resolves to the
+        # sandbox shim, so what comes up is the tour's screen and no real CLI is
+        # ever invoked — the point of the step is that they typed it.
+        which = sandbox_run("/bin/bash", "-c", "command -v claude")
+        report.check(
+            "9  `claude` resolves inside the sandbox, not to a real CLI",
+            which.startswith("/tmp/") and "shim" in which,
+            which,
+        )
+        terminal.type(b"claude\r", 4)
+        report.check("9  starting claude", wait_step(terminal, 9), f"step={step()}")
+
         panes = tmux("list-panes", "-a", "-F", "#{pane_id}").stdout.split()
         report.check(
-            "8  the split pane became an agent, and a second joined",
+            "9  the pane they started it in is claude, and codex joined",
             len(panes) >= 3,
             str(panes),
         )
         paths = tmux("list-panes", "-a", "-F", "#{pane_current_path}").stdout.split()
         report.check(
-            "8  nothing runs outside the sandbox workspace",
+            "9  nothing runs outside the sandbox workspace",
             bool(paths) and all(p.startswith("/tmp/muxa-onboarding-home") for p in paths),
             str(paths),
         )
         report.check(
-            "8  the windows are named after Works, not processes",
+            "9  the windows are named after Works, not processes",
             set(tmux("list-windows", "-a", "-F", "#{window_name}").stdout.split())
             == {"checkout", "release-checks"},
             tmux("list-windows", "-a", "-F", "#{window_name}").stdout.split(),
         )
 
         terminal.type(b"muxa watch\r", 4)
-        report.check("9  running watch", wait_step(terminal, 9), f"step={step()}")
+        report.check("10  running watch", wait_step(terminal, 10), f"step={step()}")
 
         explains_attend = {"en": "blocked longest", "ko": "가장 오래 막힌"}[args.lang]
         report.check(
-            "9  the step says what attend does", explains_attend in title_text(), title_text()
+            "10  the step says what attend does", explains_attend in title_text(), title_text()
         )
         terminal.type(b"q", 2)
         terminal.type(b"muxa attend\r", 4)
-        report.check("10  attend", wait_step(terminal, 10), f"step={step()}")
+        report.check("11  attend", wait_step(terminal, 11), f"step={step()}")
 
         explains_return = {"en": "pane you were in", "ko": "직전에 있던 pane"}[args.lang]
         report.check(
-            "10  the step says what Ctrl-b ; does", explains_return in title_text(), title_text()
+            "11  the step says what Ctrl-b ; does", explains_return in title_text(), title_text()
         )
         terminal.type(b"\x02;", 3)
-        report.check("11  back in your own pane", wait_step(terminal, 11), f"step={step()}")
+        report.check("12  back in your own pane", wait_step(terminal, 12), f"step={step()}")
 
         terminal.type(b'muxa msg send @claude "how far along?"\r', 4)
-        report.check("12  messaging a peer", wait_step(terminal, 12), f"step={step()}")
+        report.check("13  messaging a peer", wait_step(terminal, 13), f"step={step()}")
 
         sent = sandbox_muxa(muxa, "msg", "list", "--mailbox", "sent", "--json")
         report.check(
-            "12  claude replied through muxa on its own", '"completed"' in sent, sent[-300:]
+            "13  claude replied through muxa on its own", '"completed"' in sent, sent[-300:]
+        )
+        # The step tells them `list` shows what came back. Reading it the way
+        # they will — no `--json` — has to actually show the answer.
+        answer = {"en": "regression test", "ko": "회귀 테스트"}[args.lang]
+        plain = sandbox_muxa(muxa, "msg", "list", "--mailbox", "sent")
+        report.check("13  `msg list` shows the reply body", answer in plain, plain[-300:])
+        receipt = sandbox_muxa(muxa, "msg", "send", "@claude", "ping", "--no-reply")
+        report.check(
+            "13  `msg send` answers in one line, not a JSON dump",
+            receipt.count("\n") == 1 and receipt.startswith("sent  "),
+            receipt[:200],
         )
 
         terminal.type(b"muxa msg list\r", 4)
-        report.check("13  reading the mailbox", wait_step(terminal, 13), f"step={step()}")
+        report.check("14  reading the mailbox", wait_step(terminal, 14), f"step={step()}")
 
         terminal.type(b"muxa msg inbox\r", 4)
-        report.check("14  claiming the inbox", wait_step(terminal, 14), f"step={step()}")
+        report.check("15  claiming the inbox", wait_step(terminal, 15), f"step={step()}")
 
         terminal.type(b"\x02d", 4)
         for _ in range(12):

--- a/scripts/live-tour-smoke.py
+++ b/scripts/live-tour-smoke.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Drive `muxa onboard --tour live` the way a learner would, and check that the
+tour follows.
+
+The live tour advertises something specific: it never intercepts a keystroke,
+so every step has to be reachable by typing the command the narration asks for.
+That claim is only worth anything if something types those commands and watches
+the tour keep up — which is what this does.
+
+The narration is read back out of tmux (`show -g status-format[0]`) rather than
+scraped off the screen, so a rendering change cannot make this pass or fail for
+the wrong reason.
+
+    scripts/live-tour-smoke.py [--muxa target/debug/muxa]
+"""
+
+import argparse
+import fcntl
+import os
+import pty
+import re
+import select
+import struct
+import subprocess
+import sys
+import termios
+import time
+
+SANDBOX = "muxa-onboarding"
+STEP_MARK = re.compile(r"onboarding · (\d+)/(\d+)")
+
+
+class Terminal:
+    """A pty with a `muxa onboard --tour live` running in it."""
+
+    def __init__(self, muxa: str, lang: str) -> None:
+        self.buffer = b""
+        self.exited = False
+        self.pid, self.fd = pty.fork()
+        if self.pid == 0:
+            os.environ["TERM"] = "xterm-256color"
+            # The tour refuses to nest, and CI may well run inside tmux.
+            for stale in ("TMUX", "TMUX_PANE"):
+                os.environ.pop(stale, None)
+            os.execv(muxa, [muxa, "onboard", "--tour", "live", "--lang", lang])
+            os._exit(127)
+        fcntl.ioctl(self.fd, termios.TIOCSWINSZ, struct.pack("HHHH", 50, 200, 0, 0))
+        os.set_blocking(self.fd, False)
+
+    def pump(self, seconds: float) -> None:
+        end = time.time() + seconds
+        while time.time() < end:
+            ready, _, _ = select.select([self.fd], [], [], 0.1)
+            if not ready:
+                continue
+            try:
+                chunk = os.read(self.fd, 1 << 18)
+            except OSError:
+                return
+            if not chunk:
+                return
+            self.buffer += chunk
+
+    def type(self, text: bytes, settle: float = 2.0) -> None:
+        try:
+            os.write(self.fd, text)
+        except OSError:
+            pass
+        self.pump(settle)
+
+    def finished(self) -> bool:
+        # Cached: `waitpid` reaps, so asking twice raises ChildProcessError
+        # rather than answering.
+        if self.exited:
+            return True
+        try:
+            done, _ = os.waitpid(self.pid, os.WNOHANG)
+        except ChildProcessError:
+            self.exited = True
+            return True
+        self.exited = done != 0
+        return self.exited
+
+    def kill(self) -> None:
+        if not self.exited:
+            try:
+                os.kill(self.pid, 9)
+                os.waitpid(self.pid, 0)
+            except OSError:
+                pass
+        try:
+            os.close(self.fd)
+        except OSError:
+            pass
+
+    def text(self) -> str:
+        return self.buffer.decode("utf-8", "replace")
+
+
+def tmux(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["tmux", "-L", SANDBOX, *args], capture_output=True, text=True, timeout=10
+    )
+
+
+def step() -> int | None:
+    found = STEP_MARK.search(tmux("show", "-g", "status-format[0]").stdout)
+    return int(found.group(1)) if found else None
+
+
+def cue() -> str:
+    return tmux("show", "-g", "status-format[2]").stdout
+
+
+def wait_step(terminal: Terminal, target: int, timeout: float = 60) -> bool:
+    end = time.time() + timeout
+    while time.time() < end:
+        if step() == target:
+            return True
+        terminal.pump(0.4)
+    return False
+
+
+class Report:
+    def __init__(self) -> None:
+        self.failures: list[str] = []
+        self.passes = 0
+
+    def check(self, label: str, ok: bool, detail: str = "") -> bool:
+        if ok:
+            self.passes += 1
+            print(f"  ok    {label}")
+        else:
+            self.failures.append(label)
+            print(f"  FAIL  {label}" + (f"\n        {detail}" if detail else ""))
+        return ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--muxa", default=os.environ.get("MUXA_BIN", "target/debug/muxa"))
+    parser.add_argument("--lang", default="en")
+    args = parser.parse_args()
+    muxa = os.path.abspath(args.muxa)
+
+    report = Report()
+    terminal = Terminal(muxa, args.lang)
+    try:
+        # Sandbox up, daemon up, the learner's shell.
+        terminal.pump(12)
+
+        print("act I — tmux")
+        report.check("step 1 is showing", step() == 1, f"step={step()}")
+        report.check("the cue asks for tmux new-session", "tmux new-session" in cue(), cue())
+
+        terminal.type(b"tmux new-session -s muxa-onboarding\r", 4)
+        report.check("creating a session advances", wait_step(terminal, 2), f"step={step()}")
+
+        terminal.type(b"\x02c", 3)  # Ctrl-b c
+        report.check("a second window advances", wait_step(terminal, 3), f"step={step()}")
+
+        terminal.type(b"\x02d", 3)  # Ctrl-b d
+        report.check("detaching advances", wait_step(terminal, 4), f"step={step()}")
+
+        terminal.type(b"tmux attach -t muxa-onboarding\r", 4)
+        report.check("reattaching advances", wait_step(terminal, 5), f"step={step()}")
+
+        print("act II — muxa")
+        panes = tmux("list-panes", "-a", "-F", "#{pane_id}").stdout.split()
+        report.check("two agents joined the learner's window", len(panes) >= 3, str(panes))
+
+        terminal.type(b"muxa watch\r", 4)
+        report.check("running watch advances", wait_step(terminal, 6), f"step={step()}")
+
+        terminal.type(b"q", 2)
+        terminal.type(b"muxa attend\r", 4)
+        report.check("attend advances", wait_step(terminal, 7), f"step={step()}")
+
+        # attend put the learner in codex's pane, which is the point of it —
+        # and that pane has no shell. Step 7 teaches `Ctrl-b ;` to get back, so
+        # type exactly that rather than repositioning the cursor out of band,
+        # or the test stops covering the step it claims to.
+        terminal.type(b"\x02;", 2)
+
+        terminal.type(b'muxa msg send @claude "how far along?"\r', 4)
+        report.check("messaging a peer advances", wait_step(terminal, 8), f"step={step()}")
+
+        terminal.type(b"muxa msg inbox\r", 4)
+        report.check("claiming the inbox advances", wait_step(terminal, 9), f"step={step()}")
+
+        terminal.type(b"\x02d", 4)  # Ctrl-b d finishes the tour
+        for _ in range(12):
+            if terminal.finished():
+                break
+            terminal.pump(2)
+        report.check("the tour exits on its own", terminal.finished())
+        report.check(
+            "it says the sandbox is gone",
+            "sandbox is gone" in terminal.text(),
+            terminal.text()[-300:],
+        )
+    finally:
+        terminal.kill()
+
+    print("nothing left behind")
+    report.check("no tmux server survives", tmux("list-sessions").returncode != 0)
+    strays = subprocess.run(
+        ["pgrep", "-f", f"{SANDBOX}-config"], capture_output=True, text=True
+    ).stdout.strip()
+    report.check("no daemon survives", strays == "", strays)
+
+    print(f"\n{report.passes} passed, {len(report.failures)} failed")
+    return 1 if report.failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/live-tour-smoke.py
+++ b/scripts/live-tour-smoke.py
@@ -107,17 +107,23 @@ def tmux(*args: str) -> subprocess.CompletedProcess:
     )
 
 
+def banner() -> str:
+    """Row 0 belongs to tmux — its own session and window list, which the tour
+    deliberately leaves alone so the learner can see what their keystrokes did."""
+    return tmux("show", "-g", "status-format[1]").stdout
+
+
 def step() -> int | None:
-    found = STEP_MARK.search(tmux("show", "-g", "status-format[0]").stdout)
+    found = STEP_MARK.search(banner())
     return int(found.group(1)) if found else None
 
 
 def cue() -> str:
-    return tmux("show", "-g", "status-format[2]").stdout
+    return tmux("show", "-g", "status-format[3]").stdout
 
 
 def title_text() -> str:
-    return tmux("show", "-g", "status-format[1]").stdout
+    return tmux("show", "-g", "status-format[2]").stdout
 
 
 def sandbox_muxa(muxa: str, *args: str) -> str:
@@ -271,12 +277,20 @@ def main() -> int:
         print("act I — tmux")
         report.check("step 1 is showing", step() == 1, f"step={step()}")
         report.check("the cue asks for tmux new-session", "tmux new-session" in cue(), cue())
+        report.check(
+            "tmux's own status row is left alone",
+            "status-format[0]" in tmux("show", "-g", "status-format[0]").stdout
+            and "window-status" in tmux("show", "-g", "status-format[0]").stdout,
+            tmux("show", "-g", "status-format[0]").stdout[:120],
+        )
 
         terminal.type(b"tmux new-session -s muxa-onboarding\r", 4)
         report.check("creating a session advances", wait_step(terminal, 2), f"step={step()}")
 
         terminal.type(b"\x02c", 3)  # Ctrl-b c
         report.check("a second window advances", wait_step(terminal, 3), f"step={step()}")
+        # "Did that work?" is the question the learner is holding at every step.
+        report.check("the step confirms what the last action did", "✓" in banner(), banner())
 
         terminal.type(b"\x02d", 3)  # Ctrl-b d
         report.check("detaching advances", wait_step(terminal, 4), f"step={step()}")

--- a/scripts/live-tour-smoke.py
+++ b/scripts/live-tour-smoke.py
@@ -116,6 +116,26 @@ def cue() -> str:
     return tmux("show", "-g", "status-format[2]").stdout
 
 
+def title_text() -> str:
+    return tmux("show", "-g", "status-format[1]").stdout
+
+
+def sandbox_muxa(muxa: str, *args: str) -> str:
+    """Run muxa as the learner's pane, which is the only origin the daemon
+    accepts for a mailbox query."""
+    env = dict(os.environ)
+    for line in subprocess.run(
+        ["bash", "scripts/muxa-sandbox.sh", "env", "--name", SANDBOX],
+        capture_output=True, text=True,
+    ).stdout.splitlines():
+        if line.startswith("export ") and "=" in line:
+            key, _, value = line[len("export "):].partition("=")
+            env[key] = value.split(':"$PATH"')[0].strip("'")
+    env["TMUX"] = env.get("MUXA_SANDBOX_TMUX_ENV", "")
+    env["TMUX_PANE"] = tmux("display-message", "-p", "#{pane_id}").stdout.strip()
+    return subprocess.run([muxa, *args], capture_output=True, text=True, env=env).stdout
+
+
 def title_row() -> str:
     return tmux("show", "-g", "status-format[1]").stdout.strip()
 
@@ -261,6 +281,12 @@ def main() -> int:
         terminal.type(b"\x02d", 3)  # Ctrl-b d
         report.check("detaching advances", wait_step(terminal, 4), f"step={step()}")
 
+        # Step 3 tells them to run `tmux ls`; the tour's own placeholder session
+        # showing up in that output is plumbing leaking through the lesson.
+        sessions = tmux("list-sessions", "-F", "#{session_name}").stdout.split()
+        report.check("the placeholder session is not in `tmux ls`",
+                     "_sandbox" not in sessions, str(sessions))
+
         terminal.type(b"tmux attach -t muxa-onboarding\r", 4)
         report.check("reattaching advances", wait_step(terminal, 5), f"step={step()}")
 
@@ -286,9 +312,18 @@ def main() -> int:
         terminal.type(b"muxa watch\r", 4)
         report.check("running watch advances", wait_step(terminal, 6), f"step={step()}")
 
+        # A cue that names a command without saying what it does leaves the
+        # learner running things blind.
+        explains_attend = {"en": "blocked longest", "ko": "가장 오래 막힌"}[args.lang]
+        report.check("the attend step says what attend does",
+                     explains_attend in title_text(), title_text())
+
         terminal.type(b"q", 2)
         terminal.type(b"muxa attend\r", 4)
         report.check("attend advances", wait_step(terminal, 7), f"step={step()}")
+        explains_return = {"en": "last pane you were in", "ko": "직전에 있던 pane"}[args.lang]
+        report.check("the return step says what Ctrl-b ; does",
+                     explains_return in title_text(), title_text())
 
         # attend put the learner in codex's pane, which is the point of it —
         # and that pane has no shell. Step 7 teaches `Ctrl-b ;` to get back, so
@@ -298,6 +333,15 @@ def main() -> int:
 
         terminal.type(b'muxa msg send @claude "how far along?"\r', 4)
         report.check("messaging a peer advances", wait_step(terminal, 8), f"step={step()}")
+
+        # claude answers through the mailbox, not just on its own screen, and
+        # before the learner runs anything to fetch it.
+        sent = sandbox_muxa(muxa, "msg", "list", "--mailbox", "sent", "--json")
+        report.check(
+            "claude replied through muxa on its own",
+            '"completed"' in sent,
+            sent[-300:],
+        )
 
         terminal.type(b"muxa msg inbox\r", 4)
         report.check("claiming the inbox advances", wait_step(terminal, 9), f"step={step()}")

--- a/scripts/live-tour-smoke.py
+++ b/scripts/live-tour-smoke.py
@@ -268,6 +268,21 @@ def main() -> int:
         panes = tmux("list-panes", "-a", "-F", "#{pane_id}").stdout.split()
         report.check("two agents joined the learner's window", len(panes) >= 3, str(panes))
 
+        # The tour claims to be a sandbox. If `ls` shows the learner their own
+        # repository, or watch prints their real path, it is not one.
+        paths = tmux("list-panes", "-a", "-F", "#{pane_current_path}").stdout.split()
+        report.check(
+            "nothing runs outside the sandbox workspace",
+            paths and all(p.startswith("/tmp/muxa-onboarding-home") for p in paths),
+            str(paths),
+        )
+        report.check(
+            "the windows are named after Works, not processes",
+            set(tmux("list-windows", "-a", "-F", "#{window_name}").stdout.split())
+            == {"checkout", "release-checks"},
+            tmux("list-windows", "-a", "-F", "#{window_name}").stdout.split(),
+        )
+
         terminal.type(b"muxa watch\r", 4)
         report.check("running watch advances", wait_step(terminal, 6), f"step={step()}")
 

--- a/scripts/live-tour-smoke.py
+++ b/scripts/live-tour-smoke.py
@@ -28,12 +28,13 @@ import time
 
 SANDBOX = "muxa-onboarding"
 STEP_MARK = re.compile(r"onboarding · (\d+)/(\d+)")
+STEPS_TOTAL = range(9)
 
 
 class Terminal:
     """A pty with a `muxa onboard --tour live` running in it."""
 
-    def __init__(self, muxa: str, lang: str) -> None:
+    def __init__(self, muxa: str, lang: str, no_quiz: bool = False) -> None:
         self.buffer = b""
         self.exited = False
         self.pid, self.fd = pty.fork()
@@ -42,7 +43,10 @@ class Terminal:
             # The tour refuses to nest, and CI may well run inside tmux.
             for stale in ("TMUX", "TMUX_PANE"):
                 os.environ.pop(stale, None)
-            os.execv(muxa, [muxa, "onboard", "--tour", "live", "--lang", lang])
+            argv = [muxa, "onboard", "--tour", "live", "--lang", lang]
+            if no_quiz:
+                argv.append("--no-quiz")
+            os.execv(muxa, argv)
             os._exit(127)
         fcntl.ioctl(self.fd, termios.TIOCSWINSZ, struct.pack("HHHH", 50, 200, 0, 0))
         os.set_blocking(self.fd, False)
@@ -121,6 +125,20 @@ def wait_step(terminal: Terminal, target: int, timeout: float = 60) -> bool:
     return False
 
 
+def wait_past(terminal: Terminal, target: int, timeout: float = 60) -> bool:
+    """At least `target`. One skip can advance more than one step: skipping
+    "detach" lands on "attach", which is already true for someone who never
+    left, so the tour moves straight on."""
+    end = time.time() + timeout
+    while time.time() < end:
+        current = step()
+        if current is not None and current >= target:
+            return True
+        terminal.pump(0.4)
+    current = step()
+    return current is not None and current >= target
+
+
 class Report:
     def __init__(self) -> None:
         self.failures: list[str] = []
@@ -136,14 +154,80 @@ class Report:
         return ok
 
 
+def escape_hatch(muxa: str, args, report: "Report") -> int:
+    """Issue #76 was a gate with no way around it. This checks the live tour
+    cannot repeat that: `--no-quiz` offers the way past from the first step, and
+    F12 walks the whole tour without the learner doing any of it.
+
+    Skipping has to leave the world consistent too — Act II introduces agents,
+    and there has to be a session for them to arrive in."""
+    print("escape hatch")
+    terminal = Terminal(muxa, args.lang, no_quiz=True)
+    try:
+        terminal.pump(12)
+        report.check("step 1 is showing", step() == 1, f"step={step()}")
+        report.check("--no-quiz offers the way past immediately", "F12" in cue(), cue())
+        report.check(
+            "step 1 is legible before anyone is attached",
+            "tmux new-session" in terminal.text(),
+            terminal.text()[-400:],
+        )
+
+        # F12 is a tmux binding, so it only reaches the tour once the learner is
+        # attached. Step 1 is the single step outside tmux, and its way past is
+        # that it is a plain command.
+        terminal.type(b"tmux new-session -s muxa-onboarding\r", 4)
+        report.check("step 1 done for real", wait_step(terminal, 2), f"step={step()}")
+
+        target = 3
+        while target <= len(STEPS_TOTAL):
+            terminal.type(b"\x1b[24~", 1.5)  # F12
+            if not report.check(f"F12 reaches step {target} or past it",
+                                wait_past(terminal, target, 45), f"step={step()}"):
+                break
+            reached = step() or target
+            if reached >= 5 and target < 5:
+                # The agents joined a session the learner never made themselves.
+                panes = tmux("list-panes", "-a", "-F", "#{pane_id}").stdout.split()
+                report.check("the agents still had a window to arrive in", len(panes) >= 3,
+                             str(panes))
+            target = reached + 1
+
+        terminal.type(b"\x1b[24~", 2)  # F12 past the last step
+        for _ in range(10):
+            if terminal.finished():
+                break
+            terminal.pump(2)
+        report.check("the tour exits", terminal.finished())
+    finally:
+        terminal.kill()
+
+    report.check("no tmux server survives", tmux("list-sessions").returncode != 0)
+    strays = subprocess.run(
+        ["pgrep", "-f", f"{SANDBOX}-config"], capture_output=True, text=True
+    ).stdout.strip()
+    report.check("no daemon survives", strays == "", strays)
+    print(f"\n{report.passes} passed, {len(report.failures)} failed")
+    return 1 if report.failures else 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--muxa", default=os.environ.get("MUXA_BIN", "target/debug/muxa"))
     parser.add_argument("--lang", default="en")
+    parser.add_argument(
+        "--mode",
+        choices=["tour", "skip"],
+        default="tour",
+        help="tour: type a learner's commands. skip: use the escape hatch instead.",
+    )
     args = parser.parse_args()
     muxa = os.path.abspath(args.muxa)
 
     report = Report()
+    if args.mode == "skip":
+        return escape_hatch(muxa, args, report)
+
     terminal = Terminal(muxa, args.lang)
     try:
         # Sandbox up, daemon up, the learner's shell.

--- a/scripts/live-tour-smoke.py
+++ b/scripts/live-tour-smoke.py
@@ -194,9 +194,12 @@ def main() -> int:
                 break
             terminal.pump(2)
         report.check("the tour exits on its own", terminal.finished())
+        # Both languages, because the summary is the only place the tour tells
+        # the learner nothing was left on their machine.
+        gone = {"en": "sandbox is gone", "ko": "sandbox는 사라졌습니다"}[args.lang]
         report.check(
             "it says the sandbox is gone",
-            "sandbox is gone" in terminal.text(),
+            gone in terminal.text(),
             terminal.text()[-300:],
         )
     finally:

--- a/scripts/muxa-sandbox.sh
+++ b/scripts/muxa-sandbox.sh
@@ -35,6 +35,7 @@ CONFIG_SRC=
 MUXAD_BIN=
 MUXA_BIN=
 TMUX_BIN=
+TMUX_CONFIG=
 ALLOW_INSIDE_TMUX=0
 KEEP_HOLDER=0
 EXTRA_PATHS=()
@@ -59,6 +60,7 @@ Options:
   --muxad <path>        muxad binary (default: target/debug, then $PATH)
   --muxa <path>         muxa binary (default: target/debug, then $PATH)
   --tmux <path>         Real tmux binary, resolved before the shim shadows it
+  --tmux-config <path>  tmux config for the sandbox server; /dev/null for none
   --extra-path <dir>    Prepend to the sandbox PATH; repeatable
   --allow-inside-tmux   Permit `up` while $TMUX is set
   --keep-holder         Leave the placeholder session alive after `up`
@@ -95,6 +97,8 @@ while [ "$#" -gt 0 ]; do
     --muxa=*) MUXA_BIN=${1#--muxa=}; shift ;;
     --tmux) [ "$#" -ge 2 ] || die '--tmux needs a path'; TMUX_BIN=$2; shift 2 ;;
     --tmux=*) TMUX_BIN=${1#--tmux=}; shift ;;
+    --tmux-config) [ "$#" -ge 2 ] || die '--tmux-config needs a path'; TMUX_CONFIG=$2; shift 2 ;;
+    --tmux-config=*) TMUX_CONFIG=${1#--tmux-config=}; shift ;;
     --extra-path) [ "$#" -ge 2 ] || die '--extra-path needs a directory'; EXTRA_PATHS+=("$2"); shift 2 ;;
     --extra-path=*) EXTRA_PATHS+=("${1#--extra-path=}"); shift ;;
     --allow-inside-tmux) ALLOW_INSIDE_TMUX=1; shift ;;
@@ -137,7 +141,15 @@ resolve_bins() {
   fi
 }
 
-tm() { "$TMUX_BIN" -u -L "$NAME" "$@"; }
+# `-f` is recorded at `up` so later commands — and `env` consumers — reach the
+# same server the same way.
+tm() {
+  if [ -n "$TMUX_CONFIG" ]; then
+    "$TMUX_BIN" -u -f "$TMUX_CONFIG" -L "$NAME" "$@"
+  else
+    "$TMUX_BIN" -u -L "$NAME" "$@"
+  fi
+}
 
 # --------------------------------------------------------------------------
 # status / down
@@ -446,6 +458,7 @@ export MUXA_SANDBOX_NAME='$NAME'
 export MUXA_SANDBOX_SHIM='$SB_SHIM'
 export MUXA_SANDBOX_HOLDER='$HOLDER_SESSION'
 export MUXA_SANDBOX_TMUX='$TMUX_BIN'
+export MUXA_SANDBOX_TMUX_CONFIG='$TMUX_CONFIG'
 export MUXA_SANDBOX_LOG='$SB_LOG'
 # A hook client stamps events with \$TMUX. Seeding from your own tmux session
 # without this makes muxad drop every event as out-of-scope.

--- a/scripts/split-arrow-check.py
+++ b/scripts/split-arrow-check.py
@@ -14,6 +14,7 @@ import argparse
 import importlib.util
 import pathlib
 import sys
+import time
 
 HERE = pathlib.Path(__file__).resolve().parent
 spec = importlib.util.spec_from_file_location("parity", HERE / "onboarding-parity.py")
@@ -51,7 +52,11 @@ def probe(muxa: str, gap_ms: int | None) -> bool:
             tour.send(b"\x1b[C")
         else:
             tour.send(b"\x1b")
-            tour.pump(gap_ms / 1000)
+            # `Tour.pump` waits in 50 ms select calls, so using it here made a
+            # claimed 20 ms gap exceed the product's old 50 ms grace period.
+            # Sleep directly: output between the two halves is irrelevant, and
+            # the duration printed below now describes the input we sent.
+            time.sleep(gap_ms / 1000)
             tour.send(b"[C")
         return tour.wait_for_step(ARROW_STEP + 1)
     finally:
@@ -59,20 +64,18 @@ def probe(muxa: str, gap_ms: int | None) -> bool:
 
 
 def advances(muxa: str, gap_ms: int | None, attempts: int) -> bool:
-    """Whether the arrow ever gets through.
+    """Whether the arrow gets through on every attempt.
 
-    Driving a TUI over a pty is timing-sensitive: reaching the gate, or seeing
-    the step counter move, times out perhaps one run in ten under load. Retry
-    rather than ship a flaky gate — the signal survives it, because a binary
-    that drops the key fails every attempt, not one in ten.
+    Requiring every probe to pass prevents an unsplit/coalesced write in one
+    attempt from concealing a handler that still drops genuinely torn input.
     """
-    return any(probe(muxa, gap_ms) for _ in range(attempts))
+    return all(probe(muxa, gap_ms) for _ in range(attempts))
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--muxa", default="target/debug/muxa")
-    ap.add_argument("--attempts", type=int, default=3, help="retries before failing")
+    ap.add_argument("--attempts", type=int, default=2, help="successful probes required")
     # Below about 5 ms the two writes coalesce in the pty often enough to be
     # nondeterministic, which exercises the *un*-split path and makes the check
     # flaky rather than strict. Real split escapes are milliseconds apart.


### PR DESCRIPTION
## Summary

Adds `muxa onboard --tour live`: fifteen one-action steps against a real,
throwaway tmux server, `muxad`, mailbox, and scripted agent panes. The existing
simulated tour remains the default.

Act I teaches the tmux lifecycle that muxa relies on: create a session and
window, inspect the tree, detach, prove the session survived, reattach, and
split a pane. Act II turns that pane into a scripted Claude peer, adds Codex,
then walks through real `muxa watch`, `muxa attend`, `muxa msg send`, `list`,
and `inbox` operations.

Narration lives in tmux status rows and never owns the keyboard. Each step polls
real tmux or muxa state and confirms the previous action. `F12` becomes an
escape hatch after 45 seconds (`--no-quiz` enables it immediately), and `F2`
switches language.

## Isolation and failure behavior

- Every invocation gets a private mode-0700, PID-scoped directory, sandbox
  daemon, data directory, and explicit tmux socket. Concurrent tours cannot
  observe, reuse, or tear down one another's state.
- Teardown runs on normal completion, errors, panic unwinding, and handled
  `Ctrl-C`/`SIGTERM`/`SIGHUP` paths.
- tmux, muxa, hook, and scripted mailbox failures are checked and reported
  instead of silently leaving a step that can never advance.
- Automatic default pane handles from #98 are reconciled by moving the learner
  to `@you` before assigning `@claude` and `@codex`, freeing the room-local
  alias namespace deterministically.
- Skipping the message step creates its prerequisite request, so the next
  scripted reply and mailbox steps remain coherent.

The sandbox script is embedded with `include_str!`, so installed binaries do
not depend on a repository checkout while `scripts/muxa-sandbox.sh` remains the
single tested source.

## Verification

`scripts/live-tour-smoke.py` drives the tour over a PTY with the same commands a
learner types and reads narration back from tmux itself.

```text
tour --lang en   35 passed, 0 failed
tour --lang ko   35 passed, 0 failed
--mode skip      18 passed, 0 failed
sandbox smoke    31 passed, 0 failed
```

The English and Korean/skip runs were also overlapped to exercise independent
namespaces. In addition:

- `cargo test -p muxa-cli onboarding`: 36 unit + 1 e2e passed
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- split-arrow PTY check: whole plus 10/20/45 ms torn sequences passed
- `cargo fmt --all -- --check` and `git diff --check`: clean

## Rollout

The simulated tour remains the default; callers opt into this implementation
with `--tour live`.
