### PR TITLE
ci(release): publish the release the tag already earned

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,26 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v5
+
+      # A tag whose binaries report a different version, or whose notes were
+      # never cut, is worth catching here rather than after four builds have
+      # run and a draft is sitting in the releases page.
+      - name: Verify the tag matches the tree
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          crate="$(sed -n '/^\[workspace\.package\]/,/^\[/p' Cargo.toml \
+            | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)"
+          if [ "$crate" != "$version" ]; then
+            echo "::error::tag $tag does not match the workspace version $crate — bump Cargo.toml or retag" >&2
+            exit 1
+          fi
+          if ! grep -qF "## [$version]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [$version]' section — cut it before tagging" >&2
+            exit 1
+          fi
+
       - name: Create draft GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -113,6 +133,7 @@ jobs:
       # Dry-run path: surface the built archive + checksum as a workflow
       # artifact so it can be downloaded and inspected without cutting
       # an actual GitHub Release.
+      # (see the `publish` job below for what happens after the matrix)
       - name: Upload archive as workflow artifact (dry-run)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
@@ -123,3 +144,49 @@ jobs:
             muxa-${{ steps.ref.outputs.name }}-${{ matrix.target }}.tar.gz.sha256
           if-no-files-found: error
           retention-days: 14
+
+  # Flip the draft once — and only once — every archive is attached.
+  #
+  # Ordering is the whole point. `tap-bump` fires on `release: published`, and
+  # a release published before its assets exist hands the Homebrew formula
+  # download URLs that 404 (v0.8.27 shipped that way and the bump died with
+  # "no assets to download"). `needs: [build]` is what keeps that from
+  # happening: with `fail-fast: false`, one broken target leaves the release a
+  # draft for a human to look at instead of publishing a partial set.
+  publish:
+    name: publish release
+    needs: [create-release, build]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      # The release notes are the CHANGELOG section for this version,
+      # verbatim. Generated notes would restate the commit subjects the
+      # section already explains in prose.
+      - name: Extract the CHANGELOG section for this tag
+        id: notes
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          awk -v want="## [$version]" '
+            index($0, want) == 1 { inside = 1; next }
+            inside && /^## \[/    { exit }
+            inside                { print }
+          ' CHANGELOG.md > notes.md
+          if [ ! -s notes.md ]; then
+            echo "::error::no CHANGELOG entries under '## [$version]'" >&2
+            exit 1
+          fi
+          echo "bytes=$(wc -c < notes.md)" >> "$GITHUB_OUTPUT"
+
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          gh release edit "$tag" --draft=false --notes-file notes.md
+          echo "::notice::published $tag (${{ steps.notes.outputs.bytes }} bytes of notes); tap-bump takes it from here"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,30 +66,32 @@ for the deferred stub.
    version you have not run is how a broken release gets tagged.
 3. Commit as `release: vX.Y.Z`, push `main`, then push the annotated tag.
 
-Pushing the tag is the whole trigger. **Do not run `gh release create`**:
-the workflow creates the draft itself and the build matrix uploads four
-archives into it. Creating the release by hand publishes it before the
-archives exist, and `tap-bump` — which fires on *published* — dies with
-"no assets to download".
+Pushing the tag is the whole trigger, and everything after it is automatic.
+**Do not run `gh release create`**: the workflow creates the draft itself, the
+build matrix uploads four archives into it, and only then does the `publish`
+job flip the draft — with the tag's `CHANGELOG.md` section as its notes.
+Creating the release by hand publishes it before the archives exist, and
+`tap-bump` — which fires on *published* — dies with "no assets to download".
 
-4. When the build finishes, publish the draft with the changelog section
-   as its notes:
+The run refuses to start when the tag disagrees with the tree: the workspace
+version in `Cargo.toml` must equal the tag, and `CHANGELOG.md` must already
+have that `## [X.Y.Z]` section. Both are cheaper to catch before four builds
+than after.
 
-   ```bash
-   gh release edit vX.Y.Z --draft=false --notes-file <(awk '/## \[X.Y.Z\]/{f=1;next}/^## \[/{f=0}f' CHANGELOG.md)
-   ```
+4. Watch the run. It publishes on its own; you only step in when it does not:
 
-5. Bump the Homebrew tap:
+   - a build target failed, so the release stays a draft on purpose — fix the
+     target and re-push the tag, or publish the partial set deliberately;
+   - the `publish` job failed — publish by hand with
+     `gh release edit vX.Y.Z --draft=false --notes-file <(awk '/## \[X.Y.Z\]/{f=1;next}/^## \[/{f=0}f' CHANGELOG.md)`.
 
-   ```bash
-   scripts/bump-tap.sh vX.Y.Z
-   ```
-
-   The `tap-bump` workflow does this automatically only when the
-   `TAP_GITHUB_TOKEN` secret is set; without it the job succeeds with a
-   "skipping" notice and the formula quietly stays behind. The script is
-   idempotent — running it on an already-current tap prints "nothing to
-   push" and exits.
+5. The Homebrew tap follows the published release through `tap-bump`, which
+   needs the `TAP_GITHUB_TOKEN` secret (a fine-grained PAT with Contents
+   read/write on `Open330/homebrew-tap`). Without it — including when the token
+   expires — the job still *succeeds*, with a "skipping" notice, and the
+   formula quietly stays behind: if `brew` keeps offering the old version after
+   a release, suspect the token first. Recover with `scripts/bump-tap.sh
+   vX.Y.Z`, which is idempotent and prints "nothing to push" on a current tap.
 
 ## Project layout
 


### PR DESCRIPTION
## What was manual

`git push origin vX.Y.Z` built and uploaded four archives into a **draft**, and stopped. A human then ran

```bash
gh release edit vX.Y.Z --draft=false --notes-file <(awk ... CHANGELOG.md)
```

Until that happened the release was invisible to users and `tap-bump` — which fires on `release: published` — never ran, so Homebrew kept serving the previous version. On v0.8.37 the gap was about seven minutes; it is however long nobody is watching.

## What this does

A `publish` job flips the draft once the matrix finishes, with the tag's `CHANGELOG.md` section verbatim as the release notes.

`needs: [build]` is the load-bearing part. Publishing before the archives are attached is exactly what killed the v0.8.27 tap bump (`no assets to download`), and `fail-fast: false` means a single broken target now leaves the release a draft for a human to look at rather than publishing a partial set. An empty extraction fails the job rather than publishing placeholder notes — the release stays a draft and the old manual command still works.

`create-release` also gained a pre-flight check: the workspace version in `Cargo.toml` must equal the tag, and `CHANGELOG.md` must already carry that `## [X.Y.Z]` section. A tag whose binaries report a different version used to be discovered after four builds, or after shipping.

## Verification

The workflow cannot be exercised without cutting a release, so both scripts were run against this tree directly:

- version extraction from `[workspace.package]` → `0.8.37`, matching the tag that shipped it;
- the changelog guard finds `## [0.8.37]` and rejects a version that has no section;
- the notes extraction produces **byte-identical output** (modulo blank lines) to the 17.7 KB notes that were published by hand for v0.8.37.

The YAML parses and the job graph is `create-release → build → publish`.

## Follow-on

`TAP_GITHUB_TOKEN` is now configured, and its push path was verified end to end (a no-op formula edit pushed by `github-actions[bot]`), so with this merged a release is: push the tag, watch it go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVQaf1oSAj6ZkgBg2uY2Gk
