### PR TITLE
feat(watch): rename from the tree, and give each terminal its own view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Every terminal on a workspace gets its own current window.** New
+  `tmux-auto-view` init component, on by default: two tmux hooks hand an
+  arriving client its own session-group view, so two terminals on one workspace
+  stop following each other's window switches. Both hooks matter —
+  `client-attached` covers `tmux attach`, and `client-session-changed` covers
+  `switch-client`, which is what `muxa watch`'s Enter does and what a terminal
+  that was already open goes through. `muxa workspace view` does the work and
+  can be run by hand; it is a no-op for a session's sole client and reuses one
+  view per terminal, so nothing accumulates. Views are named
+  `<session>~view~<pid>` and vanish on detach. Opt one session out with
+  `tmux set-option -t <session> @no_auto_view 1`.
+- **`R` renames the session, window, or pane under the cursor in `muxa
+  watch`.** The form opens prefilled with the current name and cursor at the
+  end, since renaming is usually an edit; Enter on an untouched prefill is a
+  cancel rather than a write. Window renames go through muxa's naming policy —
+  whitespace normalized to `-`, and a name already used in that session refused,
+  because tmux matches `session:window` targets by prefix. A pane has no name in
+  tmux, so that level sets the pane title, which is the string watch displays.
+- **New `tmux-window-names` init component**, on by default: turns off tmux's
+  `automatic-rename` and binds `prefix + ,` to `muxa window rename`. A window
+  is a Work Run under muxa's model, so naming it after whatever process is
+  running in it overwrites the Work with `node` or `claude` the moment an agent
+  starts.
+
 ### Changed
 
 - **Work pipelines now have daemon-owned, generation-aware Run state.** The
@@ -48,7 +74,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.35] - 2026-08-22
 
 ### Added
-
 - **Google Antigravity CLI (`agy`) is a first-class agent.** agy replaced the
   Gemini CLI upstream but shares none of its hook contract, so muxa's existing
   Gemini support was silently inert against it: agy reads

--- a/README.md
+++ b/README.md
@@ -272,7 +272,8 @@ Korean is selected automatically for a Korean locale, can be requested with
 | `muxa work init` | Describe a work pipeline in your own words; an agent writes the `[ticket]`/`[[route]]`/`[pipeline.*]` config, validated and shown before anything is written. |
 | `muxa work up cal-1234 --body "..."` | Resolve the ticket, route it to a workspace, and create whichever pipeline agent panes are missing — delivering the request to the ones already running. Re-running converges; also `muxa_start_work` over MCP. See [docs/PIPELINE.md](docs/PIPELINE.md). |
 | `muxa work start muxa-onboarding --workspace muxa --agent codex ...` | Create/reuse workspace session `muxa`, create/reuse its work window, and add an agent pane. |
-| `muxa workspace list/show/close` | Inspect or explicitly close workspace/project sessions. |
+| `muxa workspace list/show/view/close` | Inspect, give the current terminal an independent grouped view of, or explicitly close workspace/project sessions. |
+| `muxa window rename NAME` | Give a tmux window a stable normalized name, or restore process-based naming with `--auto`. |
 | `muxa work list/show/close [--workspace muxa]` | Inspect Work and its current Run binding, or explicitly close that Run window. |
 | `muxa agent start --host tmux --workspace muxa --work muxa-onboarding ...` | Add an allowlisted agent pane to one managed tmux Work window; also exposed as MCP `muxa_start_agent`. |
 | `muxa agent control (--pane %N\|--session pty-N) --action interrupt` | Interrupt or explicitly terminate one managed tmux pane or muxa-owned PTY agent session. |

--- a/crates/muxa-cli/src/init/components.rs
+++ b/crates/muxa-cli/src/init/components.rs
@@ -15,6 +15,12 @@ pub enum Component {
     TmuxStatusLine,
     /// `prefix + Q` → `display-popup -B muxa peek`
     TmuxPeek,
+    /// muxa owns window names: `automatic-rename off` + `prefix+,` renames
+    /// through `muxa window rename`
+    TmuxWindowNames,
+    /// Every terminal on a workspace gets its own current window, via a
+    /// session group created on attach and on jump
+    TmuxAutoView,
     /// Claude Code shell hooks + statusLine
     ClaudeHooks,
     /// Codex shell hooks
@@ -46,6 +52,8 @@ impl Component {
         Component::TmuxPopup,
         Component::TmuxStatusLine,
         Component::TmuxPeek,
+        Component::TmuxWindowNames,
+        Component::TmuxAutoView,
         Component::ClaudeHooks,
         Component::CodexHooks,
         Component::GeminiHooks,
@@ -65,6 +73,8 @@ impl Component {
             Component::TmuxPopup => "tmux-popup",
             Component::TmuxStatusLine => "tmux-statusline",
             Component::TmuxPeek => "tmux-peek",
+            Component::TmuxWindowNames => "tmux-window-names",
+            Component::TmuxAutoView => "tmux-auto-view",
             Component::ClaudeHooks => "claude-hooks",
             Component::CodexHooks => "codex-hooks",
             Component::GeminiHooks => "gemini-hooks",
@@ -89,6 +99,8 @@ impl Component {
             Component::TmuxPopup => "tmux: prefix+s watch + prefix+S Fleet + prefix+D dashboard",
             Component::TmuxStatusLine => "tmux: per-pane agent glyphs in status-right",
             Component::TmuxPeek => "tmux: prefix+Q overlays each pane with its agent",
+            Component::TmuxWindowNames => "tmux: muxa owns window names (prefix+, renames)",
+            Component::TmuxAutoView => "tmux: each terminal gets its own window view",
             Component::ClaudeHooks => "Claude Code: shell hooks + statusLine",
             Component::CodexHooks => "OpenAI Codex: shell hooks",
             Component::GeminiHooks => "Gemini CLI: shell hooks",
@@ -109,6 +121,10 @@ impl Component {
             Component::TmuxPopup => "open muxa without replacing the current agent pane",
             Component::TmuxStatusLine => "● / ○ / ▶ per pane, refreshed every 2s",
             Component::TmuxPeek => "display-panes with summary + prompt; digit jumps",
+            Component::TmuxWindowNames => {
+                "stops `automatic-rename` overwriting a Work name with `node`"
+            }
+            Component::TmuxAutoView => "two terminals on one workspace stop following each other",
             Component::ClaudeHooks => "auto-detect when ~/.claude/settings.json exists",
             Component::CodexHooks => "auto-detect when ~/.codex/config.toml exists",
             Component::GeminiHooks => "auto-detect when ~/.gemini/settings.json exists",
@@ -156,11 +172,15 @@ impl Component {
                 Component::TmuxPopup,
                 Component::TmuxStatusLine,
                 Component::TmuxPeek,
+                Component::TmuxWindowNames,
+                Component::TmuxAutoView,
             ],
             Preset::Standard => vec![
                 Component::TmuxPopup,
                 Component::TmuxStatusLine,
                 Component::TmuxPeek,
+                Component::TmuxWindowNames,
+                Component::TmuxAutoView,
                 Component::ClaudeHooks,
                 Component::CodexHooks,
                 Component::GeminiHooks,

--- a/crates/muxa-cli/src/init/detect.rs
+++ b/crates/muxa-cli/src/init/detect.rs
@@ -58,6 +58,17 @@ impl Detection {
             out.push(Component::TmuxPopup);
             out.push(Component::TmuxStatusLine);
             out.push(Component::TmuxPeek);
+            // Pre-checked because the default it replaces is actively wrong
+            // for muxa's model: `automatic-rename` renames a Work window
+            // after whatever process is running in it, so every window ends
+            // up called `node` or `claude` and the Work it stands for is
+            // invisible in tmux's own status line and window list.
+            out.push(Component::TmuxWindowNames);
+            // Pre-checked for the same reason: the tmux default is wrong for
+            // how muxa is used. One session has one current window, so a
+            // second terminal on a workspace cannot sit on a second Work —
+            // and there is no way to discover that the fix is a session group.
+            out.push(Component::TmuxAutoView);
             // A collaboration room *is* a tmux window, so tmux is the only
             // prerequisite. Pre-checked rather than opt-in: leaving it dark
             // is what made `m`/`b` answer "collaboration is disabled" on

--- a/crates/muxa-cli/src/init/files/tmux.rs
+++ b/crates/muxa-cli/src/init/files/tmux.rs
@@ -57,6 +57,69 @@ pub const PEEK_BODY: &str = r#"# prefix + q: display-panes, plus each pane's age
 # Replaces tmux's stock display-panes; `muxa init --uninstall` puts it back.
 bind-key q display-popup -B -E -w 100% -h 100% -x 0 -y 0 "muxa peek""#;
 
+/// The body that goes inside the `tmux-auto-view` marker block.
+///
+/// One tmux session has one current window, shared by every client attached to
+/// it. Under muxa's model a window is a Work Run, so two terminals on one
+/// workspace cannot sit on two different Work items — switching one switches
+/// the other. A *session group* is the only mechanism that separates them: the
+/// window list stays shared, each session keeps its own current window.
+///
+/// Two hooks, because there are two ways into a busy session and only covering
+/// one leaves the feature looking broken. `client-attached` is a terminal
+/// running `tmux attach`. `client-session-changed` is `switch-client` — which
+/// is what `muxa watch`'s Enter does, and what a terminal that was already
+/// open when this was installed goes through. Measured on tmux 3.4: with only
+/// the attach hook, jumping from watch put both terminals back in one session
+/// and they followed each other from there.
+///
+/// Self-limiting rather than recursive: the view each hook creates has exactly
+/// one client, so the `session_attached > 1` guard is false for the switch
+/// into it. `muxa workspace view` is a no-op for a sole client, so a single
+/// terminal never grows a second session.
+///
+/// Only `#{client_name}` is interpolated, and deliberately: the hook body is
+/// already three quoting levels deep (`set-hook "…"` → `if -F '…'` →
+/// `run-shell \"…\"`), and a fourth pair around each value terminates the
+/// enclosing one — it broke exactly that way in testing, with tmux reporting
+/// `syntax error` and the client left sharing a session. A client name is a
+/// tty path with no spaces, so it needs no quoting, and `muxa workspace view`
+/// resolves the session and the pid from the client itself.
+///
+/// Per-session opt-out, for when two terminals *should* mirror each other
+/// (pairing, screen sharing): `tmux set-option -t <session> @no_auto_view 1`.
+pub const AUTO_VIEW_BODY: &str = r#"# Each terminal on a workspace gets its own current window, via a session
+# group. Both hooks are needed: attach covers `tmux attach`, session-changed
+# covers `switch-client` — which is what `muxa watch`'s Enter does.
+# Mirror two terminals instead: tmux set-option -t <session> @no_auto_view 1
+set-hook -g client-attached "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"muxa workspace view --client #{client_name}\"'"
+set-hook -g client-session-changed "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"muxa workspace view --client #{client_name}\"'""#;
+
+/// The body that goes inside the `tmux-window-names` marker block.
+///
+/// tmux's `automatic-rename` renames each window after the command running in
+/// it. Under muxa's model a window *is* a Work Run, so the name it was given —
+/// by `muxa work up`, or by hand — is overwritten with `node` or `claude` the
+/// moment an agent starts, and the Work the window stands for stops being
+/// visible in tmux's own window list and status line. Off is the setting that
+/// matches what a window means here.
+///
+/// `prefix + ,` keeps tmux's muscle memory but routes through muxa: whitespace
+/// normalizes to `-`, and a name already used in that session is refused,
+/// because tmux matches `session:window` targets by prefix and a duplicate
+/// silently addresses the wrong window. `#{window_id}` is expanded by
+/// `run-shell`, and `%%` by `command-prompt`; `-I "#W"` prefills the name so
+/// the prompt is an edit rather than a retype. Measured end to end on tmux 3.4
+/// by driving a real client's tty.
+///
+/// One window can opt back into tmux's dynamic name with
+/// `muxa window rename --auto`.
+pub const WINDOW_NAMES_BODY: &str = r##"# muxa owns window names: a window is a Work Run, not the process in it.
+# `muxa window rename --auto` opts one window back into tmux's dynamic name.
+set-window-option -g automatic-rename off
+# prefix + , renames through muxa: whitespace to `-`, duplicates refused.
+bind-key , command-prompt -I "#W" "run-shell \"muxa window rename --window '#{window_id}' -- '%%'\""##;
+
 /// The body that goes inside the `tmux-statusline` marker block.
 ///
 /// Two segments: a GLOBAL attention summary (`⚠ N need you`, red, empty
@@ -99,6 +162,8 @@ pub fn upsert(original: &str, component: Component) -> (String, Outcome) {
         Component::TmuxPopup => marker::upsert(original, component.id(), POPUP_BODY),
         Component::TmuxStatusLine => marker::upsert(original, component.id(), STATUSLINE_BODY),
         Component::TmuxPeek => marker::upsert(original, component.id(), PEEK_BODY),
+        Component::TmuxWindowNames => marker::upsert(original, component.id(), WINDOW_NAMES_BODY),
+        Component::TmuxAutoView => marker::upsert(original, component.id(), AUTO_VIEW_BODY),
         _ => (original.to_string(), Outcome::Unchanged),
     }
 }
@@ -106,9 +171,11 @@ pub fn upsert(original: &str, component: Component) -> (String, Outcome) {
 /// Reverse a previous `upsert`. No-op if the block is already absent.
 pub fn remove(original: &str, component: Component) -> (String, Outcome) {
     match component {
-        Component::TmuxPopup | Component::TmuxStatusLine | Component::TmuxPeek => {
-            marker::remove(original, component.id())
-        }
+        Component::TmuxPopup
+        | Component::TmuxStatusLine
+        | Component::TmuxPeek
+        | Component::TmuxWindowNames
+        | Component::TmuxAutoView => marker::remove(original, component.id()),
         _ => (original.to_string(), Outcome::Unchanged),
     }
 }

--- a/crates/muxa-cli/src/init/files/tmux.rs
+++ b/crates/muxa-cli/src/init/files/tmux.rs
@@ -86,14 +86,18 @@ bind-key q display-popup -B -E -w 100% -h 100% -x 0 -y 0 "muxa peek""#;
 /// tty path with no spaces, so it needs no quoting, and `muxa workspace view`
 /// resolves the session and the pid from the client itself.
 ///
+/// The fixed array index makes re-sourcing idempotent without replacing a
+/// user's existing hook at index 0. tmux hooks are arrays; an unindexed
+/// `set-hook -g client-attached ...` silently overwrites that first entry.
+///
 /// Per-session opt-out, for when two terminals *should* mirror each other
 /// (pairing, screen sharing): `tmux set-option -t <session> @no_auto_view 1`.
 pub const AUTO_VIEW_BODY: &str = r#"# Each terminal on a workspace gets its own current window, via a session
 # group. Both hooks are needed: attach covers `tmux attach`, session-changed
 # covers `switch-client` — which is what `muxa watch`'s Enter does.
 # Mirror two terminals instead: tmux set-option -t <session> @no_auto_view 1
-set-hook -g client-attached "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"muxa workspace view --client #{client_name}\"'"
-set-hook -g client-session-changed "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"muxa workspace view --client #{client_name}\"'""#;
+set-hook -g 'client-attached[9000]' "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"muxa workspace view --client #{client_name}\"'"
+set-hook -g 'client-session-changed[9000]' "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"muxa workspace view --client #{client_name}\"'""#;
 
 /// The body that goes inside the `tmux-window-names` marker block.
 ///
@@ -107,10 +111,15 @@ set-hook -g client-session-changed "if -F '#{&&:#{>:#{session_attached},1},#{==:
 /// `prefix + ,` keeps tmux's muscle memory but routes through muxa: whitespace
 /// normalizes to `-`, and a name already used in that session is refused,
 /// because tmux matches `session:window` targets by prefix and a duplicate
-/// silently addresses the wrong window. `#{window_id}` is expanded by
-/// `run-shell`, and `%%` by `command-prompt`; `-I "#W"` prefills the name so
-/// the prompt is an edit rather than a retype. Measured end to end on tmux 3.4
-/// by driving a real client's tty.
+/// silently addresses the wrong window. `-I "#W"` prefills the name so the
+/// prompt is an edit rather than a retype. Its response is first stored in a
+/// per-client tmux buffer (`%%%` escapes quotes for tmux's parser); the fixed
+/// shell command carries only native ids and the buffer name, never the user
+/// text. The CLI consumes and deletes the buffer before renaming, while the
+/// fixed shell cleanup also removes it if muxa cannot start. `run-shell` stays
+/// synchronous so it cannot race the preceding `set-buffer`. Measured end to
+/// end on tmux 3.4 by driving a real client's tty, including shell syntax in
+/// the submitted name.
 ///
 /// One window can opt back into tmux's dynamic name with
 /// `muxa window rename --auto`.
@@ -118,7 +127,7 @@ pub const WINDOW_NAMES_BODY: &str = r##"# muxa owns window names: a window is a 
 # `muxa window rename --auto` opts one window back into tmux's dynamic name.
 set-window-option -g automatic-rename off
 # prefix + , renames through muxa: whitespace to `-`, duplicates refused.
-bind-key , command-prompt -I "#W" "run-shell \"muxa window rename --window '#{window_id}' -- '%%'\""##;
+bind-key , command-prompt -F -I "#W" "set-buffer -b 'muxa-window-name-#{client_pid}' -- \"%%%\" ; run-shell \"muxa window rename --window '#{window_id}' --buffer 'muxa-window-name-#{client_pid}'; tmux delete-buffer -b 'muxa-window-name-#{client_pid}' 2>/dev/null || true\"""##;
 
 /// The body that goes inside the `tmux-statusline` marker block.
 ///
@@ -255,6 +264,30 @@ mod tests {
         let (after3, o3) = remove(&after2, Component::TmuxPeek);
         assert_eq!(o3, Outcome::Removed);
         assert!(!after3.contains("muxa peek"));
+    }
+
+    #[test]
+    fn auto_view_uses_owned_hook_slots_without_clobbering_user_hooks() {
+        let (after, outcome) = upsert("", Component::TmuxAutoView);
+        assert_eq!(outcome, Outcome::Inserted);
+        assert!(after.contains("client-attached[9000]"));
+        assert!(after.contains("client-session-changed[9000]"));
+        assert!(!after.contains("set-hook -g client-attached \""));
+
+        let (after2, outcome2) = upsert(&after, Component::TmuxAutoView);
+        assert_eq!(outcome2, Outcome::Unchanged);
+        assert_eq!(after2, after);
+    }
+
+    #[test]
+    fn window_rename_prompt_keeps_user_text_out_of_the_shell() {
+        let (after, outcome) = upsert("", Component::TmuxWindowNames);
+        assert_eq!(outcome, Outcome::Inserted);
+        assert!(after.contains("set-buffer -b 'muxa-window-name-#{client_pid}' -- \\\"%%%\\\""));
+        assert!(after.contains("--buffer 'muxa-window-name-#{client_pid}'"));
+        assert!(after.contains("; tmux delete-buffer -b 'muxa-window-name-#{client_pid}'"));
+        assert!(!after.contains("run-shell -b"));
+        assert!(!after.contains("-- '%%"));
     }
 
     #[test]

--- a/crates/muxa-cli/src/init/plan.rs
+++ b/crates/muxa-cli/src/init/plan.rs
@@ -95,7 +95,11 @@ pub fn build(
 
     for c in &comps {
         match c {
-            Component::TmuxPopup | Component::TmuxStatusLine | Component::TmuxPeek => {
+            Component::TmuxPopup
+            | Component::TmuxStatusLine
+            | Component::TmuxPeek
+            | Component::TmuxWindowNames
+            | Component::TmuxAutoView => {
                 tmux_selected = true;
                 plan_tmux(direction, *c, tmux_path.as_ref(), &mut actions)?;
             }

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -3075,7 +3075,7 @@ mod tests {
     }
 
     #[test]
-    fn window_rename_cli_supports_explicit_and_automatic_names() {
+    fn window_rename_cli_supports_explicit_automatic_and_buffered_names() {
         let args = Args::try_parse_from([
             "muxa",
             "window",
@@ -3093,6 +3093,7 @@ mod tests {
             panic!("expected window rename");
         };
         assert_eq!(rename.name.as_deref(), Some("CAL-7175 auth refactor"));
+        assert!(rename.buffer.is_none());
         assert_eq!(rename.window.as_deref(), Some("@42"));
         assert!(!rename.auto);
         assert!(rename.json);
@@ -3109,6 +3110,25 @@ mod tests {
             "muxa", "window", "rename", "name", "--window", "@42", "--auto"
         ])
         .is_err());
+
+        let args = Args::try_parse_from([
+            "muxa",
+            "window",
+            "rename",
+            "--window",
+            "@42",
+            "--buffer",
+            "muxa-window-name-123",
+        ])
+        .unwrap();
+        let Cmd::Window {
+            action: WindowCmd::Rename(rename),
+        } = args.cmd
+        else {
+            panic!("expected buffered window rename");
+        };
+        assert_eq!(rename.buffer.as_deref(), Some("muxa-window-name-123"));
+        assert!(rename.name.is_none());
     }
 
     #[test]

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -428,6 +428,9 @@ enum WorkspaceCmd {
     Show(tmux_work::WorkspaceShowArgs),
     /// Close a workspace session, including every work and agent.
     Close(tmux_work::WorkspaceCloseArgs),
+    /// Give this terminal its own view of a workspace, so two terminals on one
+    /// session stop following each other's window switches.
+    View(tmux_work::WorkspaceViewArgs),
 }
 
 #[derive(Debug, Subcommand)]
@@ -588,6 +591,7 @@ fn run_workspace_cmd(action: WorkspaceCmd) -> Result<()> {
         WorkspaceCmd::List(args) => tmux_work::run_workspace_list(args),
         WorkspaceCmd::Show(args) => tmux_work::run_workspace_show(args),
         WorkspaceCmd::Close(args) => tmux_work::run_workspace_close(args),
+        WorkspaceCmd::View(args) => tmux_work::run_workspace_view(args),
     }
 }
 

--- a/crates/muxa-cli/src/onboarding.rs
+++ b/crates/muxa-cli/src/onboarding.rs
@@ -2016,7 +2016,7 @@ mod tests {
         assert!(shortcuts.contains("m / M"));
         assert!(shortcuts.contains("a / A"));
         assert!(shortcuts.contains("Alt-K"));
-        assert!(shortcuts.contains("n / w / R      new pane / work up a pipeline / rename the row"));
+        assert!(shortcuts.contains("n / w / R      new window/pane / work up / rename the row"));
     }
 
     #[test]

--- a/crates/muxa-cli/src/onboarding.rs
+++ b/crates/muxa-cli/src/onboarding.rs
@@ -2016,7 +2016,7 @@ mod tests {
         assert!(shortcuts.contains("m / M"));
         assert!(shortcuts.contains("a / A"));
         assert!(shortcuts.contains("Alt-K"));
-        assert!(shortcuts.contains("n / w          new window or agent pane / work up a pipeline"));
+        assert!(shortcuts.contains("n / w / R      new pane / work up a pipeline / rename the row"));
     }
 
     #[test]

--- a/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_help_overlay.snap
+++ b/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_help_overlay.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/muxa-cli/src/watch.rs
-assertion_line: 24495
 expression: "snapshot_helpers::buffer_string(&terminal)"
 ---
  muxa watch   1 agent  + 0 panes   sort PANE ID   <clock>
@@ -16,7 +15,7 @@ j/k move  ·  type or / filter  ·  : commands  ·  ? help
 │                           │  gg/G · Home/End first / last selectable row                                     │                           │
 │                           │  PgUp/PgDn       page; Ctrl-U/Ctrl-D half page                                   │                           │
 │                           │  Enter          attach via active window/pane or exact pane                      │                           │
-│                           │  n / w          new window or agent pane / work up a pipeline                    │                           │
+│                           │  n / w / R      new pane / work up a pipeline / rename the row                   │                           │
 │                           │  a / A          ask / history; d deletes one · D clears all in A                 │                           │
 │                           │                                                                                  │                           │
 │                           │Commands & inspection                                                             │                           │

--- a/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_help_overlay.snap
+++ b/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_help_overlay.snap
@@ -15,7 +15,7 @@ j/k move  ·  type or / filter  ·  : commands  ·  ? help
 │                           │  gg/G · Home/End first / last selectable row                                     │                           │
 │                           │  PgUp/PgDn       page; Ctrl-U/Ctrl-D half page                                   │                           │
 │                           │  Enter          attach via active window/pane or exact pane                      │                           │
-│                           │  n / w / R      new pane / work up a pipeline / rename the row                   │                           │
+│                           │  n / w / R      new window/pane / work up / rename the row                       │                           │
 │                           │  a / A          ask / history; d deletes one · D clears all in A                 │                           │
 │                           │                                                                                  │                           │
 │                           │Commands & inspection                                                             │                           │

--- a/crates/muxa-cli/src/tmux_work.rs
+++ b/crates/muxa-cli/src/tmux_work.rs
@@ -338,6 +338,148 @@ pub struct WorkspaceCloseArgs {
     pub json: bool,
 }
 
+#[derive(Debug, clap::Args)]
+pub struct WorkspaceViewArgs {
+    /// Session to view. Defaults to the session the calling client is in.
+    #[arg(long)]
+    pub session: Option<String>,
+    /// tmux client to move, e.g. `/dev/pts/71`. Defaults to the calling one.
+    #[arg(long)]
+    pub client: Option<String>,
+    /// Suffix that names the view. Defaults to the client's pid, which keeps
+    /// one terminal to one view instead of a new session per jump.
+    #[arg(long = "client-pid")]
+    pub client_pid: Option<String>,
+    /// Emit JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Name for a client's private view of `session`.
+///
+/// `<session>~view~<suffix>` sorts next to the session it mirrors and reads as
+/// what it is. Safe despite tmux matching session names by prefix, because an
+/// exact match wins over prefix candidates — measured on tmux 3.4 with
+/// `callabo`, `callabo-set` and `callabo~view~1734560` all present, `-t
+/// callabo` resolves to `callabo`.
+fn view_session_name(session: &str, suffix: &str) -> String {
+    format!("{session}~view~{suffix}")
+}
+
+/// Give one tmux client its own view of a session, so two terminals on one
+/// workspace stop following each other's window switches.
+///
+/// A tmux session has a single current window shared by every client attached
+/// to it. A *session group* is the only thing that separates them: the window
+/// list stays shared, but each session in the group keeps its own current
+/// window. This puts the client into one.
+///
+/// A no-op when the client is the session's only one — a lone terminal needs
+/// no view, and creating one anyway would leave a second session in every
+/// listing for nothing.
+pub fn run_workspace_view(args: WorkspaceViewArgs) -> Result<()> {
+    let client = match args.client.clone() {
+        Some(client) => client,
+        None => tmux_output(&["display-message", "-p", "#{client_name}"])?
+            .trim()
+            .to_string(),
+    };
+    if client.is_empty() {
+        bail!("no tmux client to move; pass --client");
+    }
+    let session = match args.session.clone() {
+        Some(session) => session,
+        None => tmux_output(&["display-message", "-p", "-t", &client, "#{session_name}"])?
+            .trim()
+            .to_string(),
+    };
+    if session.is_empty() {
+        bail!("no tmux session for client {client:?}; pass --session");
+    }
+    let attached: u32 = tmux_output(&[
+        "display-message",
+        "-p",
+        "-t",
+        &client,
+        "#{session_attached}",
+    ])?
+    .trim()
+    .parse()
+    .unwrap_or(0);
+    if attached <= 1 {
+        if args.json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "client": client,
+                    "session": session,
+                    "view": serde_json::Value::Null,
+                    "reason": "sole client",
+                }))?
+            );
+        }
+        return Ok(());
+    }
+
+    let suffix = args.client_pid.clone().unwrap_or_else(|| {
+        tmux_output(&["display-message", "-p", "-t", &client, "#{client_pid}"])
+            .map(|pid| pid.trim().to_string())
+            .unwrap_or_default()
+    });
+    let suffix = if suffix.is_empty() {
+        std::process::id().to_string()
+    } else {
+        suffix
+    };
+    let mut name = view_session_name(&session, &suffix);
+    // A terminal regrouping a second time asks for the name it had before.
+    // That usually succeeds — `destroy-unattached` has reaped the old view by
+    // then — but the ordering is not guaranteed, and a clash would otherwise
+    // abort the regroup and leave the client sharing a session.
+    if tmux_status(&["has-session", "-t", &format!("={name}")]).is_ok() {
+        name = format!("{name}-{}", std::process::id());
+    }
+
+    // `=` anchors the target: tmux matches session names by prefix otherwise,
+    // and real session sets collide (`callabo` also matches `callabo-set`).
+    let view = tmux_output(&[
+        "new-session",
+        "-dP",
+        "-F",
+        "#{session_id}",
+        "-t",
+        &format!("={session}"),
+        "-s",
+        &name,
+    ])?
+    .trim()
+    .to_string();
+
+    // Move the client in BEFORE `destroy-unattached`. Setting that option on a
+    // session that still has no client makes tmux reap it on the spot, which
+    // silently undoes the whole thing.
+    if let Err(error) = tmux_status(&["switch-client", "-c", &client, "-t", &view]) {
+        let _ = tmux_status(&["kill-session", "-t", &view]);
+        return Err(error);
+    }
+    tmux_status(&["set-option", "-t", &view, "destroy-unattached", "on"])?;
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "client": client,
+                "session": session,
+                "view": name,
+                "view_id": view,
+            }))?
+        );
+    } else {
+        println!("client {client} now views {session} as {name}");
+    }
+    Ok(())
+}
+
 pub async fn run_agent_control(args: AgentControlArgs, client: &Client) -> Result<()> {
     let result = if let Some(session) = args.session.as_deref() {
         let sessions = client
@@ -1785,7 +1927,10 @@ fn sanitize_window_name(name: &str) -> String {
     sanitize_session_name(name)
 }
 
-fn normalize_window_name(raw: &str) -> Result<String> {
+/// Normalize a user-supplied name: whitespace to `-`, no control characters,
+/// bounded length. Shared with `watch`'s rename form so both entry points
+/// produce the same name for the same keystrokes.
+pub(crate) fn normalize_window_name(raw: &str) -> Result<String> {
     let value = metadata(raw, 64)?;
     if value.chars().any(char::is_control) {
         bail!("window name cannot contain control characters");
@@ -1948,6 +2093,33 @@ fn print_result(result: &ManageResult, json: bool) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn view_session_name_sorts_beside_the_session_it_mirrors() {
+        // `<session>~view~<pid>` rather than `view~<pid>~<session>`: the view
+        // lands next to its session in `list-sessions` and in watch's tree.
+        // Safe despite tmux's prefix matching because an exact name match wins
+        // — `-t callabo` resolves to `callabo`, not to this.
+        assert_eq!(
+            view_session_name("callabo", "1734560"),
+            "callabo~view~1734560"
+        );
+    }
+
+    #[test]
+    fn view_session_name_keeps_one_terminal_to_one_view() {
+        // The suffix is the client's pid, so the same terminal regrouping
+        // twice asks for the same name instead of leaving a trail of sessions
+        // behind every jump.
+        assert_eq!(
+            view_session_name("muxa", "42"),
+            view_session_name("muxa", "42")
+        );
+        assert_ne!(
+            view_session_name("muxa", "42"),
+            view_session_name("muxa", "43")
+        );
+    }
     use super::*;
 
     #[test]

--- a/crates/muxa-cli/src/tmux_work.rs
+++ b/crates/muxa-cli/src/tmux_work.rs
@@ -236,15 +236,24 @@ pub struct WindowRenameArgs {
     /// New stable display name. Whitespace is normalized to `-`.
     #[arg(
         value_name = "NAME",
-        required_unless_present = "auto",
-        conflicts_with = "auto"
+        required_unless_present_any = ["auto", "buffer"],
+        conflicts_with_all = ["auto", "buffer"]
     )]
     pub name: Option<String>,
+    /// Read the name from a tmux paste buffer and delete it. Used by the
+    /// generated `prefix + ,` binding so prompt text never enters a shell.
+    #[arg(
+        long,
+        value_name = "BUFFER",
+        hide = true,
+        conflicts_with_all = ["name", "auto"]
+    )]
+    pub buffer: Option<String>,
     /// Exact window target such as @42. Defaults to the current tmux pane's window.
     #[arg(long, value_name = "TARGET")]
     pub window: Option<String>,
     /// Restore tmux's dynamic process-based automatic window name.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "buffer")]
     pub auto: bool,
     /// Emit JSON.
     #[arg(long)]
@@ -366,6 +375,219 @@ fn view_session_name(session: &str, suffix: &str) -> String {
     format!("{session}~view~{suffix}")
 }
 
+const VIEW_SESSION_FORMAT: &str =
+    "#{session_id}\t#{session_name}\t#{session_attached}\t#{session_group}\t#{destroy-unattached}";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ViewSession {
+    id: String,
+    name: String,
+    attached: u32,
+    group: Option<String>,
+    destroy_unattached: bool,
+}
+
+fn parse_view_session(line: &str) -> Result<ViewSession> {
+    let mut fields = line.trim_end_matches(['\r', '\n']).splitn(5, '\t');
+    let id = fields.next().unwrap_or_default().to_string();
+    let name = fields.next().unwrap_or_default().to_string();
+    let attached = fields
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("tmux did not report session_attached"))?
+        .parse::<u32>()
+        .context("tmux reported an invalid session_attached value")?;
+    let group = fields
+        .next()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let destroy_unattached = match fields.next().unwrap_or_default().trim() {
+        "1" | "on" => true,
+        "0" | "off" => false,
+        value => bail!("tmux reported an invalid destroy-unattached value {value:?}"),
+    };
+    if id.is_empty() || name.is_empty() {
+        bail!("tmux did not report a session id and name");
+    }
+    Ok(ViewSession {
+        id,
+        name,
+        attached,
+        group,
+        destroy_unattached,
+    })
+}
+
+fn list_view_sessions() -> Result<Vec<ViewSession>> {
+    tmux_output(&["list-sessions", "-F", VIEW_SESSION_FORMAT])?
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(parse_view_session)
+        .collect()
+}
+
+fn resolve_view_session(target: &str) -> Result<ViewSession> {
+    parse_view_session(&tmux_output(&[
+        "display-message",
+        "-p",
+        "-t",
+        target,
+        VIEW_SESSION_FORMAT,
+    ])?)
+}
+
+fn tmux_session_id_cmp(left: &str, right: &str) -> std::cmp::Ordering {
+    let sequence = |id: &str| id.strip_prefix('$').and_then(|raw| raw.parse::<u64>().ok());
+    match (sequence(left), sequence(right)) {
+        (Some(left), Some(right)) => left.cmp(&right),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => left.cmp(right),
+    }
+}
+
+/// Pick the same representative as topology folding. `session_group` keeps
+/// the original name after `rename-session`, so the only durable ordering is
+/// tmux's monotonically allocated numeric session id.
+fn canonical_view_source(target: &ViewSession, sessions: &[ViewSession]) -> ViewSession {
+    let Some(group) = target.group.as_deref() else {
+        return target.clone();
+    };
+    sessions
+        .iter()
+        .filter(|session| session.group.as_deref() == Some(group))
+        .min_by(|left, right| tmux_session_id_cmp(&left.id, &right.id))
+        .cloned()
+        .unwrap_or_else(|| target.clone())
+}
+
+fn expected_view_group(source: &ViewSession) -> &str {
+    source.group.as_deref().unwrap_or(&source.name)
+}
+
+/// A renamed original session should lend its new name to future views. If
+/// that original is gone and the oldest survivor is itself a generated view,
+/// remove its final view suffix instead of producing
+/// `base~view~1~view~2` on every regroup. The session-group name cannot be
+/// used as the base because tmux does not update it after `rename-session`.
+fn view_name_base(source: &ViewSession) -> &str {
+    let differs_from_group = source
+        .group
+        .as_deref()
+        .is_some_and(|group| group != source.name);
+    if source.destroy_unattached || differs_from_group {
+        if let Some((base, suffix)) = source.name.rsplit_once("~view~") {
+            if !base.is_empty() && !suffix.is_empty() {
+                return base;
+            }
+        }
+    }
+    &source.name
+}
+
+/// Reuse only a view created but not yet occupied by a racing invocation, or
+/// the view the same client has already entered. An attached session owned by
+/// another client is a name collision, not this terminal's private view.
+fn reusable_view<'a>(
+    sessions: &'a [ViewSession],
+    name: &str,
+    source: &ViewSession,
+    client_session_id: &str,
+) -> Option<&'a ViewSession> {
+    sessions.iter().find(|session| {
+        session.name == name
+            && session.group.as_deref() == Some(expected_view_group(source))
+            && (session.attached == 0 || session.id == client_session_id)
+    })
+}
+
+struct PreparedView {
+    id: String,
+    name: String,
+    created: bool,
+}
+
+fn prepare_view(
+    client: &str,
+    source: &ViewSession,
+    suffix: &str,
+    sessions: &[ViewSession],
+) -> Result<PreparedView> {
+    let base_name = view_session_name(view_name_base(source), suffix);
+    let current_id = resolve_view_session(client)?.id;
+    let existing = reusable_view(sessions, &base_name, source, &current_id);
+    let mut name = base_name;
+    if existing.is_none() && sessions.iter().any(|session| session.name == name) {
+        name = unique_name(name, |candidate| {
+            sessions.iter().any(|session| session.name == candidate)
+        });
+    }
+    if let Some(existing) = existing {
+        return Ok(PreparedView {
+            id: existing.id.clone(),
+            name,
+            created: false,
+        });
+    }
+
+    let create = tmux_output(&[
+        "new-session",
+        "-dP",
+        "-F",
+        "#{session_id}",
+        "-t",
+        &source.id,
+        "-s",
+        &name,
+    ]);
+    match create {
+        Ok(id) => Ok(PreparedView {
+            id: id.trim().to_string(),
+            name,
+            created: true,
+        }),
+        Err(create_error) => {
+            // Another hook invocation may have won the create between our
+            // listing and `new-session`. Reuse only its unattached view or the
+            // session this same client already entered.
+            let refreshed = list_view_sessions()?;
+            let refreshed_client_id = resolve_view_session(client)?.id;
+            let Some(existing) = reusable_view(&refreshed, &name, source, &refreshed_client_id)
+            else {
+                return Err(create_error);
+            };
+            Ok(PreparedView {
+                id: existing.id.clone(),
+                name,
+                created: false,
+            })
+        }
+    }
+}
+
+fn activate_view(client: &str, original_session_id: &str, view: &PreparedView) -> Result<()> {
+    // Move the client in BEFORE `destroy-unattached`. Setting that option on a
+    // session that still has no client makes tmux reap it on the spot.
+    if let Err(error) = tmux_status(&["switch-client", "-c", client, "-t", &view.id]) {
+        if view.created {
+            let _ = tmux_status(&["kill-session", "-t", &view.id]);
+        }
+        return Err(error);
+    }
+    if let Err(error) = tmux_status(&["set-option", "-t", &view.id, "destroy-unattached", "on"]) {
+        if let Err(rollback) =
+            tmux_status(&["switch-client", "-c", client, "-t", original_session_id])
+        {
+            bail!("{error}; could not return client to {original_session_id}: {rollback}");
+        }
+        if view.created {
+            let _ = tmux_status(&["kill-session", "-t", &view.id]);
+        }
+        return Err(error);
+    }
+    Ok(())
+}
+
 /// Give one tmux client its own view of a session, so two terminals on one
 /// workspace stop following each other's window switches.
 ///
@@ -387,32 +609,21 @@ pub fn run_workspace_view(args: WorkspaceViewArgs) -> Result<()> {
     if client.is_empty() {
         bail!("no tmux client to move; pass --client");
     }
-    let session = match args.session.clone() {
-        Some(session) => session,
-        None => tmux_output(&["display-message", "-p", "-t", &client, "#{session_name}"])?
-            .trim()
-            .to_string(),
+    let client_session = resolve_view_session(&client)
+        .with_context(|| format!("resolve the current session for client {client:?}"))?;
+    let target = match args.session.as_deref() {
+        Some(session) => resolve_view_session(session)
+            .with_context(|| format!("resolve requested session {session:?}"))?,
+        None => client_session.clone(),
     };
-    if session.is_empty() {
-        bail!("no tmux session for client {client:?}; pass --session");
-    }
-    let attached: u32 = tmux_output(&[
-        "display-message",
-        "-p",
-        "-t",
-        &client,
-        "#{session_attached}",
-    ])?
-    .trim()
-    .parse()
-    .unwrap_or(0);
-    if attached <= 1 {
+    let other_clients = client_session.attached.saturating_sub(1);
+    if other_clients == 0 {
         if args.json {
             println!(
                 "{}",
                 serde_json::to_string_pretty(&serde_json::json!({
                     "client": client,
-                    "session": session,
+                    "session": target.name,
                     "view": serde_json::Value::Null,
                     "reason": "sole client",
                 }))?
@@ -421,61 +632,34 @@ pub fn run_workspace_view(args: WorkspaceViewArgs) -> Result<()> {
         return Ok(());
     }
 
-    let suffix = args.client_pid.clone().unwrap_or_else(|| {
-        tmux_output(&["display-message", "-p", "-t", &client, "#{client_pid}"])
-            .map(|pid| pid.trim().to_string())
-            .unwrap_or_default()
-    });
+    let suffix = match args.client_pid.clone() {
+        Some(suffix) => suffix,
+        None => tmux_output(&["display-message", "-p", "-t", &client, "#{client_pid}"])?
+            .trim()
+            .to_string(),
+    };
     let suffix = if suffix.is_empty() {
         std::process::id().to_string()
     } else {
         suffix
     };
-    let mut name = view_session_name(&session, &suffix);
-    // A terminal regrouping a second time asks for the name it had before.
-    // That usually succeeds — `destroy-unattached` has reaped the old view by
-    // then — but the ordering is not guaranteed, and a clash would otherwise
-    // abort the regroup and leave the client sharing a session.
-    if tmux_status(&["has-session", "-t", &format!("={name}")]).is_ok() {
-        name = format!("{name}-{}", std::process::id());
-    }
-
-    // `=` anchors the target: tmux matches session names by prefix otherwise,
-    // and real session sets collide (`callabo` also matches `callabo-set`).
-    let view = tmux_output(&[
-        "new-session",
-        "-dP",
-        "-F",
-        "#{session_id}",
-        "-t",
-        &format!("={session}"),
-        "-s",
-        &name,
-    ])?
-    .trim()
-    .to_string();
-
-    // Move the client in BEFORE `destroy-unattached`. Setting that option on a
-    // session that still has no client makes tmux reap it on the spot, which
-    // silently undoes the whole thing.
-    if let Err(error) = tmux_status(&["switch-client", "-c", &client, "-t", &view]) {
-        let _ = tmux_status(&["kill-session", "-t", &view]);
-        return Err(error);
-    }
-    tmux_status(&["set-option", "-t", &view, "destroy-unattached", "on"])?;
+    let sessions = list_view_sessions()?;
+    let source = canonical_view_source(&target, &sessions);
+    let view = prepare_view(&client, &source, &suffix, &sessions)?;
+    activate_view(&client, &client_session.id, &view)?;
 
     if args.json {
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
                 "client": client,
-                "session": session,
-                "view": name,
-                "view_id": view,
+                "session": source.name,
+                "view": view.name,
+                "view_id": view.id,
             }))?
         );
     } else {
-        println!("client {client} now views {session} as {name}");
+        println!("client {client} now views {} as {}", source.name, view.name);
     }
     Ok(())
 }
@@ -529,7 +713,11 @@ pub async fn run_agent_control(args: AgentControlArgs, client: &Client) -> Resul
 }
 
 pub fn run_window_rename(args: WindowRenameArgs) -> Result<()> {
-    let result = rename_window(args.window.as_deref(), args.name.as_deref(), args.auto)?;
+    let name = match args.buffer.as_deref() {
+        Some(buffer) => Some(take_window_name_buffer(buffer)?),
+        None => args.name.clone(),
+    };
+    let result = rename_window(args.window.as_deref(), name.as_deref(), args.auto)?;
     if args.json {
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else if result.automatic {
@@ -544,6 +732,19 @@ pub fn run_window_rename(args: WindowRenameArgs) -> Result<()> {
         );
     }
     Ok(())
+}
+
+/// Move one command-prompt response across the tmux boundary without ever
+/// interpolating it into a shell command. The binding stores the response in
+/// a per-client named buffer; this reads and immediately deletes that buffer.
+fn take_window_name_buffer(buffer: &str) -> Result<String> {
+    if buffer.trim().is_empty() {
+        bail!("tmux buffer name cannot be empty");
+    }
+    let value = tmux_output(&["show-buffer", "-b", buffer])?;
+    tmux_status(&["delete-buffer", "-b", buffer])
+        .with_context(|| format!("delete consumed tmux buffer {buffer:?}"))?;
+    Ok(value.trim_end_matches(['\r', '\n']).to_string())
 }
 
 /// Report that this agent has finished its part, which is what opens an
@@ -1935,6 +2136,9 @@ pub(crate) fn normalize_window_name(raw: &str) -> Result<String> {
     if value.chars().any(char::is_control) {
         bail!("window name cannot contain control characters");
     }
+    if value.contains("#{") || value.contains("#(") {
+        bail!("window name cannot contain tmux format expansions");
+    }
     let mut normalized = String::new();
     for ch in value.chars() {
         if ch.is_whitespace() {
@@ -2093,6 +2297,23 @@ fn print_result(result: &ManageResult, json: bool) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    fn view_session(
+        id: &str,
+        name: &str,
+        attached: u32,
+        group: Option<&str>,
+        destroy_unattached: bool,
+    ) -> ViewSession {
+        ViewSession {
+            id: id.into(),
+            name: name.into(),
+            attached,
+            group: group.map(str::to_string),
+            destroy_unattached,
+        }
+    }
 
     #[test]
     fn view_session_name_sorts_beside_the_session_it_mirrors() {
@@ -2120,7 +2341,72 @@ mod tests {
             view_session_name("muxa", "43")
         );
     }
-    use super::*;
+
+    #[test]
+    fn canonical_view_source_survives_base_session_rename() {
+        let renamed = view_session("$99", "renamed", 2, Some("base"), false);
+        let later_view = view_session("$107", "base~view~42", 1, Some("base"), true);
+        let sessions = vec![later_view.clone(), renamed.clone()];
+
+        assert_eq!(canonical_view_source(&later_view, &sessions), renamed);
+    }
+
+    #[test]
+    fn orphaned_view_strips_one_view_suffix_without_nesting() {
+        let orphan = view_session("$107", "base~view~42", 2, Some("base"), true);
+        assert_eq!(view_name_base(&orphan), "base");
+        assert_eq!(
+            view_session_name(view_name_base(&orphan), "43"),
+            "base~view~43"
+        );
+
+        let leaked_orphan = view_session("$108", "base~view~44", 2, Some("base"), false);
+        assert_eq!(view_name_base(&leaked_orphan), "base");
+
+        let renamed_orphan = view_session("$109", "renamed~view~45", 2, Some("base"), false);
+        assert_eq!(view_name_base(&renamed_orphan), "renamed");
+        assert_eq!(
+            view_session_name(view_name_base(&renamed_orphan), "46"),
+            "renamed~view~46"
+        );
+
+        let renamed_base = view_session("$99", "renamed", 2, Some("base"), false);
+        assert_eq!(view_name_base(&renamed_base), "renamed");
+
+        let deliberate_name = view_session(
+            "$100",
+            "project~view~draft",
+            2,
+            Some("project~view~draft"),
+            false,
+        );
+        assert_eq!(view_name_base(&deliberate_name), "project~view~draft");
+    }
+
+    #[test]
+    fn reusable_view_does_not_take_over_another_clients_session() {
+        let source = view_session("$1", "base", 2, Some("base"), false);
+        let occupied = view_session("$2", "base~view~42", 1, Some("base"), true);
+        let sessions = vec![source.clone(), occupied.clone()];
+
+        assert!(reusable_view(&sessions, &occupied.name, &source, "$1").is_none());
+        assert_eq!(
+            reusable_view(&sessions, &occupied.name, &source, "$2"),
+            Some(&occupied)
+        );
+
+        let available = view_session("$3", "base~view~43", 0, Some("base"), false);
+        let sessions = vec![source.clone(), available.clone()];
+        assert_eq!(
+            reusable_view(&sessions, &available.name, &source, "$1"),
+            Some(&available)
+        );
+    }
+
+    #[test]
+    fn parse_view_session_refuses_a_malformed_attached_count() {
+        assert!(parse_view_session("$1\tbase\tnot-a-number\t\toff").is_err());
+    }
 
     #[test]
     fn workspace_and_work_ids_are_normalized_and_tmux_safe() {
@@ -2144,6 +2430,8 @@ mod tests {
             "topology-watch"
         );
         assert!(normalize_window_name("\n").is_err());
+        assert!(normalize_window_name("#(printf hidden)").is_err());
+        assert!(normalize_window_name("#{session_name}").is_err());
     }
 
     #[test]

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -1692,7 +1692,7 @@ pub(crate) fn help_overlay_text() -> Vec<&'static str> {
         "  gg/G · Home/End first / last selectable row",
         "  PgUp/PgDn       page; Ctrl-U/Ctrl-D half page",
         "  Enter          attach via active window/pane or exact pane",
-        "  n / w          new window or agent pane / work up a pipeline",
+        "  n / w / R      new pane / work up a pipeline / rename the row",
         "  a / A          ask / history; d deletes one · D clears all in A",
         "",
         "Commands & inspection",
@@ -1770,6 +1770,39 @@ struct AskComposer {
 /// wanting the same text box is not a reason to give them the same key.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct WorkComposer {
+    input: String,
+    cursor: usize,
+}
+
+/// Which level of the tree `R` is renaming, and what tmux calls the thing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RenameLevel {
+    Session,
+    Window,
+    Pane,
+}
+
+impl RenameLevel {
+    fn label(self) -> &'static str {
+        match self {
+            RenameLevel::Session => "session",
+            RenameLevel::Window => "window",
+            // tmux has no pane *name*; the closest durable, displayable
+            // string is the pane title, which is what watch already shows.
+            RenameLevel::Pane => "pane title",
+        }
+    }
+}
+
+/// Rename form for the row under the cursor. Carries the node key rather than
+/// re-reading the selection on submit: a refresh can move the cursor while the
+/// form is open, and renaming whatever happens to be selected a second later
+/// is not what the user asked for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RenameComposer {
+    key: TopologyNodeKey,
+    level: RenameLevel,
+    original: String,
     input: String,
     cursor: usize,
 }
@@ -2704,6 +2737,7 @@ pub(crate) struct App {
     /// `Some` while the `a` ask composer is open.
     ask_composer: Option<AskComposer>,
     work_composer: Option<WorkComposer>,
+    rename: Option<RenameComposer>,
     ask_panel: AskPanelState,
     ask_entries: Vec<muxa::ask::AskEntry>,
     /// Agent the next question goes to, as the daemon reports it.
@@ -2961,6 +2995,7 @@ impl App {
             spawn: None,
             ask_composer: None,
             work_composer: None,
+            rename: None,
             ask_panel: AskPanelState::default(),
             ask_entries: Vec::new(),
             ask_agent: "claude".into(),
@@ -3512,6 +3547,45 @@ impl App {
 
     fn selected_node_key(&self) -> Option<TopologyNodeKey> {
         self.selected_tree_target().map(|target| target.key)
+    }
+
+    /// Open the rename form on the row under the cursor, prefilled with the
+    /// name it has now.
+    ///
+    /// The cursor lands at the end of the prefill: renaming is usually an edit
+    /// of what is there (`cal-7306` → `cal-7306-review`), and a cursor at
+    /// column zero turns the first keystroke into a prefix splice.
+    fn open_rename(&mut self) {
+        let Some(node) = self.selected_node() else {
+            self.set_hint(
+                "rename needs a session, window, or pane row",
+                HintLevel::Warn,
+            );
+            return;
+        };
+        let (key, level, original) = match node {
+            TopologyNodeRef::Session(session) => (
+                session.node_key(),
+                RenameLevel::Session,
+                session.name.clone(),
+            ),
+            TopologyNodeRef::Window(window) => {
+                (window.node_key(), RenameLevel::Window, window.name.clone())
+            }
+            TopologyNodeRef::Pane(pane) => (pane.node_key(), RenameLevel::Pane, pane.title.clone()),
+        };
+        if key.endpoint().host != muxa::HostKind::Tmux {
+            self.set_hint("rename is tmux-only for now", HintLevel::Warn);
+            return;
+        }
+        let cursor = original.chars().count();
+        self.rename = Some(RenameComposer {
+            key,
+            level,
+            original: original.clone(),
+            input: original,
+            cursor,
+        });
     }
 
     fn selected_node(&self) -> Option<TopologyNodeRef<'_>> {
@@ -7139,6 +7213,14 @@ pub async fn run(
                 Action::OpenWorkUp => {
                     app.work_composer = Some(WorkComposer::default());
                 }
+                Action::SubmitRename => {
+                    if let Some(rename) = app.rename.take() {
+                        match apply_rename(&rename) {
+                            Ok(message) => app.set_hint(message, HintLevel::Ok),
+                            Err(e) => app.set_hint(format!("rename failed: {e}"), HintLevel::Err),
+                        }
+                    }
+                }
                 Action::SubmitWorkUp => {
                     if let Some(work) = app.work_composer.take() {
                         let in_tmux = std::env::var_os("TMUX").is_some();
@@ -8412,6 +8494,7 @@ pub(crate) enum Action {
     OpenWorkUp,
     /// Run `muxa work up` for whatever the composer holds.
     SubmitWorkUp,
+    SubmitRename,
     None,
     Quit,
     Refresh,
@@ -8607,6 +8690,10 @@ fn execute_palette_command(app: &mut App, input: &str) -> Action {
             Action::InspectorSplitChanged
         }
         "b" | "mailbox" => Action::OpenCollaborationMailbox,
+        "rename" => {
+            app.open_rename();
+            Action::None
+        }
         "copy" | "yank" => quick_copy_action(app),
         "kill" => quick_kill_action(app),
         "abort" => quick_abort_action(app),
@@ -8748,6 +8835,9 @@ fn handle_event(ev: Event, app: &mut App) -> Action {
 
     if app.work_composer.is_some() {
         return handle_work_composer_event(code, modifiers, app);
+    }
+    if app.rename.is_some() {
+        return handle_rename_event(code, modifiers, app);
     }
     if app.ask_composer.is_some() {
         return handle_ask_composer_event(code, modifiers, app);
@@ -8954,6 +9044,10 @@ fn handle_event(ev: Event, app: &mut App) -> Action {
         }
         KeyCode::Char('a') if app.browse_keys_active() => Action::OpenAsk,
         KeyCode::Char('w') if app.browse_keys_active() => Action::OpenWorkUp,
+        KeyCode::Char('R') if app.browse_keys_active() => {
+            app.open_rename();
+            Action::None
+        }
         KeyCode::Char('A') if app.browse_keys_active() => Action::OpenAskPanel,
         KeyCode::Char('h') if app.browse_keys_active() => {
             app.move_to_work_parent();
@@ -9145,6 +9239,114 @@ fn work_up_window_args(exe: &str, work: &str) -> Vec<String> {
 /// embedded `'`.
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+/// Whether `list-windows` output already gives `name` to a *different* window.
+///
+/// Equality on the id, not the name, is what lets a window keep the name it
+/// already has: re-submitting an unchanged prefill must be a no-op, not a
+/// collision with itself.
+fn window_name_taken(listing: &str, window_id: &str, name: &str) -> bool {
+    listing.lines().any(|line| {
+        line.split_once('\t')
+            .is_some_and(|(id, current)| id.trim() != window_id && current.trim() == name)
+    })
+}
+
+/// Apply a rename to tmux. Returns the message to show on success.
+///
+/// Sessions and windows have real names; a pane does not, so `RenameLevel::Pane`
+/// sets the pane *title* — the string watch already displays for a pane, and the
+/// only per-pane label tmux persists.
+fn apply_rename(rename: &RenameComposer) -> std::result::Result<String, String> {
+    let socket = Some(rename.key.endpoint().socket.as_str());
+    let name = crate::tmux_work::normalize_window_name(&rename.input).map_err(|e| e.to_string())?;
+    let run = |args: &[&str]| -> std::result::Result<(), String> {
+        muxa::tmux::run_control_on(socket, args).map_err(|e| e.to_string())
+    };
+    match (&rename.key, rename.level) {
+        (TopologyNodeKey::Session(session), _) => {
+            run(&["rename-session", "-t", &session.session_id, &name])?;
+        }
+        (TopologyNodeKey::Window(window), _) => {
+            // Session-scoped uniqueness, for the reason tmux targets make it
+            // matter: `session:window` matches names by prefix, so a duplicate
+            // silently addresses the wrong window.
+            let listing = muxa::tmux::capture_control_on(
+                socket,
+                &[
+                    "list-windows",
+                    "-t",
+                    &window.session.session_id,
+                    "-F",
+                    "#{window_id}\t#{window_name}",
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            if window_name_taken(&listing, &window.window_id, &name) {
+                return Err(format!(
+                    "window name {name:?} is already used in this session"
+                ));
+            }
+            // Pin the mode rather than relying on `rename-window` turning
+            // automatic-rename off as a side effect.
+            run(&[
+                "set-window-option",
+                "-t",
+                &window.window_id,
+                "automatic-rename",
+                "off",
+            ])?;
+            run(&["rename-window", "-t", &window.window_id, &name])?;
+        }
+        (TopologyNodeKey::Pane(pane), _) => {
+            run(&["select-pane", "-t", &pane.pane_id, "-T", &name])?;
+        }
+    }
+    Ok(format!("renamed {} to {name:?}", rename.level.label()))
+}
+
+fn handle_rename_event(code: KeyCode, modifiers: KeyModifiers, app: &mut App) -> Action {
+    if code == KeyCode::Backspace
+        && app
+            .rename
+            .as_ref()
+            .is_some_and(|rename| rename.input.is_empty())
+    {
+        app.rename = None;
+        return Action::None;
+    }
+    let Some(rename) = app.rename.as_mut() else {
+        return Action::None;
+    };
+    match code {
+        KeyCode::Esc => {
+            app.rename = None;
+            Action::None
+        }
+        KeyCode::Enter => {
+            if rename.input.trim().is_empty() {
+                app.set_hint("a name is required", HintLevel::Warn);
+                Action::None
+            } else if rename.input == rename.original {
+                // Submitting the untouched prefill means "never mind".
+                app.rename = None;
+                Action::None
+            } else {
+                Action::SubmitRename
+            }
+        }
+        KeyCode::Char('v') if modifiers.contains(KeyModifiers::CONTROL) => {
+            if let Some(pasted) = system_clipboard_text() {
+                insert_str_at(&mut rename.input, &mut rename.cursor, &pasted);
+            }
+            Action::None
+        }
+        other => {
+            spawn_edit_text(other, modifiers, &mut rename.input, &mut rename.cursor);
+            Action::None
+        }
+    }
 }
 
 fn handle_work_composer_event(code: KeyCode, modifiers: KeyModifiers, app: &mut App) -> Action {
@@ -10420,6 +10622,7 @@ pub(crate) fn render(f: &mut Frame, app: &mut App) {
         render_ask_panel(f, popup_area, app);
     }
     render_work_composer_overlay(f, chunks[1], app);
+    render_rename_overlay(f, chunks[1], app);
     if app.ask_composer.is_some() {
         let skills_open = app
             .ask_composer
@@ -10691,6 +10894,56 @@ fn spawn_popup_rect(r: Rect, spawn: &SpawnComposer) -> Rect {
 
 /// Draw the `w` composer over `area`, or nothing when it is closed. Folded
 /// into one call so `render` stays inside its line budget.
+fn render_rename_overlay(f: &mut Frame, area: Rect, app: &App) {
+    if app.rename.is_none() {
+        return;
+    }
+    let popup_area = message_composer_rect(area, false);
+    f.render_widget(Clear, popup_area);
+    render_rename(f, popup_area, app);
+}
+
+fn render_rename(f: &mut Frame, area: Rect, app: &App) {
+    use unicode_width::UnicodeWidthStr;
+    let theme = watch_theme(app.watch_cfg.theme.unwrap_or_default());
+    let Some(rename) = app.rename.as_ref() else {
+        return;
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.action))
+        .border_type(theme.border_type)
+        .title(Span::styled(
+            // The level is in the title because the same key opens the form on
+            // three different things, and "which one is this about" has to be
+            // answerable without looking back at the cursor behind the popup.
+            format!(" rename {} ", rename.level.label()),
+            theme.action_badge().add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(area);
+    let view = truncate_prompt_input(&rename.input, usize::from(inner.width.saturating_sub(2)));
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw("> "),
+            Span::raw(view.text.clone()),
+        ]))
+        .block(block),
+        area,
+    );
+    let before: String = view
+        .text
+        .chars()
+        .take(rename.cursor.saturating_sub(view.skipped_chars))
+        .collect();
+    let x = inner
+        .x
+        .saturating_add(2)
+        .saturating_add(u16::try_from(before.width()).unwrap_or(u16::MAX));
+    if x < inner.x + inner.width {
+        f.set_cursor_position((x, inner.y));
+    }
+}
+
 fn render_work_composer_overlay(f: &mut Frame, area: Rect, app: &App) {
     if app.work_composer.is_none() {
         return;
@@ -22339,6 +22592,9 @@ sort = ["state"]
             // The real handler shells out to tmux; the test harness stops at
             // the state change so nothing spawns a window.
             Action::SubmitWorkUp => app.work_composer = None,
+            // Same reasoning: the run loop applies the rename through tmux, so
+            // the harness only takes the composer the way the run loop does.
+            Action::SubmitRename => app.rename = None,
             Action::TogglePreviewMode => {
                 if let Some(p) = app.preview.as_mut() {
                     p.mode = match p.mode {
@@ -23184,6 +23440,106 @@ sort = ["state"]
         app
     }
 
+    fn rename_app(level: RenameLevel, original: &str) -> App {
+        let mut app = App::with_legacy_config(WatchConfig::default());
+        app.rename = Some(RenameComposer {
+            key: TopologyNodeKey::Window(muxa::WindowKey {
+                session: muxa::SessionKey {
+                    endpoint: muxa::BackendEndpoint {
+                        host: muxa::HostKind::Tmux,
+                        socket: "default".into(),
+                    },
+                    session_id: "$1".into(),
+                },
+                window_id: "@4".into(),
+            }),
+            level,
+            original: original.into(),
+            input: original.into(),
+            cursor: original.chars().count(),
+        });
+        app
+    }
+
+    #[test]
+    fn rename_submitting_an_untouched_prefill_is_a_cancel() {
+        // The form opens prefilled, so Enter on an unchanged field is the most
+        // likely accident in it. Renaming a window to the name it already has
+        // would still pin `automatic-rename off` as a side effect, which is a
+        // real change nobody asked for.
+        let mut app = rename_app(RenameLevel::Window, "cal-7306");
+        let action = handle_rename_event(KeyCode::Enter, KeyModifiers::NONE, &mut app);
+        assert!(matches!(action, Action::None));
+        assert!(app.rename.is_none(), "the form closes");
+    }
+
+    #[test]
+    fn rename_submits_only_a_changed_name() {
+        let mut app = rename_app(RenameLevel::Window, "cal-7306");
+        {
+            let rename = app.rename.as_mut().expect("form is open");
+            spawn_edit_text(
+                KeyCode::Char('!'),
+                KeyModifiers::NONE,
+                &mut rename.input,
+                &mut rename.cursor,
+            );
+        }
+        let action = handle_rename_event(KeyCode::Enter, KeyModifiers::NONE, &mut app);
+        assert!(matches!(action, Action::SubmitRename));
+        // The composer survives until the run loop takes it — the apply needs
+        // the key it captured when the form opened.
+        assert!(app.rename.is_some());
+    }
+
+    #[test]
+    fn rename_refuses_an_empty_name_without_closing() {
+        let mut app = rename_app(RenameLevel::Session, "callabo");
+        app.rename.as_mut().unwrap().input.clear();
+        app.rename.as_mut().unwrap().cursor = 0;
+        // Enter on an empty field warns rather than submitting; Backspace on
+        // an empty field is the deliberate way out.
+        let action = handle_rename_event(KeyCode::Enter, KeyModifiers::NONE, &mut app);
+        assert!(matches!(action, Action::None));
+        assert!(
+            app.rename.is_some(),
+            "an empty name must not close the form"
+        );
+        handle_rename_event(KeyCode::Backspace, KeyModifiers::NONE, &mut app);
+        assert!(app.rename.is_none());
+    }
+
+    #[test]
+    fn rename_escape_abandons_the_edit() {
+        let mut app = rename_app(RenameLevel::Pane, "claude");
+        app.rename.as_mut().unwrap().input.push_str("-review");
+        handle_rename_event(KeyCode::Esc, KeyModifiers::NONE, &mut app);
+        assert!(app.rename.is_none());
+    }
+
+    #[test]
+    fn window_name_taken_excludes_the_window_being_renamed() {
+        let listing = "@1\tbuild\n@4\tcal-7306\n@9\treview\n";
+        // Keeping your own name is not a collision with yourself.
+        assert!(!window_name_taken(listing, "@4", "cal-7306"));
+        // Another window holding it is.
+        assert!(window_name_taken(listing, "@4", "review"));
+        // Free names are free.
+        assert!(!window_name_taken(listing, "@4", "cal-7307"));
+        // Whole-field equality, never a prefix: `build` must not match
+        // `build-2`, or a rename would be refused against a name nobody has.
+        assert!(!window_name_taken(listing, "@4", "build-2"));
+    }
+
+    #[test]
+    fn rename_level_names_what_tmux_actually_changes() {
+        // A pane has no name in tmux; the form says "pane title" so the label
+        // matches the thing that ends up different.
+        assert_eq!(RenameLevel::Session.label(), "session");
+        assert_eq!(RenameLevel::Window.label(), "window");
+        assert_eq!(RenameLevel::Pane.label(), "pane title");
+    }
+
     #[test]
     fn kill_action_disabled_for_paneless_row() {
         let mut app = app_with_paneless_and_pane();
@@ -23455,7 +23811,7 @@ sort = ["state"]
         assert!(body.contains("m / M          message selected agent / mailbox (b alias)"));
         assert!(body.contains("i / e          (in mailbox) claim inbox / reply"));
         assert!(body.contains("a / A          ask / history; d deletes one · D clears all in A"));
-        assert!(body.contains("n / w          new window or agent pane / work up a pipeline"));
+        assert!(body.contains("n / w / R      new pane / work up a pipeline / rename the row"));
         // The exit keys deliberately live in the overlay's border rather
         // than the matrix — the body is clipped by terminal height, and
         // "how to leave" must not be the row that falls off.

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -1692,7 +1692,7 @@ pub(crate) fn help_overlay_text() -> Vec<&'static str> {
         "  gg/G · Home/End first / last selectable row",
         "  PgUp/PgDn       page; Ctrl-U/Ctrl-D half page",
         "  Enter          attach via active window/pane or exact pane",
-        "  n / w / R      new pane / work up a pipeline / rename the row",
+        "  n / w / R      new window/pane / work up / rename the row",
         "  a / A          ask / history; d deletes one · D clears all in A",
         "",
         "Commands & inspection",
@@ -7214,9 +7214,16 @@ pub async fn run(
                     app.work_composer = Some(WorkComposer::default());
                 }
                 Action::SubmitRename => {
-                    if let Some(rename) = app.rename.take() {
-                        match apply_rename(&rename) {
-                            Ok(message) => app.set_hint(message, HintLevel::Ok),
+                    let result = app.rename.as_ref().map(apply_rename);
+                    if let Some(result) = result {
+                        match result {
+                            Ok(message) => {
+                                app.rename = None;
+                                app.set_hint(message, HintLevel::Ok);
+                            }
+                            // Keep the form and its input open so a duplicate,
+                            // invalid value, or transient tmux failure can be
+                            // corrected instead of making the user retype it.
                             Err(e) => app.set_hint(format!("rename failed: {e}"), HintLevel::Err),
                         }
                     }
@@ -9253,6 +9260,36 @@ fn window_name_taken(listing: &str, window_id: &str, name: &str) -> bool {
     })
 }
 
+/// Session names and pane titles are labels, not Work window ids. Preserve
+/// their internal whitespace; applying the window policy here would turn a
+/// pane title such as `Claude review` into `Claude-review` as a side effect of
+/// changing one character.
+fn rename_label(raw: &str, level: RenameLevel) -> std::result::Result<String, String> {
+    let value = raw.trim();
+    if value.is_empty() {
+        return Err(format!("{} cannot be empty", level.label()));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(format!(
+            "{} cannot contain control characters",
+            level.label()
+        ));
+    }
+    if value.len() > 64 {
+        return Err(format!("{} is too long (max 64 bytes)", level.label()));
+    }
+    if value.contains("#{") || value.contains("#(") {
+        return Err(format!(
+            "{} cannot contain tmux format expansions",
+            level.label()
+        ));
+    }
+    if level == RenameLevel::Session && value.chars().any(|ch| matches!(ch, '.' | ':')) {
+        return Err("session name cannot contain '.' or ':'".into());
+    }
+    Ok(value.to_string())
+}
+
 /// Apply a rename to tmux. Returns the message to show on success.
 ///
 /// Sessions and windows have real names; a pane does not, so `RenameLevel::Pane`
@@ -9260,7 +9297,12 @@ fn window_name_taken(listing: &str, window_id: &str, name: &str) -> bool {
 /// only per-pane label tmux persists.
 fn apply_rename(rename: &RenameComposer) -> std::result::Result<String, String> {
     let socket = Some(rename.key.endpoint().socket.as_str());
-    let name = crate::tmux_work::normalize_window_name(&rename.input).map_err(|e| e.to_string())?;
+    let name = match rename.level {
+        RenameLevel::Window => {
+            crate::tmux_work::normalize_window_name(&rename.input).map_err(|e| e.to_string())?
+        }
+        RenameLevel::Session | RenameLevel::Pane => rename_label(&rename.input, rename.level)?,
+    };
     let run = |args: &[&str]| -> std::result::Result<(), String> {
         muxa::tmux::run_control_on(socket, args).map_err(|e| e.to_string())
     };
@@ -23541,6 +23583,26 @@ sort = ["state"]
     }
 
     #[test]
+    fn rename_rules_preserve_label_spaces_but_normalize_window_spaces() {
+        assert_eq!(
+            rename_label(" Claude review updated ", RenameLevel::Pane).unwrap(),
+            "Claude review updated"
+        );
+        assert_eq!(
+            rename_label("two terminals", RenameLevel::Session).unwrap(),
+            "two terminals"
+        );
+        assert_eq!(
+            crate::tmux_work::normalize_window_name("CAL-1 review").unwrap(),
+            "CAL-1-review"
+        );
+        assert!(rename_label("bad:name", RenameLevel::Session).is_err());
+        assert!(rename_label("bad\ntitle", RenameLevel::Pane).is_err());
+        assert!(rename_label("#{session_name}", RenameLevel::Pane).is_err());
+        assert!(rename_label(&"a".repeat(65), RenameLevel::Pane).is_err());
+    }
+
+    #[test]
     fn kill_action_disabled_for_paneless_row() {
         let mut app = app_with_paneless_and_pane();
         // Find the paneless row by walking the rows — sort may have
@@ -23811,7 +23873,7 @@ sort = ["state"]
         assert!(body.contains("m / M          message selected agent / mailbox (b alias)"));
         assert!(body.contains("i / e          (in mailbox) claim inbox / reply"));
         assert!(body.contains("a / A          ask / history; d deletes one · D clears all in A"));
-        assert!(body.contains("n / w / R      new pane / work up a pipeline / rename the row"));
+        assert!(body.contains("n / w / R      new window/pane / work up / rename the row"));
         // The exit keys deliberately live in the overlay's border rather
         // than the matrix — the body is clipped by terminal height, and
         // "how to leave" must not be the row that falls off.

--- a/crates/muxa/src/tmux/mod.rs
+++ b/crates/muxa/src/tmux/mod.rs
@@ -294,6 +294,29 @@ pub fn run_control_on(socket: Option<&str>, args: &[&str]) -> Result<(), TmuxErr
     }
 }
 
+/// Run one tmux control command against an explicitly identified server and
+/// return its stdout.
+///
+/// The reading counterpart to [`run_control_on`], for the control ops that
+/// need an answer rather than an exit status — checking whether a name is
+/// already taken in a session before renaming into it, say. Same server
+/// pinning and the same bounded error shape.
+pub fn capture_control_on(socket: Option<&str>, args: &[&str]) -> Result<String, TmuxError> {
+    let mut cmd = tmux_command_targeting(socket);
+    cmd.args(args);
+    let out = command_output_with_timeout(
+        cmd,
+        TMUX_COMMAND_TIMEOUT,
+        format!("tmux {}", args.join(" ")),
+    )?;
+    if !out.status.success() {
+        return Err(TmuxError::NonZero(
+            String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        ));
+    }
+    String::from_utf8(out.stdout).map_err(|e| TmuxError::BadOutput(e.to_string()))
+}
+
 /// The `send-keys` argv (after any server-scope flags) for a literal text
 /// injection. Split out from [`send_text_on`] so the argument construction is
 /// unit-testable without a running tmux server.

--- a/crates/muxa/src/topology.rs
+++ b/crates/muxa/src/topology.rs
@@ -393,12 +393,12 @@ pub struct TopologySnapshot {
 /// Left alone the topology shows the same workspace two or three times over,
 /// with the agents attached to whichever copy happened to be scanned first.
 ///
-/// The surviving member is the one whose name *is* the group name: tmux names
-/// a group after the session it was created from, so that one is the real
-/// workspace and the rest are per-terminal views of it. If it is gone — a view
-/// outliving the session it was opened from — the lexically first session id
-/// wins. Which member that is matters less than that it is the same one on
-/// every tick, instead of whichever the scan happened to reach first.
+/// The oldest live member (the lowest numeric `$N` session id) survives. tmux
+/// creates every grouped sibling after the session it was created from, so the
+/// original workspace is the oldest member even after it is renamed. The
+/// group name cannot identify it: `rename-session` does not update
+/// `#{session_group}`. If the original is gone, the oldest remaining view is a
+/// stable fallback instead of whichever row the scan happened to return first.
 ///
 /// Rows for the other members are rewritten onto the survivor's identity and
 /// then deduplicated by pane, which is what actually merges the trees: the
@@ -418,9 +418,7 @@ fn fold_session_groups(rows: Vec<(HostKind, PaneInfo)>) -> Vec<(HostKind, PaneIn
         let key = (*host, pane.socket.clone(), group.clone());
         let candidate = (pane.session_id.clone(), pane.session.clone());
         match survivors.get(&key) {
-            // The group's namesake always wins, whatever order it arrives in.
-            Some((_, name)) if *name == group => {}
-            Some((id, _)) if *id <= candidate.0 && pane.session != group => {}
+            Some((id, _)) if !tmux_session_id_is_earlier(&candidate.0, id) => {}
             _ => {
                 survivors.insert(key, candidate);
             }
@@ -446,6 +444,19 @@ fn fold_session_groups(rows: Vec<(HostKind, PaneInfo)>) -> Vec<(HostKind, PaneIn
         }
     }
     folded
+}
+
+/// tmux session ids are monotonically allocated decimal numbers prefixed by
+/// `$`. Compare that numeric payload rather than the rendered string: `$107`
+/// is newer than `$99`, despite sorting before it lexically.
+fn tmux_session_id_is_earlier(candidate: &str, current: &str) -> bool {
+    let sequence = |id: &str| id.strip_prefix('$').and_then(|raw| raw.parse::<u64>().ok());
+    match (sequence(candidate), sequence(current)) {
+        (Some(candidate), Some(current)) => candidate < current,
+        (Some(_), None) => true,
+        (None, Some(_)) => false,
+        (None, None) => candidate < current,
+    }
 }
 
 impl TopologySnapshot {
@@ -894,24 +905,24 @@ mod tests {
     }
 
     #[test]
-    fn folding_keeps_the_session_the_group_is_named_after() {
-        // `view~9~base` is a per-terminal view of `base`; `base` is the
-        // workspace. Whichever order the scan reports them in, the workspace
-        // is what survives — the view is an artifact of how someone attached.
+    fn folding_keeps_the_original_session_after_it_is_renamed() {
+        // tmux leaves `session_group` as `base` after the original session is
+        // renamed. The original still survives because it has the older
+        // numeric id; relying on the stale group name would select no member.
         for rows in [
             vec![
-                grouped("$0", "base", "base"),
-                grouped("$1", "view~9~base", "base"),
+                grouped("$99", "renamed", "base"),
+                grouped("$107", "base~view~9", "base"),
             ],
             vec![
-                grouped("$1", "view~9~base", "base"),
-                grouped("$0", "base", "base"),
+                grouped("$107", "base~view~9", "base"),
+                grouped("$99", "renamed", "base"),
             ],
         ] {
             let folded = fold_session_groups(rows);
             assert_eq!(folded.len(), 1, "the duplicate row must be dropped");
-            assert_eq!(folded[0].1.session, "base");
-            assert_eq!(folded[0].1.session_id, "$0");
+            assert_eq!(folded[0].1.session, "renamed");
+            assert_eq!(folded[0].1.session_id, "$99");
         }
     }
 
@@ -920,12 +931,12 @@ mod tests {
         // A view can outlive the session it was opened from. There is then no
         // right answer, only a stable one: the same member every tick, not
         // whichever the scan reached first.
-        let a = grouped("$1", "view~9~base", "base");
-        let b = grouped("$2", "view~8~base", "base");
+        let a = grouped("$9", "view~9~base", "base");
+        let b = grouped("$107", "view~8~base", "base");
         let forward = fold_session_groups(vec![a.clone(), b.clone()]);
         let reverse = fold_session_groups(vec![b, a]);
         assert_eq!(forward.len(), 1);
-        assert_eq!(forward[0].1.session_id, "$1");
+        assert_eq!(forward[0].1.session_id, "$9");
         assert_eq!(reverse[0].1.session_id, forward[0].1.session_id);
     }
 

--- a/crates/muxa/src/topology.rs
+++ b/crates/muxa/src/topology.rs
@@ -95,6 +95,22 @@ pub enum TopologyNodeKey {
     Pane(PaneKey),
 }
 
+impl TopologyNodeKey {
+    /// The backend endpoint this node lives on, whatever level it is.
+    ///
+    /// Every level carries the same endpoint through its ancestry, so callers
+    /// that only need "which server, which multiplexer" — a rename, a control
+    /// command — do not have to match the variant to find out.
+    #[must_use]
+    pub fn endpoint(&self) -> &BackendEndpoint {
+        match self {
+            TopologyNodeKey::Session(session) => &session.endpoint,
+            TopologyNodeKey::Window(window) => &window.session.endpoint,
+            TopologyNodeKey::Pane(pane) => &pane.window.session.endpoint,
+        }
+    }
+}
+
 /// Whether a hierarchy level is native, mapped without inventing nodes, or
 /// unavailable from a backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/docs/WATCH.ko.md
+++ b/docs/WATCH.ko.md
@@ -37,6 +37,7 @@ child pane은 agent session을 바인딩합니다. `view = "pane"`은 pane별로
 | `Enter` | 선택한 pane에 바로 attach. |
 | `n` | workspace session과 work window를 생성/재사용하고 agent pane 추가. |
 | `w` | pipeline 실행: work id를 입력하면 `muxa work up`을 실행하는 window로 넘어갑니다. |
+| `R` / `:rename` | 선택한 tmux session/window 이름 또는 pane title 변경. |
 | `\|` | list/inspector 분할 순환: 50/50 → 70/30 → 30/70. |
 | `a` / `A` | 설정한 agent에게 headless 질의 / 답변 이력 보기. |
 | `m` / `M` | 선택한 agent에게 request 보내기 / incoming·sent mailbox 열기. |
@@ -239,6 +240,14 @@ bind-key D display-popup -E -w 95% -h 90% "muxa dashboard"
 `prefix+s`가 관측과 협업의 기본 진입점입니다. `prefix+D`는 더 상세한 Dashboard를
 바로 여는 선택 단축키입니다.
 
+## 안정적인 tmux 이름
+
+`muxa init`은 `tmux-window-names` 컴포넌트를 기본으로 켭니다. tmux의 process 기반
+`automatic-rename`을 꺼서 Work window가 `node`나 `claude`로 덮어써지지 않게 하고,
+익숙한 `prefix + ,` prompt를 `muxa window rename`으로 연결합니다. window 이름의
+공백은 `-`로 정규화하며 같은 session 안의 중복 이름은 거부합니다. 특정 window만
+동적 이름으로 되돌리려면 `muxa window rename --auto`를 실행합니다.
+
 ## 한 workspace를 터미널 두 개로 보기
 
 tmux session은 current window를 하나만 가지며, attach된 모든 client가 그 window를
@@ -251,9 +260,12 @@ current window를 따로 가집니다.
 client에게 자기 view를 주는 훅 두 개를 겁니다.
 
 ```tmux
-set-hook -g client-attached "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"muxa workspace view --client #{client_name}\"'"
-set-hook -g client-session-changed "…같은 내용…"
+set-hook -g 'client-attached[9000]' "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"muxa workspace view --client #{client_name}\"'"
+set-hook -g 'client-session-changed[9000]' "…같은 내용…"
 ```
+
+전용 hook array slot을 쓰므로 config를 다시 source해도 중복되지 않고, 사용자가 같은
+이벤트에 설치한 다른 hook도 덮어쓰지 않습니다.
 
 **훅이 두 개여야 합니다.** `client-attached`는 `tmux attach`로 붙는 터미널을,
 `client-session-changed`는 `switch-client`를 덮습니다 — 후자가 watch의 `Enter`가

--- a/docs/WATCH.ko.md
+++ b/docs/WATCH.ko.md
@@ -243,52 +243,39 @@ bind-key D display-popup -E -w 95% -h 90% "muxa dashboard"
 
 tmux session은 current window를 하나만 가지며, attach된 모든 client가 그 window를
 봅니다. 따라서 같은 session에 두 터미널을 붙이면 서로 다른 Work window에 머무를 수
-없고, 한쪽에서 window를 바꾸면 다른 쪽도 따라갑니다. muxa의 제약이 아니라 tmux의
-모델입니다.
+없습니다. muxa의 제약이 아니라 tmux의 모델이고, 이를 바꾸는 유일한 수단이
+*session group*입니다 — window 목록은 공유하되 group 안의 각 session이 자기
+current window를 따로 가집니다.
 
-한 workspace의 Work Run 두 개를 나란히 보려면 두 번째 터미널을 *session group*으로
-attach하세요. window는 그대로 공유하되 group 안의 각 session이 자기 current window를
-따로 가집니다.
-
-```sh
-# 터미널 1
-tmux attach -t callabo
-
-# 터미널 2 — 같은 window, 독립적인 view, detach하면 사라짐
-tmux new-session -t callabo \; set-option destroy-unattached on
-```
-
-`tmux attach -t <session>` 자체가 이렇게 동작하게 하려면 — 따로 외울 명령 없이 —
-grouping을 `client-attached` hook 뒤에 둡니다. 이미 다른 client가 붙어 있을 때만
-동작하므로, 터미널이 하나뿐이면 평소대로 진짜 session에 붙고 여분의 session도
-생기지 않습니다.
+`muxa init`이 이를 `tmux-auto-view` 컴포넌트로 설치하며 기본으로 켜집니다. 도착한
+client에게 자기 view를 주는 훅 두 개를 겁니다.
 
 ```tmux
-set-hook -g client-attached "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"~/.local/bin/tmux-attach-view #{session_name} #{client_name} #{client_pid}\"'"
+set-hook -g client-attached "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"muxa workspace view --client #{client_name}\"'"
+set-hook -g client-session-changed "…같은 내용…"
 ```
 
-스크립트는 view를 만들고 도착한 client를 그쪽으로 옮깁니다.
+**훅이 두 개여야 합니다.** `client-attached`는 `tmux attach`로 붙는 터미널을,
+`client-session-changed`는 `switch-client`를 덮습니다 — 후자가 watch의 `Enter`가
+하는 일이고, 컴포넌트 설치 이전부터 열려 있던 터미널이 지나는 경로입니다. tmux
+3.4에서 실측: attach 훅만 있으면 watch에서 점프할 때 두 터미널이 다시 한 session에
+묶이고 그때부터 서로를 따라다닙니다.
+
+터미널이 하나면 아무 일도 일어나지 않습니다. `muxa workspace view`는 자기가 그
+session의 유일한 client이면 no-op이므로 단일 터미널 workspace에 여분의 session이
+생기지 않고, 재그룹하는 터미널은 자기 view를 재사용해 점프마다 session이 쌓이지
+않습니다.
+
+이미 붙어 있는 터미널에는 직접 실행할 수도 있습니다.
 
 ```sh
-name="view~$3~$1"
-new=$(tmux new-session -dP -F '#{session_id}' -t "=$1" -s "$name")
-tmux switch-client -c "$2" -t "$new"
-tmux set-option -t "$new" destroy-unattached on
+muxa workspace view
 ```
 
-세 가지가 결정적이며 모두 tmux 3.4에서 실측했습니다. `destroy-unattached`는
-반드시 `switch-client` **뒤에** 걸어야 합니다 — client가 아직 없는 session에 걸면
-그 자리에서 reap되어 전체가 조용히 무효화됩니다. `#{session_id}`가 아니라 session
-이름을 넘깁니다 — id는 `$0`이고 `run-shell`은 명령을 셸에 넘기므로 셸이 이를
-확장해 버립니다. view 이름은 원본 session 이름이 아니라 `view~<pid>~<session>`
-입니다 — 그래야 `callabo`를 찾는 prefix 조회가 진짜 session 대신 view를 집어가는
-일이 없습니다.
-
-한 session만 예외로 두려면 `tmux set-option -t <session> @no_auto_view 1` —
-두 터미널이 *일부러* 같은 화면을 봐야 할 때(페어링, 화면 공유)입니다.
-
-`command-alias`로는 안 됩니다. tmux는 내장 명령 이름을 alias보다 먼저 해석하므로
-`attach-session` alias는 참조되지 않습니다.
+view 이름은 `<session>~view~<pid>`라 원본 session 옆에 정렬됩니다. tmux가 session
+이름을 prefix로 매칭하는데도 안전한 이유는 **정확 일치가 우선**하기 때문입니다 —
+`callabo`, `callabo-set`, `callabo~view~1734560`이 모두 있어도 `-t callabo`는
+`callabo`로 해석됩니다. detach하면 사라지므로 view가 쌓이지 않습니다.
 
 window 크기를 session에 붙은 가장 작은 client가 아니라 실제로 그 window를 보고
 있는 터미널 기준으로 잡으려면 window 단위 sizing을 함께 켭니다.
@@ -309,23 +296,20 @@ setw -g aggressive-resize on
 | `smallest` + `aggressive-resize on` | **200x49** | 80x23 |
 | `smallest` + `aggressive-resize off` | 80x23 | 80x23 |
 
-`smallest` 단독은 전형적인 함정입니다 — 어디든 작은 client가 하나 붙어 있으면
-내 window가 쪼그라듭니다. `aggressive-resize`가 "아무 client"를 "이 window를
-current로 갖는 client"로 좁혀 주는데, 이것이 위에서 만든 view 분리와 정확히
-맞물립니다. 터미널이 하나뿐이면 smallest가 곧 그 터미널이므로 일반적인 단일
-터미널 사용에는 변화가 없습니다.
+`smallest` 단독은 전형적인 함정입니다 — 어디든 작은 client가 붙어 있으면 내
+window가 쪼그라듭니다. `aggressive-resize`가 "아무 client"를 "이 window를 current로
+갖는 client"로 좁혀 주고, 이것이 view 분리와 정확히 맞물립니다. 터미널이 하나뿐이면
+smallest가 곧 그 터미널이라 단일 터미널 사용에는 변화가 없습니다.
 
-watch에서 `Enter`로 이동할 때는 대상 window를 session까지 포함해 지정하므로, 요청한
-터미널만 움직이고 group의 다른 session은 보고 있던 window를 유지합니다. 이때 watch가
-어느 client에서 키를 눌렀는지 알아야 하는데, `muxa init`이 심는 `prefix+s` 바인딩이
-`--caller-client '#{client_name}'`으로 그 값을 넘깁니다. 이 플래그가 없는 수동
-바인딩은 tmux의 활동 기반 추측으로 되돌아가고, 터미널이 둘일 때 그 추측은 자주
-틀립니다.
+watch에서 `Enter`로 이동할 때는 대상 window를 `<session_id>:<window_id>`로
+지정하므로, 요청한 터미널만 움직이고 group의 다른 session은 보고 있던 window를
+유지합니다.
 
-알려진 거친 부분: grouped session은 별개의 tmux session id이므로 watch topology에
-같은 window/pane을 담은 두 번째 트리로 나타납니다. agent 메타데이터는 첫 트리에
-붙고 중복 트리는 맨 pane으로 보입니다. 집계와 통계는 pane 단위 키라서 중복으로
-세지지 않습니다.
+반대로 두 터미널이 *일부러* 같은 화면을 봐야 한다면(페어링, 화면 공유):
+
+```sh
+tmux set-option -t <session> @no_auto_view 1
+```
 
 ## macOS 메뉴바 (BarShelf)
 

--- a/docs/WATCH.md
+++ b/docs/WATCH.md
@@ -301,51 +301,42 @@ optional shortcut to the richer Dashboard.
 One tmux session has one current window, and every client attached to it shows
 that window. Two terminals attached to the same session therefore cannot sit on
 two different Work windows — switching one switches the other. That is tmux's
-model, not a muxa limitation.
+model, not a muxa limitation, and a *session group* is the only thing that
+changes it: the window list stays shared, but each session in the group keeps
+its own current window.
 
-To watch two Work Runs of one workspace side by side, attach the second
-terminal to a *session group* instead. Windows stay shared, but each session in
-the group keeps its own current window:
-
-```sh
-# terminal 1
-tmux attach -t callabo
-
-# terminal 2 — same windows, independent view, disappears on detach
-tmux new-session -t callabo \; set-option destroy-unattached on
-```
-
-To keep `tmux attach -t <session>` itself doing this — no second command to
-remember — put the grouping behind a `client-attached` hook. It fires only when
-the session already had another client, so a lone terminal still attaches to the
-real session and no extra session is created:
+`muxa init` installs this as the `tmux-auto-view` component, on by default. It
+sets two hooks that hand an arriving client its own view:
 
 ```tmux
-set-hook -g client-attached "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"~/.local/bin/tmux-attach-view #{session_name} #{client_name} #{client_pid}\"'"
+set-hook -g client-attached "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"muxa workspace view --client #{client_name}\"'"
+set-hook -g client-session-changed "…same…"
 ```
 
-where the script creates the view and moves the arriving client into it:
+**Both hooks are needed.** `client-attached` covers a terminal running `tmux
+attach`. `client-session-changed` covers `switch-client` — which is what
+watch's `Enter` does, and what a terminal that was already open when the
+component was installed goes through. Measured on tmux 3.4: with only the
+attach hook, jumping from watch put both terminals back into one session and
+they followed each other from there.
+
+Nothing runs for a lone terminal. `muxa workspace view` is a no-op when its
+client is the session's only one, so a single-terminal workspace never grows a
+second session, and a terminal that regroups reuses its own view rather than
+leaving a trail of sessions behind every jump.
+
+You can also run it by hand — on a terminal that was already attached, for
+instance:
 
 ```sh
-name="view~$3~$1"
-new=$(tmux new-session -dP -F '#{session_id}' -t "=$1" -s "$name")
-tmux switch-client -c "$2" -t "$new"
-tmux set-option -t "$new" destroy-unattached on
+muxa workspace view
 ```
 
-Three details are load-bearing, each measured on tmux 3.4. `destroy-unattached`
-must be set *after* `switch-client`: on a session that still has no client tmux
-reaps it on the spot, silently undoing the whole thing. The session name is
-passed, not `#{session_id}` — the id is `$0`, and `run-shell` hands its command
-to a shell that expands it. And the view is named `view~<pid>~<session>` rather
-than after the session it mirrors, so a prefix lookup for `callabo` can never
-match a view instead of the real thing.
-
-`tmux set-option -t <session> @no_auto_view 1` opts one session out, for when
-two terminals *should* mirror each other (pairing, screen sharing).
-
-`command-alias` cannot do this: tmux resolves built-in command names before
-aliases, so an alias for `attach-session` is never consulted.
+The view is named `<session>~view~<pid>`, so it sorts beside the session it
+mirrors. That is safe despite tmux matching session names by prefix, because an
+exact match wins: with `callabo`, `callabo-set` and `callabo~view~1734560` all
+present, `-t callabo` resolves to `callabo`. It disappears on detach, so views
+never pile up.
 
 Pair it with per-window sizing, so a window is sized to the terminals actually
 looking at it rather than to the smallest client anywhere on the session:
@@ -367,23 +358,21 @@ each on its own window:
 | `smallest` + `aggressive-resize off` | 80x23 | 80x23 |
 
 `smallest` on its own is the classic footgun — any small client anywhere
-shrinks your window. `aggressive-resize` is what narrows "any client" to "a
-client whose current window this is", which is exactly the separation the views
-above create. With one terminal attached, smallest is that terminal, so nothing
+shrinks your window. `aggressive-resize` narrows "any client" to "a client
+whose current window this is", which is exactly the separation the views
+create. With one terminal attached, smallest is that terminal, so nothing
 changes for ordinary single-terminal use.
 
-Jumping from watch (`Enter`) addresses the target window by session, so it
-moves only the terminal that asked and leaves the grouped sibling on the window
-it was showing. For that to hold, watch needs to know which client pressed the
-key — the `prefix+s` binding written by `muxa init` passes it as
-`--caller-client '#{client_name}'`. A hand-rolled binding without that flag
-falls back to tmux's activity-based guess, which with two terminals attached is
-routinely the wrong one.
+Jumping from watch (`Enter`) addresses the target window as
+`<session_id>:<window_id>`, so it moves only the terminal that asked and leaves
+the grouped sibling on the window it was showing.
 
-Known rough edge: the grouped session is a distinct tmux session id, so the
-watch topology lists it as a second tree carrying the same windows and panes.
-Agent metadata attaches to the first tree; the duplicate shows as bare panes.
-Counts and stats are keyed per pane and are not doubled.
+To mirror instead — two terminals deliberately showing the same thing, for
+pairing or screen sharing:
+
+```sh
+tmux set-option -t <session> @no_auto_view 1
+```
 
 ## macOS Menu Bar with BarShelf
 

--- a/docs/WATCH.md
+++ b/docs/WATCH.md
@@ -58,6 +58,7 @@ children keep their aggregate state markers.
 | `Enter` | Attach to the selected pane. |
 | `n` | Create/reuse a workspace session and work window, then add an agent pane. |
 | `w` | Run a pipeline: type a work id and hand off to a window running `muxa work up`. |
+| `R` / `:rename` | Rename the selected tmux session or window, or set the selected pane title. |
 | `\|` | Cycle the list/inspector split: 50/50 → 70/30 → 30/70. |
 | `a` / `A` | Ask the configured agent a headless question / browse the answers. |
 | `m` / `M` | Message the selected agent / open incoming/sent mailbox. |
@@ -296,6 +297,15 @@ bind-key D display-popup -E -w 95% -h 90% "muxa dashboard"
 `prefix+s` is the normal watch and collaboration entry point. `prefix+D` is an
 optional shortcut to the richer Dashboard.
 
+## Stable tmux Names
+
+`muxa init` enables the `tmux-window-names` component by default. It turns off
+tmux's process-based `automatic-rename`, so a Work window keeps its useful name
+instead of becoming `node` or `claude`, and routes the familiar `prefix + ,`
+prompt through `muxa window rename`. Window whitespace is normalized to `-`
+and duplicate names in one session are refused. Restore dynamic naming for one
+window with `muxa window rename --auto`.
+
 ## Two Terminals on One Workspace
 
 One tmux session has one current window, and every client attached to it shows
@@ -309,9 +319,12 @@ its own current window.
 sets two hooks that hand an arriving client its own view:
 
 ```tmux
-set-hook -g client-attached "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"muxa workspace view --client #{client_name}\"'"
-set-hook -g client-session-changed "…same…"
+set-hook -g 'client-attached[9000]' "if -F '#{&&:#{>:#{session_attached},1},#{==:#{@no_auto_view},}}' 'run-shell \"muxa workspace view --client #{client_name}\"'"
+set-hook -g 'client-session-changed[9000]' "…same…"
 ```
+
+The dedicated hook-array slot keeps reloading idempotent and leaves unrelated
+user hooks in their own slots intact.
 
 **Both hooks are needed.** `client-attached` covers a terminal running `tmux
 attach`. `client-session-changed` covers `switch-client` — which is what


### PR DESCRIPTION
This PR completes three pieces of the two-terminal, window-per-Work workflow: rename from the watch tree, stable Work window names, and independent per-terminal tmux views.

## Rename from `muxa watch`

`R` and `:rename` edit the selected tmux session, window, or pane title.

- The form is prefilled with the current value and places the cursor at the end.
- Submitting an untouched value cancels without changing tmux state.
- A failed rename keeps the form and input open so the value can be corrected.
- Window names normalize whitespace to `-`, remain limited to 64 bytes, and must be unique within their session.
- Session names and pane titles preserve internal spaces; session names reject tmux's `.` and `:` separators.
- Control characters and tmux format expansions (`#{...}` / `#(...)`) are rejected.
- The composer keeps the original topology key, so a refresh cannot redirect the rename to a different row.

The existing help row was compacted to include `R` without pushing refresh help below the overlay's fixed height.

## Stable Work window names

The default `tmux-window-names` init component disables process-based `automatic-rename` and keeps the familiar `prefix + ,` prompt, routed through `muxa window rename`. A single window can opt back into dynamic naming with `muxa window rename --auto`.

Prompt input never enters a shell command. `command-prompt` writes it to a per-client named tmux buffer, while `run-shell` receives only a native window id and fixed buffer name. The CLI consumes and deletes the buffer before renaming; a fixed shell cleanup also removes it when muxa cannot start. This closes quote-breaking command injection while preserving the complete literal input.

## Independent view per terminal

The default `tmux-auto-view` component installs both required hooks:

| hook | covers |
| --- | --- |
| `client-attached[9000]` | a new `tmux attach` client |
| `client-session-changed[9000]` | `switch-client`, including watch's Enter action |

The indexed hook slots keep re-sourcing idempotent and do not overwrite unrelated user hooks. `@no_auto_view=1` remains the per-session opt-out for intentional mirroring.

`muxa workspace view` is a no-op for a sole client. When another client shares the session, it creates or safely reuses a grouped `<session>~view~<client-pid>` session and enables `destroy-unattached` only after switching the client into it.

Review hardening adds:

- canonical group selection by numeric tmux session id (`$99` before `$107`), which keeps the original session after a rename and makes topology folding deterministic;
- stable view naming when a renamed original session disappears, without accumulating `~view~...~view~...` suffixes;
- collision and create-race handling that never takes over another client's attached view;
- rollback and cleanup when switching the client or setting `destroy-unattached` fails;
- propagation of tmux lookup failures instead of silently falling back to an unrelated process id.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- isolated live-tmux tests with real pseudo-terminal clients confirmed:
  - two terminals retain independent current windows;
  - indexed muxa hooks coexist with a user hook;
  - a quote-breaking shell payload becomes only the normalized window name, leaves no injected tmux option, and removes its buffer;
  - after `base` is grouped, renamed, and removed, regrouping creates `renamed~view~222` rather than `renamed~view~111~view~222` even while the group name remains stale.

English and Korean watch docs now cover `R`, stable window names, the two auto-view hooks, hook ownership, and the opt-out.
