### PR TITLE
feat(collab): address a spawned pane before its agent registers

### DIFF
--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -1496,8 +1496,9 @@ async fn call_peer(
         common["peer_pending"] = json!(true);
         common["delivery"] = json!(format!(
             "pane {} has no registered agent session yet; muxad delivers this request as soon as \
-             the pane reads idle. Wait on request_id {} with muxa_wait_reply — never watch the \
-             pane with capture-pane or sleep.",
+             that pane reports idle, which needs muxa to see an agent process there. Wait on \
+             request_id {} with muxa_wait_reply — never watch the pane with capture-pane or \
+             sleep. If the reply times out, check `muxa status` for a row on the pane.",
             selection.pane, sent.id
         ));
     }
@@ -1681,6 +1682,16 @@ fn select_peer(
             format!("explicit pane {}", peer.pane),
         )));
     }
+    if is_pane_selector(pane_target) {
+        // An explicitly addressed pane that hosts no registered peer is not an
+        // error here: muxad resolves a muxa-launched pane whose agent has not
+        // registered yet, and refuses anything else. Deciding that locally
+        // would duplicate — and could contradict — the authoritative guard.
+        return Ok(Some(PeerSelection::pending(
+            pane_target.to_string(),
+            format!("explicit pane {pane_target}, pending its agent's registration"),
+        )));
+    }
     if let Some(kind) = provider_kind(target) {
         let candidates = live
             .iter()
@@ -1737,6 +1748,12 @@ fn select_peer(
             "alias @{alias} matches multiple peers; use an exact pane id"
         )),
     }
+}
+
+/// Does this selector name a concrete pane? `%N` for tmux/zellij, and the
+/// namespaced ids other hosts use (`herdr:…`, `cmux:…`, `rmux:%N`).
+fn is_pane_selector(target: &str) -> bool {
+    target.starts_with('%') || muxa::backend::pane_id_host_kind(target).is_some()
 }
 
 fn peer_is_eligible(peer: &Participant) -> bool {
@@ -1916,6 +1933,20 @@ async fn spawn_peer(
         registrations,
     )
     .await?;
+    if peer.is_none() && !has_pane_readiness_signal(program) {
+        // Delivery to an unregistered pane needs a row that reports `Idle`,
+        // which means discovery must classify the process or a screen manifest
+        // must cover it. Neither holds for opencode today, so queueing against
+        // the pane would promise a delivery that can never happen — fail fast
+        // with something the caller can act on instead.
+        return Err(format!(
+            "created {} peer pane {} but it did not register within {timeout_secs}s, and muxa has no readiness signal for {} panes; keep the pane, submit one prompt in it so its hooks fire, then call again with target=\"pane:{}\"",
+            agent_program_label(program),
+            started.pane,
+            agent_program_label(program),
+            started.pane
+        ));
+    }
     // Registration is not a precondition for sending. An agent that registers
     // on boot (claude) lands in the grace window above; codex creates its
     // session — and so fires its first hook — only when a prompt arrives, so
@@ -1941,6 +1972,25 @@ async fn spawn_peer(
         ),
     };
     Ok((selection, started))
+}
+
+/// Can muxad tell that a pane of this program is ready for input before its
+/// agent registers?
+///
+/// That requires the pane to carry a registry row, which comes from discovery
+/// classifying the process (`discovery::classify_command`) or from a bundled
+/// screen manifest. Opencode has neither today — `DiscoveryReport::bump`
+/// documents that it is never synthesized — so a request queued against an
+/// unregistered opencode pane would wait forever.
+fn has_pane_readiness_signal(program: crate::agent_launch::AgentProgram) -> bool {
+    use crate::agent_launch::AgentProgram;
+    match program {
+        AgentProgram::Claude
+        | AgentProgram::Codex
+        | AgentProgram::Gemini
+        | AgentProgram::Antigravity => true,
+        AgentProgram::Opencode => false,
+    }
 }
 
 async fn wait_for_spawned_peer_registration(
@@ -3160,6 +3210,40 @@ mod tests {
             select_peer(&room, "@muxa-peer").unwrap().unwrap().pane,
             "%3"
         );
+    }
+
+    /// An explicitly addressed pane with no registered peer is handed to muxad
+    /// as a pending selection — that is the documented retry after a spawn,
+    /// and the daemon owns the decision about whether the pane is addressable.
+    #[test]
+    fn explicit_pane_target_without_a_registered_peer_stays_addressable() {
+        let current = peer_participant(AgentKind::ClaudeCode, "%1", AgentState::Idle);
+        let room = peer_room(current, vec![]);
+
+        let selection = select_peer(&room, "pane:%3").unwrap().unwrap();
+        assert_eq!(selection.pane, "%3");
+        assert!(selection.peer.is_none(), "no registered peer to pin to");
+
+        let bare = select_peer(&room, "%3").unwrap().unwrap();
+        assert_eq!(bare.pane, "%3");
+
+        // A non-pane selector still reports that nothing matched.
+        assert!(select_peer(&room, "@nobody")
+            .unwrap_err()
+            .contains("no eligible peer matches"));
+    }
+
+    /// Queueing against a pane only makes sense when muxa can tell that the
+    /// pane became ready. Opencode has neither a discovery classification nor
+    /// a screen manifest, so its spawns must keep failing fast.
+    #[test]
+    fn only_providers_with_a_readiness_signal_fall_back_to_the_pane() {
+        use crate::agent_launch::AgentProgram;
+        assert!(has_pane_readiness_signal(AgentProgram::Codex));
+        assert!(has_pane_readiness_signal(AgentProgram::Claude));
+        assert!(has_pane_readiness_signal(AgentProgram::Gemini));
+        assert!(has_pane_readiness_signal(AgentProgram::Antigravity));
+        assert!(!has_pane_readiness_signal(AgentProgram::Opencode));
     }
 
     #[test]

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -50,6 +50,13 @@ const PROBE_TIMEOUT: Duration = Duration::from_millis(750);
 
 /// Default `muxa_wait_for_change` timeout when the caller omits one.
 const DEFAULT_WAIT_SECS: u64 = 30;
+
+/// How long a spawned peer is given to register before the request is queued
+/// against its pane instead. Agents that register on boot (claude fires
+/// `SessionStart` within a second) resolve inside this window and keep the
+/// ordinary session-pinned path; the rest cost one grace period, not a
+/// failure — codex cannot register until a prompt reaches it.
+const DEFAULT_SPAWN_GRACE_SECS: u64 = 10;
 /// Hard ceiling on `muxa_wait_for_change` so a caller can't pin the stdio
 /// loop forever on a typo'd huge timeout.
 const MAX_WAIT_SECS: u64 = 600;
@@ -617,7 +624,7 @@ fn tool_definitions() -> Vec<Value> {
                     "timeout_secs": { "type": "integer", "minimum": 1, "maximum": 600, "description": "Reply wait timeout. Default 300." },
                     "spawn_if_missing": { "type": "boolean", "description": "Default false. Create a same-window bypass-permission peer only after explicit user confirmation." },
                     "spawn_agent": { "type": "string", "enum": ["claude", "codex", "gemini", "agy", "opencode"], "description": "Provider to create when spawn_if_missing=true. Defaults to the current agent's opposite provider." },
-                    "spawn_timeout_secs": { "type": "integer", "minimum": 1, "maximum": 60, "description": "How long to wait for the new pane to register as a collaboration peer. Default 30." },
+                    "spawn_timeout_secs": { "type": "integer", "minimum": 1, "maximum": 60, "description": "Grace period for the new pane to register as a collaboration peer before the request is queued against the pane itself. Default 10. Never poll the pane instead of raising this." },
                     "air_artifacts": {
                         "type": "array",
                         "maxItems": 8,
@@ -1277,8 +1284,31 @@ fn collaboration_guide(room: RoomContext) -> Value {
 
 #[derive(Debug, Clone)]
 struct PeerSelection {
-    peer: Participant,
+    /// The registered peer, when one exists. `None` for a pane muxa just
+    /// launched whose agent has not registered a session yet — the request is
+    /// addressed to the pane and the daemon adopts it onto the session that
+    /// registers there.
+    peer: Option<Participant>,
+    pane: String,
     reason: String,
+}
+
+impl PeerSelection {
+    fn registered(peer: Participant, reason: String) -> Self {
+        Self {
+            pane: peer.pane.clone(),
+            peer: Some(peer),
+            reason,
+        }
+    }
+
+    fn pending(pane: String, reason: String) -> Self {
+        Self {
+            peer: None,
+            pane,
+            reason,
+        }
+    }
 }
 
 /// Read a prior peer's structured response without asking it to do new work.
@@ -1443,7 +1473,7 @@ async fn call_peer(
         paths,
         air_artifacts,
     };
-    let selector = format!("pane:{}", selection.peer.pane);
+    let selector = format!("pane:{}", selection.pane);
     let sent = match client
         .collaboration_send(&origin, &selector, &request)
         .await
@@ -1451,9 +1481,10 @@ async fn call_peer(
         Ok(request) => request,
         Err(error) => return error_result(&format!("call_peer send failed: {error}")),
     };
-    let common = json!({
+    let peer_pending = selection.peer.is_none();
+    let mut common = json!({
         "sent": true,
-        "selected_peer": selection.peer,
+        "selected_peer": selection.peer.clone().unwrap_or_else(|| sent.to.clone()),
         "selection_reason": selection.reason,
         "expanded_skill": expanded_skill,
         "spawned": spawned,
@@ -1461,6 +1492,15 @@ async fn call_peer(
         "kind": kind,
         "work_mode": work_mode,
     });
+    if peer_pending {
+        common["peer_pending"] = json!(true);
+        common["delivery"] = json!(format!(
+            "pane {} has no registered agent session yet; muxad delivers this request as soon as \
+             the pane reads idle. Wait on request_id {} with muxa_wait_reply — never watch the \
+             pane with capture-pane or sleep.",
+            selection.pane, sent.id
+        ));
+    }
     if !args.get("wait").and_then(Value::as_bool).unwrap_or(true) {
         let mut payload = common;
         payload["completed"] = json!(false);
@@ -1487,6 +1527,11 @@ async fn call_peer(
             payload["reason"] = json!("timeout");
             payload["timeout_secs"] = json!(timeout_secs);
             payload["request"] = json!(sent);
+            payload["next_step"] = json!(format!(
+                "the request stays queued for {}; call muxa_wait_reply with request_id {} to keep \
+                 waiting, or muxa_peer_report later. Do not poll the pane.",
+                selection.pane, sent.id
+            ));
             json_result(&payload)
         }
         Err(error) => error_result(&format!("call_peer wait failed: {error}")),
@@ -1621,19 +1666,20 @@ fn select_peer(
         || target.eq_ignore_ascii_case("@muxa-peer")
         || target.eq_ignore_ascii_case("peer")
     {
-        return Ok(best_peer(&live, &room.current).map(|peer| PeerSelection {
-            peer: peer.clone(),
-            reason:
+        return Ok(best_peer(&live, &room.current).map(|peer| {
+            PeerSelection::registered(
+                peer.clone(),
                 "auto: healthy different-provider preference, then state and numeric pane order"
                     .into(),
+            )
         }));
     }
     let pane_target = target.strip_prefix("pane:").unwrap_or(target);
     if let Some(peer) = live.iter().copied().find(|peer| peer.pane == pane_target) {
-        return Ok(Some(PeerSelection {
-            peer: peer.clone(),
-            reason: format!("explicit pane {}", peer.pane),
-        }));
+        return Ok(Some(PeerSelection::registered(
+            peer.clone(),
+            format!("explicit pane {}", peer.pane),
+        )));
     }
     if let Some(kind) = provider_kind(target) {
         let candidates = live
@@ -1641,12 +1687,9 @@ fn select_peer(
             .copied()
             .filter(|peer| peer.agent_kind == kind)
             .collect::<Vec<_>>();
-        return Ok(
-            best_peer(&candidates, &room.current).map(|peer| PeerSelection {
-                peer: peer.clone(),
-                reason: format!("explicit provider {kind}"),
-            }),
-        );
+        return Ok(best_peer(&candidates, &room.current).map(|peer| {
+            PeerSelection::registered(peer.clone(), format!("explicit provider {kind}"))
+        }));
     }
     if let Some(role) = target.strip_prefix("role:") {
         let matches = live
@@ -1660,10 +1703,10 @@ fn select_peer(
             .collect::<Vec<_>>();
         return match matches.as_slice() {
             [] => Err(format!("no eligible peer has role {role:?}")),
-            [peer] => Ok(Some(PeerSelection {
-                peer: (*peer).clone(),
-                reason: format!("explicit role {role}"),
-            })),
+            [peer] => Ok(Some(PeerSelection::registered(
+                (*peer).clone(),
+                format!("explicit role {role}"),
+            ))),
             _ => Err(format!(
                 "role {role:?} matches multiple peers; use @alias or pane id"
             )),
@@ -1686,10 +1729,10 @@ fn select_peer(
         [] => Err(format!(
             "no eligible peer matches {target:?}; use auto, a provider, @alias, role:<name>, or pane id"
         )),
-        [peer] => Ok(Some(PeerSelection {
-            peer: (*peer).clone(),
-            reason: format!("explicit alias @{alias}"),
-        })),
+        [peer] => Ok(Some(PeerSelection::registered(
+            (*peer).clone(),
+            format!("explicit alias @{alias}"),
+        ))),
         _ => Err(format!(
             "alias @{alias} matches multiple peers; use an exact pane id"
         )),
@@ -1863,7 +1906,7 @@ async fn spawn_peer(
     let timeout_secs = args
         .get("spawn_timeout_secs")
         .and_then(Value::as_u64)
-        .unwrap_or(30)
+        .unwrap_or(DEFAULT_SPAWN_GRACE_SECS)
         .clamp(1, 60);
     let peer = wait_for_spawned_peer_registration(
         client,
@@ -1872,26 +1915,32 @@ async fn spawn_peer(
         timeout_secs,
         registrations,
     )
-    .await?
-    .ok_or_else(|| {
-        format!(
-            "created {} peer pane {} but it did not register for collaboration within {timeout_secs}s; keep the pane, verify its hooks/MCP setup, then call again with target=\"pane:{}\"",
-            agent_program_label(program),
-            started.pane,
-            started.pane
-        )
-    })?;
-    Ok((
-        PeerSelection {
+    .await?;
+    // Registration is not a precondition for sending. An agent that registers
+    // on boot (claude) lands in the grace window above; codex creates its
+    // session — and so fires its first hook — only when a prompt arrives, so
+    // waiting for it here would deadlock against the very request we are about
+    // to send. Address the pane instead: muxad queues the request and delivers
+    // it when the pane reads idle.
+    let selection = match peer {
+        Some(peer) => PeerSelection::registered(
             peer,
-            reason: format!(
+            format!(
                 "spawned {} in {} after explicit confirmation for target {target:?}",
                 agent_program_label(program),
                 started.pane
             ),
-        },
-        started,
-    ))
+        ),
+        None => PeerSelection::pending(
+            started.pane.clone(),
+            format!(
+                "spawned {} in {}; queued for the pane, which has not registered a session yet",
+                agent_program_label(program),
+                started.pane
+            ),
+        ),
+    };
+    Ok((selection, started))
 }
 
 async fn wait_for_spawned_peer_registration(
@@ -3105,13 +3154,10 @@ mod tests {
         );
 
         let selected = select_peer(&room, "auto").unwrap().unwrap();
-        assert_eq!(selected.peer.pane, "%3");
+        assert_eq!(selected.pane, "%3");
+        assert_eq!(select_peer(&room, "@claude").unwrap().unwrap().pane, "%2");
         assert_eq!(
-            select_peer(&room, "@claude").unwrap().unwrap().peer.pane,
-            "%2"
-        );
-        assert_eq!(
-            select_peer(&room, "@muxa-peer").unwrap().unwrap().peer.pane,
+            select_peer(&room, "@muxa-peer").unwrap().unwrap().pane,
             "%3"
         );
     }
@@ -3142,10 +3188,7 @@ mod tests {
         other.roles = vec!["rust".into()];
         let room = peer_room(current, vec![reviewer, other]);
 
-        assert_eq!(
-            select_peer(&room, "@reviewer").unwrap().unwrap().peer.pane,
-            "%2"
-        );
+        assert_eq!(select_peer(&room, "@reviewer").unwrap().unwrap().pane, "%2");
         assert!(select_peer(&room, "role:rust")
             .unwrap_err()
             .contains("multiple peers"));

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -49,6 +49,83 @@ pub const CONSOLE_PANE: &str = "console";
 /// shares one sender identity no matter which pane the console was opened from.
 pub const CONSOLE_SESSION_ID: &str = "console";
 
+/// Session-id prefix of a **pending** recipient: a muxa-launched pane that
+/// hosts an agent CLI which has not registered a session yet.
+///
+/// Codex is why this exists. Its `SessionStart` hook fires when the first
+/// prompt is submitted, not when the TUI boots — a freshly spawned codex pane
+/// therefore cannot become a participant until something types into it, while
+/// the sender is waiting for exactly that registration. Addressing the *pane*
+/// breaks the deadlock: the request is queued immediately, the daemon's waker
+/// delivers it once the pane reads idle (a screen-detected row is enough), and
+/// the concrete session that registers there adopts the request the first time
+/// it claims or answers it — see [`pin_pending_recipient`].
+///
+/// The id is only ever a placeholder inside `to`. Every ordinary match stays
+/// session-pinned; [`addresses`] is the single seam where a pane-scoped
+/// recipient is honoured.
+pub const PENDING_SESSION_PREFIX: &str = "pending-pane:";
+
+/// Is this the placeholder identity of a pane whose agent has not registered?
+#[must_use]
+pub fn is_pending_session(session_id: &str) -> bool {
+    session_id.starts_with(PENDING_SESSION_PREFIX)
+}
+
+/// The placeholder session id for one pane on one control endpoint. Pane ids
+/// repeat across tmux servers, so the endpoint rides along: `same_endpoint`
+/// compares `(pane, socket, session)` and must not collapse two servers'
+/// `%3` into one recipient.
+fn pending_session_id(pane: &str, socket: Option<&str>) -> String {
+    match socket {
+        Some(socket) => format!("{PENDING_SESSION_PREFIX}{socket}:{pane}"),
+        None => format!("{PENDING_SESSION_PREFIX}{pane}"),
+    }
+}
+
+/// Does `caller` own the request addressed to `to`?
+///
+/// The ordinary answer is the session-pinned one. The exception is a *pending*
+/// recipient: the request was addressed to a pane before any session existed
+/// there, so the real agent that registered on that pane — and only on that
+/// exact pane and control endpoint — owns it too.
+fn addresses(to: &Participant, caller: &Participant) -> bool {
+    if to.same_endpoint(caller) {
+        return true;
+    }
+    is_pending_session(&to.agent_session_id)
+        && !is_pending_session(&caller.agent_session_id)
+        && !caller.console
+        && to.pane == caller.pane
+        && to.socket == caller.socket
+}
+
+/// Pin a pending recipient to the concrete session now acting as it, so every
+/// later match is the ordinary session-pinned one and a *different* agent
+/// reusing the pane can never inherit the work.
+///
+/// Returns whether anything changed, so callers can persist only real edits.
+fn pin_pending_recipient(request: &mut CollaborationRequest, caller: &Participant) -> bool {
+    if !is_pending_session(&request.to.agent_session_id)
+        || is_pending_session(&caller.agent_session_id)
+        || caller.console
+    {
+        return false;
+    }
+    // Keep the alias/roles the launcher stamped when the registering session
+    // has none of its own: they are what `@alias` / `role:` routing already
+    // resolved this pane by.
+    let mut pinned = caller.clone();
+    if pinned.alias.is_none() {
+        pinned.alias.clone_from(&request.to.alias);
+    }
+    if pinned.roles.is_empty() {
+        pinned.roles.clone_from(&request.to.roles);
+    }
+    request.to = pinned;
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CollaborationOrigin {
     pub pane: String,
@@ -986,12 +1063,16 @@ impl CollaborationStore {
         {
             let mut requests = self.requests.write().await;
             for request in requests.values_mut() {
-                if request.to.same_endpoint(caller)
+                if addresses(&request.to, caller)
                     && matches!(
                         request.status,
                         RequestStatus::Queued | RequestStatus::Claimed
                     )
                 {
+                    // The session pulling this inbox is the one the pane's
+                    // pending request was waiting for: adopt it, so every
+                    // later match is session-pinned.
+                    changed |= pin_pending_recipient(request, caller);
                     if request.status == RequestStatus::Queued {
                         request.status = if request.expects_reply {
                             RequestStatus::Claimed
@@ -1041,12 +1122,13 @@ impl CollaborationStore {
             let Some(request) = requests.get_mut(request_id) else {
                 return Err(CollaborationError::NotFound(request_id.to_string()));
             };
-            if !request.to.same_endpoint(caller) {
+            if !addresses(&request.to, caller) {
                 return Err(CollaborationError::NotParticipant(request_id.to_string()));
             }
             if request.status != RequestStatus::Queued || request.notified_at.is_some() {
                 None
             } else {
+                pin_pending_recipient(request, caller);
                 request.status = RequestStatus::Claimed;
                 request.claimed_at = Some(OffsetDateTime::now_utc());
                 request.wake_delivery = Some(WakeDeliveryState::Prepared);
@@ -1124,12 +1206,13 @@ impl CollaborationStore {
             let request = requests
                 .get_mut(request_id)
                 .ok_or_else(|| CollaborationError::NotFound(request_id.to_string()))?;
-            if !request.to.same_endpoint(caller) {
+            if !addresses(&request.to, caller) {
                 return Err(CollaborationError::NotParticipant(request_id.to_string()));
             }
             if request.status.is_terminal() {
                 return Err(CollaborationError::AlreadyTerminal(request_id.to_string()));
             }
+            pin_pending_recipient(request, caller);
             request.status = status;
             request.reply = Some(CollaborationReply {
                 status,
@@ -1163,7 +1246,7 @@ impl CollaborationStore {
                 .get_mut(request_id)
                 .ok_or_else(|| CollaborationError::NotFound(request_id.to_string()))?;
             let is_sender = request.from.same_endpoint(caller);
-            if !is_sender && !request.to.same_endpoint(caller) {
+            if !is_sender && !addresses(&request.to, caller) {
                 return Err(CollaborationError::NotParticipant(request_id.to_string()));
             }
             if is_sender && request.reply.is_some() && request.reply_read_at.is_none() {
@@ -1233,10 +1316,10 @@ impl CollaborationStore {
             .values()
             .filter(|request| match scope {
                 MailboxScope::Caller => match mailbox {
-                    RequestMailbox::Incoming => request.to.same_endpoint(caller),
+                    RequestMailbox::Incoming => addresses(&request.to, caller),
                     RequestMailbox::Sent => request.from.same_endpoint(caller),
                     RequestMailbox::All => {
-                        request.from.same_endpoint(caller) || request.to.same_endpoint(caller)
+                        request.from.same_endpoint(caller) || addresses(&request.to, caller)
                     }
                 },
                 MailboxScope::Room => match mailbox {
@@ -1391,7 +1474,7 @@ impl CollaborationStore {
             .await
             .values()
             .filter(|request| {
-                request.to.same_endpoint(participant)
+                addresses(&request.to, participant)
                     && (request.status == RequestStatus::Queued || request.wake_delivery.is_some())
             })
             .count()
@@ -1724,6 +1807,181 @@ fn select_target(
     }
 }
 
+/// Resolve an explicit `pane:%N` target whose agent has not registered yet.
+///
+/// This is the fallback [`resolve_target`] cannot serve: `participants_from`
+/// only admits real, session-pinned rows, so a pane muxa launched a moment ago
+/// is invisible until its agent's first hook — which, for codex, never comes
+/// unaided (see [`PENDING_SESSION_PREFIX`]).
+///
+/// Deliberately narrow. It requires all of:
+/// * an **explicit pane selector** — `peer`, `@alias` and `role:` stay
+///   registered-peer concepts, so no automatic routing can land here;
+/// * a pane muxa itself marked as an agent launch (`@muxa_agent_role` /
+///   `@muxa_agent_alias`) or that discovery already classified as an agent
+///   CLI, so a request can never be typed at a human's shell;
+/// * no live participant on that pane, so a registered agent always wins; and
+/// * the sender's own room, unless the deployment widened scope to the host.
+pub fn resolve_pending_pane_target(
+    sender: &Participant,
+    selector: &str,
+    participants: &[Participant],
+    agents: &[Agent],
+    panes: &[PaneInfo],
+    scope: crate::config::CollaborationScope,
+) -> Result<Participant, CollaborationError> {
+    let pane_id = selector.strip_prefix("pane:").unwrap_or(selector);
+    if !pane_id.starts_with('%') && crate::backend::pane_id_host_kind(pane_id).is_none() {
+        return Err(CollaborationError::UnknownTarget(selector.to_string()));
+    }
+    if pane_id == sender.pane {
+        return Err(CollaborationError::UnknownTarget(selector.to_string()));
+    }
+    // A registered agent on the pane is always the better recipient, and
+    // `resolve_target` already had its chance at it.
+    if participants
+        .iter()
+        .any(|participant| participant.pane == pane_id)
+    {
+        return Err(CollaborationError::UnknownTarget(selector.to_string()));
+    }
+    let pane = unique_pane(pane_id, sender.socket.as_deref(), panes)
+        .ok_or_else(|| CollaborationError::UnknownTarget(selector.to_string()))?;
+    let socket = pane.socket.clone().or_else(|| sender.socket.clone());
+    let row = live_pane_row(pane_id, socket.as_deref(), agents);
+    if !muxa_launched_agent_pane(pane, row) {
+        return Err(CollaborationError::UnknownTarget(selector.to_string()));
+    }
+    let pending = pane_participant(pane, socket, row);
+    if scope != crate::config::CollaborationScope::Host && pending.room != sender.room {
+        return Err(CollaborationError::UnknownTarget(selector.to_string()));
+    }
+    Ok(pending)
+}
+
+/// The recipient to deliver a *pending* request to, or `None` while the pane
+/// is not ready for input.
+///
+/// Readiness is the pane's current row, whatever produced it: a hook, or the
+/// discovery/screen placeholder that stands in before the agent registers. A
+/// discovered agent pane reads `Idle`, which includes the seconds a TUI spends
+/// booting — that is deliberate and safe: keys sent then sit in the pty until
+/// the TUI reads them (verified against codex mid-`Starting MCP servers`,
+/// where the queued prompt arrived verbatim).
+///
+/// What must hold delivery is a pane asking a question, and that is exactly
+/// what the bundled screen manifests classify: codex's startup trust gate
+/// lands the row on `WaitingInput`/`WaitingChoice`, never `Idle`, so a queued
+/// request cannot answer a policy prompt by accident. A vanished pane yields
+/// `None` too, so work queued for a dead pane stays queued instead of being
+/// typed at whatever replaced it.
+#[must_use]
+pub fn pending_recipient_ready(
+    to: &Participant,
+    agents: &[Agent],
+    panes: &[PaneInfo],
+) -> Option<Participant> {
+    if !is_pending_session(&to.agent_session_id) {
+        return None;
+    }
+    let pane = unique_pane(&to.pane, to.socket.as_deref(), panes)?;
+    let row = live_pane_row(&to.pane, to.socket.as_deref(), agents)?;
+    if row.state != AgentState::Idle {
+        return None;
+    }
+    let socket = pane.socket.clone().or_else(|| to.socket.clone());
+    let ready = pane_participant(pane, socket, Some(row));
+    // The identity must stay byte-identical to `request.to`: delivery reserves
+    // the request through `prepare_direct_wake`, which is session-pinned.
+    (ready.same_endpoint(to)).then_some(ready)
+}
+
+/// The one pane with this id, disambiguated by control endpoint the same way
+/// [`participants_from`] does — pane ids repeat across tmux servers.
+fn unique_pane<'a>(
+    pane_id: &str,
+    socket: Option<&str>,
+    panes: &'a [PaneInfo],
+) -> Option<&'a PaneInfo> {
+    let candidates: Vec<_> = panes
+        .iter()
+        .filter(|pane| pane.pane_id == pane_id)
+        .collect();
+    match candidates.as_slice() {
+        [pane] => Some(pane),
+        [] => None,
+        _ => {
+            let socket = socket?;
+            let mut matching = candidates.into_iter().filter(|pane| {
+                pane.socket.as_deref().is_some_and(|candidate| {
+                    crate::backend::pane_endpoints_match(Some(pane_id), candidate, socket)
+                })
+            });
+            let first = matching.next()?;
+            matching.next().is_none().then_some(first)
+        }
+    }
+}
+
+/// The live agent row occupying a pane, real or synthetic. Discovery and
+/// screen detection share one synthetic key per pane, so at most one row is
+/// returned for a pane that has never registered a session.
+fn live_pane_row<'a>(
+    pane_id: &str,
+    socket: Option<&str>,
+    agents: &'a [Agent],
+) -> Option<&'a Agent> {
+    agents
+        .iter()
+        .filter(|agent| {
+            agent.pane.as_deref() == Some(pane_id)
+                && agent.state != AgentState::Stopped
+                && socket.is_none_or(|socket| {
+                    agent.tmux_socket.as_deref().is_none_or(|candidate| {
+                        crate::backend::pane_endpoints_match(Some(pane_id), candidate, socket)
+                    })
+                })
+        })
+        // A real row wins a tie with a synthetic placeholder for the same pane.
+        .min_by_key(|agent| {
+            u8::from(
+                agent
+                    .session_id
+                    .starts_with(crate::state::SYNTHETIC_SESSION_PREFIX),
+            )
+        })
+}
+
+/// Evidence that an agent CLI — not a human's shell — occupies this pane:
+/// muxa's own launch marks, or a discovery row that classified the process.
+fn muxa_launched_agent_pane(pane: &PaneInfo, row: Option<&Agent>) -> bool {
+    pane.agent_role.is_some()
+        || pane.agent_alias.is_some()
+        || row.is_some_and(|row| row.kind != AgentKind::Task && row.kind != AgentKind::Unknown)
+}
+
+/// Build the pane-scoped participant a pending recipient is addressed as.
+fn pane_participant(pane: &PaneInfo, socket: Option<String>, row: Option<&Agent>) -> Participant {
+    Participant {
+        agent_kind: row.map_or(AgentKind::Unknown, |row| row.kind),
+        agent_session_id: pending_session_id(&pane.pane_id, socket.as_deref()),
+        pane: pane.pane_id.clone(),
+        socket: socket.clone(),
+        room: pane_room(&pane.pane_id, pane, socket),
+        tmux_session_id: (!pane.session_id.is_empty()).then(|| pane.session_id.clone()),
+        tmux_session_name: Some(pane.session.clone()),
+        window_name: (!pane.window_name.is_empty()).then(|| pane.window_name.clone()),
+        // `Starting` is the honest state for a pane whose agent has not
+        // reported anything yet; the waker refuses to type into it until a row
+        // says `Idle`.
+        state: row.map_or(AgentState::Starting, |row| row.state),
+        cwd: (!pane.current_path.is_empty()).then(|| pane.current_path.clone()),
+        alias: pane.agent_alias.clone(),
+        roles: pane.agent_role.clone().into_iter().collect(),
+        console: false,
+    }
+}
+
 pub async fn room_context(
     mailbox: &CollaborationStore,
     current: Participant,
@@ -2035,6 +2293,250 @@ mod tests {
             vec!["rust".to_string()],
             "the registered role set replaces the launcher's, never merges",
         );
+    }
+
+    /// A pane muxa launched but whose agent has not registered yet is
+    /// addressable by pane id. This is the codex spawn case: no hook can fire
+    /// until a prompt arrives, so waiting for registration before sending
+    /// would deadlock.
+    #[tokio::test]
+    async fn explicit_pane_target_resolves_a_launched_pane_with_no_session() {
+        let sender = participant("%1", "sender");
+        let mut launched = pane_info("%2");
+        launched.agent_role = Some("peer".into());
+        let panes = vec![pane_info("%1"), launched];
+        let agents = Vec::new();
+
+        // Ordinary resolution has nothing to select: the pane hosts no
+        // participant.
+        assert!(resolve_target(&sender, "pane:%2", &[], CollaborationScope::Window).is_err());
+
+        let pending = resolve_pending_pane_target(
+            &sender,
+            "pane:%2",
+            &[],
+            &agents,
+            &panes,
+            CollaborationScope::Window,
+        )
+        .expect("launched pane resolves");
+        assert_eq!(pending.pane, "%2");
+        assert!(is_pending_session(&pending.agent_session_id));
+        assert_eq!(
+            pending.state,
+            AgentState::Starting,
+            "a pane with no row at all has reported nothing yet",
+        );
+        assert_eq!(pending.roles, vec!["peer".to_string()]);
+    }
+
+    /// The guards that keep a queued request off a human's shell and off a
+    /// pane that already has a registered agent.
+    #[tokio::test]
+    async fn pending_pane_target_refuses_unmarked_panes_and_registered_ones() {
+        let sender = participant("%1", "sender");
+        let plain = pane_info("%2");
+        let panes = vec![pane_info("%1"), plain];
+
+        // No muxa launch mark and no classified row: not an agent pane.
+        assert!(resolve_pending_pane_target(
+            &sender,
+            "pane:%2",
+            &[],
+            &[],
+            &panes,
+            CollaborationScope::Window,
+        )
+        .is_err());
+
+        // A registered participant on the pane always wins; the pending path
+        // must not shadow it with a pane-scoped placeholder.
+        let registered = participant("%2", "real-session");
+        let mut launched = pane_info("%2");
+        launched.agent_role = Some("peer".into());
+        assert!(resolve_pending_pane_target(
+            &sender,
+            "pane:%2",
+            std::slice::from_ref(&registered),
+            &[],
+            &[pane_info("%1"), launched],
+            CollaborationScope::Window,
+        )
+        .is_err());
+
+        // Automatic routing never lands on a pending pane.
+        assert!(resolve_pending_pane_target(
+            &sender,
+            "peer",
+            &[],
+            &[],
+            &panes,
+            CollaborationScope::Window,
+        )
+        .is_err());
+    }
+
+    /// Delivery waits for the pane to read idle — a screen-detected row is
+    /// enough, which is the only readiness signal a pre-session codex emits.
+    #[tokio::test]
+    async fn pending_recipient_becomes_deliverable_once_the_pane_reads_idle() {
+        let store = crate::Store::shared();
+        let id = crate::event::AgentId {
+            kind: AgentKind::Codex,
+            session_id: format!("{}default:%2", crate::state::SYNTHETIC_SESSION_PREFIX),
+            surface: None,
+            pane: Some("%2".into()),
+            tmux_socket: Some("default".into()),
+            cwd: Some("/repo".into()),
+        };
+        store
+            .apply(&crate::event::AgentEvent::Started {
+                id: id.clone(),
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+
+        let sender = participant("%1", "sender");
+        let mut launched = pane_info("%2");
+        launched.agent_role = Some("peer".into());
+        let panes = vec![pane_info("%1"), launched];
+        let agents = store.snapshot().await;
+        let pending = resolve_pending_pane_target(
+            &sender,
+            "pane:%2",
+            &[],
+            &agents,
+            &panes,
+            CollaborationScope::Window,
+        )
+        .expect("discovered agent pane resolves");
+        assert_eq!(pending.agent_kind, AgentKind::Codex);
+
+        // A discovered agent pane reads idle, boot window included.
+        let ready = pending_recipient_ready(&pending, &agents, &panes).expect("idle pane delivers");
+        assert!(ready.same_endpoint(&pending), "identity must stay pinned");
+        assert_eq!(ready.state, AgentState::Idle);
+
+        // The startup gate — screen detection's whole reason for covering
+        // codex — must hold delivery rather than answer the question.
+        store
+            .apply(&crate::event::AgentEvent::NotificationFired {
+                id,
+                level: crate::event::NotificationLevel::NeedsInput,
+                message: "codex is waiting".into(),
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+        let waiting = store.snapshot().await;
+        assert!(pending_recipient_ready(&pending, &waiting, &panes).is_none());
+
+        // A pane that vanished delivers to nothing.
+        assert!(pending_recipient_ready(&pending, &agents, &[pane_info("%1")]).is_none());
+    }
+
+    /// The session that finally registers on the pane adopts the request, and
+    /// from then on the request is session-pinned like any other.
+    #[tokio::test]
+    async fn a_registering_session_adopts_and_pins_its_pane_request() {
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let sender = participant("%1", "sender");
+        let mut pending = participant("%2", "placeholder");
+        pending.agent_session_id = format!("{PENDING_SESSION_PREFIX}default:%2");
+        pending.state = AgentState::Starting;
+        pending.roles = vec!["peer".into()];
+
+        let request = mailbox
+            .create(
+                sender.clone(),
+                pending.clone(),
+                NewRequest {
+                    kind: RequestKind::Review,
+                    body: "review the diff".into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::ReadOnly,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // An agent on a different pane must never inherit the work.
+        let intruder = participant("%3", "other-session");
+        assert!(mailbox.claim_for(&intruder).await.unwrap().is_empty());
+
+        let registered = participant("%2", "codex-session");
+        let inbox = mailbox.claim_for(&registered).await.unwrap();
+        assert_eq!(inbox.len(), 1, "the pane's agent claims the queued request");
+        assert_eq!(inbox[0].id, request.id);
+
+        let stored = mailbox.get_for(&registered, &request.id).await.unwrap();
+        assert_eq!(
+            stored.to.agent_session_id, "codex-session",
+            "the claiming session is pinned into the recipient",
+        );
+        assert_eq!(
+            stored.to.roles,
+            vec!["peer".to_string()],
+            "the launcher's role survives adoption when the session has none",
+        );
+
+        // Pinned means pinned: the placeholder no longer matches.
+        assert!(mailbox.claim_for(&pending).await.unwrap().is_empty());
+
+        let replied = mailbox
+            .reply(
+                &registered,
+                &request.id,
+                RequestStatus::Completed,
+                "looks good".into(),
+                Vec::new(),
+                Vec::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(replied.status, RequestStatus::Completed);
+    }
+
+    /// A pending request answered without an inbox pull — the direct-wake path
+    /// — is adopted just the same.
+    #[tokio::test]
+    async fn a_pending_request_can_be_answered_by_the_registered_session_directly() {
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let sender = participant("%1", "sender");
+        let mut pending = participant("%2", "placeholder");
+        pending.agent_session_id = format!("{PENDING_SESSION_PREFIX}default:%2");
+
+        let request = mailbox
+            .create(
+                sender,
+                pending,
+                NewRequest {
+                    kind: RequestKind::Question,
+                    body: "is the release green?".into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::ReadOnly,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let registered = participant("%2", "codex-session");
+        assert_eq!(mailbox.unread_count(&registered).await, 1);
+        let replied = mailbox
+            .reply(
+                &registered,
+                &request.id,
+                RequestStatus::Completed,
+                "green".into(),
+                Vec::new(),
+                Vec::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(replied.to.agent_session_id, "codex-session");
     }
 
     #[tokio::test]

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -98,6 +98,13 @@ fn addresses(to: &Participant, caller: &Participant) -> bool {
         && !caller.console
         && to.pane == caller.pane
         && to.socket == caller.socket
+        // The room too, not just the endpoint. Session ids are globally
+        // unique, so the session-pinned path needs no such guard; pane ids are
+        // only unique per server and restart at `%0` when one does, and a
+        // queued request outlives that. Without the room a stale pending
+        // request could be adopted by whatever agent later occupies the same
+        // pane id in an unrelated window.
+        && to.room == caller.room
 }
 
 /// Pin a pending recipient to the concrete session now acting as it, so every
@@ -1889,11 +1896,20 @@ pub fn pending_recipient_ready(
     if row.state != AgentState::Idle {
         return None;
     }
+    // Re-apply the send-time guard at delivery time. `@muxa_agent_role` is a
+    // tmux *pane* option that outlives the process it was stamped for, so a
+    // kept-alive pane stays addressable; without this re-check an unrelated
+    // `Task`/`Unknown` row idling there would be enough to get a request body
+    // typed into it.
+    if !muxa_launched_agent_pane(pane, Some(row)) {
+        return None;
+    }
     let socket = pane.socket.clone().or_else(|| to.socket.clone());
     let ready = pane_participant(pane, socket, Some(row));
-    // The identity must stay byte-identical to `request.to`: delivery reserves
-    // the request through `prepare_direct_wake`, which is session-pinned.
-    (ready.same_endpoint(to)).then_some(ready)
+    // The identity must stay byte-identical to `request.to` — delivery
+    // reserves the request through the session-pinned `prepare_direct_wake` —
+    // and the pane must still live in the room the request was addressed to.
+    (ready.same_endpoint(to) && ready.room == to.room).then_some(ready)
 }
 
 /// The one pane with this id, disambiguated by control endpoint the same way
@@ -2496,6 +2512,77 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(replied.status, RequestStatus::Completed);
+    }
+
+    /// Pane ids restart at `%0` when a tmux server does, and a queued request
+    /// outlives that. Ownership therefore checks the room as well as the
+    /// endpoint, or a recycled pane id would inherit unrelated work.
+    #[tokio::test]
+    async fn a_recycled_pane_id_in_another_room_does_not_inherit_the_request() {
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let sender = participant("%1", "sender");
+        let mut pending = participant("%2", "placeholder");
+        pending.agent_session_id = format!("{PENDING_SESSION_PREFIX}default:%2");
+
+        mailbox
+            .create(
+                sender,
+                pending,
+                NewRequest {
+                    kind: RequestKind::Review,
+                    body: "review the diff".into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::ReadOnly,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut elsewhere = participant("%2", "unrelated-session");
+        elsewhere.room.window_id = "@9".into();
+        assert!(
+            mailbox.claim_for(&elsewhere).await.unwrap().is_empty(),
+            "same pane id, different room: not the addressed pane",
+        );
+        assert_eq!(mailbox.unread_count(&elsewhere).await, 0);
+
+        let same_room = participant("%2", "codex-session");
+        assert_eq!(mailbox.claim_for(&same_room).await.unwrap().len(), 1);
+    }
+
+    /// The launch mark is a tmux *pane* option that outlives the process it was
+    /// stamped for, so the delivery gate re-applies the send-time evidence
+    /// rather than trusting the mark alone.
+    #[tokio::test]
+    async fn delivery_refuses_a_pane_whose_agent_evidence_is_gone() {
+        let store = crate::Store::shared();
+        store
+            .apply(&crate::event::AgentEvent::Started {
+                id: crate::event::AgentId {
+                    kind: AgentKind::Unknown,
+                    session_id: format!("{}default:%2", crate::state::SYNTHETIC_SESSION_PREFIX),
+                    surface: None,
+                    pane: Some("%2".into()),
+                    tmux_socket: Some("default".into()),
+                    cwd: None,
+                },
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+        let agents = store.snapshot().await;
+        let mut pending = participant("%2", "placeholder");
+        pending.agent_session_id = format!("{PENDING_SESSION_PREFIX}default:%2");
+
+        // No launch mark left, and the row classifies as nothing in
+        // particular: the pane is no longer evidently an agent.
+        assert!(pending_recipient_ready(&pending, &agents, &[pane_info("%2")]).is_none());
+
+        // The same row on a pane muxa marked is still deliverable.
+        let mut marked = pane_info("%2");
+        marked.agent_role = Some("peer".into());
+        assert!(pending_recipient_ready(&pending, &agents, &[marked]).is_some());
     }
 
     /// A pending request answered without an inbox pull — the direct-wake path

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -1445,6 +1445,10 @@ fn unique_pane_endpoint(pane: &str, agents: &[Agent]) -> Result<Option<String>, 
 struct CollaborationTopology {
     participants: Vec<collaboration::Participant>,
     panes: Vec<crate::tmux::PaneInfo>,
+    /// The raw registry rows behind `participants`, kept so a pane whose agent
+    /// has not registered yet can still be addressed explicitly — a real row
+    /// is not the only evidence that an agent CLI occupies a pane.
+    agents: Vec<crate::state::Agent>,
 }
 
 impl CollaborationTopology {
@@ -1472,6 +1476,31 @@ impl CollaborationTopology {
     ) -> Result<collaboration::Participant, collaboration::CollaborationError> {
         collaboration::resolve_origin(origin, &self.participants, &self.panes)
     }
+
+    /// Resolve a send target, falling back to an explicit pane that muxa
+    /// launched but whose agent has not registered a session yet.
+    ///
+    /// The fallback only ever runs after the ordinary resolution failed, and
+    /// it returns that original error when it does not apply — an unroutable
+    /// target must keep reporting why it was unroutable.
+    fn resolve_target(
+        &self,
+        sender: &collaboration::Participant,
+        target: &str,
+        scope: crate::config::CollaborationScope,
+    ) -> Result<collaboration::Participant, collaboration::CollaborationError> {
+        collaboration::resolve_target(sender, target, &self.participants, scope).or_else(|error| {
+            collaboration::resolve_pending_pane_target(
+                sender,
+                target,
+                &self.participants,
+                &self.agents,
+                &self.panes,
+                scope,
+            )
+            .map_err(|_| error)
+        })
+    }
 }
 
 async fn collaboration_participants(
@@ -1494,6 +1523,7 @@ async fn collaboration_participants(
     CollaborationTopology {
         participants,
         panes,
+        agents,
     }
 }
 
@@ -2380,13 +2410,9 @@ async fn handle(
                     let topology =
                         collaboration_participants(&store, &backends, &collaboration).await;
                     let result = topology.resolve_origin(&origin).and_then(|sender| {
-                        collaboration::resolve_target(
-                            &sender,
-                            &target,
-                            &topology.participants,
-                            collaboration.scope(),
-                        )
-                        .map(|recipient| (sender, recipient))
+                        topology
+                            .resolve_target(&sender, &target, collaboration.scope())
+                            .map(|recipient| (sender, recipient))
                     });
                     let response = match result {
                         Ok((sender, recipient)) => {

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -871,9 +871,12 @@ async fn wake_idle_collaboration_peers_with_inflight(
     collaboration.enrich_participants(&mut participants).await;
 
     for request in requests {
-        let Some(recipient) = idle_collaboration_participant(&participants, &request.to) else {
+        let Some(recipient) =
+            ready_collaboration_recipient(&participants, &agents, &panes, &request)
+        else {
             continue;
         };
+        let recipient = &recipient;
         let wake_key = collaboration_wake_key(recipient);
         if wake_inflight.contains(&wake_key) {
             continue;
@@ -916,8 +919,27 @@ async fn wake_idle_collaboration_peers_with_inflight(
         }
     }
 
+    wake_senders_of_ready_replies(
+        collaboration,
+        &participants,
+        backends,
+        replies,
+        wake_inflight,
+    )
+    .await;
+}
+
+/// Tell each sender that a terminal reply is waiting. Reply bodies always stay
+/// in the mailbox, so this is a notice pass with no payload policy.
+async fn wake_senders_of_ready_replies(
+    collaboration: &CollaborationStore,
+    participants: &[muxa::collaboration::Participant],
+    backends: &[muxa::SharedBackend],
+    replies: Vec<CollaborationRequest>,
+    wake_inflight: &mut HashSet<(String, Option<String>, String)>,
+) {
     for request in replies {
-        let Some(sender) = idle_collaboration_participant(&participants, &request.from) else {
+        let Some(sender) = idle_collaboration_participant(participants, &request.from) else {
             continue;
         };
         let wake_key = collaboration_wake_key(sender);
@@ -1131,6 +1153,39 @@ fn collaboration_request_source(request: &CollaborationRequest) -> String {
         CollaborationOriginMatch::Unverifiable => "; origin unverified",
     };
     format!("via {surface} representing {represented} ({actor}{mismatch})")
+}
+
+/// The participant a queued request may be delivered to *right now*.
+///
+/// The ordinary case is its session-pinned recipient, idle. A **pending**
+/// recipient — a launched pane whose agent has not registered a session yet —
+/// resolves two further ways: a real session that registered on that pane
+/// after the request was queued, or the pane's own discovery/screen row once
+/// it reads idle. The latter is what unblocks codex, whose `SessionStart` hook
+/// cannot fire until something is typed at it. Discovery supplies the idle
+/// row; screen detection's job here is the opposite one, holding delivery
+/// while the pane sits on its startup approval gate.
+fn ready_collaboration_recipient(
+    participants: &[muxa::collaboration::Participant],
+    agents: &[muxa::state::Agent],
+    panes: &[muxa::tmux::PaneInfo],
+    request: &CollaborationRequest,
+) -> Option<muxa::collaboration::Participant> {
+    if let Some(participant) = idle_collaboration_participant(participants, &request.to) {
+        return Some(participant.clone());
+    }
+    if !muxa::collaboration::is_pending_session(&request.to.agent_session_id) {
+        return None;
+    }
+    participants
+        .iter()
+        .find(|participant| {
+            participant.pane == request.to.pane
+                && participant.socket == request.to.socket
+                && participant.state == muxa::AgentState::Idle
+        })
+        .cloned()
+        .or_else(|| muxa::collaboration::pending_recipient_ready(&request.to, agents, panes))
 }
 
 fn idle_collaboration_participant<'a>(
@@ -2399,6 +2454,117 @@ mod tests {
             assert_eq!(delivered[0].0, "%2");
             assert!(delivered[0].1.contains(&request.id));
         }
+
+        shutdown_tx.send(()).unwrap();
+        waker.await.unwrap();
+    }
+
+    /// The spawn deadlock, end to end: a pane muxa launched carries only a
+    /// synthetic row — no session has registered, so it is not a participant —
+    /// yet the request queued against it is delivered as soon as the pane
+    /// reads idle. Without this the sender would wait for a registration that
+    /// codex cannot produce until something types at it.
+    #[tokio::test]
+    async fn collaboration_waker_delivers_to_a_launched_pane_before_it_registers() {
+        let store = muxa::Store::shared();
+        add_agent(&store, "%1", "sender", AgentKind::ClaudeCode).await;
+        add_agent(
+            &store,
+            "%2",
+            &format!("{}default:%2", muxa::state::SYNTHETIC_SESSION_PREFIX),
+            AgentKind::Codex,
+        )
+        .await;
+        let mut launched = collaboration_pane("%2", "1");
+        launched.agent_role = Some("peer".into());
+        let panes = vec![collaboration_pane("%1", "0"), launched];
+        let agents = store.snapshot().await;
+        let participants = muxa::collaboration::participants_from(&agents, &panes);
+        assert!(
+            participants
+                .iter()
+                .all(|participant| participant.pane != "%2"),
+            "a synthetic row is not a participant — that is the whole problem",
+        );
+        let sender = participants
+            .iter()
+            .find(|participant| participant.pane == "%1")
+            .unwrap()
+            .clone();
+        let pending = muxa::collaboration::resolve_pending_pane_target(
+            &sender,
+            "pane:%2",
+            &participants,
+            &agents,
+            &panes,
+            muxa::config::CollaborationScope::Window,
+        )
+        .expect("a launched agent pane is addressable by pane id");
+
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let sends = Arc::new(Mutex::new(Vec::new()));
+        let backend: muxa::SharedBackend = Arc::new(CollaborationWakeBackend {
+            panes,
+            sends: sends.clone(),
+        });
+        let mut cfg = Config::default();
+        cfg.collaboration.enabled = true;
+        cfg.collaboration.wake = CollaborationWake::IdleOnly;
+        let (shutdown_tx, _) = broadcast::channel(1);
+        let waker = spawn_collaboration_waker_task(
+            &cfg,
+            mailbox.clone(),
+            store.clone(),
+            vec![backend],
+            &shutdown_tx,
+        )
+        .expect("enabled collaboration should spawn a waker");
+
+        let request = mailbox
+            .create(
+                sender,
+                pending,
+                NewRequest {
+                    kind: RequestKind::Review,
+                    body: "review the pending diff".into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::ReadOnly,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_millis(500), async {
+            loop {
+                if sends.lock().unwrap().len() >= 2 && mailbox.pending_unnotified().await.is_empty()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("a pending pane recipient should be woken like any other");
+        {
+            let delivered = sends.lock().unwrap();
+            assert_eq!(delivered[0].0, "%2");
+            assert!(delivered[0].1.contains(&request.id));
+        }
+
+        // The session that finally registers adopts the request.
+        add_agent(&store, "%2", "codex-session", AgentKind::Codex).await;
+        let registered = muxa::collaboration::participants_from(
+            &store.snapshot().await,
+            &[collaboration_pane("%1", "0"), collaboration_pane("%2", "1")],
+        )
+        .into_iter()
+        .find(|participant| participant.pane == "%2")
+        .expect("the hook row registers the pane");
+        let inbox = mailbox.claim_for(&registered).await.unwrap();
+        assert_eq!(inbox.len(), 1);
+        assert_eq!(inbox[0].id, request.id);
 
         shutdown_tx.send(()).unwrap();
         waker.await.unwrap();

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -772,9 +772,7 @@ fn spawn_collaboration_waker_task(
                                 | muxa::AgentState::Stopped
                                 | muxa::AgentState::Error
                         ) {
-                            if let Some(key) = collaboration_wake_key_for_agent(&transition.agent) {
-                                wake_inflight.remove(&key);
-                            }
+                            clear_wake_inflight_for_agent(&mut wake_inflight, &transition.agent);
                         }
                         should_scan
                     }
@@ -1213,14 +1211,22 @@ fn collaboration_wake_key(
     )
 }
 
-fn collaboration_wake_key_for_agent(
+/// Drop the wake debounce for everything addressed at this agent's pane.
+///
+/// Keyed by endpoint rather than session id on purpose: a request queued
+/// against a pane that had not registered yet carries a `pending-pane:`
+/// placeholder, which no registry row will ever name. Matching the row's own
+/// session id would leave that entry suppressing further wakes to the pane
+/// until the slow reconcile tick cleared the whole set.
+fn clear_wake_inflight_for_agent(
+    wake_inflight: &mut HashSet<(String, Option<String>, String)>,
     agent: &muxa::Agent,
-) -> Option<(String, Option<String>, String)> {
-    Some((
-        agent.pane.clone()?,
-        agent.tmux_socket.clone(),
-        agent.session_id.clone(),
-    ))
+) {
+    let Some(pane) = agent.pane.as_deref() else {
+        return;
+    };
+    wake_inflight
+        .retain(|(key_pane, key_socket, _)| key_pane != pane || *key_socket != agent.tmux_socket);
 }
 
 async fn send_collaboration_wake(
@@ -2457,6 +2463,42 @@ mod tests {
 
         shutdown_tx.send(()).unwrap();
         waker.await.unwrap();
+    }
+
+    /// A pending recipient's debounce is keyed by the placeholder session id,
+    /// which no registry row will ever name. Clearing has to be endpoint-based
+    /// or a second request to the same pane stays suppressed until the slow
+    /// reconcile tick.
+    #[tokio::test]
+    async fn wake_debounce_for_a_pending_pane_clears_on_that_pane_s_transition() {
+        let store = muxa::Store::shared();
+        add_agent(&store, "%2", "synthetic-7:default:%2", AgentKind::Codex).await;
+        let row = store
+            .snapshot()
+            .await
+            .into_iter()
+            .find(|agent| agent.pane.as_deref() == Some("%2"))
+            .expect("the pane has a row");
+
+        let mut wake_inflight = HashSet::new();
+        wake_inflight.insert((
+            "%2".to_string(),
+            Some("default".to_string()),
+            "pending-pane:default:%2".to_string(),
+        ));
+        wake_inflight.insert((
+            "%3".to_string(),
+            Some("default".to_string()),
+            "other-session".to_string(),
+        ));
+
+        clear_wake_inflight_for_agent(&mut wake_inflight, &row);
+
+        assert!(
+            !wake_inflight.iter().any(|(pane, _, _)| pane == "%2"),
+            "the pending key for this pane must clear",
+        );
+        assert_eq!(wake_inflight.len(), 1, "other panes are untouched");
     }
 
     /// The spawn deadlock, end to end: a pane muxa launched carries only a

--- a/docs/COLLABORATION.ko.md
+++ b/docs/COLLABORATION.ko.md
@@ -271,7 +271,11 @@ agent 재시작이며 GitHub를 대체 transport로 사용하지 않습니다.
 agent는 아예 동작하지 않습니다. codex는 TUI가 뜰 때가 아니라 첫 프롬프트가 제출될 때
 `SessionStart`를 발생시키므로, 보내기 전에 등록을 기다리면 지금 보내려는 그 request와
 교착합니다. muxad는 pane이 idle로 읽히는 즉시 배달하고, 그 pane에 처음 등록한 agent
-session이 request를 인계받습니다. 그 뒤부터는 다른 request와 똑같이 session에 고정됩니다.
+session이 request를 인계받습니다(같은 room·pane·endpoint일 때만). 그 뒤부터는 다른
+request와 똑같이 session에 고정됩니다. 준비 여부는 muxa가 그 pane에서 agent
+프로세스를 볼 수 있어야 판단되므로, 이 fallback은 discovery가 분류하거나 screen
+manifest가 있는 provider에만 적용됩니다. `opencode` pane spawn은 큐잉 대신 종전처럼
+빠르게 실패합니다.
 결과에는 `peer_pending: true`와 `request_id`가 실리며, 대기는 `muxa_wait_reply`로 합니다.
 `tmux capture-pane` polling으로 대체하지 마세요.
 

--- a/docs/COLLABORATION.ko.md
+++ b/docs/COLLABORATION.ko.md
@@ -265,7 +265,15 @@ agent 재시작이며 GitHub를 대체 transport로 사용하지 않습니다.
 스킬을 읽으므로 스킬 변경이나 Muxa 업그레이드 뒤에는 기존 agent를 재시작하세요.
 승인된 자동 spawn에서는 pane을 만들기 전에 daemon transition stream을 먼저 구독하고,
 해당 pane의 agent 등록 이벤트가 왔을 때만 room context를 다시 읽습니다. 기존의
-500ms 등록 polling loop는 사용하지 않습니다.
+500ms 등록 polling loop는 사용하지 않습니다. 등록은 전제 조건이 아니라 유예
+구간입니다. `spawn_timeout_secs`(기본 10초) 안에 등록되지 않으면 request는 session이
+아니라 **pane**을 수신자로 큐에 들어갑니다. 이 fallback이 없으면 세션을 지연 생성하는
+agent는 아예 동작하지 않습니다. codex는 TUI가 뜰 때가 아니라 첫 프롬프트가 제출될 때
+`SessionStart`를 발생시키므로, 보내기 전에 등록을 기다리면 지금 보내려는 그 request와
+교착합니다. muxad는 pane이 idle로 읽히는 즉시 배달하고, 그 pane에 처음 등록한 agent
+session이 request를 인계받습니다. 그 뒤부터는 다른 request와 똑같이 session에 고정됩니다.
+결과에는 `peer_pending: true`와 `request_id`가 실리며, 대기는 `muxa_wait_reply`로 합니다.
+`tmux capture-pane` polling으로 대체하지 마세요.
 
 대기는 model이 주도하는 polling loop가 아니라 MCP tool call 하나를 blocking하는
 방식입니다. muxad는 durable mailbox의 단조 증가 revision을 구독하고, revision이
@@ -351,7 +359,13 @@ prompt/message/path/provider 식별자를 넣어서는 안 됩니다.
 
 `Working`, `WaitingInput`, `WaitingChoice`, `Error` 상태에는 입력하지 않습니다.
 화면 감지로 생성된 synthetic agent는 안정적인 session identity가 없어 room
-participant나 자동 wake 대상이 아닙니다. `wake = "never"`로 설정하면 mailbox는
+participant가 아니며 자동 선택 대상도 아닙니다. 예외는 하나입니다. muxa가 띄웠지만
+아직 agent가 등록하지 않은 pane을 **명시적으로 pane 지정**해 보낸 request는 pending
+pane 수신자를 갖고, 그 pane의 synthetic 행은 오직 배달 시점을 정하는 idle 게이트로만
+쓰입니다. 안전장치는 그대로입니다. 시작 승인 게이트는 번들 screen manifest가
+`WaitingInput`/`WaitingChoice`로 분류하므로 배달이 보류되고, muxa launch mark도 없고
+agent 프로세스로 분류되지도 않은 pane은 이 경로로 주소가 지정되지 않으므로 사람의
+shell에 request가 들어갈 일은 없습니다. `wake = "never"`로 설정하면 mailbox는
 유지하면서 모든 입력 주입을 끌 수 있습니다.
 
 기본값인 `wake_payload = "operator_full"`은 resolved sender가 operator console인

--- a/docs/COLLABORATION.md
+++ b/docs/COLLABORATION.md
@@ -255,7 +255,11 @@ codex fires `SessionStart` when its first prompt is submitted, not when its TUI
 boots, so waiting for registration before sending would deadlock against the
 very request being sent. muxad delivers a pane-addressed request as soon as the
 pane reads idle, and the first agent session to register on that pane adopts
-it; from then on the request is session-pinned like any other. The result
+it — same room, same pane, same control endpoint — after which the request is
+session-pinned like any other. Readiness needs muxa to see an agent process on
+the pane, so the fallback is limited to providers discovery classifies or a
+screen manifest covers; a spawned `opencode` pane still fails fast instead of
+queueing work nothing would deliver. The result
 reports `peer_pending: true` and a `request_id` — wait on that with
 `muxa_wait_reply`, never with `tmux capture-pane` polling.
 

--- a/docs/COLLABORATION.md
+++ b/docs/COLLABORATION.md
@@ -247,7 +247,17 @@ confirmation. Restart existing agents after changing skills or upgrading Muxa
 because their MCP process loads tools and templates at startup.
 For a confirmed automatic spawn, Muxa arms the daemon transition subscription
 before creating the pane and re-reads room context only when that pane's agent
-registers; there is no fixed 500 ms registration loop.
+registers; there is no fixed 500 ms registration loop. Registration is a grace
+period, not a precondition: `spawn_timeout_secs` (default 10) bounds how long
+the call waits before the request is queued against the *pane* instead of a
+session. That fallback is what makes lazily-registering agents work at all —
+codex fires `SessionStart` when its first prompt is submitted, not when its TUI
+boots, so waiting for registration before sending would deadlock against the
+very request being sent. muxad delivers a pane-addressed request as soon as the
+pane reads idle, and the first agent session to register on that pane adopts
+it; from then on the request is session-pinned like any other. The result
+reports `peer_pending: true` and a `request_id` — wait on that with
+`muxa_wait_reply`, never with `tmux capture-pane` polling.
 
 Waiting is a single blocking MCP call, not a model-driven polling loop. muxad
 subscribes to a monotonic durable-mailbox revision and re-reads the exact
@@ -301,8 +311,17 @@ The mailbox is persisted to `$XDG_DATA_HOME/muxa/collaboration.json` before
 delivery. With `idle_only`, muxad injects only when the exact
 hook-authoritative participant is `Idle`. It never injects into `Working`,
 `WaitingInput`, `WaitingChoice`, or `Error` panes. Synthetic screen-detected
-agents have no stable session identity, so they are not room participants or
-auto-wake targets.
+agents have no stable session identity, so they are not room participants and
+are never selected automatically.
+
+The single exception is a request explicitly addressed to a pane Muxa launched
+whose agent has not registered yet. Such a request carries a *pending pane*
+recipient, and the pane's synthetic row serves only as the idle gate for
+delivering it. Safety is unchanged where it matters: a startup approval gate
+still blocks delivery, because the bundled screen manifests classify it as
+`WaitingInput`/`WaitingChoice` rather than `Idle`. A pane with no muxa launch
+mark and no classified agent process is never addressable this way, so a
+human's shell can never receive a queued request.
 
 `wake_payload = "operator_full"` is the default. Requests whose resolved sender
 is the operator console — currently watch and dashboard messages — are claimed

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -182,7 +182,12 @@ Automatic spawning defaults to the other provider when possible. Before it
 creates the pane, the tool arms muxad's transition stream and then re-reads the
 authoritative room only when the spawned pane registers. This removes the old
 500 ms peer-registration polling loop and closes the fast-start lost-wakeup
-race.
+race. Registration is a grace period rather than a precondition:
+`spawn_timeout_secs` (default 10) bounds it, and a pane that has not registered
+by then receives the request as a *pending pane* recipient — muxad delivers it
+once the pane reads idle and the session that registers there adopts it. The
+result then carries `peer_pending: true`; keep waiting with `muxa_wait_reply`
+on the returned `request_id` and never fall back to `tmux capture-pane`.
 
 Registered message skills can be selected with or without a leading slash:
 


### PR DESCRIPTION
## The bug

`muxa_call_peer --spawn_if_missing` waits for the new pane to register as a participant before it sends. For codex that wait can never succeed.

Measured on this machine, isolated tmux socket + a fake `muxa` on `PATH` logging every hook invocation:

| agent | pane created → `session_start` hook | hook carries pane |
|---|---|---|
| `claude --dangerously-skip-permissions` | **+0.62s** | `PANE=%0` ✅ |
| `codex --yolo`, left idle | **no hook for 116s** | — |
| `codex --yolo`, after first prompt | prompt **+0.4s** | `PANE=%0` ✅ |

codex creates its session lazily — the rollout file's birth time matches the prompt submission, not the TUI launch. So the peer cannot register until something types at it, while the sender refuses to type until it registers. `spawn_timeout_secs` (max 60) is unwinnable, and the timeout message (*"keep the pane, verify its hooks/MCP setup, then call again"*) is what pushes callers into the `tmux capture-pane` polling loops the collaboration model explicitly forbids.

## The fix

Address the **pane** instead of the session. A request may now carry a *pending pane* recipient: muxad queues it immediately, delivers it once the pane reads idle, and the first agent session that registers there adopts it — after which the request is session-pinned like any other.

- `resolve_pending_pane_target` resolves an explicit `pane:%N` selector to a pane muxa launched (or that discovery classified as an agent CLI) with no live participant, inside the sender's room. `peer` / `@alias` / `role:` never reach it, so nothing is auto-routed to an unregistered pane and a human's shell is never addressable.
- `addresses` is the single seam where a pane-scoped recipient matches; `pin_pending_recipient` binds the request to the session that claims, answers, or takes direct delivery of it.
- The waker gates delivery on the pane's row reading `Idle`. The boot window is safe — keys sent mid-`Starting MCP servers` arrive verbatim (measured) — while codex's startup approval gate stays blocked, because the bundled screen manifest classifies it as waiting, not idle.
- `spawn_timeout_secs` becomes a grace period (default 10s) rather than a deadline: fast-registering agents keep the session-pinned path, the rest fall back to the pane. The result reports `peer_pending` plus the `request_id` to wait on, and says not to poll the pane.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` are clean. Six new tests cover the resolution rules, both refusal guards, the idle gate, and adoption/pinning through claim + reply, plus one muxad end-to-end wake test.

End to end against real binaries (isolated daemon socket, `XDG_DATA_HOME`, and tmux socket, with a pane whose foreground command is a fake `codex` that never fires a hook):

1. `muxa msg send pane:%1` is accepted — `to.agent_session_id = pending-pane:muxae2e:%1`.
2. muxad types the mailbox notice into that pane with no polling anywhere.
3. A codex `session_start` hook on that pane, then `muxa msg inbox`, claims the request and pins `to` to the real session id.
4. `muxa msg reply` reaches the original sender.
5. Guards hold: an unmarked shell pane is refused (`target "pane:%2" is not a peer in this tmux window`) and receives nothing, and `peer` auto-routing still reports `no peer is available` while a pending pane exists.

## Notes

No TTL for pending requests: no request kind expires today, so expiring only this one would be inconsistent. A pane that dies simply stops receiving delivery and the request stays queued, exactly as for any other recipient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVQaf1oSAj6ZkgBg2uY2Gk
