### PR TITLE
feat(watch): add a collaboration screen across every room

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -200,6 +200,10 @@
 # view = "pane"       # full session → window → pane depth
 # layout = "tree"     # selectable hierarchy (default)
 # layout = "swarm"    # dense collaboration-room clusters
+# Which list watch opens on. `topology` is everything view/layout describe;
+# `collab` lists collaboration requests across every room the daemon holds.
+# screen = "topology" # (default)
+# screen = "collab"
 # How tree children open:
 #   focus  — selected session reveals windows; selected window reveals panes
 #            in pane view, while sibling paths stay folded (default)

--- a/crates/muxa-cli/src/collab_screen.rs
+++ b/crates/muxa-cli/src/collab_screen.rs
@@ -1,0 +1,491 @@
+//! The fleet-wide collaboration screen for `muxa watch`.
+//!
+//! `M` opens one agent's mailbox — whichever row the cursor is on. This screen
+//! answers the question no per-row overlay can: what is the *whole fleet*
+//! saying. Its rows are collaboration requests rather than topology nodes,
+//! which is why it is a screen of its own rather than another `layout` over
+//! the same node set.
+//!
+//! The [`WatchView`] axis carries over unchanged and means here what it means
+//! everywhere else — how coarsely to group. A request is filed under the room
+//! it was *raised* in, because that is the window an operator would go to in
+//! order to ask about it.
+
+use muxa::collaboration::{CollaborationRequest, Participant, RequestStatus};
+use muxa::config::WatchView;
+use ratatui::layout::Constraint;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Cell, Row};
+use time::OffsetDateTime;
+
+use crate::watch::WatchThemeSpec;
+
+/// Longest body excerpt kept on a row. The full text is one `Enter` away in
+/// the mailbox, so the list optimises for scanning many rows at once.
+const BODY_EXCERPT: usize = 60;
+
+#[derive(Debug, Default)]
+pub(crate) struct CollabScreen {
+    /// Newest first, exactly as the daemon returned them.
+    requests: Vec<CollaborationRequest>,
+    /// Index into the *visible* (filtered) requests, not into `requests`.
+    selected: usize,
+    /// Why the listing is missing, when it is. Kept separate from an empty
+    /// listing: "the daemon refused" and "the fleet is quiet" are different
+    /// answers and must not render the same.
+    pub(crate) unavailable: Option<String>,
+    /// A listing has been attempted. Distinguishes the first paint (before
+    /// any fetch has returned) from a genuinely empty fleet.
+    pub(crate) loaded: bool,
+}
+
+/// One rendered line: either a grouping header or a request.
+#[derive(Debug, PartialEq)]
+pub(crate) enum CollabRow<'a> {
+    Group(String),
+    Request(&'a CollaborationRequest),
+}
+
+impl CollabScreen {
+    pub(crate) fn set_requests(&mut self, requests: Vec<CollaborationRequest>) {
+        self.requests = requests;
+        self.unavailable = None;
+        self.loaded = true;
+        self.clamp();
+    }
+
+    pub(crate) fn fail(&mut self, reason: String) {
+        self.requests.clear();
+        self.unavailable = Some(reason);
+        self.loaded = true;
+        self.selected = 0;
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.requests.is_empty()
+    }
+
+    pub(crate) fn selected_index(&self) -> usize {
+        self.selected
+    }
+
+    /// The requests a filter leaves on screen, newest first.
+    pub(crate) fn visible<'a>(&'a self, filter: &str) -> Vec<&'a CollaborationRequest> {
+        let needle = filter.trim().to_lowercase();
+        self.requests
+            .iter()
+            .filter(|request| needle.is_empty() || matches_filter(request, &needle))
+            .collect()
+    }
+
+    pub(crate) fn selected_request(&self, filter: &str) -> Option<&CollaborationRequest> {
+        self.visible(filter).get(self.selected).copied()
+    }
+
+    /// Rows to paint: the visible requests with a header inserted whenever the
+    /// group changes. `WatchView::Pane` groups nothing — at pane granularity
+    /// every row already names both of its endpoints.
+    pub(crate) fn rows<'a>(&'a self, view: WatchView, filter: &str) -> Vec<CollabRow<'a>> {
+        let mut rows = Vec::new();
+        let mut current: Option<String> = None;
+        for request in self.visible(filter) {
+            if let Some(group) = group_of(request, view) {
+                if current.as_ref() != Some(&group) {
+                    rows.push(CollabRow::Group(group.clone()));
+                    current = Some(group);
+                }
+            }
+            rows.push(CollabRow::Request(request));
+        }
+        rows
+    }
+
+    /// Move the cursor within the filtered listing, saturating at both ends.
+    ///
+    /// Saturating rather than wrapping: this list is time-ordered, so running
+    /// off the bottom and landing on the newest request would read as the list
+    /// having jumped on its own.
+    pub(crate) fn move_selection(&mut self, delta: isize, filter: &str) {
+        let len = self.visible(filter).len();
+        if len == 0 {
+            self.selected = 0;
+            return;
+        }
+        let last = len - 1;
+        self.selected = if delta >= 0 {
+            self.selected.saturating_add(delta.unsigned_abs()).min(last)
+        } else {
+            self.selected.saturating_sub(delta.unsigned_abs())
+        };
+    }
+
+    pub(crate) fn select_first(&mut self) {
+        self.selected = 0;
+    }
+
+    pub(crate) fn select_last(&mut self, filter: &str) {
+        self.selected = self.visible(filter).len().saturating_sub(1);
+    }
+
+    /// Keep the cursor inside the listing after a refresh replaced it.
+    fn clamp(&mut self) {
+        let len = self.requests.len();
+        self.selected = if len == 0 {
+            0
+        } else {
+            self.selected.min(len - 1)
+        };
+    }
+}
+
+/// Where a participant sits, in the names an operator navigates by.
+///
+/// A room id alone (`@7` on some socket) locates nothing a human can act on;
+/// the tmux session and window names do. Fall back to the ids only when the
+/// scan that would have supplied the names has not run yet.
+pub(crate) fn location(participant: &Participant) -> String {
+    if participant.console {
+        return "console".to_string();
+    }
+    let session = participant
+        .tmux_session_name
+        .as_deref()
+        .or(participant.tmux_session_id.as_deref())
+        .unwrap_or("?");
+    let window = participant
+        .window_name
+        .as_deref()
+        .unwrap_or(&participant.room.window_id);
+    format!("{session}:{window}")
+}
+
+/// The group a request is filed under, or `None` when the view groups nothing.
+fn group_of(request: &CollaborationRequest, view: WatchView) -> Option<String> {
+    // The sender's room: an operator chasing a request goes to where it was
+    // raised. Console-dispatched requests carry no room of their own, so they
+    // file under the peer they were aimed at instead of a "console" bucket
+    // that would collect every unrelated operator message into one heap.
+    let anchor = if request.from.console {
+        &request.to
+    } else {
+        &request.from
+    };
+    match view {
+        WatchView::Session => Some(
+            anchor
+                .tmux_session_name
+                .clone()
+                .or_else(|| anchor.tmux_session_id.clone())
+                .unwrap_or_else(|| "?".to_string()),
+        ),
+        WatchView::Window => Some(location(anchor)),
+        WatchView::Pane => None,
+    }
+}
+
+fn matches_filter(request: &CollaborationRequest, needle: &str) -> bool {
+    let ends = [&request.from, &request.to];
+    ends.iter().any(|p| {
+        p.label().to_lowercase().contains(needle) || location(p).to_lowercase().contains(needle)
+    }) || request.body.to_lowercase().contains(needle)
+        || format!("{:?}", request.kind)
+            .to_lowercase()
+            .contains(needle)
+        || format!("{:?}", request.status)
+            .to_lowercase()
+            .contains(needle)
+}
+
+/// Compact age, one unit wide enough to scan a column of them at a glance.
+pub(crate) fn age(now: OffsetDateTime, at: OffsetDateTime) -> String {
+    let secs = (now - at).whole_seconds().max(0);
+    match secs {
+        s if s < 60 => format!("{s}s"),
+        s if s < 3600 => format!("{}m", s / 60),
+        s if s < 86400 => format!("{}h", s / 3600),
+        s => format!("{}d", s / 86400),
+    }
+}
+
+fn excerpt(body: &str) -> String {
+    let flat = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    if flat.chars().count() <= BODY_EXCERPT {
+        return flat;
+    }
+    let cut: String = flat.chars().take(BODY_EXCERPT - 1).collect();
+    format!("{cut}…")
+}
+
+pub(crate) const COLUMNS: [Constraint; 5] = [
+    Constraint::Length(5),
+    Constraint::Percentage(32),
+    Constraint::Length(9),
+    Constraint::Length(10),
+    Constraint::Min(20),
+];
+
+pub(crate) const HEADERS: [&str; 5] = ["AGE", "FROM → TO", "KIND", "STATUS", "MESSAGE"];
+
+/// Render one row. Group headers span the table as a single labelled line.
+pub(crate) fn row<'a>(
+    entry: &CollabRow<'a>,
+    now: OffsetDateTime,
+    theme: WatchThemeSpec,
+    selected: bool,
+) -> Row<'a> {
+    match entry {
+        CollabRow::Group(label) => Row::new(vec![
+            Cell::from(""),
+            Cell::from(Line::from(Span::styled(
+                label.clone(),
+                theme.table_header_style(),
+            ))),
+            Cell::from(""),
+            Cell::from(""),
+            Cell::from(""),
+        ]),
+        CollabRow::Request(request) => {
+            let route = format!(
+                "{} [{}] → {} [{}]",
+                request.from.label(),
+                location(&request.from),
+                request.to.label(),
+                location(&request.to),
+            );
+            let cells = vec![
+                Cell::from(age(now, request.created_at)),
+                Cell::from(route),
+                Cell::from(kind_label(request)),
+                Cell::from(status_label(request.status)),
+                Cell::from(excerpt(&request.body)),
+            ];
+            let row = Row::new(cells);
+            if selected {
+                row.style(theme.selected_style())
+            } else {
+                row
+            }
+        }
+    }
+}
+
+fn kind_label(request: &CollaborationRequest) -> String {
+    format!("{:?}", request.kind).to_lowercase()
+}
+
+fn status_label(status: RequestStatus) -> String {
+    format!("{status:?}").to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use muxa::collaboration::{RequestKind, RoomId, WorkMode};
+    use muxa::event::{AgentKind, AgentState};
+
+    fn participant(pane: &str, session: &str, window: &str) -> Participant {
+        Participant {
+            agent_kind: AgentKind::ClaudeCode,
+            agent_session_id: format!("session-{pane}"),
+            pane: pane.into(),
+            socket: Some("default".into()),
+            room: RoomId {
+                host: "tmux".into(),
+                socket: Some("default".into()),
+                window_id: format!("@{}", window.len()),
+            },
+            tmux_session_id: Some("$1".into()),
+            tmux_session_name: Some(session.into()),
+            window_name: Some(window.into()),
+            state: AgentState::Idle,
+            cwd: None,
+            alias: None,
+            roles: Vec::new(),
+            console: false,
+        }
+    }
+
+    fn request(id: &str, from: Participant, to: Participant, body: &str) -> CollaborationRequest {
+        CollaborationRequest {
+            id: id.into(),
+            from,
+            to,
+            provenance: None,
+            kind: RequestKind::Question,
+            body: body.into(),
+            expects_reply: true,
+            work_mode: WorkMode::ReadOnly,
+            paths: Vec::new(),
+            air_artifacts: Vec::new(),
+            status: RequestStatus::Queued,
+            created_at: OffsetDateTime::now_utc(),
+            claimed_at: None,
+            wake_delivery: None,
+            notified_at: None,
+            reply_notified_at: None,
+            reply_read_at: None,
+            reply: None,
+        }
+    }
+
+    fn screen() -> CollabScreen {
+        let mut screen = CollabScreen::default();
+        screen.set_requests(vec![
+            request(
+                "req_1",
+                participant("%1", "callabo", "CAL-7330"),
+                participant("%2", "callabo", "CAL-7330"),
+                "review the auth change",
+            ),
+            request(
+                "req_2",
+                participant("%3", "callabo", "CAL-7331"),
+                participant("%4", "callabo", "CAL-7331"),
+                "upload chunking looks wrong",
+            ),
+            request(
+                "req_3",
+                participant("%5", "muxa", "watch"),
+                participant("%6", "muxa", "watch"),
+                "who owns the refresh path",
+            ),
+        ]);
+        screen
+    }
+
+    #[test]
+    fn window_view_files_each_request_under_the_room_it_was_raised_in() {
+        let screen = screen();
+        let rows = screen.rows(WatchView::Window, "");
+        let groups: Vec<_> = rows
+            .iter()
+            .filter_map(|row| match row {
+                CollabRow::Group(label) => Some(label.clone()),
+                CollabRow::Request(_) => None,
+            })
+            .collect();
+        assert_eq!(
+            groups,
+            vec!["callabo:CAL-7330", "callabo:CAL-7331", "muxa:watch"]
+        );
+        assert_eq!(rows.len(), 6, "three headers, three requests");
+    }
+
+    #[test]
+    fn session_view_collapses_windows_into_one_header_each() {
+        let screen = screen();
+        let groups: Vec<_> = screen
+            .rows(WatchView::Session, "")
+            .into_iter()
+            .filter_map(|row| match row {
+                CollabRow::Group(label) => Some(label),
+                CollabRow::Request(_) => None,
+            })
+            .collect();
+        // Two callabo requests sit under one header; muxa opens the next.
+        assert_eq!(groups, vec!["callabo", "muxa"]);
+    }
+
+    #[test]
+    fn pane_view_groups_nothing_because_every_row_names_both_ends() {
+        let screen = screen();
+        let rows = screen.rows(WatchView::Pane, "");
+        assert_eq!(rows.len(), 3);
+        assert!(rows.iter().all(|row| matches!(row, CollabRow::Request(_))));
+    }
+
+    #[test]
+    fn a_console_dispatch_files_under_the_peer_it_was_aimed_at() {
+        // The console has no room of its own. Filing its traffic under a
+        // "console" bucket would pile every unrelated operator message into
+        // one heap, which is the opposite of what grouping is for.
+        let mut screen = CollabScreen::default();
+        let console = Participant::console(RoomId {
+            host: "tmux".into(),
+            socket: Some("default".into()),
+            window_id: "@1".into(),
+        });
+        screen.set_requests(vec![request(
+            "req_1",
+            console,
+            participant("%2", "callabo", "CAL-7330"),
+            "ship it",
+        )]);
+        let groups: Vec<_> = screen
+            .rows(WatchView::Window, "")
+            .into_iter()
+            .filter_map(|row| match row {
+                CollabRow::Group(label) => Some(label),
+                CollabRow::Request(_) => None,
+            })
+            .collect();
+        assert_eq!(groups, vec!["callabo:CAL-7330"]);
+    }
+
+    #[test]
+    fn the_filter_reaches_the_session_a_request_happened_in() {
+        // Finding "everything CAL-7331 said" is the reason to widen the
+        // listing in the first place, so the window name has to be matchable
+        // and not just the message text.
+        let screen = screen();
+        assert_eq!(screen.visible("cal-7331").len(), 1);
+        assert_eq!(screen.visible("muxa:watch").len(), 1);
+        assert_eq!(screen.visible("chunking").len(), 1);
+        assert_eq!(screen.visible("callabo").len(), 2);
+        assert!(screen.visible("nothing here").is_empty());
+    }
+
+    #[test]
+    fn selection_saturates_instead_of_wrapping() {
+        let mut screen = screen();
+        screen.move_selection(-1, "");
+        assert_eq!(screen.selected_index(), 0, "already at the newest");
+        screen.move_selection(99, "");
+        assert_eq!(screen.selected_index(), 2, "stops at the oldest");
+        assert_eq!(screen.selected_request("").unwrap().id, "req_3");
+    }
+
+    #[test]
+    fn a_refresh_that_shrinks_the_listing_keeps_the_cursor_in_range() {
+        let mut screen = screen();
+        screen.select_last("");
+        assert_eq!(screen.selected_index(), 2);
+        screen.set_requests(vec![request(
+            "req_9",
+            participant("%1", "callabo", "CAL-7330"),
+            participant("%2", "callabo", "CAL-7330"),
+            "only one left",
+        )]);
+        assert_eq!(screen.selected_index(), 0);
+        assert_eq!(screen.selected_request("").unwrap().id, "req_9");
+    }
+
+    #[test]
+    fn a_refused_listing_is_not_an_empty_fleet() {
+        let mut screen = screen();
+        screen.fail("mailbox unavailable".into());
+        assert!(screen.is_empty());
+        assert_eq!(screen.unavailable.as_deref(), Some("mailbox unavailable"));
+        assert!(screen.loaded);
+    }
+
+    #[test]
+    fn ages_read_in_one_unit() {
+        let now = OffsetDateTime::now_utc();
+        assert_eq!(age(now, now), "0s");
+        assert_eq!(age(now, now - time::Duration::seconds(90)), "1m");
+        assert_eq!(age(now, now - time::Duration::hours(5)), "5h");
+        assert_eq!(age(now, now - time::Duration::days(3)), "3d");
+        // A clock that jumped backwards must not render a negative age.
+        assert_eq!(age(now, now + time::Duration::minutes(5)), "0s");
+    }
+
+    #[test]
+    fn a_long_body_is_cut_to_one_scannable_line() {
+        let long = "word ".repeat(40);
+        let cut = excerpt(&long);
+        assert_eq!(cut.chars().count(), BODY_EXCERPT);
+        assert!(cut.ends_with('…'));
+        assert_eq!(excerpt("multi\n  line   body"), "multi line body");
+    }
+}

--- a/crates/muxa-cli/src/fleet_cli.rs
+++ b/crates/muxa-cli/src/fleet_cli.rs
@@ -424,6 +424,9 @@ pub(crate) async fn run_fleet(
                     include_paneless,
                     view,
                     layout,
+                    // Fleet watch renders remote hosts, and a collaboration
+                    // listing is scoped to the local daemon's rooms.
+                    screen: None,
                     sort,
                     theme,
                     caller_pane: None,

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -3,6 +3,7 @@
 mod activity_query;
 mod agent_launch;
 mod attend;
+mod collab_screen;
 mod daemon;
 mod dashboard_tui;
 mod doctor;
@@ -203,6 +204,10 @@ enum Cmd {
         /// Presentation of the same topology: nested tree (default) or swarm.
         #[arg(long, value_enum)]
         layout: Option<WatchLayoutArg>,
+        /// Which list to open on: the topology (default), or collaboration
+        /// across every room the daemon holds.
+        #[arg(long, value_enum)]
+        screen: Option<WatchScreenArg>,
         /// One-shot sibling sort: name, latest/activity/act, duration/dur, st/state, pane, or pane-id.
         #[arg(long, value_enum)]
         sort: Option<WatchSortArg>,
@@ -541,6 +546,21 @@ pub(crate) enum WatchLayoutArg {
     Swarm,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum WatchScreenArg {
+    Topology,
+    Collab,
+}
+
+impl From<WatchScreenArg> for muxa::config::WatchScreen {
+    fn from(value: WatchScreenArg) -> Self {
+        match value {
+            WatchScreenArg::Topology => Self::Topology,
+            WatchScreenArg::Collab => Self::Collab,
+        }
+    }
+}
+
 impl From<WatchLayoutArg> for muxa::config::WatchLayout {
     fn from(value: WatchLayoutArg) -> Self {
         match value {
@@ -699,6 +719,7 @@ async fn main() -> Result<()> {
             include_paneless,
             view,
             layout,
+            screen,
             sort,
             theme,
             caller_client,
@@ -719,6 +740,7 @@ async fn main() -> Result<()> {
                         include_paneless,
                         view,
                         layout,
+                        screen,
                         sort,
                         theme,
                         caller_pane: caller_pane.filter(|p| p.starts_with('%')),
@@ -734,6 +756,7 @@ async fn main() -> Result<()> {
                     include_paneless,
                     view,
                     layout,
+                    screen,
                     sort,
                     theme,
                     // Same unexpanded-format guard as the client: a literal
@@ -1595,6 +1618,7 @@ pub(crate) struct WatchInvocation {
     pub(crate) include_paneless: bool,
     pub(crate) view: Option<WatchViewArg>,
     pub(crate) layout: Option<WatchLayoutArg>,
+    pub(crate) screen: Option<WatchScreenArg>,
     pub(crate) sort: Option<WatchSortArg>,
     pub(crate) theme: Option<ThemeArg>,
     pub(crate) caller_pane: Option<String>,
@@ -1645,6 +1669,7 @@ pub(crate) async fn cmd_watch(
         include_paneless,
         view,
         layout,
+        screen,
         sort,
         theme,
         caller_pane,
@@ -1662,6 +1687,9 @@ pub(crate) async fn cmd_watch(
     };
     if let Some(view) = view {
         watch_cfg.view = view.into();
+    }
+    if let Some(screen) = screen {
+        watch_cfg.screen = screen.into();
     }
     if let Some(layout) = layout {
         watch_cfg.layout = layout.into();

--- a/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_help_overlay.snap
+++ b/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_help_overlay.snap
@@ -27,8 +27,8 @@ j/k move  ·  type or / filter  ·  : commands  ·  ? help
 │                           │  [/] · f/c      (in preview) agent / geometry / content                          │                           │
 │                           │  Enter          (in preview) jump to pinned pane                                 │                           │
 │                           │  m / M          message selected agent / mailbox (b alias)                       │                           │
+│                           │  Alt-1 / Alt-2  screen: topology / collaboration across all rooms                │                           │
 │                           │  i / e          (in mailbox) claim inbox / reply                                 │                           │
-│                           │                                                                                  │                           │
 │                           │Sorting                                                                           │                           │
 │                           │  Alt-S/L/D/T    sibling name / latest / duration / state                         │                           │
 │                           │State markers                                                                     │                           │

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -38,11 +38,12 @@ use crossterm::terminal::{
 };
 use muxa::collaboration::{
     AirArtifactProfile, AirArtifactReference, CollaborationOrigin, CollaborationRequest,
-    NewRequest, Participant, RequestKind, RequestMailbox, RequestStatus, RoomContext, WorkMode,
+    MailboxScope, NewRequest, Participant, RequestKind, RequestMailbox, RequestStatus, RoomContext,
+    WorkMode,
 };
 use muxa::config::{
-    IconSet, WatchCollaborationMode, WatchConfig, WatchLayout, WatchSortKey, WatchSummary,
-    WatchTheme, WatchTreeExpansion, WatchView, WidthSpec,
+    IconSet, WatchCollaborationMode, WatchConfig, WatchLayout, WatchScreen, WatchSortKey,
+    WatchSummary, WatchTheme, WatchTreeExpansion, WatchView, WidthSpec,
 };
 use muxa::event::RateLimitScope;
 use muxa::ipc::{Client, RuntimeError};
@@ -63,6 +64,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
     Block, BorderType, Borders, Cell, Clear, HighlightSpacing, Paragraph, Row, Table, TableState,
+    Wrap,
 };
 use ratatui::{Frame, Terminal};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
@@ -70,6 +72,7 @@ use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use tokio::time::MissedTickBehavior;
 
+use crate::collab_screen::{self, CollabRow, CollabScreen};
 use crate::message_skill::{
     insert_prompt as insert_message_skill_prompt, matching_skills, remove as remove_message_skill,
     upsert as upsert_message_skill, validate_name as validate_message_skill_name,
@@ -1704,8 +1707,8 @@ pub(crate) fn help_overlay_text() -> Vec<&'static str> {
         "  [/] · f/c      (in preview) agent / geometry / content",
         "  Enter          (in preview) jump to pinned pane",
         "  m / M          message selected agent / mailbox (b alias)",
+        "  Alt-1 / Alt-2  screen: topology / collaboration across all rooms",
         "  i / e          (in mailbox) claim inbox / reply",
-        "",
         "Sorting",
         "  Alt-S/L/D/T    sibling name / latest / duration / state",
         "State markers",
@@ -2723,6 +2726,10 @@ pub(crate) struct App {
     /// glance preference, not configuration.
     inspector_split: InspectorSplit,
     collaboration_mailbox: CollaborationMailboxState,
+    /// Fleet-wide collaboration listing, populated only while its screen is
+    /// the one on show — an operator surface has no business polling every
+    /// room in the daemon to render a topology tree.
+    pub(crate) collab: CollabScreen,
     collaboration_composer: Option<CollaborationComposer>,
     /// Reusable templates loaded once from `[message.skills]`; palette
     /// filtering never touches disk or the daemon.
@@ -2988,6 +2995,7 @@ impl App {
             collaboration_scope: muxa::config::CollaborationScope::default(),
             inspector_split,
             collaboration_mailbox: CollaborationMailboxState::default(),
+            collab: CollabScreen::default(),
             collaboration_composer: None,
             message_skills: BTreeMap::new(),
             message_skill_editor: None,
@@ -3289,6 +3297,39 @@ impl App {
         if let Some(selected) = selected {
             self.restore_selection(Some(selected));
         }
+    }
+
+    /// Switch which list watch is showing.
+    ///
+    /// Nothing about the topology changes, so the tree keeps its cursor,
+    /// expansion and filter for when the operator comes back to it.
+    pub(crate) fn apply_screen(&mut self, screen: WatchScreen) {
+        self.watch_cfg.screen = screen;
+        if matches!(screen, WatchScreen::Collab) {
+            // The cursor belongs to whatever the listing turns out to hold,
+            // and the previous visit's row is not it.
+            self.collab.select_first();
+        }
+    }
+
+    /// The topology key for a pane a collaboration request named, when that
+    /// pane is still on screen. Requests outlive the panes that sent them, so
+    /// this is genuinely optional rather than an invariant.
+    pub(crate) fn pane_key_for(&self, pane_id: &str, socket: Option<&str>) -> Option<PaneKey> {
+        self.topology
+            .sessions
+            .iter()
+            .flat_map(|session| session.windows.iter())
+            .flat_map(|window| window.panes.iter())
+            .find(|pane| {
+                pane.key.pane_id == pane_id
+                    // A pane id is only unique within one server, so a socket
+                    // the request carried has to match as well.
+                    && socket.is_none_or(|socket| {
+                        pane.key.window.session.endpoint.socket == socket
+                    })
+            })
+            .map(|pane| pane.key.clone())
     }
 
     pub(crate) fn apply_layout(&mut self, layout: WatchLayout) {
@@ -7095,6 +7136,7 @@ pub async fn run(
                 Action::Refresh => {
                     request_refresh(&mut app, &wake_tx);
                     refresh_watch_collaboration(client, &mut app).await;
+                    refresh_fleet_collaboration(client, &mut app).await;
                 }
                 Action::OpenPreview => {
                     let pane_key = if app.uses_tree() {
@@ -7204,6 +7246,17 @@ pub async fn run(
                         WatchView::Pane => "pane",
                     };
                     app.set_hint(format!("view: {label}"), HintLevel::Ok);
+                }
+                Action::SetScreen(screen) => {
+                    app.apply_screen(screen);
+                    let label = match screen {
+                        WatchScreen::Topology => "topology",
+                        WatchScreen::Collab => "collab",
+                    };
+                    app.set_hint(format!("screen: {label}"), HintLevel::Ok);
+                    // Arriving at an empty list and waiting out a poll tick
+                    // would read as "nothing is happening" on a busy fleet.
+                    refresh_fleet_collaboration(client, &mut app).await;
                 }
                 Action::SetLayout(layout) => {
                     app.apply_layout(layout);
@@ -7729,6 +7782,35 @@ fn friendly_watch_collaboration_error(error: &str) -> String {
             .into();
     }
     error.into()
+}
+
+/// Load every room's traffic for the collaboration screen.
+///
+/// Console-scoped by construction: the daemon refuses a widened listing to a
+/// pane agent, and the operator sitting in front of `muxa watch` is exactly
+/// the caller that is entitled to it. Skipped whenever the screen is not on
+/// show, so a topology-only session never pays for it.
+async fn refresh_fleet_collaboration(client: &Client, app: &mut App) {
+    if !matches!(app.watch_cfg.screen, WatchScreen::Collab) {
+        return;
+    }
+    let Some(origin) = app.collaboration.origin.clone() else {
+        app.collab.fail(collaboration_open_hint().into());
+        return;
+    };
+    let origin = CollaborationOrigin {
+        console: true,
+        ..origin
+    };
+    match client
+        .collaboration_list_scoped(&origin, RequestMailbox::All, MailboxScope::All)
+        .await
+    {
+        Ok(requests) => app.collab.set_requests(requests),
+        Err(error) => app
+            .collab
+            .fail(friendly_watch_collaboration_error(&error.to_string())),
+    }
 }
 
 async fn refresh_watch_collaboration(client: &Client, app: &mut App) {
@@ -8518,6 +8600,7 @@ pub(crate) enum Action {
     SetView(WatchView),
     /// Change presentation without changing topology granularity.
     SetLayout(WatchLayout),
+    SetScreen(WatchScreen),
     /// Resolve the selected row as a same-window collaboration peer and open
     /// the durable request composer.
     OpenCollaborationMessage,
@@ -8651,6 +8734,14 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         description: "show swarm clusters",
     },
     CommandSpec {
+        command: "screen topology",
+        description: "show sessions, windows and panes",
+    },
+    CommandSpec {
+        command: "screen collab",
+        description: "show collaboration across every room",
+    },
+    CommandSpec {
         command: "kill",
         description: "close selected session/window/pane (confirm)",
     },
@@ -8726,6 +8817,8 @@ fn execute_palette_command(app: &mut App, input: &str) -> Action {
         "view session" | "view sessions" => Action::SetView(WatchView::Session),
         "view window" | "view windows" => Action::SetView(WatchView::Window),
         "view pane" | "view panes" => Action::SetView(WatchView::Pane),
+        "screen topology" | "topology" => Action::SetScreen(WatchScreen::Topology),
+        "screen collab" | "collab" => Action::SetScreen(WatchScreen::Collab),
         "layout tree" => Action::SetLayout(WatchLayout::Tree),
         "layout swarm" => Action::SetLayout(WatchLayout::Swarm),
         "" => {
@@ -8920,9 +9013,23 @@ fn handle_event(ev: Event, app: &mut App) -> Action {
                 app.toggle_event_inbox();
                 Action::None
             }
+            // Digits, not letters: plain typing is the filter here, so the
+            // screen axis has to live on a modifier, and every letter worth
+            // having is already spoken for.
+            KeyCode::Char('1') => Action::SetScreen(WatchScreen::Topology),
+            KeyCode::Char('2') => Action::SetScreen(WatchScreen::Collab),
             KeyCode::Char('?') => Action::Quick(QuickAction::ShowHelp),
             _ => Action::None,
         };
+    }
+
+    // The collab screen lists requests rather than nodes, so movement has
+    // nothing to move through in the tree. Everything it does not claim —
+    // filter typing, `:`, `/`, `r`, `?`, `q` — falls through unchanged.
+    if matches!(app.watch_cfg.screen, WatchScreen::Collab) {
+        if let Some(action) = handle_collab_screen_key(code, modifiers, app) {
+            return action;
+        }
     }
 
     if app.pending_g && !matches!(code, KeyCode::Char('g') | KeyCode::Esc) {
@@ -9371,6 +9478,87 @@ fn finish_rename(
         // retype it. Nothing changed, so nothing needs refreshing.
         Err(e) => app.set_hint(format!("rename failed: {e}"), HintLevel::Err),
     }
+}
+
+/// Keys the collaboration screen claims. `None` lets the key fall through to
+/// the ordinary table handling.
+///
+/// Letters are only claimed while no filter is being typed, exactly as the
+/// tree does it — otherwise `j` in a search would jump the cursor instead of
+/// narrowing the list.
+fn handle_collab_screen_key(
+    code: KeyCode,
+    modifiers: KeyModifiers,
+    app: &mut App,
+) -> Option<Action> {
+    let filter = app.search_query.clone();
+    let page = isize::try_from(app.table_page_rows.max(1)).unwrap_or(isize::MAX);
+    let browsing = app.browse_keys_active();
+    match code {
+        KeyCode::Down => app.collab.move_selection(1, &filter),
+        KeyCode::Up => app.collab.move_selection(-1, &filter),
+        KeyCode::Char('j') if browsing => app.collab.move_selection(1, &filter),
+        KeyCode::Char('k') if browsing => app.collab.move_selection(-1, &filter),
+        KeyCode::PageDown => app.collab.move_selection(page, &filter),
+        KeyCode::PageUp => app.collab.move_selection(-page, &filter),
+        KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => {
+            app.collab.move_selection(page / 2, &filter);
+        }
+        KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => {
+            app.collab.move_selection(-(page / 2), &filter);
+        }
+        KeyCode::Home => app.collab.select_first(),
+        KeyCode::End => app.collab.select_last(&filter),
+        KeyCode::Char('G') if browsing => app.collab.select_last(&filter),
+        KeyCode::Char('g') if browsing => {
+            if app.pending_g {
+                app.pending_g = false;
+                app.collab.select_first();
+            } else {
+                app.pending_g = true;
+            }
+        }
+        // Enter goes where the request went. The peer's pane is the useful
+        // end: the console dispatches from nowhere in particular, and a
+        // request whose peer is the console is a reply the operator already
+        // has on screen.
+        KeyCode::Enter => return Some(collab_attach_action(app, &filter)),
+        _ => return None,
+    }
+    Some(Action::None)
+}
+
+/// Resolve `Enter` on the collaboration screen to a pane to attach to.
+fn collab_attach_action(app: &mut App, filter: &str) -> Action {
+    // Enter goes where the request went, so the peer's pane is the useful
+    // end. Clone what is needed before hinting: the lookup borrows `app`.
+    let peer = app.collab.selected_request(filter).map(|request| {
+        let peer = if request.to.console {
+            &request.from
+        } else {
+            &request.to
+        };
+        (
+            peer.pane.clone(),
+            peer.socket.clone(),
+            peer.label(),
+            peer.console,
+        )
+    });
+    let Some((pane, socket, label, console)) = peer else {
+        return Action::None;
+    };
+    if console {
+        app.set_hint("that request never left the console", HintLevel::Warn);
+        return Action::None;
+    }
+    if let Some(key) = app.pane_key_for(&pane, socket.as_deref()) {
+        return Action::AttachTopologyPane(key);
+    }
+    // Requests outlive their panes, so this is ordinary rather than an error:
+    // say which pane is gone instead of leaving Enter silent.
+    app.set_hint(format!("{label} is no longer on any pane"), HintLevel::Warn);
+    Action::None
 }
 
 fn handle_rename_event(code: KeyCode, modifiers: KeyModifiers, app: &mut App) -> Action {
@@ -12177,6 +12365,93 @@ fn help_popup_rect(r: Rect) -> Rect {
 ///
 /// Looks up the row by `pane_id` every frame so background refreshes that
 /// re-sort the table can't bump us onto a different agent's content.
+/// The fleet-wide collaboration listing.
+///
+/// Deliberately its own table rather than the topology one: the columns
+/// identify a request and both of its endpoints, and none of the node columns
+/// (state, duration, prompt) mean anything for a message.
+fn render_collab_screen(f: &mut Frame, area: Rect, app: &mut App) {
+    let theme = watch_theme(app.watch_cfg.theme.unwrap_or_default());
+    let filter = app.search_query.clone();
+    let entries = app.collab.rows(app.watch_cfg.view, &filter);
+    let visible = app.collab.visible(&filter).len();
+    let selected = app.collab.selected_index();
+    let title = format!(" Collab · fleet ({visible}) ");
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.border_style())
+        .border_type(theme.border_type)
+        .title(title);
+
+    if let Some(reason) = app.collab.unavailable.clone() {
+        f.render_widget(
+            Paragraph::new(reason)
+                .style(theme.dim_style())
+                .block(block)
+                .wrap(Wrap { trim: true }),
+            area,
+        );
+        return;
+    }
+    if entries.is_empty() {
+        // "Loading" and "the fleet said nothing" look identical on an empty
+        // grid, and one of them is a reason to keep waiting.
+        let hint = if !app.collab.loaded {
+            "loading the fleet's collaboration…"
+        } else if app.collab.is_empty() {
+            "no collaboration requests in any room yet — `m` sends the first one"
+        } else {
+            "no request matches this filter"
+        };
+        f.render_widget(
+            Paragraph::new(hint)
+                .style(theme.dim_style())
+                .block(block)
+                .alignment(Alignment::Center),
+            area,
+        );
+        return;
+    }
+
+    let now = OffsetDateTime::now_utc();
+    // The cursor counts requests, not rows: group headers are not selectable,
+    // so the nth request is the nth *selectable* line.
+    let mut request_index = 0usize;
+    let mut selected_row = None;
+    let rows: Vec<Row> = entries
+        .iter()
+        .enumerate()
+        .map(|(row_index, entry)| {
+            let is_selected = match entry {
+                CollabRow::Group(_) => false,
+                CollabRow::Request(_) => {
+                    let hit = request_index == selected;
+                    if hit {
+                        selected_row = Some(row_index);
+                    }
+                    request_index += 1;
+                    hit
+                }
+            };
+            collab_screen::row(entry, now, theme, is_selected)
+        })
+        .collect();
+    let header = Row::new(
+        collab_screen::HEADERS
+            .iter()
+            .map(|header| Cell::from(*header).style(theme.table_header_style())),
+    )
+    .height(1);
+    let table = Table::new(rows, collab_screen::COLUMNS)
+        .header(header)
+        .block(block)
+        .highlight_symbol("> ")
+        .highlight_spacing(HighlightSpacing::Always);
+    let mut state = TableState::default();
+    state.select(selected_row);
+    f.render_stateful_widget(table, area, &mut state);
+}
+
 fn render_preview(f: &mut Frame, area: Rect, app: &App) {
     let theme = watch_theme(app.watch_cfg.theme.unwrap_or_default());
     let preview = app
@@ -12614,6 +12889,10 @@ fn render_header(f: &mut Frame, area: Rect, app: &App, tree_targets: Option<&[Tr
 /// separate [`WatchView`] concern.
 fn render_body(f: &mut Frame, area: Rect, app: &mut App, tree_targets: Option<&[TreeTarget]>) {
     let split_inspector = app.inspector_enabled
+        // The inspector describes the selected *pane*, and the collab screen's
+        // cursor is on a request. Halving the table to show an unrelated pane
+        // costs the two columns that identify both ends of a message.
+        && !matches!(app.watch_cfg.screen, WatchScreen::Collab)
         && area.width >= 120
         && if app.uses_tree() {
             selected_tree_target_from(app, tree_targets.unwrap_or_default()).is_some()
@@ -12671,6 +12950,10 @@ fn render_primary_body(
     tree_targets: Option<&[TreeTarget]>,
 ) {
     app.table_page_rows = usize::from(area.height.saturating_sub(3).max(1));
+    if matches!(app.watch_cfg.screen, WatchScreen::Collab) {
+        render_collab_screen(f, area, app);
+        return;
+    }
     if app.legacy_flat_table {
         render_table(f, area, app);
     } else if app.watch_cfg.layout == WatchLayout::Swarm {
@@ -22696,6 +22979,11 @@ sort = ["state"]
             Action::SetLayout(layout) => {
                 app.apply_layout(layout);
             }
+            // The run loop also reloads the fleet listing here; the harness
+            // stops at the state change so no test needs a daemon.
+            Action::SetScreen(screen) => {
+                app.apply_screen(screen);
+            }
             // Quick-action paths aren't exercised through `press` —
             // tests that need them call `handle_event` directly so
             // they can inspect the `Action` variant. Anything we
@@ -23510,6 +23798,162 @@ sort = ["state"]
             vec![fake_pane("%42", "main", 2, 0, "claude")],
         );
         app
+    }
+
+    fn collab_participant(pane: &str, session: &str, window: &str) -> Participant {
+        Participant {
+            agent_kind: AgentKind::ClaudeCode,
+            agent_session_id: format!("agent-{pane}"),
+            pane: pane.into(),
+            socket: Some("default".into()),
+            room: muxa::collaboration::RoomId {
+                host: "tmux".into(),
+                socket: Some("default".into()),
+                window_id: "@4".into(),
+            },
+            tmux_session_id: Some("$1".into()),
+            tmux_session_name: Some(session.into()),
+            window_name: Some(window.into()),
+            state: AgentState::Idle,
+            cwd: None,
+            alias: None,
+            roles: Vec::new(),
+            console: false,
+        }
+    }
+
+    fn collab_request(to_pane: &str) -> CollaborationRequest {
+        CollaborationRequest {
+            id: "req_1".into(),
+            from: collab_participant("%1", "callabo", "CAL-7330"),
+            to: collab_participant(to_pane, "callabo", "CAL-7330"),
+            provenance: None,
+            kind: RequestKind::Review,
+            body: "check the upload chunking".into(),
+            expects_reply: true,
+            work_mode: WorkMode::ReadOnly,
+            paths: Vec::new(),
+            air_artifacts: Vec::new(),
+            status: RequestStatus::Queued,
+            created_at: OffsetDateTime::now_utc(),
+            claimed_at: None,
+            wake_delivery: None,
+            notified_at: None,
+            reply_notified_at: None,
+            reply_read_at: None,
+            reply: None,
+        }
+    }
+
+    /// A watch sitting on the collab screen, with one request whose peer pane
+    /// is `to_pane` and a topology that really holds `%2`.
+    fn collab_app(to_pane: &str) -> App {
+        let mut app = App::with_legacy_config(WatchConfig::default());
+        app.set_data(
+            Vec::new(),
+            vec![fake_topology_pane(
+                "default", "$1", "callabo", "@4", "CAL-7330", 4, "%2", 0,
+            )],
+        );
+        app.collab.set_requests(vec![collab_request(to_pane)]);
+        app.apply_screen(WatchScreen::Collab);
+        app
+    }
+
+    #[test]
+    fn alt_digits_pick_the_screen() {
+        // Plain letters are the filter, so the axis lives on a modifier.
+        let mut app = App::with_legacy_config(WatchConfig::default());
+        assert!(matches!(
+            alt_key_action(&mut app, '2'),
+            Action::SetScreen(WatchScreen::Collab)
+        ));
+        assert!(matches!(
+            alt_key_action(&mut app, '1'),
+            Action::SetScreen(WatchScreen::Topology)
+        ));
+    }
+
+    #[test]
+    fn the_palette_reaches_both_screens() {
+        let mut app = App::with_legacy_config(WatchConfig::default());
+        assert!(matches!(
+            execute_palette_command(&mut app, "screen collab"),
+            Action::SetScreen(WatchScreen::Collab)
+        ));
+        assert!(matches!(
+            execute_palette_command(&mut app, "topology"),
+            Action::SetScreen(WatchScreen::Topology)
+        ));
+    }
+
+    #[test]
+    fn enter_on_a_collab_row_goes_to_the_peer_pane() {
+        // The peer is the end that has the work; the sender is often the
+        // console, which is nowhere to attach to.
+        let mut app = collab_app("%2");
+        let action = handle_event(
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            &mut app,
+        );
+        match action {
+            Action::AttachTopologyPane(key) => {
+                assert_eq!(key.pane_id, "%2");
+                assert_eq!(key.window.session.endpoint.socket, "default");
+            }
+            other => panic!("expected an attach to the peer pane, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn enter_says_which_pane_is_gone_instead_of_doing_nothing() {
+        // Requests outlive their panes. Silence here reads as a broken key.
+        let mut app = collab_app("%99");
+        let action = handle_event(
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            &mut app,
+        );
+        assert!(matches!(action, Action::None));
+        let hint = app.footer_hint.as_ref().expect("a hint explains the no-op");
+        assert!(
+            hint.message.contains("%99") && hint.message.contains("no longer"),
+            "unexpected hint: {}",
+            hint.message
+        );
+    }
+
+    #[test]
+    fn the_collab_screen_still_leaves_typing_to_the_filter() {
+        // `j` is a movement key only while nothing is being searched for —
+        // the same rule the tree follows.
+        let mut app = collab_app("%2");
+        app.arm_explicit_search();
+        let _ = handle_event(
+            Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+            &mut app,
+        );
+        assert_eq!(app.search_query, "j", "the keystroke went to the filter");
+        assert_eq!(app.collab.selected_index(), 0);
+    }
+
+    #[test]
+    fn the_collab_screen_paints_where_each_request_happened() {
+        let mut app = collab_app("%2");
+        let backend = ratatui::backend::TestBackend::new(160, 12);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &mut app)).unwrap();
+        let painted: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+        // Both ends, the room each sits in, and the message itself: without
+        // the location a fleet-wide list cannot say where the work happened.
+        assert!(painted.contains("callabo:CAL-7330"), "{painted}");
+        assert!(painted.contains("Collab"), "{painted}");
+        assert!(painted.contains("check the upload chunking"), "{painted}");
     }
 
     fn rename_app(level: RenameLevel, original: &str) -> App {

--- a/crates/muxa/src/config.rs
+++ b/crates/muxa/src/config.rs
@@ -1509,6 +1509,9 @@ pub struct WatchConfig {
     /// Presentation of the same canonical topology. Defaults to `tree`.
     #[serde(default)]
     pub layout: WatchLayout,
+    /// Which list `muxa watch` opens on. Defaults to `topology`.
+    #[serde(default)]
+    pub screen: WatchScreen,
     /// How tree children are revealed. `focus` keeps only the selected path
     /// open, `always` expands every node through the configured `view`, and
     /// `manual` changes expansion only through the tree navigation keys.
@@ -1613,6 +1616,23 @@ pub enum WatchLayout {
     /// Dense animated collaboration-room clusters. Node identities and the
     /// requested topology depth remain unchanged.
     Swarm,
+}
+
+/// What `muxa watch` is a list *of*.
+///
+/// Orthogonal to [`WatchView`] (how coarsely to group) and [`WatchLayout`]
+/// (how to draw it): those two are presentations of the same canonical node
+/// set, while a screen chooses the data plane. Collaboration rows are
+/// requests, not topology nodes, which is why it is a screen rather than a
+/// fourth layout.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WatchScreen {
+    /// Sessions, windows and panes — everything `layout` and `view` describe.
+    #[default]
+    Topology,
+    /// Collaboration requests across every room the daemon holds.
+    Collab,
 }
 
 /// Expansion policy for the selectable watch topology tree.
@@ -1751,6 +1771,7 @@ impl Default for WatchConfig {
             widths,
             view: WatchView::Window,
             layout: WatchLayout::Tree,
+            screen: WatchScreen::Topology,
             tree_expansion: WatchTreeExpansion::Focus,
             summary: WatchSummary::default(),
             detail: DetailConfig::default(),

--- a/docs/WATCH.ko.md
+++ b/docs/WATCH.ko.md
@@ -121,10 +121,32 @@ inbox를 열면 확인 처리됩니다.
 탐색 중 `:`를 누르면 명령 팔레트가 열립니다. 명령을 입력하고 `Enter`로 실행하며,
 `Tab`은 첫 번째 일치 항목을 완성하고 `Esc`는 취소합니다. `refresh`, `preview`,
 `copy`, `attention`, `events`, `inspector`, `sort latest|duration|session|state`,
-`view pane|session|swarm`, `help`, `quit`를 지원합니다. `kill`과 `abort`는 기존과
+`view pane|session|swarm`, `screen topology|collab`, `help`, `quit`를
+지원합니다. `kill`과 `abort`는 기존과
 동일하게 확인 popup을 거칩니다. `view` 변경은 cached snapshot에 즉시 반영되며
 현재 watch process의 이후 refresh에도 유지됩니다.
 
+
+## 화면(Screen)
+
+`muxa watch`는 두 가지 목록 중 하나를 보여주며 `Alt-1` / `Alt-2`, 팔레트의
+`screen topology|collab`, `--screen`, `[watch] screen`으로 전환합니다.
+
+`topology`는 session → window → pane 트리이고 `view`·`layout`이 설명하는 모든
+것이 여기 적용됩니다. `collab`은 대신 협업 *request*를 나열합니다 — 커서가 놓인
+방만 보여주는 `M`과 달리 daemon이 가진 모든 room이 대상입니다. 행이 무엇이냐가
+다르기 때문에 `layout`의 값이 아니라 별도 화면입니다.
+
+`view` 축은 그대로 이어집니다: `session`은 tmux session별, `window`는 room별로
+묶고 `pane`은 평면 목록입니다. request는 그것이 제기된 room 아래에 묶이므로 어느
+묶음에서도 작업이 일어난 위치를 알 수 있습니다. 타이핑하면 양쪽 끝의 alias,
+`session:window`, 메시지, kind, status를 대상으로 필터링합니다. `Enter`는 상대
+pane으로 이동합니다 — request는 pane보다 오래 남으므로 상대 pane이 사라졌으면
+아무 일도 안 하는 대신 그 사실을 알려줍니다.
+
+자기 mailbox 너머를 보는 것은 operator console 작업이라, 이 화면은 CLI와 같은
+트리에서 빌드된 daemon을 요구합니다. 구버전 daemon은 caller 범위 결과로 조용히
+답하는 대신 그 사실을 보고합니다.
 
 ## Ask
 

--- a/docs/WATCH.md
+++ b/docs/WATCH.md
@@ -169,9 +169,31 @@ Press `:` while browsing to open the command palette. Type a command and press
 `Enter`; `Tab` completes the first visible match and `Esc` cancels. Available
 commands include `refresh`, `preview`, `copy`, `attention`, `events`,
 `inspector`, `sort latest|duration|session|state`, `view pane|session|swarm`,
-`help`, and `quit`. `kill` and `abort` still open the normal confirmation popup.
+`screen topology|collab`, `help`, and `quit`. `kill` and `abort` still open the normal confirmation popup.
 Runtime `view` changes use the cached snapshot immediately and remain active
 for subsequent refreshes in the current watch process.
+
+## Screens
+
+`muxa watch` shows one of two lists, chosen with `Alt-1` / `Alt-2`, the
+`screen topology|collab` palette command, `--screen`, or `[watch] screen`.
+
+`topology` is the session → window → pane tree, and everything `view` and
+`layout` describe applies to it. `collab` lists collaboration *requests*
+instead — every room the daemon holds, not just the one under the cursor,
+which is what `M` shows. That difference in what a row *is* is why this is a
+screen rather than another `layout`.
+
+The `view` axis carries over: `session` groups the listing by tmux session,
+`window` by room, and `pane` leaves it flat. A request is filed under the room
+it was raised in, so a listing at any grouping says where the work happened.
+Typing filters on either end's alias, its `session:window`, the message, the
+kind, and the status. `Enter` attaches to the peer's pane — requests outlive
+panes, so a request whose peer is gone says so rather than doing nothing.
+
+Widening past your own mailbox is an operator-console operation, so the screen
+needs a daemon built from the same tree as the CLI; an older one is reported
+rather than silently answered with a caller-scoped listing.
 
 ## Ask
 


### PR DESCRIPTION
Stage 2, on top of #106.

## Problem

`M` opens the mailbox of whichever agent the cursor is on. Seeing what the *fleet* is saying meant walking the tree agent by agent, and nothing showed which session or window a message came from.

## The axis

`muxa watch` already has two axes, and both are presentations of one canonical node set: `view` (session/window/pane depth) and `layout` (tree/swarm). A collaboration list is not that — its rows are **requests**, not topology nodes. So this adds a third, orthogonal axis rather than a third `layout` value:

| axis | values | question it answers |
|---|---|---|
| `screen` (new) | `topology`, `collab` | what is this a list *of* |
| `view` | session, window, pane | how coarsely to group |
| `layout` | tree, swarm | how to draw the topology |

Reachable via `Alt-1` / `Alt-2` (digits, because plain letters are the filter), `:screen topology|collab`, `--screen`, and `[watch] screen`.

## The screen

- **`view` carries over as grouping depth** — by session, by room, or flat. A request files under the room it was *raised* in, since that is the window an operator would go to. Console dispatches have no room of their own, so they file under the peer they were aimed at instead of piling into one operator bucket.
- **Every row names both ends and where each sits** (`alias@pane [session:window]`), which is the attribution the fleet view needs. No extra lookup: requests already carry it.
- **Typing filters** over both ends' aliases, their `session:window`, the body, the kind and the status — case-insensitively, so `cal-7331` finds `CAL-7331`.
- **`Enter` attaches to the peer's pane.** Requests outlive panes, so one whose peer is gone says which pane instead of leaving the key silent.
- **The inspector folds away** on this screen: it describes the selected *pane*, and here the cursor is on a request. Keeping it cost the two columns that identify a message.
- **Loading, empty and refused are three different messages.** "The daemon refused" must not render as "the fleet is quiet".
- Fetching is console-scoped (#106) and runs only while the screen is on show, so a topology-only session never pays for it.

## Tests

`collab_screen` (10): grouping per view, console-dispatch anchoring, filter reach, saturating selection, cursor clamped when a refresh shrinks the listing, refusal ≠ empty, age formatting including a backwards clock, excerpt trimming.

`watch` (6): `Alt-1`/`Alt-2` and the palette both reach the axis, `Enter` resolves to the peer's pane key, a missing pane hints instead of no-op, typing still goes to the filter, and a TestBackend render asserts the painted frame carries both ends, the room, and the message.

`cargo test --workspace` — 1707 green; fmt and `clippy --workspace --all-targets --all-features -D warnings` clean.

## Notes

- The help overlay gained a line without growing: a separator blank was dropped, otherwise the last binding was pushed out of the box on a 24-row terminal.
- Live end-to-end needs a daemon built from this tree; the running 0.8.36 daemon answers the skew error from #106 rather than a stale listing. Not restarted here — this machine is running a lot of live agent sessions.
- Follow-ups worth doing: the footer hint line still reads topology-first (`h/l tree`), and a request's full body still needs `M`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVQaf1oSAj6ZkgBg2uY2Gk