### PR TITLE
feat(onboarding): end by naming the keys `muxa init` binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The live tour's ending names the keys `muxa init` binds.** It taught
+  `muxa watch` as something you type — true in the sandbox, where nothing is
+  installed — and stopped there, so a learner who finished went on typing it
+  instead of pressing `prefix + s`. The closing summary now lists `prefix + s`,
+  `S`, `D`, `q` and `,` with what each opens, and a test holds that list
+  against the bindings `muxa init` actually writes: a hand-kept copy of
+  somebody else's keys goes stale the first time they change one, and this one
+  tells the learner what their own machine will do.
+
 ### Fixed
 
 - **An alias reserved with `--alias` reached the daemon the launch was talking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   somebody else's keys goes stale the first time they change one, and this one
   tells the learner what their own machine will do.
 
+  It also points at oh-my-zsh's `tmux` plugin for `ta` / `ts` / `tl`, rather
+  than writing them into anyone's shell rc. That plugin builds them as
+  functions with session-name completion; a plain alias would not have it, and
+  ours would shadow the better version depending on load order.
+
 ### Fixed
 
 - **An alias reserved with `--alias` reached the daemon the launch was talking

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -2318,6 +2318,39 @@ const WORTH_KNOWING: &[(&str, &str, &str)] = &[
     ),
 ];
 
+/// What `muxa init` binds, once muxa is installed for real.
+///
+/// The tour teaches `muxa watch` as something you type, because in the sandbox
+/// that is what it is. On an installed muxa it is one key — and a learner who
+/// finishes without being told that goes on typing it.
+const AFTER_INIT: &[(&str, &str, &str)] = &[
+    (
+        "prefix + s",
+        "`muxa watch`, over the whole screen",
+        "`muxa watch`를 전체 화면으로",
+    ),
+    (
+        "prefix + S",
+        "the same across every host in the Fleet",
+        "Fleet의 모든 host를 한 화면에",
+    ),
+    (
+        "prefix + D",
+        "`muxa dashboard` — Work cards, prompts, collaboration",
+        "`muxa dashboard` — Work 카드·프롬프트·협업",
+    ),
+    (
+        "prefix + q",
+        "`muxa peek` — every pane in this window, with a digit to jump by",
+        "`muxa peek` — 이 window의 모든 pane, 숫자로 이동",
+    ),
+    (
+        "prefix + ,",
+        "rename the window, which is to say name the Work",
+        "window 이름 변경 — 곧 Work에 이름 붙이기",
+    ),
+];
+
 /// The tour installs nothing, so it has to say how to get a real muxa.
 const INSTALLING: &[(&str, &str, &str)] = &[
     (
@@ -2369,6 +2402,12 @@ fn next_steps(language: UiLanguage) {
         "Installing it for real",
         "실제로 설치하기",
         INSTALLING,
+    );
+    section(
+        language,
+        "What `muxa init` binds, so you stop typing them",
+        "`muxa init`이 걸어주는 키 — 이제 타이핑하지 않아도 됩니다",
+        AFTER_INIT,
     );
 
     println!();
@@ -2462,6 +2501,30 @@ mod tests {
             Detect::ActivePaneIsCodex
         ));
         assert_eq!(CLAUDE_FINISHES_STEP, STEPS.len() - 1);
+    }
+
+    /// The keys the ending promises are the keys `muxa init` actually binds.
+    ///
+    /// A hand-kept list of somebody else's bindings is a list that goes stale
+    /// the first time they change one — and this one tells the learner what
+    /// their own machine will do, so being wrong is worse than being absent.
+    #[test]
+    fn the_ending_promises_only_keys_init_binds() {
+        let bound = format!(
+            "{}\n{}\n{}",
+            crate::init::files::tmux::POPUP_BODY,
+            crate::init::files::tmux::PEEK_BODY,
+            crate::init::files::tmux::WINDOW_NAMES_BODY,
+        );
+        for (key, ..) in AFTER_INIT {
+            let suffix = key
+                .strip_prefix("prefix + ")
+                .unwrap_or_else(|| panic!("{key} is not a prefix binding"));
+            assert!(
+                bound.contains(&format!("bind-key {suffix} ")),
+                "the ending promises `{key}`, which `muxa init` does not bind"
+            );
+        }
     }
 
     /// Every step says what the last action accomplished, in both languages.

--- a/crates/muxa-cli/src/onboarding/live.rs
+++ b/crates/muxa-cli/src/onboarding/live.rs
@@ -2426,6 +2426,19 @@ fn next_steps(language: UiLanguage) {
         println!("  {line}");
     }
     println!();
+    // Not something muxa installs, and deliberately so: oh-my-zsh's tmux
+    // plugin already gives these names, with session-name completion that a
+    // plain alias would not have. Writing our own into somebody's rc would
+    // shadow the better version depending on load order. Point at it instead.
+    println!(
+        "  {}",
+        tr(
+            language,
+            "In your shell:  oh-my-zsh's `tmux` plugin gives `ta` / `ts` / `tl`, with session-name completion",
+            "셸에서:  oh-my-zsh의 `tmux` 플러그인이 `ta` / `ts` / `tl` 을 세션 이름 자동완성과 함께 줍니다",
+        )
+    );
+    println!();
     println!(
         "  {}",
         tr(


### PR DESCRIPTION
The tour teaches `muxa watch` as something you type. That is true inside the
sandbox, which installs nothing — but on an installed muxa it is `prefix + s`,
and a learner who finishes without being told goes on typing it.

The closing summary now lists them, next to the install commands that produce
them:

```
`muxa init`이 걸어주는 키 — 이제 타이핑하지 않아도 됩니다
  prefix + s   `muxa watch`를 전체 화면으로
  prefix + S   Fleet의 모든 host를 한 화면에
  prefix + D   `muxa dashboard` — Work 카드·프롬프트·협업
  prefix + q   `muxa peek` — 이 window의 모든 pane, 숫자로 이동
  prefix + ,   window 이름 변경 — 곧 Work에 이름 붙이기
```

## Held to the real bindings

`the_ending_promises_only_keys_init_binds` checks every key in the list against
`init::files::tmux`'s `POPUP_BODY`, `PEEK_BODY` and `WINDOW_NAMES_BODY`. A
hand-kept copy of somebody else's keys goes stale the first time they change
one, and this list tells the learner what their own machine will do — being
wrong about that is worse than saying nothing. Adding a `prefix + Z` nobody
binds fails the test.

## Note on the request

This started as "we hand out `ta` / `tl` aliases at install — mention those
too". I could not find them: no `ta` or `tl` in the tree, none anywhere in the
history (`git log -S`), and none in the requester's own shell config. What
`muxa init` installs is tmux bindings, not shell aliases, so that is what the
ending names. If those aliases live somewhere I did not look, say where and I
will add them.

## Verification

`cargo build --workspace --bins`, `fmt --check`, `clippy --all-targets` (0
warnings), `cargo test --workspace` clean. Live tour 37/37 — the ending is
printed after the last step, so the smoke covers it reaching the learner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)