### PR TITLE
fix(agent): address the session, not a window that shares its name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
+      # `window_placement` drives a private tmux server; without tmux the test
+      # skips itself and the regression it guards goes unwatched here.
+      - run: sudo apt-get update && sudo apt-get install -y tmux
       # e2e tests shell out to `muxad` / `muxa` — those bins live in other
       # workspace packages and cargo test won't build them otherwise.
       - run: cargo build --workspace --bins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`--placement window` no longer collides with a window named after its own
+  session.** Adding a window to an existing session failed with `create window
+  failed: index 0 in use`, and removing every other window did not help. Muxa
+  resolved a pane/window/session target to the owning session's *name* and
+  passed it to `tmux new-window -t`, which takes a **window** target: a string
+  with no colon is looked up as a window in the caller's current session before
+  it is tried as a session. Muxa's own topology makes that collision the common
+  case rather than a corner — one session per workspace, whose first window is
+  usually named after it — so `-t junia` found the window `junia` at index 0 and
+  refused to create anything there. The target is now the session *id* with a
+  trailing colon (`$7:`), which cannot be read as a window name and leaves the
+  index for tmux to choose. A failing launch also names the resolved target,
+  since the address tmux was given is not the one the caller typed. Covered by
+  a regression test that drives the real binary against a private tmux server
+  laid out that way, through all four addresses muxa accepts — session id,
+  session name, window id, pane id.
+
+
 ### Added
 
 - **MCP agents can call an explicitly authorized agent on any Fleet host.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   usually named after it — so `-t junia` found the window `junia` at index 0 and
   refused to create anything there. The target is now the session *id* with a
   trailing colon (`$7:`), which cannot be read as a window name and leaves the
-  index for tmux to choose. A failing launch also names the resolved target,
+  index for tmux to choose.
+
+  Reading the target had the same flaw with a quieter ending: asked plainly for
+  `--target junia`, tmux answered with the id of whichever session owned a
+  window named `junia` — the caller's — so the window was created there, in the
+  wrong session, without an error. A name is now resolved as a session first
+  (`junia:`) and falls back to the plain form, which is what a window-name
+  target needs and the only form ids accept. A failing launch also names the
+  resolved target,
   since the address tmux was given is not the one the caller typed. Covered by
   a regression test that drives the real binary against a private tmux server
   laid out that way, through all four addresses muxa accepts — session id,

--- a/crates/muxa-cli/src/agent_launch.rs
+++ b/crates/muxa-cli/src/agent_launch.rs
@@ -844,28 +844,28 @@ fn resolve_placement_target(request: &mut StartRequest, cwd: &Path) -> Result<()
 /// **Reading the input.** `--target junia` means the session `junia`. Asked
 /// plainly, tmux answers with whatever window named `junia` sits in the
 /// caller's session — a different session's id, returned without complaint. A
-/// trailing colon forces the session reading, so a name is resolved that way
-/// first and only falls back to the plain form (which is what a window *name*
-/// target needs, and the only form ids accept).
+/// trailing colon forces the session reading, so every target is tried that
+/// way first and falls back to the plain form. The fallback is what pane and
+/// window ids need (tmux rejects `%5:` outright) and what a window *name*
+/// target needs; asking tmux which spelling it accepts beats guessing from the
+/// first character, which a session named `$work` or a window named `%tmp`
+/// would answer wrongly.
 ///
 /// **Writing the output.** The answer is the session id with its own trailing
 /// colon: `$7` cannot be re-read as a window name, and the colon means "window
 /// unspecified", which is what leaves the index for tmux to choose. A session
 /// target without it still carries its current window's index along.
 fn resolve_window_session(target: &str) -> Result<String> {
-    let is_id = target.starts_with(['%', '@', '$']);
     let mut last_error = None;
     let mut session = None;
-    // Ids are already unambiguous, and tmux rejects `%5:` / `@3:` outright.
-    if !is_id {
-        match session_id_of(&format!("{target}:"))? {
-            Ok(found) => session = Some(found),
-            Err(error) => last_error = Some(error),
-        }
-    }
-    if session.is_none() {
-        match session_id_of(target)? {
-            Ok(found) => session = Some(found),
+    for spelling in [format!("{target}:"), target.to_string()] {
+        match session_id_of(&spelling)? {
+            Ok(found) => {
+                session = Some(found);
+                break;
+            }
+            // Keep the plain form's complaint: it is the one that describes a
+            // target tmux does not know at all.
             Err(error) => last_error = Some(error),
         }
     }

--- a/crates/muxa-cli/src/agent_launch.rs
+++ b/crates/muxa-cli/src/agent_launch.rs
@@ -835,41 +835,69 @@ fn resolve_placement_target(request: &mut StartRequest, cwd: &Path) -> Result<()
 
 /// The `new-window -t` target for the session that owns `target`.
 ///
-/// Two details carry the whole fix for a `create window failed: index 0 in
-/// use` that made new windows impossible in a session muxa itself lays out.
+/// tmux reads a colonless string as a **window** in the caller's current
+/// session before it tries it as a session, and muxa's own topology makes that
+/// collision ordinary rather than unlucky: one session per workspace, whose
+/// first window is commonly named after it. Both ends of this function exist
+/// for that.
 ///
-/// **The session id, not its name.** `new-window -t` takes a *window* target,
-/// and a string with no colon is looked up as a window in the caller's current
-/// session before it is tried as a session. Muxa's own topology — one session
-/// per workspace, whose first window is usually named after it — makes that
-/// collision the common case, not a corner: `-t junia` finds the window named
-/// `junia` at index 0 and refuses to create anything there. A `$7` id cannot
-/// be read as a window name.
+/// **Reading the input.** `--target junia` means the session `junia`. Asked
+/// plainly, tmux answers with whatever window named `junia` sits in the
+/// caller's session — a different session's id, returned without complaint. A
+/// trailing colon forces the session reading, so a name is resolved that way
+/// first and only falls back to the plain form (which is what a window *name*
+/// target needs, and the only form ids accept).
 ///
-/// **The trailing colon.** `$7:` means "this session, window unspecified",
-/// which is what leaves the index for tmux to choose. Without it a session
-/// target still carries its current window's index along.
+/// **Writing the output.** The answer is the session id with its own trailing
+/// colon: `$7` cannot be re-read as a window name, and the colon means "window
+/// unspecified", which is what leaves the index for tmux to choose. A session
+/// target without it still carries its current window's index along.
 fn resolve_window_session(target: &str) -> Result<String> {
+    let is_id = target.starts_with(['%', '@', '$']);
+    let mut last_error = None;
+    let mut session = None;
+    // Ids are already unambiguous, and tmux rejects `%5:` / `@3:` outright.
+    if !is_id {
+        match session_id_of(&format!("{target}:"))? {
+            Ok(found) => session = Some(found),
+            Err(error) => last_error = Some(error),
+        }
+    }
+    if session.is_none() {
+        match session_id_of(target)? {
+            Ok(found) => session = Some(found),
+            Err(error) => last_error = Some(error),
+        }
+    }
+    let session = session.ok_or_else(|| {
+        let detail = last_error
+            .filter(|error| !error.is_empty())
+            .map_or(String::new(), |error| format!(": {error}"));
+        anyhow::anyhow!("cannot resolve tmux target {target:?}{detail}")
+    })?;
+    Ok(format!("{session}:"))
+}
+
+/// The session id tmux reports for one target spelling, or the message it
+/// refused with. The outer `Result` is reserved for not being able to run tmux
+/// at all, which is not something another spelling can recover from.
+fn session_id_of(target: &str) -> Result<std::result::Result<String, String>> {
     let output = muxa::tmux::tmux_command_scoped()
         .args(["display-message", "-p", "-t", target, "#{session_id}"])
         .output()
         .context("resolve tmux window target")?;
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        bail!(
-            "cannot resolve tmux target {target:?}{}",
-            if stderr.is_empty() {
-                String::new()
-            } else {
-                format!(": {stderr}")
-            }
-        );
+        return Ok(Err(String::from_utf8_lossy(&output.stderr)
+            .trim()
+            .to_string()));
     }
     let session = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if session.is_empty() {
-        bail!("tmux target {target:?} resolved to an empty session");
+        return Ok(Err(format!(
+            "tmux target {target:?} resolved to an empty session"
+        )));
     }
-    Ok(format!("{session}:"))
+    Ok(Ok(session))
 }
 
 fn tmux_args(request: &StartRequest, cwd: &Path, command: &str) -> Result<Vec<String>> {

--- a/crates/muxa-cli/src/agent_launch.rs
+++ b/crates/muxa-cli/src/agent_launch.rs
@@ -580,8 +580,16 @@ pub fn start(mut request: StartRequest) -> Result<StartResult> {
         .context("run tmux agent launcher")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        // Name the resolved `-t` value: the input the caller gave (a pane id,
+        // a session name) is not what tmux was asked for, and the difference
+        // between them is usually the bug.
+        let target = args
+            .iter()
+            .position(|arg| arg == "-t")
+            .and_then(|at| args.get(at + 1))
+            .map_or(String::new(), |target| format!(" (target {target:?})"));
         bail!(
-            "tmux {} failed{}",
+            "tmux {} failed{target}{}",
             args.first().map_or("command", String::as_str),
             if stderr.is_empty() {
                 String::new()
@@ -825,9 +833,25 @@ fn resolve_placement_target(request: &mut StartRequest, cwd: &Path) -> Result<()
     Ok(())
 }
 
+/// The `new-window -t` target for the session that owns `target`.
+///
+/// Two details carry the whole fix for a `create window failed: index 0 in
+/// use` that made new windows impossible in a session muxa itself lays out.
+///
+/// **The session id, not its name.** `new-window -t` takes a *window* target,
+/// and a string with no colon is looked up as a window in the caller's current
+/// session before it is tried as a session. Muxa's own topology — one session
+/// per workspace, whose first window is usually named after it — makes that
+/// collision the common case, not a corner: `-t junia` finds the window named
+/// `junia` at index 0 and refuses to create anything there. A `$7` id cannot
+/// be read as a window name.
+///
+/// **The trailing colon.** `$7:` means "this session, window unspecified",
+/// which is what leaves the index for tmux to choose. Without it a session
+/// target still carries its current window's index along.
 fn resolve_window_session(target: &str) -> Result<String> {
     let output = muxa::tmux::tmux_command_scoped()
-        .args(["display-message", "-p", "-t", target, "#{session_name}"])
+        .args(["display-message", "-p", "-t", target, "#{session_id}"])
         .output()
         .context("resolve tmux window target")?;
     if !output.status.success() {
@@ -845,7 +869,7 @@ fn resolve_window_session(target: &str) -> Result<String> {
     if session.is_empty() {
         bail!("tmux target {target:?} resolved to an empty session");
     }
-    Ok(session)
+    Ok(format!("{session}:"))
 }
 
 fn tmux_args(request: &StartRequest, cwd: &Path, command: &str) -> Result<Vec<String>> {
@@ -1133,12 +1157,17 @@ mod tests {
     #[test]
     fn window_and_session_plans_use_the_requested_surface() {
         let mut window = request(AgentProgram::Claude, Placement::Window);
-        window.target = Some("muxa".into());
+        // What `resolve_window_session` hands on: a session id, and a trailing
+        // colon that leaves the window index to tmux.
+        window.target = Some("$7:".into());
         window.name = Some("review".into());
         let args = tmux_args(&window, Path::new("/tmp"), "claude").unwrap();
         assert_eq!(args[0], "new-window");
         assert!(args.windows(2).any(|pair| pair == ["-n", "review"]));
-        assert!(args.windows(2).any(|pair| pair == ["-t", "muxa"]));
+        assert!(
+            args.windows(2).any(|pair| pair == ["-t", "$7:"]),
+            "a bare session name would be read as a window in the caller's session: {args:?}",
+        );
 
         let mut session = request(AgentProgram::Gemini, Placement::Session);
         session.target = None;

--- a/crates/muxa-cli/tests/window_placement.rs
+++ b/crates/muxa-cli/tests/window_placement.rs
@@ -1,0 +1,205 @@
+//! `--placement window` must land in the session the target belongs to, at an
+//! index tmux picks, even when a window is named after that session.
+//!
+//! This is the shape muxa's own topology produces — one session per workspace,
+//! whose first window is commonly named after it — and it used to fail with
+//! `create window failed: index 0 in use`: `new-window -t <name>` takes a
+//! *window* target, so a colonless string is looked up as a window in the
+//! caller's current session before it is tried as a session.
+//!
+//! The test drives the real `muxa` binary against a private tmux server, with
+//! a stand-in `claude` on `PATH` so no agent CLI has to exist on the machine.
+//! It skips when tmux is not installed.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn muxa() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_muxa"))
+}
+
+fn tmux_installed() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
+/// A tmux server of our own: private socket, and `-f /dev/null` so the
+/// operator's `~/.tmux.conf` (hooks included) stays out of the test.
+struct Server {
+    socket: PathBuf,
+    _dir: tempfile::TempDir,
+}
+
+impl Server {
+    fn start(dir: tempfile::TempDir) -> Self {
+        let socket = dir.path().join("tmux.sock");
+        let server = Self { socket, _dir: dir };
+        server
+            .tmux(&[
+                "new-session",
+                "-d",
+                "-s",
+                "junia",
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "-c",
+                "/tmp",
+            ])
+            .expect("start the test tmux server");
+        // The collision under test: window 0 carries the session's own name.
+        server
+            .tmux(&["rename-window", "-t", "junia:0", "junia"])
+            .expect("name window 0 after the session");
+        server
+    }
+
+    fn tmux(&self, args: &[&str]) -> Result<String, String> {
+        let out = Command::new("tmux")
+            .arg("-f")
+            .arg("/dev/null")
+            .arg("-S")
+            .arg(&self.socket)
+            .args(args)
+            .output()
+            .expect("run tmux");
+        let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if out.status.success() {
+            Ok(stdout)
+        } else {
+            Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
+        }
+    }
+
+    fn query(&self, args: &[&str]) -> String {
+        self.tmux(args).expect("tmux query")
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.tmux(&["kill-server"]);
+    }
+}
+
+/// A `claude` that stays in its pane and needs nothing installed.
+fn stub_agent_dir(root: &Path) -> PathBuf {
+    let bin = root.join("bin");
+    std::fs::create_dir_all(&bin).expect("create stub bin dir");
+    let claude = bin.join("claude");
+    std::fs::write(&claude, "#!/bin/sh\nexec sleep 600\n").expect("write stub claude");
+    std::fs::set_permissions(&claude, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod stub claude");
+    bin
+}
+
+#[test]
+fn window_placement_lands_in_the_target_session_beside_a_same_named_window() {
+    if !tmux_installed() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stub_bin = stub_agent_dir(dir.path());
+    let server = Server::start(dir);
+
+    let session_id = server.query(&["display-message", "-p", "-t", "junia", "#{session_id}"]);
+    let window_id = server.query(&["display-message", "-p", "-t", "junia:0", "#{window_id}"]);
+    let pane_id = server.query(&["display-message", "-p", "-t", "junia:0", "#{pane_id}"]);
+    let server_pid = server.query(&["display-message", "-p", "#{pid}"]);
+    // What a caller inside that session has in its environment. It is what
+    // gives tmux a "current session" to resolve an ambiguous target against,
+    // so without it the collision cannot happen at all.
+    let tmux_env = format!(
+        "{},{},{}",
+        server.socket.display(),
+        server_pid,
+        session_id.trim_start_matches('$'),
+    );
+
+    // Every address muxa accepts for the same session.
+    for (nth, target) in [
+        session_id.as_str(),
+        "junia",
+        window_id.as_str(),
+        pane_id.as_str(),
+    ]
+    .iter()
+    .enumerate()
+    {
+        let name = format!("GH-13{nth}");
+        let path = format!(
+            "{}:{}",
+            stub_bin.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let out = Command::new(muxa())
+            .args([
+                "agent",
+                "start",
+                "--agent",
+                "claude",
+                "--placement",
+                "window",
+                "--target",
+                target,
+                "--name",
+                &name,
+                "--cwd",
+                "/tmp",
+                "--json",
+            ])
+            .env("PATH", path)
+            .env("MUXA_TMUX_SOCKET", &server.socket)
+            .env("TMUX", &tmux_env)
+            .env("TMUX_PANE", &pane_id)
+            .output()
+            .expect("run muxa agent start");
+        assert!(
+            out.status.success(),
+            "target {target:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr),
+        );
+
+        let placed = server.query(&[
+            "list-windows",
+            "-t",
+            "junia",
+            "-F",
+            "#{window_index} #{window_name} #{pane_current_command}",
+        ]);
+        let row = placed
+            .lines()
+            .find(|line| line.split_whitespace().nth(1) == Some(name.as_str()))
+            .unwrap_or_else(|| panic!("no window named {name} in junia; windows:\n{placed}"));
+        let index: u32 = row
+            .split_whitespace()
+            .next()
+            .and_then(|idx| idx.parse().ok())
+            .expect("window index");
+        assert_ne!(index, 0, "index 0 belongs to the session's first window");
+        // The stub is what ran, so a machine with a real `claude` on PATH
+        // cannot make this test pass for the wrong reason.
+        assert!(
+            row.ends_with("sleep"),
+            "the stub agent should own the new pane: {row}",
+        );
+    }
+
+    // Four launches, four windows, all in the session that was addressed.
+    let windows = server.query(&["list-windows", "-a", "-F", "#{session_name}:#{window_name}"]);
+    assert_eq!(
+        windows
+            .lines()
+            .filter(|w| w.starts_with("junia:GH-13"))
+            .count(),
+        4,
+        "windows:\n{windows}",
+    );
+}

--- a/crates/muxa-cli/tests/window_placement.rs
+++ b/crates/muxa-cli/tests/window_placement.rs
@@ -75,6 +75,20 @@ impl Server {
         server
             .tmux(&["rename-window", "-t", "caller:0", "junia"])
             .expect("name the caller's window after the target session");
+        // A window name that matches no session, so addressing it can only be
+        // served by falling back from the session spelling to the plain one.
+        server
+            .tmux(&[
+                "new-window",
+                "-d",
+                "-t",
+                "caller:",
+                "-n",
+                "scratch",
+                "-c",
+                "/tmp",
+            ])
+            .expect("add the caller's scratch window");
         server
     }
 
@@ -115,6 +129,79 @@ fn stub_agent_dir(root: &Path) -> PathBuf {
     std::fs::set_permissions(&claude, std::fs::Permissions::from_mode(0o755))
         .expect("chmod stub claude");
     bin
+}
+
+/// What every launch in this test shares: where the stub lives, and the
+/// environment of a caller sitting in the `caller` session.
+struct Launch<'a> {
+    stub_bin: &'a Path,
+    tmux_env: &'a str,
+    caller_pane: &'a str,
+}
+
+/// Start one agent addressed by `target`, then assert where it landed:
+/// `owner`'s session, at an index tmux picked, running the stub.
+fn launch_and_assert(server: &Server, launch: &Launch<'_>, target: &str, owner: &str, name: &str) {
+    let path = format!(
+        "{}:{}",
+        launch.stub_bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let out = Command::new(muxa())
+        .args([
+            "agent",
+            "start",
+            "--agent",
+            "claude",
+            "--placement",
+            "window",
+            "--target",
+            target,
+            "--name",
+            name,
+            "--cwd",
+            "/tmp",
+            "--json",
+        ])
+        .env("PATH", path)
+        .env("MUXA_TMUX_SOCKET", &server.socket)
+        .env("TMUX", launch.tmux_env)
+        .env("TMUX_PANE", launch.caller_pane)
+        .output()
+        .expect("run muxa agent start");
+    assert!(
+        out.status.success(),
+        "target {target:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // Where it landed, across every session on the server: a window in the
+    // wrong one is the silent half of this bug.
+    let placed = server.query(&[
+        "list-windows",
+        "-a",
+        "-F",
+        "#{session_name} #{window_index} #{window_name}",
+    ]);
+    let row = placed
+        .lines()
+        .find(|line| line.split_whitespace().nth(2) == Some(name))
+        .unwrap_or_else(|| panic!("no window named {name} anywhere; windows:\n{placed}"));
+    let mut fields = row.split_whitespace();
+    let session = fields.next().expect("session name");
+    let index: u32 = fields
+        .next()
+        .and_then(|idx| idx.parse().ok())
+        .expect("window index");
+    assert_eq!(
+        session, owner,
+        "target {target:?} addresses {owner}; windows:\n{placed}",
+    );
+    assert_ne!(index, 0, "index 0 belongs to the session's first window");
+    // The stub is what ran, so a machine with a real `claude` on PATH cannot
+    // make this test pass for the wrong reason.
+    let command = wait_for_pane_command(server, &format!("{owner}:{index}"));
+    assert_eq!(command, "sleep", "the stub agent should own the new pane");
 }
 
 /// tmux runs the launch through `sh -c`, which then execs the stub, so the
@@ -164,82 +251,35 @@ fn window_placement_lands_in_the_target_session_beside_a_same_named_window() {
         caller_session.trim_start_matches('$'),
     );
 
-    // Every address muxa accepts for the same session.
-    for (nth, target) in [
-        session_id.as_str(),
-        "junia",
-        window_id.as_str(),
-        pane_id.as_str(),
+    // Every address muxa accepts, and the session each one names. The last
+    // is a *window* name owned by no session of that name: only the fallback
+    // from the session spelling to the plain one can resolve it, and it
+    // belongs to the caller's session rather than the target's.
+    for (nth, (target, owner)) in [
+        (session_id.as_str(), "junia"),
+        ("junia", "junia"),
+        (window_id.as_str(), "junia"),
+        (pane_id.as_str(), "junia"),
+        ("scratch", "caller"),
     ]
     .iter()
     .enumerate()
     {
-        let name = format!("GH-13{nth}");
-        let path = format!(
-            "{}:{}",
-            stub_bin.display(),
-            std::env::var("PATH").unwrap_or_default()
+        launch_and_assert(
+            &server,
+            &Launch {
+                stub_bin: &stub_bin,
+                tmux_env: &tmux_env,
+                caller_pane: &caller_pane,
+            },
+            target,
+            owner,
+            &format!("GH-13{nth}"),
         );
-        let out = Command::new(muxa())
-            .args([
-                "agent",
-                "start",
-                "--agent",
-                "claude",
-                "--placement",
-                "window",
-                "--target",
-                target,
-                "--name",
-                &name,
-                "--cwd",
-                "/tmp",
-                "--json",
-            ])
-            .env("PATH", path)
-            .env("MUXA_TMUX_SOCKET", &server.socket)
-            .env("TMUX", &tmux_env)
-            .env("TMUX_PANE", &caller_pane)
-            .output()
-            .expect("run muxa agent start");
-        assert!(
-            out.status.success(),
-            "target {target:?} failed: {}",
-            String::from_utf8_lossy(&out.stderr),
-        );
-
-        // Where it landed, across every session on the server: a window in
-        // `caller` would be the silent half of this bug.
-        let placed = server.query(&[
-            "list-windows",
-            "-a",
-            "-F",
-            "#{session_name} #{window_index} #{window_name}",
-        ]);
-        let row = placed
-            .lines()
-            .find(|line| line.split_whitespace().nth(2) == Some(name.as_str()))
-            .unwrap_or_else(|| panic!("no window named {name} anywhere; windows:\n{placed}"));
-        let mut fields = row.split_whitespace();
-        let session = fields.next().expect("session name");
-        let index: u32 = fields
-            .next()
-            .and_then(|idx| idx.parse().ok())
-            .expect("window index");
-        assert_eq!(
-            session, "junia",
-            "target {target:?} addressed junia; windows:\n{placed}",
-        );
-        assert_ne!(index, 0, "index 0 belongs to the session's first window");
-        // The stub is what ran, so a machine with a real `claude` on PATH
-        // cannot make this test pass for the wrong reason. The pane goes
-        // through `sh -c` first, so give the exec a moment to land.
-        let command = wait_for_pane_command(&server, &format!("junia:{index}"));
-        assert_eq!(command, "sleep", "the stub agent should own the new pane");
     }
 
-    // Four launches, four windows, every one of them in the addressed
-    // session and none in the caller's.
+    // Every launch landed where its address pointed: the four session
+    // addresses in `junia`, the window name in the session that owns it.
     let windows = server.query(&["list-windows", "-a", "-F", "#{session_name}:#{window_name}"]);
     assert_eq!(
         windows
@@ -249,8 +289,12 @@ fn window_placement_lands_in_the_target_session_beside_a_same_named_window() {
         4,
         "windows:\n{windows}",
     );
-    assert!(
-        !windows.lines().any(|w| w.starts_with("caller:GH-13")),
-        "nothing may be created in the caller's session; windows:\n{windows}",
+    assert_eq!(
+        windows
+            .lines()
+            .filter(|w| w.starts_with("caller:GH-13"))
+            .count(),
+        1,
+        "only the window-name address belongs to the caller; windows:\n{windows}",
     );
 }

--- a/crates/muxa-cli/tests/window_placement.rs
+++ b/crates/muxa-cli/tests/window_placement.rs
@@ -53,10 +53,28 @@ impl Server {
                 "/tmp",
             ])
             .expect("start the test tmux server");
-        // The collision under test: window 0 carries the session's own name.
+        // A second session, standing in for the pane a caller runs from, whose
+        // window carries the *target* session's name. That is the collision:
+        // tmux reads a colonless `junia` as this window before it tries the
+        // session, which is both how `index 0 in use` happened and how a
+        // window could land in the caller's session instead.
         server
-            .tmux(&["rename-window", "-t", "junia:0", "junia"])
-            .expect("name window 0 after the session");
+            .tmux(&[
+                "new-session",
+                "-d",
+                "-s",
+                "caller",
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "-c",
+                "/tmp",
+            ])
+            .expect("start the caller session");
+        server
+            .tmux(&["rename-window", "-t", "caller:0", "junia"])
+            .expect("name the caller's window after the target session");
         server
     }
 
@@ -99,6 +117,27 @@ fn stub_agent_dir(root: &Path) -> PathBuf {
     bin
 }
 
+/// tmux runs the launch through `sh -c`, which then execs the stub, so the
+/// foreground command reported the instant the window appears may still be the
+/// shell. Poll briefly rather than race it.
+fn wait_for_pane_command(server: &Server, window: &str) -> String {
+    let mut command = String::new();
+    for _ in 0..50 {
+        command = server.query(&[
+            "display-message",
+            "-p",
+            "-t",
+            window,
+            "#{pane_current_command}",
+        ]);
+        if command == "sleep" {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(40));
+    }
+    command
+}
+
 #[test]
 fn window_placement_lands_in_the_target_session_beside_a_same_named_window() {
     if !tmux_installed() {
@@ -109,18 +148,20 @@ fn window_placement_lands_in_the_target_session_beside_a_same_named_window() {
     let stub_bin = stub_agent_dir(dir.path());
     let server = Server::start(dir);
 
-    let session_id = server.query(&["display-message", "-p", "-t", "junia", "#{session_id}"]);
+    let session_id = server.query(&["display-message", "-p", "-t", "junia:", "#{session_id}"]);
     let window_id = server.query(&["display-message", "-p", "-t", "junia:0", "#{window_id}"]);
     let pane_id = server.query(&["display-message", "-p", "-t", "junia:0", "#{pane_id}"]);
+    let caller_session = server.query(&["display-message", "-p", "-t", "caller:", "#{session_id}"]);
+    let caller_pane = server.query(&["display-message", "-p", "-t", "caller:0", "#{pane_id}"]);
     let server_pid = server.query(&["display-message", "-p", "#{pid}"]);
-    // What a caller inside that session has in its environment. It is what
+    // What a caller running inside `caller` has in its environment. It is what
     // gives tmux a "current session" to resolve an ambiguous target against,
     // so without it the collision cannot happen at all.
     let tmux_env = format!(
         "{},{},{}",
         server.socket.display(),
         server_pid,
-        session_id.trim_start_matches('$'),
+        caller_session.trim_start_matches('$'),
     );
 
     // Every address muxa accepts for the same session.
@@ -158,7 +199,7 @@ fn window_placement_lands_in_the_target_session_beside_a_same_named_window() {
             .env("PATH", path)
             .env("MUXA_TMUX_SOCKET", &server.socket)
             .env("TMUX", &tmux_env)
-            .env("TMUX_PANE", &pane_id)
+            .env("TMUX_PANE", &caller_pane)
             .output()
             .expect("run muxa agent start");
         assert!(
@@ -167,32 +208,38 @@ fn window_placement_lands_in_the_target_session_beside_a_same_named_window() {
             String::from_utf8_lossy(&out.stderr),
         );
 
+        // Where it landed, across every session on the server: a window in
+        // `caller` would be the silent half of this bug.
         let placed = server.query(&[
             "list-windows",
-            "-t",
-            "junia",
+            "-a",
             "-F",
-            "#{window_index} #{window_name} #{pane_current_command}",
+            "#{session_name} #{window_index} #{window_name}",
         ]);
         let row = placed
             .lines()
-            .find(|line| line.split_whitespace().nth(1) == Some(name.as_str()))
-            .unwrap_or_else(|| panic!("no window named {name} in junia; windows:\n{placed}"));
-        let index: u32 = row
-            .split_whitespace()
+            .find(|line| line.split_whitespace().nth(2) == Some(name.as_str()))
+            .unwrap_or_else(|| panic!("no window named {name} anywhere; windows:\n{placed}"));
+        let mut fields = row.split_whitespace();
+        let session = fields.next().expect("session name");
+        let index: u32 = fields
             .next()
             .and_then(|idx| idx.parse().ok())
             .expect("window index");
+        assert_eq!(
+            session, "junia",
+            "target {target:?} addressed junia; windows:\n{placed}",
+        );
         assert_ne!(index, 0, "index 0 belongs to the session's first window");
         // The stub is what ran, so a machine with a real `claude` on PATH
-        // cannot make this test pass for the wrong reason.
-        assert!(
-            row.ends_with("sleep"),
-            "the stub agent should own the new pane: {row}",
-        );
+        // cannot make this test pass for the wrong reason. The pane goes
+        // through `sh -c` first, so give the exec a moment to land.
+        let command = wait_for_pane_command(&server, &format!("junia:{index}"));
+        assert_eq!(command, "sleep", "the stub agent should own the new pane");
     }
 
-    // Four launches, four windows, all in the session that was addressed.
+    // Four launches, four windows, every one of them in the addressed
+    // session and none in the caller's.
     let windows = server.query(&["list-windows", "-a", "-F", "#{session_name}:#{window_name}"]);
     assert_eq!(
         windows
@@ -201,5 +248,9 @@ fn window_placement_lands_in_the_target_session_beside_a_same_named_window() {
             .count(),
         4,
         "windows:\n{windows}",
+    );
+    assert!(
+        !windows.lines().any(|w| w.starts_with("caller:GH-13")),
+        "nothing may be created in the caller's session; windows:\n{windows}",
     );
 }


### PR DESCRIPTION
Fixes #119.

## The address tmux was given was not a session

`new-window -t` takes a **window** target, and a string with no colon is looked up as a window in the caller's *current* session before it is tried as a session. `resolve_window_session` reduced a pane/window/session input to the session's **name**, so the launch ran

```text
tmux new-window -d -P -F '#{pane_id}' -t junia -n GH-131 ...
```

and tmux read `junia` as the window named `junia`, at index 0, in the session the caller was sitting in. Hence `create window failed: index 0 in use`, and hence removing the *other* windows never helped — the occupied index was the one it had resolved to.

Muxa's own topology makes this ordinary rather than unlucky: one session per workspace, whose first window is commonly named after it. Reproduced against tmux 3.4 with exactly that layout:

```console
$ muxa agent start --agent claude --placement window --target '$0' --name GH-131
Error: tmux new-window failed: create window failed: index 0 in use
```

The silent half is worse than the loud one: when the colliding name happened to match a *free* index, the window was created — in the caller's session, not the one addressed.

## Fix

The resolved target is the session id with a trailing colon (`$7:`). An id cannot be read as a window name, and the colon means "window unspecified", which is what leaves the index for tmux to choose. Both halves are needed: a session target without the colon still carries its current window's index along.

A failed launch now also names the resolved `-t` value, because the address tmux was given is never the one the caller typed.

## Coverage

The existing unit test asserted `-t muxa` — the ambiguous form this removes — and could not have caught the bug, because it never runs tmux. It now pins the colon-suffixed id.

`crates/muxa-cli/tests/window_placement.rs` drives the real `muxa` binary against a private tmux server (`-f /dev/null`, own socket, killed on drop) laid out with the collision, through all four addresses muxa accepts — session id, session name, window id, pane id — asserting each lands in that session at a nonzero index under the requested name. A stand-in `claude` on `PATH` keeps it independent of what is installed, and the test asserts the stub is what owns the new pane so a machine with a real `claude` cannot pass it for the wrong reason.

Verified in both directions: reverting the fix fails the test with the issue's exact error, `create window failed: index 0 in use`.

CI's `test` job now installs tmux; without it the test would skip itself and the regression would go unwatched there.

## Not addressed

The issue's closing observation — a managed launch creating `junia-2` instead of adopting `junia` — is left alone deliberately. The report attributes it to 16 long-lived `muxa mcp` processes running deleted binaries, which is a different failure (a stale server answering with old logic) from the one above, and the index-0 defect reproduces with no daemon at all. Worth its own issue if it recurs against current binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVQaf1oSAj6ZkgBg2uY2Gk
