### PR TITLE
feat(collab): deliver operator wake bodies by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Operator messages now carry their body directly by default, without making
+  agent delegation equally permissive.** The new default `wake_payload =
+  "operator_full"` claims and injects requests sent by the resolved operator
+  console (watch/dashboard), while agent-originated MCP and CLI requests remain
+  body-free mailbox notices. Explicit `notice` and `full` retain their strict
+  all-notice and all-direct behavior. This is a delivery policy, not an
+  authorization signal: `work_mode = "execute"` cannot promote an agent request.
 - **Work pipelines now have daemon-owned, generation-aware Run state.** The
   selected pipeline, rendered desired aliases, dependency graph, Run
   generation, and each alias's `pending`/`running`/`blocked`/`done`/`failed`

--- a/README.ko.md
+++ b/README.ko.md
@@ -127,7 +127,8 @@ muxa watch
 ### `muxa watch`에서 바로 협업합니다
 
 기억할 규칙은 하나입니다. **tmux window 하나가 협업 room 하나**입니다.
-`muxa watch`를 열 때 선택되어 있던 agent가 발신자가 됩니다.
+watch/dashboard에서 사람이 보낸 메시지는 operator console이 발신자가 되고, 선택한
+agent가 수신자가 됩니다. agent가 MCP나 CLI로 보낸 요청은 해당 agent가 발신자입니다.
 
 최초 한 번만 `~/.config/muxa/config.toml`에 다음 설정을 넣고 `muxad`를 재시작한
 뒤 `muxa init`으로 `prefix+s` watch popup을 설치합니다.
@@ -136,6 +137,8 @@ muxa watch
 [collaboration]
 enabled = true
 wake = "idle_only"
+# 기본값: operator 본문은 직접 전달하고 agent 발신 본문은 mailbox에 둡니다.
+wake_payload = "operator_full"
 ```
 
 두 agent가 메시지를 직접 읽고 답할 수 있도록 MCP도 한 번 등록한 뒤 실행 중인

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ One-time setup: add the following to `~/.config/muxa/config.toml`, restart
 [collaboration]
 enabled = true
 wake = "idle_only"
-# Optional: claim and deliver request bodies directly to idle agent prompts.
-wake_payload = "full"
+# Default: deliver operator messages directly; keep agent messages as notices.
+wake_payload = "operator_full"
 ```
 
 Register the MCP server once for both agent hosts, then restart agents that

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -492,9 +492,10 @@ pub struct CollaborationConfig {
     /// `never` keeps delivery pull-only; `idle_only` wakes hook-authoritative
     /// agents only at their top-level idle prompt.
     pub wake: CollaborationWake,
-    /// `notice` injects only a mailbox notification. `full` atomically claims
-    /// each request and injects its metadata and body into the recipient's
-    /// prompt, avoiding a separate inbox tool round.
+    /// `notice` injects only a mailbox notification. `operator_full` (the
+    /// default) directly delivers requests sent by an operator console while
+    /// keeping agent-originated requests in the mailbox. `full` directly
+    /// delivers every request.
     pub wake_payload: CollaborationWakePayload,
     /// How far an explicit `pane:%N` target may reach. `window` (default)
     /// keeps requests inside the sender's tmux window — co-locating agents
@@ -514,7 +515,7 @@ impl Default for CollaborationConfig {
             enabled: false,
             path: None,
             wake: CollaborationWake::IdleOnly,
-            wake_payload: CollaborationWakePayload::Notice,
+            wake_payload: CollaborationWakePayload::OperatorFull,
             scope: CollaborationScope::default(),
             max_message_bytes: default_collaboration_max_message_bytes(),
         }
@@ -540,8 +541,9 @@ pub enum CollaborationWake {
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum CollaborationWakePayload {
-    #[default]
     Notice,
+    #[default]
+    OperatorFull,
     Full,
 }
 
@@ -2007,7 +2009,14 @@ agent-review = "create a codex pane and pass our changes for review"
         let defaults: Config = toml::from_str("[collaboration]\nenabled = true\n").unwrap();
         assert_eq!(
             defaults.collaboration.wake_payload,
-            CollaborationWakePayload::Notice
+            CollaborationWakePayload::OperatorFull
+        );
+
+        let operator: Config =
+            toml::from_str("[collaboration]\nwake_payload = \"operator_full\"\n").unwrap();
+        assert_eq!(
+            operator.collaboration.wake_payload,
+            CollaborationWakePayload::OperatorFull
         );
     }
 

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -878,9 +878,8 @@ async fn wake_idle_collaboration_peers_with_inflight(
         if wake_inflight.contains(&wake_key) {
             continue;
         }
-        if wake_payload == CollaborationWakePayload::Full
-            && direct_wake_body_is_terminal_safe(&request.body)
-        {
+        let direct_wake = collaboration_wake_includes_body(wake_payload, &request);
+        if direct_wake && direct_wake_body_is_terminal_safe(&request.body) {
             if deliver_full_collaboration_request(collaboration, recipient, &request, backends)
                 .await
             {
@@ -888,7 +887,7 @@ async fn wake_idle_collaboration_peers_with_inflight(
             }
             continue;
         }
-        if wake_payload == CollaborationWakePayload::Full {
+        if direct_wake {
             tracing::debug!(
                 request_id = request.id,
                 "direct wake body contains terminal control characters; using mailbox notice",
@@ -1092,6 +1091,20 @@ fn collaboration_work_mode(mode: muxa::collaboration::WorkMode) -> &'static str 
 fn direct_wake_body_is_terminal_safe(body: &str) -> bool {
     body.chars()
         .all(|character| matches!(character, '\n' | '\t') || !character.is_control())
+}
+
+fn collaboration_wake_includes_body(
+    wake_payload: CollaborationWakePayload,
+    request: &CollaborationRequest,
+) -> bool {
+    // `operator_full` follows the sender identity resolved by muxad. Work
+    // mode is intentionally irrelevant: `execute` describes requested work,
+    // not proof that a human authorized direct prompt injection.
+    match wake_payload {
+        CollaborationWakePayload::Notice => false,
+        CollaborationWakePayload::OperatorFull => request.from.console,
+        CollaborationWakePayload::Full => true,
+    }
 }
 
 fn collaboration_request_source(request: &CollaborationRequest) -> String {
@@ -2486,6 +2499,142 @@ mod tests {
             .unwrap();
         assert_eq!(stored.status, RequestStatus::Queued);
         assert!(stored.notified_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn operator_full_wake_injects_console_requests() {
+        let store = muxa::Store::shared();
+        add_agent(&store, "%1", "sender", AgentKind::Codex).await;
+        add_agent(&store, "%2", "recipient", AgentKind::ClaudeCode).await;
+        let panes = vec![collaboration_pane("%1", "0"), collaboration_pane("%2", "1")];
+        let participants = muxa::collaboration::participants_from(&store.snapshot().await, &panes);
+        let sender = participants
+            .iter()
+            .find(|participant| participant.pane == "%1")
+            .unwrap()
+            .clone();
+        let recipient = participants
+            .iter()
+            .find(|participant| participant.pane == "%2")
+            .unwrap()
+            .clone();
+        let console = muxa::collaboration::Participant::console(sender.room.clone());
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let operator_request = mailbox
+            .create_with_provenance(
+                console,
+                recipient.clone(),
+                NewRequest {
+                    kind: RequestKind::Task,
+                    body: "operator request body".into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::Execute,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                },
+                Some(CollaborationProvenance {
+                    client_kind: CollaborationClientKind::Watch,
+                    caller_pid: Some(4242),
+                    caller_uid: Some(1000),
+                    caller_gid: Some(1000),
+                    executable: Some("muxa".into()),
+                    observed_pane: Some("%1".into()),
+                    pane_evidence: Some(CollaborationPaneEvidence::ProcessAncestry),
+                    origin_match: CollaborationOriginMatch::Matched,
+                }),
+            )
+            .await
+            .unwrap();
+        let sends = Arc::new(Mutex::new(Vec::new()));
+        let backend: muxa::SharedBackend = Arc::new(CollaborationWakeBackend {
+            panes: panes.clone(),
+            sends: sends.clone(),
+        });
+        let mut wake_inflight = HashSet::new();
+
+        wake_idle_collaboration_peers_with_inflight(
+            &mailbox,
+            &store,
+            std::slice::from_ref(&backend),
+            CollaborationWakePayload::OperatorFull,
+            &mut wake_inflight,
+        )
+        .await;
+        {
+            let delivered = sends.lock().unwrap();
+            assert_eq!(delivered.len(), 2);
+            assert!(delivered[0].1.contains("operator request body"));
+            assert!(delivered[0]
+                .1
+                .contains("via muxa watch representing console"));
+            assert!(!delivered[0].1.contains("Read it with muxa_inbox"));
+        }
+        let stored = mailbox
+            .get_for(&recipient, &operator_request.id)
+            .await
+            .unwrap();
+        assert_eq!(stored.status, RequestStatus::Claimed);
+    }
+
+    #[tokio::test]
+    async fn operator_full_wake_keeps_agent_requests_in_the_mailbox() {
+        let store = muxa::Store::shared();
+        add_agent(&store, "%1", "sender", AgentKind::Codex).await;
+        add_agent(&store, "%2", "recipient", AgentKind::ClaudeCode).await;
+        let panes = vec![collaboration_pane("%1", "0"), collaboration_pane("%2", "1")];
+        let participants = muxa::collaboration::participants_from(&store.snapshot().await, &panes);
+        let sender = participants
+            .iter()
+            .find(|participant| participant.pane == "%1")
+            .unwrap()
+            .clone();
+        let recipient = participants
+            .iter()
+            .find(|participant| participant.pane == "%2")
+            .unwrap()
+            .clone();
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let agent_request = mailbox
+            .create(
+                sender,
+                recipient.clone(),
+                NewRequest {
+                    kind: RequestKind::Task,
+                    body: "agent delegated body".into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::Execute,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+        let sends = Arc::new(Mutex::new(Vec::new()));
+        let backend: muxa::SharedBackend = Arc::new(CollaborationWakeBackend {
+            panes,
+            sends: sends.clone(),
+        });
+        let mut wake_inflight = HashSet::new();
+
+        wake_idle_collaboration_peers_with_inflight(
+            &mailbox,
+            &store,
+            &[backend],
+            CollaborationWakePayload::OperatorFull,
+            &mut wake_inflight,
+        )
+        .await;
+        {
+            let delivered = sends.lock().unwrap();
+            assert_eq!(delivered.len(), 2);
+            assert!(delivered[0].1.contains("muxa_inbox"));
+            assert!(!delivered[0].1.contains("agent delegated body"));
+        }
+        let stored = mailbox
+            .get_for(&recipient, &agent_request.id)
+            .await
+            .unwrap();
+        assert_eq!(stored.status, RequestStatus::Queued);
     }
 
     #[tokio::test]

--- a/docs/COLLABORATION.ko.md
+++ b/docs/COLLABORATION.ko.md
@@ -64,8 +64,8 @@ muxa init --component collaboration
 [collaboration]
 enabled = true
 wake = "idle_only"
-# 선택 사항: 기본값 "notice", 원문 직접 전달은 "full"
-wake_payload = "notice"
+# 선택 사항: 기본값 "operator_full", 또는 "notice" / "full"
+wake_payload = "operator_full"
 ```
 
 이미 있는 `wake` 값은 덮어쓰지 않습니다. `never`는 "mailbox는 쓰되 내 pane은
@@ -340,18 +340,26 @@ prompt/message/path/provider 식별자를 넣어서는 안 됩니다.
 participant나 자동 wake 대상이 아닙니다. `wake = "never"`로 설정하면 mailbox는
 유지하면서 모든 입력 주입을 끌 수 있습니다.
 
-기본값인 `wake_payload = "notice"`는 짧은 mailbox 알림만 넣고 본문을 terminal에
-주입하지 않습니다. 요청을 `muxa_inbox`로 읽는 순간 원자적으로 claim합니다.
+기본값인 `wake_payload = "operator_full"`은 resolved sender가 operator console인
+watch/dashboard 요청을 원자적으로 claim해 직접 전달하고, agent가 MCP/CLI로 보낸
+요청은 짧은 mailbox 알림만 넣습니다. `notice`는 모든 요청 본문을 mailbox에 두며,
+`full`은 모든 요청을 직접 전달합니다.
 
-`wake_payload = "full"`은 terminal에 입력하기 전에 queued request 하나를
-원자적으로 claim하고, request id/source/kind/work mode/paths/AIR reference와 원문을
-구조화된 prompt로 직접 전달합니다. 이 request에는 inbox를 다시 호출할 필요가 없어
-tool round와 전체 JSON envelope를 줄입니다. idle generation 하나에는 원문 하나만
-제출하고, 실제 Idle transition이 온 뒤 다음 요청을 전달합니다. reply 본문은 이
-모드에서도 항상 mailbox에만 둡니다.
+직접 전달은 terminal에 입력하기 전에 queued request 하나를 원자적으로 claim하고,
+request id/source/kind/work mode/paths/AIR reference와 원문을 구조화된 prompt로
+전달합니다. 이 request에는 inbox를 다시 호출할 필요가 없어 tool round와 전체 JSON
+envelope를 줄입니다. idle generation 하나에는 원문 하나만 제출하고, 실제 Idle
+transition이 온 뒤 다음 요청을 전달합니다. reply 본문은 모든 모드에서 항상
+mailbox에만 둡니다.
 
-`full`은 요청 본문을 terminal과 agent prompt history에도 남기므로 민감한 본문을
-mailbox에만 두려면 `notice`를 사용하세요. terminal 제어문자가 포함된 본문은
+`operator_full`은 전달 정책이지 사람의 승인을 증명하는 장치가 아닙니다. muxad가
+resolve한 sender identity를 기준으로 하며, `work_mode = "execute"`만으로 agent 발신
+요청을 operator 요청으로 승격하거나 payload 정책을 바꾸지 않습니다. 직접 전달된
+envelope의 source 줄에는 operator surface와 caller provenance가 계속 표시됩니다.
+
+직접 전달은 요청 본문을 terminal과 agent prompt history에도 남기므로 민감한 본문을
+항상 mailbox에만 두려면 `notice`를 사용하세요. `operator_full`은 agent 발신 본문만
+mailbox에 유지합니다. terminal 제어문자가 포함된 본문은
 변형하거나 위험하게 paste하지 않고 자동으로 `notice` 경로를 사용합니다. muxad는
 prompt text 기록과 별도 Enter 제출 단계를 durable state로 구분합니다. 중단 후
 text가 이미 기록된 것이 확실하면 Enter만 재시도하고, 기록 여부가 불확실하면 원문을

--- a/docs/COLLABORATION.md
+++ b/docs/COLLABORATION.md
@@ -69,8 +69,8 @@ collaboration --uninstall` removes it). Hand-editing works just as well:
 [collaboration]
 enabled = true
 wake = "idle_only" # or "never" for pull-only delivery
-# Optional: "notice" (default) or "full" for direct request delivery.
-wake_payload = "notice"
+# Optional: "operator_full" (default), "notice", or "full".
+wake_payload = "operator_full"
 ```
 
 An existing `wake` is never overwritten — a deliberate `never` means "give me
@@ -291,20 +291,28 @@ hook-authoritative participant is `Idle`. It never injects into `Working`,
 agents have no stable session identity, so they are not room participants or
 auto-wake targets.
 
-`wake_payload = "notice"` is the default. It injects a short mailbox prompt;
-the recipient calls `muxa_inbox`, which atomically claims and returns the body.
-`wake_payload = "full"` instead claims one queued request before any terminal
-side effect, then injects a structured envelope containing request id, source,
-kind, work mode, paths, AIR references, and the original body. The recipient
-must not call inbox for that request, so one tool round and its JSON envelope
-are removed. Only one direct request is submitted per idle agent generation;
-the next waits for a real Idle transition. Terminal reply bodies always remain
-in the mailbox in both modes.
+`wake_payload = "operator_full"` is the default. Requests whose resolved sender
+is the operator console — currently watch and dashboard messages — are claimed
+and delivered directly, while agent-originated MCP and CLI requests inject only
+a mailbox notice. `notice` keeps every request body in the mailbox. `full`
+directly delivers every request. Direct delivery injects a structured envelope
+containing request id, source, kind, work mode, paths, AIR references, and the
+original body, removing one inbox tool round and its JSON envelope. Only one
+direct request is submitted per idle agent generation; the next waits for a
+real Idle transition. Terminal reply bodies always remain in the mailbox.
+
+`operator_full` is a delivery policy, not proof of human authorization. It
+uses the sender identity muxad resolved for the request; `work_mode =
+"execute"` never changes the payload policy or upgrades an agent-originated
+request into an operator request. The source line in the delivered envelope
+still records the operator surface and caller provenance for the recipient.
 
 Direct delivery deliberately makes the request body part of terminal and
 agent prompt history. Use `notice` for secrets that should remain only in the
-private mailbox. A body containing terminal control characters automatically
-falls back to `notice` rather than being transformed or pasted unsafely.
+private mailbox; `operator_full` keeps agent-originated bodies private but not
+operator-originated ones. A body containing terminal control characters
+automatically falls back to `notice` rather than being transformed or pasted
+unsafely.
 Direct delivery records whether prompt text was written
 before the separate Enter keystroke. After interruption, muxad retries only
 Enter when text is known to be buffered; if writing was uncertain, it falls

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -88,7 +88,7 @@ sandbox/자동 검토를 유지한 채 workspace 편집을 허용하고, `defaul
 [collaboration]
 enabled = true
 wake = "idle_only" # idle_only | never
-wake_payload = "notice" # notice | full
+wake_payload = "operator_full" # notice | operator_full | full
 scope = "window"   # window | host
 max_message_bytes = 16384
 ```
@@ -97,10 +97,10 @@ max_message_bytes = 16384
 optional `path` 기본값은 `$XDG_DATA_HOME/muxa/collaboration.json`이며 mailbox와
 exact-session alias/role을 함께 저장합니다.
 `idle_only`는 hook 기반 top-level agent가 Idle일 때만 입력합니다.
-기본값인 `wake_payload = "notice"`는 요청 본문을 mailbox에 두고, `full`은 idle
-generation마다 요청 하나를 원자적으로 claim한 뒤 구조화된 metadata와 본문을 직접
-입력하여 별도 inbox tool round를 없앱니다. reply wake는 두 모드 모두 본문 없는
-알림입니다.
+기본값인 `wake_payload = "operator_full"`은 watch/dashboard 같은 operator surface에서
+보낸 요청은 본문을 직접 전달하고, agent가 MCP/CLI로 보낸 요청은 mailbox 알림으로
+유지합니다. `notice`는 모든 본문을 mailbox에 두며, `full`은 모든 요청을 원자적으로
+claim해 직접 전달합니다. reply wake는 모든 모드에서 본문 없는 알림입니다.
 `scope = "host"`이면 watch에서 다른 tmux window나 session의 선택된 tracked
 agent를 정확한 pane id로 지정할 수 있습니다.
 [COLLABORATION.ko.md](COLLABORATION.ko.md)를 참고하세요.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -91,7 +91,7 @@ wall-clock safety limit, not an inactivity detector.
 [collaboration]
 enabled = true
 wake = "idle_only" # idle_only | never
-wake_payload = "notice" # notice | full
+wake_payload = "operator_full" # notice | operator_full | full
 scope = "window"   # window | host
 max_message_bytes = 16384
 ```
@@ -100,10 +100,11 @@ Opt-in durable request/reply between agents in the same stable tmux window.
 The optional `path` defaults to `$XDG_DATA_HOME/muxa/collaboration.json` and
 stores both mailbox state and exact-session aliases/roles.
 `idle_only` injects only at a hook-authoritative top-level Idle prompt.
-`wake_payload = "notice"` (the default) keeps request bodies in the mailbox;
-`full` atomically claims one request per idle generation and injects its
-structured metadata and body, avoiding a separate inbox tool round. Reply
-wakes remain body-free notifications in both modes.
+The default `wake_payload = "operator_full"` directly delivers requests sent
+from operator surfaces such as watch and dashboard, while agent-originated MCP
+and CLI requests remain mailbox notices. `notice` keeps every body in the
+mailbox; `full` atomically claims and directly delivers every request. Reply
+wakes remain body-free notifications in every mode.
 `scope = "host"` lets watch address the selected tracked agent in another
 tmux window or session by its exact pane id.
 See [COLLABORATION.md](COLLABORATION.md).

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -295,11 +295,12 @@ aliases.
 The collaboration tools are higher-level than `muxa_send_prompt`: muxad pins
 each request to the target's current agent session, persists it before wake-up,
 and restricts routing to the caller's stable tmux window. Request and reply
-wake prompts are sent only to idle agents. Request bodies stay out of the
-terminal by default; opt-in `wake_payload = "full"` atomically claims and
-delivers one structured request body per idle generation. Reply wakes remain
-body-free. Enable the tools with `[collaboration] enabled = true`; see
-`docs/COLLABORATION.ko.md`.
+wake prompts are sent only to idle agents. The default `wake_payload =
+"operator_full"` delivers operator-console bodies directly while these
+agent-originated MCP requests remain body-free mailbox notices. `notice` keeps
+every body in the mailbox; `full` directly delivers every safe request body.
+Reply wakes remain body-free. Enable the tools with `[collaboration] enabled =
+true`; see `docs/COLLABORATION.ko.md`.
 
 For rooms with several agents, call `muxa_set_identity` once per agent and
 route with `@alias` or `role:<name>`. Aliases must be unique among live peers;


### PR DESCRIPTION
## Why

The two existing wake payload modes force one global choice:

- `notice` keeps every request body in the mailbox, including a message the operator just typed in watch/dashboard.
- `full` injects every request body, including agent-originated MCP/CLI delegation.

That makes the safe default inconvenient for direct operator messages, while the convenient setting broadens direct prompt injection more than necessary.

## What

Add `wake_payload = "operator_full"` and make it the default:

| policy | operator console (watch/dashboard) | agent (MCP/CLI) |
| --- | --- | --- |
| `notice` | mailbox notice | mailbox notice |
| `operator_full` | structured body delivery | mailbox notice |
| `full` | structured body delivery | structured body delivery |

The decision uses the sender identity already resolved and persisted by muxad (`request.from.console`). No IPC or mailbox schema change is needed. The delivered envelope retains its existing source line, including the operator surface and caller provenance.

`work_mode = "execute"` is deliberately irrelevant: it describes requested work and does not prove human authorization or promote an agent request into an operator request. This remains a delivery policy, not a new trust boundary.

## Safety and compatibility

- Explicit `notice` and `full` keep their existing behavior.
- Idle/session identity gates are unchanged.
- Terminal control characters still fall back to a mailbox notice.
- Direct delivery keeps the existing atomic claim and interrupted-delivery recovery path.
- Reply bodies remain mailbox-only.

## Verification

- `cargo build --workspace --bins`
- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

Two focused daemon tests cover both halves of `operator_full`: console requests are claimed and injected with their source, while agent requests remain queued and body-free in the wake prompt.
