### PR TITLE
feat(collab): let the operator console list past its own mailbox

### DIFF
--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -35,7 +35,7 @@ use muxa::adapters::{
 };
 use muxa::collaboration::{
     AirArtifactReference, CollaborationClientKind, CollaborationOrigin, CollaborationOriginMatch,
-    NewRequest, RequestKind, RequestMailbox, RequestStatus, WorkMode,
+    MailboxScope, NewRequest, Participant, RequestKind, RequestMailbox, RequestStatus, WorkMode,
 };
 use muxa::config::{IconSet, WatchConfig, WatchSortKey, WatchTheme};
 use muxa::ipc::Client;
@@ -361,6 +361,11 @@ enum MsgCmd {
     List {
         #[arg(long, default_value = "all")]
         mailbox: String,
+        /// How wide to look: `caller` (this pane's own mailbox), `room` (every
+        /// participant in this window), or `all` (every room this daemon
+        /// holds). Anything past `caller` speaks as the operator console.
+        #[arg(long, default_value = "caller")]
+        scope: String,
         #[arg(long)]
         json: bool,
     },
@@ -897,6 +902,15 @@ fn collaboration_air_references(values: &[String]) -> Result<Vec<AirArtifactRefe
         .collect()
 }
 
+fn collaboration_list_scope(value: &str) -> Result<MailboxScope> {
+    match value {
+        "caller" | "self" | "mine" => Ok(MailboxScope::Caller),
+        "room" | "window" => Ok(MailboxScope::Room),
+        "all" | "fleet" => Ok(MailboxScope::All),
+        _ => anyhow::bail!("scope must be caller, room, or all"),
+    }
+}
+
 fn collaboration_mailbox(value: &str) -> Result<RequestMailbox> {
     match value {
         "incoming" | "inbox" => Ok(RequestMailbox::Incoming),
@@ -1037,12 +1051,11 @@ async fn cmd_msg(client: &Client, action: MsgCmd) -> Result<()> {
                 }
             }
         }
-        MsgCmd::List { mailbox, json } => {
-            let requests = client
-                .collaboration_list(&origin, collaboration_mailbox(&mailbox)?)
-                .await?;
-            print_collaboration_messages(&requests, json, &origin)?;
-        }
+        MsgCmd::List {
+            mailbox,
+            scope,
+            json,
+        } => cmd_msg_list(client, &origin, &mailbox, &scope, json).await?,
         MsgCmd::Reply {
             request_id,
             body,
@@ -1074,6 +1087,27 @@ async fn cmd_msg(client: &Client, action: MsgCmd) -> Result<()> {
         }
     }
     Ok(())
+}
+
+async fn cmd_msg_list(
+    client: &Client,
+    origin: &CollaborationOrigin,
+    mailbox: &str,
+    scope: &str,
+    json: bool,
+) -> Result<()> {
+    let scope = collaboration_list_scope(scope)?;
+    // A widened listing is the operator asking what the fleet is saying, not
+    // the pane agent asking after its own inbox — so it goes out under the
+    // console identity the daemon requires for it.
+    let listing_origin = CollaborationOrigin {
+        console: !matches!(scope, MailboxScope::Caller),
+        ..origin.clone()
+    };
+    let requests = client
+        .collaboration_list_scoped(&listing_origin, collaboration_mailbox(mailbox)?, scope)
+        .await?;
+    print_collaboration_messages(&requests, json, origin, scope)
 }
 
 async fn cmd_msg_wait(
@@ -1129,10 +1163,32 @@ fn print_collaboration_receipt(
     Ok(())
 }
 
+/// Where a participant sits, for listings that span more than one room.
+///
+/// A room id alone (`@7` on some socket) tells an operator nothing; the tmux
+/// names they navigate by do. Fall back to the ids only when the scan that
+/// would have supplied the names has not run yet.
+fn participant_location(participant: &Participant) -> String {
+    if participant.console {
+        return "console".to_string();
+    }
+    let session = participant
+        .tmux_session_name
+        .as_deref()
+        .or(participant.tmux_session_id.as_deref())
+        .unwrap_or("?");
+    let window = participant
+        .window_name
+        .as_deref()
+        .unwrap_or(&participant.room.window_id);
+    format!("{session}:{window}")
+}
+
 fn print_collaboration_messages(
     requests: &[muxa::collaboration::CollaborationRequest],
     json: bool,
     origin: &CollaborationOrigin,
+    scope: MailboxScope,
 ) -> Result<()> {
     if json {
         println!("{}", serde_json::to_string_pretty(requests)?);
@@ -1140,15 +1196,28 @@ fn print_collaboration_messages(
         println!("No collaboration messages.");
     } else {
         for request in requests {
-            let direction = if request.from.pane == origin.pane
-                && origin
-                    .socket
-                    .as_deref()
-                    .is_none_or(|socket| request.from.socket.as_deref() == Some(socket))
-            {
-                format!("to {}", request.to.label())
+            // Past the caller's own mailbox there is no "the other end" to
+            // name: the operator is reading other agents' traffic, so both
+            // ends and the window each sits in have to be on the line.
+            let direction = if matches!(scope, MailboxScope::Caller) {
+                if request.from.pane == origin.pane
+                    && origin
+                        .socket
+                        .as_deref()
+                        .is_none_or(|socket| request.from.socket.as_deref() == Some(socket))
+                {
+                    format!("to {}", request.to.label())
+                } else {
+                    format!("from {}", request.from.label())
+                }
             } else {
-                format!("from {}", request.from.label())
+                format!(
+                    "{} [{}] -> {} [{}]",
+                    request.from.label(),
+                    participant_location(&request.from),
+                    request.to.label(),
+                    participant_location(&request.to),
+                )
             };
             // Only when it is worth knowing. `matched` is every ordinary
             // request, and printing the caller's pid and pane on each of them

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -380,6 +380,26 @@ pub enum RequestMailbox {
     All,
 }
 
+/// How wide a mailbox listing reaches.
+///
+/// [`RequestMailbox`] picks a *direction*; this picks *whose* traffic is in
+/// scope. The two are independent — `Sent` at [`MailboxScope::Room`] is
+/// everything the room dispatched, not just what the caller sent.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MailboxScope {
+    /// The caller's own mailbox — all an agent is entitled to.
+    #[default]
+    Caller,
+    /// Every participant in the caller's room.
+    Room,
+    /// Every request the store holds, across rooms, sessions and hosts.
+    ///
+    /// `mailbox` stops applying here: with no endpoint to sit on one side of,
+    /// every request is equally incoming and sent.
+    All,
+}
+
 impl RequestStatus {
     pub fn is_terminal(self) -> bool {
         matches!(
@@ -540,6 +560,10 @@ pub enum CollaborationError {
     NotFound(String),
     #[error("request {0} does not belong to the calling participant")]
     NotParticipant(String),
+    #[error(
+        "listing past your own mailbox is an operator-console operation; this origin speaks for a pane agent"
+    )]
+    ScopeDenied,
     #[error("reply status must be completed, blocked, declined, or failed")]
     InvalidReplyStatus,
     #[error("request {0} is already terminal")]
@@ -1186,24 +1210,43 @@ impl CollaborationStore {
         }
     }
 
+    /// List one mailbox. `scope` widens the listing past the caller's own
+    /// endpoint; see [`MailboxScope`].
     pub async fn list_for(
         &self,
         caller: &Participant,
         mailbox: RequestMailbox,
+        scope: MailboxScope,
     ) -> Result<Vec<CollaborationRequest>, CollaborationError> {
         self.ensure_enabled()?;
+        // Reading past your own mailbox is an operator act. An agent must not
+        // be able to read what its room-mates said to each other just because
+        // it shares their window.
+        if !matches!(scope, MailboxScope::Caller) && !caller.console {
+            return Err(CollaborationError::ScopeDenied);
+        }
         let _transaction = self.transaction_lock.lock().await;
         let mut requests: Vec<_> = self
             .requests
             .read()
             .await
             .values()
-            .filter(|request| match mailbox {
-                RequestMailbox::Incoming => request.to.same_endpoint(caller),
-                RequestMailbox::Sent => request.from.same_endpoint(caller),
-                RequestMailbox::All => {
-                    request.from.same_endpoint(caller) || request.to.same_endpoint(caller)
-                }
+            .filter(|request| match scope {
+                MailboxScope::Caller => match mailbox {
+                    RequestMailbox::Incoming => request.to.same_endpoint(caller),
+                    RequestMailbox::Sent => request.from.same_endpoint(caller),
+                    RequestMailbox::All => {
+                        request.from.same_endpoint(caller) || request.to.same_endpoint(caller)
+                    }
+                },
+                MailboxScope::Room => match mailbox {
+                    RequestMailbox::Incoming => request.to.room == caller.room,
+                    RequestMailbox::Sent => request.from.room == caller.room,
+                    RequestMailbox::All => {
+                        request.from.room == caller.room || request.to.room == caller.room
+                    }
+                },
+                MailboxScope::All => true,
             })
             .cloned()
             .collect();
@@ -2413,14 +2456,14 @@ mod tests {
 
         assert_eq!(
             mailbox
-                .list_for(&sender, RequestMailbox::Sent)
+                .list_for(&sender, RequestMailbox::Sent, MailboxScope::Caller)
                 .await
                 .unwrap()
                 .len(),
             2
         );
         assert!(mailbox
-            .list_for(&recipient, RequestMailbox::Sent)
+            .list_for(&recipient, RequestMailbox::Sent, MailboxScope::Caller)
             .await
             .unwrap()
             .is_empty());
@@ -2523,7 +2566,7 @@ mod tests {
         assert!(matches!(result, Err(CollaborationError::Persistence(_))));
         assert!(mailbox.pending_unnotified().await.is_empty());
         assert!(mailbox
-            .list_for(&sender, RequestMailbox::All)
+            .list_for(&sender, RequestMailbox::All, MailboxScope::Caller)
             .await
             .unwrap()
             .is_empty());
@@ -2564,6 +2607,150 @@ mod tests {
             Err(CollaborationError::Persistence(_))
         ));
         assert!(mailbox.pending_unnotified().await.is_empty());
+    }
+
+    fn participant_in_window(pane: &str, session: &str, window_id: &str) -> Participant {
+        let mut participant = participant(pane, session);
+        participant.room.window_id = window_id.into();
+        participant
+    }
+
+    fn console_in_window(window_id: &str) -> Participant {
+        Participant::console(RoomId {
+            host: "tmux".into(),
+            socket: Some("default".into()),
+            window_id: window_id.into(),
+        })
+    }
+
+    async fn ask(store: &CollaborationStore, from: Participant, to: Participant, body: &str) {
+        store
+            .create(
+                from,
+                to,
+                NewRequest {
+                    kind: RequestKind::Question,
+                    body: body.into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::ReadOnly,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn room_scope_lists_traffic_the_caller_was_never_party_to() {
+        // The operator console dispatches and never receives, so its own
+        // mailbox says nothing about what the agents in front of it are
+        // saying to each other. That is the whole point of widening.
+        let store = CollaborationStore::in_memory(CollaborationOptions::default());
+        ask(
+            &store,
+            participant_in_window("%1", "one", "@1"),
+            participant_in_window("%2", "two", "@1"),
+            "peer to peer",
+        )
+        .await;
+        let console = console_in_window("@1");
+
+        assert!(store
+            .list_for(&console, RequestMailbox::All, MailboxScope::Caller)
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            store
+                .list_for(&console, RequestMailbox::All, MailboxScope::Room)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn all_scope_reaches_rooms_the_console_is_not_in() {
+        let store = CollaborationStore::in_memory(CollaborationOptions::default());
+        ask(
+            &store,
+            participant_in_window("%1", "one", "@1"),
+            participant_in_window("%2", "two", "@1"),
+            "inside the room",
+        )
+        .await;
+        ask(
+            &store,
+            participant_in_window("%3", "three", "@2"),
+            participant_in_window("%4", "four", "@2"),
+            "another window entirely",
+        )
+        .await;
+        // Crosses rooms: sent by @1, received in @2.
+        ask(
+            &store,
+            participant_in_window("%1", "one", "@1"),
+            participant_in_window("%3", "three", "@2"),
+            "across the two",
+        )
+        .await;
+        let console = console_in_window("@1");
+
+        assert_eq!(
+            store
+                .list_for(&console, RequestMailbox::All, MailboxScope::Room)
+                .await
+                .unwrap()
+                .len(),
+            2,
+            "the room's own traffic plus what it sent out"
+        );
+        // Direction still discriminates inside a widened scope: the crossing
+        // request left @1 and landed in @2.
+        assert_eq!(
+            store
+                .list_for(&console, RequestMailbox::Incoming, MailboxScope::Room)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            store
+                .list_for(&console, RequestMailbox::All, MailboxScope::All)
+                .await
+                .unwrap()
+                .len(),
+            3
+        );
+    }
+
+    #[tokio::test]
+    async fn an_agent_cannot_list_past_its_own_mailbox() {
+        let store = CollaborationStore::in_memory(CollaborationOptions::default());
+        ask(
+            &store,
+            participant_in_window("%1", "one", "@1"),
+            participant_in_window("%2", "two", "@1"),
+            "not yours to read",
+        )
+        .await;
+        // A room-mate, not the console: same window, no operator authority.
+        let agent = participant_in_window("%9", "nine", "@1");
+
+        for scope in [MailboxScope::Room, MailboxScope::All] {
+            assert!(matches!(
+                store.list_for(&agent, RequestMailbox::All, scope).await,
+                Err(CollaborationError::ScopeDenied)
+            ));
+        }
+        assert!(store
+            .list_for(&agent, RequestMailbox::All, MailboxScope::Caller)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -2796,7 +2983,7 @@ mod tests {
 
         assert_eq!(
             mailbox
-                .list_for(&from_here, RequestMailbox::Sent)
+                .list_for(&from_here, RequestMailbox::Sent, MailboxScope::Caller)
                 .await
                 .unwrap()
                 .len(),
@@ -2806,7 +2993,7 @@ mod tests {
         // operator reads them — by pointing the cursor at that row.
         assert_eq!(
             mailbox
-                .list_for(&recipient, RequestMailbox::Incoming)
+                .list_for(&recipient, RequestMailbox::Incoming, MailboxScope::Caller)
                 .await
                 .unwrap()
                 .len(),

--- a/crates/muxa/src/collaboration_audit.rs
+++ b/crates/muxa/src/collaboration_audit.rs
@@ -7,7 +7,8 @@
 //! store.
 
 use crate::collaboration::{
-    CollaborationOrigin, CollaborationProvenance, Participant, RequestMailbox, RequestStatus,
+    CollaborationOrigin, CollaborationProvenance, MailboxScope, Participant, RequestMailbox,
+    RequestStatus,
 };
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -58,6 +59,10 @@ pub struct CollaborationAuditEntry {
     pub request_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mailbox: Option<RequestMailbox>,
+    /// How far past the caller's own mailbox the listing reached. Absent on
+    /// operations that never widen, and on the default caller-only listing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<MailboxScope>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<RequestStatus>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -76,6 +81,7 @@ pub struct CollaborationAuditContext {
     pub target: Option<String>,
     pub request_id: Option<String>,
     pub mailbox: Option<RequestMailbox>,
+    pub scope: Option<MailboxScope>,
     pub status: Option<RequestStatus>,
     pub message_bytes: Option<usize>,
 }
@@ -91,6 +97,7 @@ impl CollaborationAuditContext {
             target: None,
             request_id: None,
             mailbox: None,
+            scope: None,
             status: None,
             message_bytes: None,
         }
@@ -117,6 +124,7 @@ impl CollaborationAuditContext {
                 .request_id
                 .or_else(|| response_request_id.map(str::to_string)),
             mailbox: self.mailbox,
+            scope: self.scope,
             status: self.status,
             message_bytes: self.message_bytes,
             result_count,

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -24,8 +24,8 @@ use crate::backend::{default_backend, HostKind, SharedBackend};
 use crate::collaboration::{
     self, AirArtifactReference, CollaborationClientKind, CollaborationOptions, CollaborationOrigin,
     CollaborationOriginMatch, CollaborationPaneEvidence, CollaborationProvenance,
-    CollaborationRequest, CollaborationStore, NewRequest, Participant, RequestMailbox,
-    RequestStatus, RoomContext,
+    CollaborationRequest, CollaborationStore, MailboxScope, NewRequest, Participant,
+    RequestMailbox, RequestStatus, RoomContext,
 };
 use crate::collaboration_audit::{
     CollaborationAuditContext, CollaborationAuditLog, CollaborationAuditOperation,
@@ -336,6 +336,11 @@ enum RequestBody {
         origin: CollaborationOrigin,
         #[serde(default)]
         mailbox: RequestMailbox,
+        /// Absent from every client built before scoped listing existed, and
+        /// defaulting to the caller's own mailbox is exactly what those
+        /// clients asked for.
+        #[serde(default)]
+        scope: MailboxScope,
     },
     CollaborationReply {
         origin: CollaborationOrigin,
@@ -465,6 +470,7 @@ const CAPABILITIES: &[&str] = &[
     "collaboration_wait",
     "collaboration_identity",
     "collaboration_provenance",
+    "collaboration_scope",
     "fleet_v1",
     "fleet_subscribe",
     "pipeline_runs_v1",
@@ -496,6 +502,12 @@ pub struct Response {
     pub max_protocol: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<Vec<&'static str>>,
+    /// The listing breadth the daemon actually applied. A daemon that predates
+    /// scoped listing simply drops the request field, so its absence here is
+    /// how a new client detects that its `--scope` was ignored rather than
+    /// silently reading a caller-scoped answer as a fleet-wide one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collaboration_scope: Option<MailboxScope>,
     /// Present only when the daemon can restart itself. It increments across
     /// each re-exec so a client can distinguish the replacement image from
     /// the old daemon still finishing an in-flight response.
@@ -575,6 +587,7 @@ impl Response {
             min_protocol: None,
             max_protocol: None,
             capabilities: None,
+            collaboration_scope: None,
             generation: None,
             sessions: None,
             session: None,
@@ -700,6 +713,14 @@ impl Response {
     fn with_collaboration_requests(requests: Vec<CollaborationRequest>) -> Self {
         let mut r = Self::ok();
         r.collaboration_requests = Some(requests);
+        r
+    }
+    fn with_scoped_collaboration_requests(
+        requests: Vec<CollaborationRequest>,
+        scope: MailboxScope,
+    ) -> Self {
+        let mut r = Self::with_collaboration_requests(requests);
+        r.collaboration_scope = Some(scope);
         r
     }
     fn with_collaboration_request(request: CollaborationRequest) -> Self {
@@ -2419,7 +2440,11 @@ async fn handle(
                     .await;
                     response
                 }
-                RequestBody::CollaborationList { origin, mailbox } => {
+                RequestBody::CollaborationList {
+                    origin,
+                    mailbox,
+                    scope,
+                } => {
                     kind = "collaboration_list";
                     collaboration_actor.observe_pane(&backends).await;
                     let mut audit_context = CollaborationAuditContext::new(
@@ -2427,11 +2452,18 @@ async fn handle(
                         origin.clone(),
                     );
                     audit_context.mailbox = Some(mailbox);
+                    // Only the widened listings are worth a ledger line of
+                    // their own — a caller-scoped list is the norm and says
+                    // nothing about reach.
+                    audit_context.scope = (!matches!(scope, MailboxScope::Caller)).then_some(scope);
                     let topology =
                         collaboration_participants(&store, &backends, &collaboration).await;
                     let response = match topology.resolve_origin(&origin) {
-                        Ok(current) => match collaboration.list_for(&current, mailbox).await {
-                            Ok(requests) => Response::with_collaboration_requests(requests),
+                        Ok(current) => match collaboration.list_for(&current, mailbox, scope).await
+                        {
+                            Ok(requests) => {
+                                Response::with_scoped_collaboration_requests(requests, scope)
+                            }
                             Err(error) => Response::err(error.to_string()),
                         },
                         Err(error) => Response::err(error.to_string()),
@@ -3387,18 +3419,44 @@ impl Client {
         serde_json::from_value(resp["collaboration_requests"].clone()).map_err(RuntimeError::Json)
     }
 
+    /// One participant's mailbox — the caller's own.
     pub async fn collaboration_list(
         &self,
         origin: &CollaborationOrigin,
         mailbox: RequestMailbox,
+    ) -> Result<Vec<CollaborationRequest>, RuntimeError> {
+        self.collaboration_list_scoped(origin, mailbox, MailboxScope::Caller)
+            .await
+    }
+
+    /// A mailbox listing that may reach past the caller's own endpoint.
+    ///
+    /// Anything wider than [`MailboxScope::Caller`] needs a console origin;
+    /// the daemon rejects the rest.
+    pub async fn collaboration_list_scoped(
+        &self,
+        origin: &CollaborationOrigin,
+        mailbox: RequestMailbox,
+        scope: MailboxScope,
     ) -> Result<Vec<CollaborationRequest>, RuntimeError> {
         let req = serde_json::json!({
             "protocol": PROTOCOL_VERSION,
             "kind": "collaboration_list",
             "origin": origin,
             "mailbox": mailbox,
+            "scope": scope,
         });
         let resp = self.call_checked(&req).await?;
+        // An older daemon ignores the field and answers the caller-scoped
+        // listing it has always answered. Reporting that as the fleet would be
+        // worse than failing: the operator would read "no cross-session
+        // traffic" off a mailbox that was never asked about it.
+        if !matches!(scope, MailboxScope::Caller) && resp["collaboration_scope"].is_null() {
+            return Err(RuntimeError::Daemon(
+                "this muxad predates scoped collaboration listing; restart the daemon from the same tree as the CLI (`muxa daemon restart`)"
+                    .into(),
+            ));
+        }
         serde_json::from_value(resp["collaboration_requests"].clone()).map_err(RuntimeError::Json)
     }
 
@@ -4271,6 +4329,128 @@ mod tests {
             CollaborationOriginMatch::Mismatched
         );
         assert_eq!(provenance.observed_pane.as_deref(), Some("%9"));
+    }
+
+    #[test]
+    fn a_list_request_without_a_scope_stays_caller_scoped() {
+        // Every muxa built before scoped listing omits the field. Defaulting
+        // it to anything wider would hand those clients other agents' mail.
+        let body: RequestBody = serde_json::from_value(serde_json::json!({
+            "kind": "collaboration_list",
+            "origin": { "pane": "%1", "socket": "default" },
+            "mailbox": "incoming",
+        }))
+        .expect("an old client's list request still parses");
+        match body {
+            RequestBody::CollaborationList { scope, .. } => {
+                assert_eq!(scope, MailboxScope::Caller);
+            }
+            other => panic!("expected a collaboration_list request, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn widening_a_listing_over_ipc_is_console_only() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("muxa-collaboration-scope.sock");
+        let store = Store::shared();
+        add_collaboration_agent(&store, "%1", "sender", AgentKind::Codex).await;
+        add_collaboration_agent(&store, "%2", "recipient", AgentKind::ClaudeCode).await;
+        add_collaboration_agent(&store, "%3", "elsewhere", AgentKind::GeminiCli).await;
+        add_collaboration_agent(&store, "%4", "elsewhere-peer", AgentKind::Codex).await;
+        // %3 and %4 sit in a second window, so they form a room of their own.
+        let other_window = |pane_id: &str, pane_index: &str| PaneInfo {
+            window_id: "@2".into(),
+            window_name: "other".into(),
+            window_index: "1".into(),
+            ..collaboration_test_pane(pane_id, pane_index)
+        };
+        let backend: SharedBackend = Arc::new(CollaborationTestBackend {
+            panes: vec![
+                collaboration_test_pane("%1", "0"),
+                collaboration_test_pane("%2", "1"),
+                other_window("%3", "0"),
+                other_window("%4", "1"),
+            ],
+        });
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let server = Server::new(sock.clone(), store)
+            .with_backends(vec![backend])
+            .with_collaboration(mailbox.clone());
+        let (tx, rx) = broadcast::channel(1);
+        let handle = tokio::spawn(async move { server.run(rx).await.unwrap() });
+        wait_for_socket(&sock).await;
+
+        let client =
+            Client::new(sock).with_collaboration_client_kind(CollaborationClientKind::Watch);
+        let origin = |pane: &str, console: bool| CollaborationOrigin {
+            pane: pane.into(),
+            socket: Some("default".into()),
+            console,
+        };
+        let ask = |from: CollaborationOrigin, to: &'static str, body: &'static str| {
+            let client = client.clone();
+            async move {
+                client
+                    .collaboration_send(
+                        &from,
+                        to,
+                        &NewRequest {
+                            kind: collaboration::RequestKind::Question,
+                            body: body.into(),
+                            expects_reply: true,
+                            work_mode: collaboration::WorkMode::ReadOnly,
+                            paths: Vec::new(),
+                            air_artifacts: Vec::new(),
+                        },
+                    )
+                    .await
+                    .unwrap();
+            }
+        };
+        ask(origin("%1", false), "%2", "inside window one").await;
+        ask(origin("%3", false), "%4", "inside window two").await;
+
+        // The console dispatched neither, so its own mailbox is empty.
+        let console = origin("%1", true);
+        assert!(client
+            .collaboration_list(&console, RequestMailbox::All)
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            client
+                .collaboration_list_scoped(&console, RequestMailbox::All, MailboxScope::Room)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        let fleet = client
+            .collaboration_list_scoped(&console, RequestMailbox::All, MailboxScope::All)
+            .await
+            .unwrap();
+        assert_eq!(fleet.len(), 2);
+        // Every row carries the window it happened in, which is what a
+        // fleet-wide listing has to render.
+        let windows: HashSet<_> = fleet
+            .iter()
+            .map(|request| request.from.room.window_id.clone())
+            .collect();
+        assert_eq!(windows.len(), 2);
+
+        // The same call from an agent is refused, room-mate or not.
+        let denied = client
+            .collaboration_list_scoped(&origin("%1", false), RequestMailbox::All, MailboxScope::All)
+            .await
+            .expect_err("an agent may not read the fleet's mail");
+        assert!(
+            denied.to_string().contains("operator-console"),
+            "unexpected error: {denied}"
+        );
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -2989,7 +2989,11 @@ mod tests {
         // watch` reads it, by pointing the cursor at that row.
         assert_eq!(
             mailbox
-                .list_for(&recipient, muxa::collaboration::RequestMailbox::Incoming)
+                .list_for(
+                    &recipient,
+                    muxa::collaboration::RequestMailbox::Incoming,
+                    muxa::collaboration::MailboxScope::Caller,
+                )
                 .await
                 .unwrap()[0]
                 .reply

--- a/docs/COLLABORATION.ko.md
+++ b/docs/COLLABORATION.ko.md
@@ -186,6 +186,10 @@ muxa msg wait req_... --timeout-secs 300
 muxa msg list --mailbox sent
 muxa msg list --mailbox incoming --json
 
+# 이 window 전체 / 이 daemon이 가진 모든 room (operator console 전용)
+muxa msg list --scope room
+muxa msg list --scope all
+
 # 아직 상대가 claim하지 않은 요청 취소
 muxa msg cancel req_...
 ```
@@ -193,6 +197,12 @@ muxa msg cancel req_...
 `send`, `reply`, `cancel`은 한 줄 영수증만 출력하고, `list`와 `inbox`는 각
 요청과 (도착했다면) 그 답장을 함께 보여줍니다. 저장된 레코드 전체가 필요하면
 `--json`을 붙이세요.
+
+`--scope`는 자기 pane의 mailbox 너머까지 목록을 넓히고, `--mailbox`는 그 안에서
+방향을 고릅니다. 기본값 `caller`를 넘어서는 조회는 operator console 자격으로
+나가며 pane agent에게는 거부됩니다 — 같은 window에 있다는 사실이 room-mate들끼리
+주고받은 내용을 읽을 권한이 되지는 않습니다. 넓힌 목록은 각 요청의 양쪽 끝과 그
+각각이 있는 `session:window`를 함께 출력합니다.
 
 tracked agent pane에서 `prefix+s`로 `muxa watch`를 열면 같은 lifecycle을 TUI로
 사용할 수 있습니다. `m`은 선택한 room peer에게 요청을 보내고, `b`는 claim 없는

--- a/docs/COLLABORATION.md
+++ b/docs/COLLABORATION.md
@@ -160,12 +160,21 @@ muxa msg inbox
 muxa msg reply req_... "review complete" --status completed
 muxa msg wait req_... --timeout-secs 300
 muxa msg list --mailbox sent
+muxa msg list --scope room     # every participant in this window
+muxa msg list --scope all      # every room this daemon holds
 muxa msg cancel req_... # queued requests only
 ```
 
 `send`, `reply`, and `cancel` print a one-line receipt; `list` and `inbox`
 print each request followed by its reply, when one has come back. Add `--json`
 to any of them for the stored record instead.
+
+`--scope` widens a listing past the pane's own mailbox, and `--mailbox` still
+picks the direction within it. Anything past the default `caller` speaks as the
+operator console and is refused for a pane agent: sharing a window does not
+entitle an agent to read what its room-mates said to each other. A widened
+listing names both ends of every request and the `session:window` each sits
+in — without that a fleet-wide list cannot say where the work happened.
 
 The same lifecycle is available interactively in `muxa watch`: `m` sends to the
 selected room peer, `b` opens non-claiming mailbox history, `i` claims the


### PR DESCRIPTION
Stage 1 of the fleet-wide collaboration view. Backend only — no `muxa watch` changes here, so the TUI work can land on top without fighting over `watch.rs`.

## Problem

`CollaborationStore::list_for` filters by the caller's own endpoint, so the only way to see what a room was saying was to ask each agent in turn. `RequestMailbox::All` reads like it covers that, but it only picks a *direction* (incoming/sent) within one mailbox.

## What this adds

An orthogonal **breadth** axis, `MailboxScope`:

| scope | reach |
|---|---|
| `caller` (default) | the caller's own mailbox — today's behaviour, unchanged |
| `room` | every participant in the caller's window |
| `all` | every room the store holds; `mailbox` stops applying, since with no endpoint to sit on one side of, every request is equally incoming and sent |

Anything past `caller` requires a **console origin**. Sharing a window must not entitle an agent to read what its room-mates said to each other, so a pane agent asking for `room` or `all` is refused with `CollaborationError::ScopeDenied`. The widened reach lands in the audit ledger (`scope` is recorded only when it is not the default, so an ordinary list still costs no extra signal).

Attribution needs no new lookup: every request already carries both participants' `room`, `tmux_session_name` and `window_name`. `muxa msg list --scope room|all` prints both ends with the `session:window` each sits in.

## Compatibility

Both skew directions are handled and tested:

- **old client → new daemon**: the request omits `scope`, `#[serde(default)]` keeps it caller-scoped. Defaulting it any wider would hand old clients other agents' mail.
- **new client → old daemon**: the old daemon ignores the field and answers the caller-scoped listing it always has. The response now echoes the scope the daemon actually applied, and the client refuses rather than reporting a caller-scoped answer as the fleet — reading "no cross-session traffic" off a mailbox that was never asked about it is worse than an error. Verified against the running 0.8.36 daemon:

  ```
  $ muxa msg list --scope all
  Error: this muxad predates scoped collaboration listing; restart the daemon
  from the same tree as the CLI (`muxa daemon restart`)
  ```

`collaboration_scope` is also advertised in the daemon's capability list.

## Tests

Store level: `room_scope_lists_traffic_the_caller_was_never_party_to`, `all_scope_reaches_rooms_the_console_is_not_in` (including direction still discriminating on a request that crosses rooms), `an_agent_cannot_list_past_its_own_mailbox`.

IPC level: `a_list_request_without_a_scope_stays_caller_scoped`, `widening_a_listing_over_ipc_is_console_only` — a real socket, two windows, asserting the console sees both rooms, that each row carries its window, and that the same call from an agent is refused.

`cargo test --workspace` — 1691 green; fmt and `clippy --workspace --all-targets --all-features -D warnings` clean.

## Next

Stage 2 is the `muxa watch` side. Note that `layout work` (in flight separately) is a *presentation of the same node set*, which is why it belongs on the `layout` axis; a collaboration surface lists **requests**, not topology nodes, so it needs its own axis rather than a fourth `layout` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVQaf1oSAj6ZkgBg2uY2Gk