### PR TITLE
fix(run): relay paste into attached PTY sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pasting into an attached muxa-owned PTY is safe and complete.** The attach
+  relay now enables bracketed paste, forwards the restored framing to the child
+  PTY so multiline input is not executed line by line, ignores leaked platform
+  shortcut keys, and restores the parent terminal state on every exit path.
+
 ## [0.8.36] - 2026-08-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   relay now enables bracketed paste, forwards the restored framing to the child
   PTY so multiline input is not executed line by line, ignores leaked platform
   shortcut keys, and restores the parent terminal state on every exit path.
+  Embedded bracket markers are removed before forwarding so clipboard control
+  bytes cannot close the paste early and execute the remainder as keystrokes.
 
 ## [0.8.36] - 2026-08-27
 

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -1216,6 +1216,10 @@ impl RawModeGuard {
         if let Err(error) =
             crossterm::execute!(std::io::stdout(), crossterm::event::EnableBracketedPaste)
         {
+            // `execute!` may have written the enable sequence before a later
+            // flush error. Best-effort reversal keeps a failed attach from
+            // leaving the parent terminal in paste mode without a guard.
+            let _ = crossterm::execute!(std::io::stdout(), crossterm::event::DisableBracketedPaste);
             let _ = crossterm::terminal::disable_raw_mode();
             return Err(error.into());
         }
@@ -1263,6 +1267,9 @@ async fn attach_session_loop(client: &Client, session_id: &str) -> Result<()> {
         while crossterm::event::poll(Duration::ZERO)? {
             match crossterm::event::read()? {
                 Event::Paste(text) => {
+                    // A detach prefix applies only to the immediately
+                    // following key, never across a whole paste event.
+                    detach_armed = false;
                     client
                         .write_session(session_id, &bracketed_paste_input(&text))
                         .await?;

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -1300,8 +1300,24 @@ async fn attach_session_loop(client: &Client, session_id: &str) -> Result<()> {
 /// shell. The parent terminal reports line feeds; PTY input expects carriage
 /// returns, with CRLF normalized first so it does not become a doubled CR.
 fn bracketed_paste_input(text: &str) -> String {
-    let normalized = text.replace("\r\n", "\n").replace('\n', "\r");
-    format!("\x1b[200~{normalized}\x1b[201~")
+    const START: &str = "\x1b[200~";
+    const END: &str = "\x1b[201~";
+
+    // Clipboard text can contain terminal controls. If an end marker reaches
+    // the child unchanged, readline leaves paste mode early and processes the
+    // remainder as ordinary keystrokes, including carriage returns that execute
+    // commands. Remove markers while streaming so overlapping inputs cannot
+    // reveal a fresh marker after an earlier one is deleted.
+    let mut defanged = Vec::with_capacity(text.len());
+    for byte in text.bytes() {
+        defanged.push(byte);
+        if defanged.ends_with(START.as_bytes()) || defanged.ends_with(END.as_bytes()) {
+            defanged.truncate(defanged.len() - START.len());
+        }
+    }
+    let defanged = String::from_utf8(defanged).expect("removing ASCII preserves UTF-8");
+    let normalized = defanged.replace("\r\n", "\n").replace('\n', "\r");
+    format!("{START}{normalized}{END}")
 }
 
 fn is_detach_prefix(key: crossterm::event::KeyEvent) -> bool {
@@ -2879,6 +2895,17 @@ mod tests {
             bracketed_paste_input("first\nsecond\r\nthird"),
             "\x1b[200~first\rsecond\rthird\x1b[201~"
         );
+    }
+
+    #[test]
+    fn attached_session_paste_cannot_close_its_own_brackets() {
+        let framed =
+            bracketed_paste_input("safe\x1b[201~\r\nnext\x1b[200~\x1b\x1b[201~[201~\r\ncommand");
+        assert!(framed.starts_with("\x1b[200~"));
+        assert!(framed.ends_with("\x1b[201~"));
+        assert_eq!(framed.matches("\x1b[200~").count(), 1);
+        assert_eq!(framed.matches("\x1b[201~").count(), 1);
+        assert_eq!(&framed[6..framed.len() - 6], "safe\rnext\rcommand");
     }
 
     #[test]

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -1213,12 +1213,19 @@ struct RawModeGuard;
 impl RawModeGuard {
     fn enter() -> Result<Self> {
         crossterm::terminal::enable_raw_mode()?;
+        if let Err(error) =
+            crossterm::execute!(std::io::stdout(), crossterm::event::EnableBracketedPaste)
+        {
+            let _ = crossterm::terminal::disable_raw_mode();
+            return Err(error.into());
+        }
         Ok(Self)
     }
 }
 
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
+        let _ = crossterm::execute!(std::io::stdout(), crossterm::event::DisableBracketedPaste);
         let _ = crossterm::terminal::disable_raw_mode();
     }
 }
@@ -1255,6 +1262,11 @@ async fn attach_session_loop(client: &Client, session_id: &str) -> Result<()> {
 
         while crossterm::event::poll(Duration::ZERO)? {
             match crossterm::event::read()? {
+                Event::Paste(text) => {
+                    client
+                        .write_session(session_id, &bracketed_paste_input(&text))
+                        .await?;
+                }
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     if detach_armed {
                         detach_armed = false;
@@ -1282,6 +1294,16 @@ async fn attach_session_loop(client: &Client, session_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Recreate the framing that crossterm strips from an `Event::Paste` before
+/// relaying it to the child PTY. Keeping the payload bracketed prevents a
+/// multiline paste from being executed one line at a time by an interactive
+/// shell. The parent terminal reports line feeds; PTY input expects carriage
+/// returns, with CRLF normalized first so it does not become a doubled CR.
+fn bracketed_paste_input(text: &str) -> String {
+    let normalized = text.replace("\r\n", "\n").replace('\n', "\r");
+    format!("\x1b[200~{normalized}\x1b[201~")
+}
+
 fn is_detach_prefix(key: crossterm::event::KeyEvent) -> bool {
     key.modifiers
         .contains(crossterm::event::KeyModifiers::CONTROL)
@@ -1290,6 +1312,13 @@ fn is_detach_prefix(key: crossterm::event::KeyEvent) -> bool {
 
 fn key_to_pty_input(key: crossterm::event::KeyEvent) -> Option<String> {
     use crossterm::event::{KeyCode, KeyModifiers};
+
+    // The parent terminal owns platform shortcuts. If one still reaches
+    // crossterm, dropping it is safer than turning Cmd+V into a literal `v`.
+    if key.modifiers.contains(KeyModifiers::SUPER) {
+        return None;
+    }
+
     Some(match key.code {
         KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
             let lower = c.to_ascii_lowercase();
@@ -2842,6 +2871,23 @@ mod tests {
             },
             at: time::OffsetDateTime::now_utc(),
         }
+    }
+
+    #[test]
+    fn attached_session_paste_is_reframed_and_normalizes_newlines() {
+        assert_eq!(
+            bracketed_paste_input("first\nsecond\r\nthird"),
+            "\x1b[200~first\rsecond\rthird\x1b[201~"
+        );
+    }
+
+    #[test]
+    fn attached_session_drops_super_shortcuts() {
+        let key = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('v'),
+            crossterm::event::KeyModifiers::SUPER,
+        );
+        assert_eq!(key_to_pty_input(key), None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Fix paste handling while attached to a muxa-owned PTY session.

- Enable bracketed paste for the parent terminal while attached.
- Re-wrap crossterm paste events before forwarding them, so multiline content
  remains one paste instead of executing line by line.
- Remove embedded bracketed-paste start/end markers before framing. Clipboard
  control bytes therefore cannot close paste mode early and execute the
  remainder as ordinary keystrokes.
- Normalize LF and CRLF input for PTY delivery.
- Ignore leaked SUPER/Cmd shortcuts instead of typing their bare character.
- Clear an armed detach prefix when a paste intervenes.
- Restore bracketed-paste and raw-mode state on normal exits, errors, and a
  partially failed enable operation.

This ports the useful paste slice from #58 onto the current protocol-6 codebase
and advances the raw attach-input work tracked by #89.

## Verification

- `cargo test -p muxa-cli attached_session`: 3 passed
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- GitHub CI: rustfmt, clippy, test, onboarding parity, sandbox, MSRV, and
  cargo-deny all passed
- `git diff --check`: clean
