### PR TITLE
ci(release): call the tap bump instead of waiting for an event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,4 +189,20 @@ jobs:
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
           gh release edit "$tag" --draft=false --notes-file notes.md
-          echo "::notice::published $tag (${{ steps.notes.outputs.bytes }} bytes of notes); tap-bump takes it from here"
+          echo "::notice::published $tag (${{ steps.notes.outputs.bytes }} bytes of notes)"
+
+  # Sync the Homebrew formula to what was just published.
+  #
+  # Called, not triggered. `tap-bump` also listens for `release: published`,
+  # but GitHub does not start workflows from events raised with the automatic
+  # `GITHUB_TOKEN` — so the publish above, performed by this workflow, is
+  # invisible to that trigger. v0.8.38 shipped that way: published on its own,
+  # with the tap left a version behind and no failure anywhere to say so.
+  tap:
+    name: bump homebrew tap
+    needs: [publish]
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/tap-bump.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/tap-bump.yml
+++ b/.github/workflows/tap-bump.yml
@@ -1,10 +1,20 @@
 name: tap-bump
 
 # Keep Open330/homebrew-tap's Formula/muxa.rb pointing at the newest
-# published release. Runs on `release: published` (NOT on tag push) so
-# the formula's download URLs are live by the time it lands — the
-# release workflow creates a *draft* whose asset URLs 404 until a
-# maintainer publishes it.
+# published release. Never on tag push: the release workflow creates a
+# *draft* whose asset URLs 404 until it is published, and a formula
+# pointing at a 404 is worse than one that is merely stale.
+#
+# Two ways in, because one of them cannot reach the other:
+#
+#   * `workflow_call`, which is how `release.yml` runs this the moment it
+#     publishes. GitHub deliberately does not start workflows from events
+#     raised with the automatic `GITHUB_TOKEN`, so the publish this repo
+#     performs for itself never produces a `release: published` any
+#     workflow can see. Calling it directly sidesteps the whole question.
+#   * `release: published`, which covers a release a human publishes from
+#     the web UI or their own credentials — the recovery path when the
+#     automated publish did not run.
 #
 # Requires the `TAP_GITHUB_TOKEN` repo secret: a fine-grained PAT with
 # Contents read/write on Open330/homebrew-tap (the default
@@ -15,6 +25,12 @@ name: tap-bump
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to sync the formula to (e.g. v0.8.38)"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -35,10 +51,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            tag="${{ inputs.tag }}"
-          else
-            tag="${{ github.event.release.tag_name }}"
+          # `inputs.tag` covers both ways in that name a tag explicitly
+          # (workflow_call and workflow_dispatch); the release event carries
+          # its own.
+          tag="${{ inputs.tag || github.event.release.tag_name }}"
+          if [ -z "$tag" ]; then
+            echo "::error::no tag to sync the formula to" >&2
+            exit 1
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A release syncs the Homebrew tap again.** `tap-bump` listens for
+  `release: published`, which worked while a human published each draft and
+  stopped the moment the release workflow started publishing for itself:
+  GitHub does not start workflows from events raised with the automatic
+  `GITHUB_TOKEN`. v0.8.38 published cleanly and left the formula on v0.8.37,
+  with nothing failing anywhere to say so — the worst shape a break can take.
+  The release run now *calls* `tap-bump` as a reusable workflow once the
+  publish job succeeds. The event trigger stays for releases published by
+  hand, and the two cannot double up, since the automated publish raises no
+  event to begin with.
+
+
 ## [0.8.38] - 2026-08-31
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,12 +85,19 @@ than after.
    - the `publish` job failed — publish by hand with
      `gh release edit vX.Y.Z --draft=false --notes-file <(awk '/## \[X.Y.Z\]/{f=1;next}/^## \[/{f=0}f' CHANGELOG.md)`.
 
-5. The Homebrew tap follows the published release through `tap-bump`, which
-   needs the `TAP_GITHUB_TOKEN` secret (a fine-grained PAT with Contents
-   read/write on `Open330/homebrew-tap`). Without it — including when the token
-   expires — the job still *succeeds*, with a "skipping" notice, and the
-   formula quietly stays behind: if `brew` keeps offering the old version after
-   a release, suspect the token first. Recover with `scripts/bump-tap.sh
+5. The Homebrew tap is synced by the release run itself, which *calls*
+   `tap-bump` after publishing rather than relying on the `release: published`
+   event — GitHub does not start workflows from events raised with the
+   automatic `GITHUB_TOKEN`, so a publish this repo performs for itself is
+   invisible to that trigger (v0.8.38 shipped with the tap a version behind
+   for exactly this reason). The event trigger remains for a release a human
+   publishes by hand.
+
+   Either way it needs the `TAP_GITHUB_TOKEN` secret (a fine-grained PAT with
+   Contents read/write on `Open330/homebrew-tap`). Without it — including when
+   the token expires — the job still *succeeds*, with a "skipping" notice, and
+   the formula quietly stays behind: if `brew` keeps offering the old version
+   after a release, suspect the token first. Recover with `scripts/bump-tap.sh
    vX.Y.Z`, which is idempotent and prints "nothing to push" on a current tap.
 
 ## Project layout


### PR DESCRIPTION
## What broke, and how quietly

`tap-bump` fires on `release: published`. That held while a person published each draft from their own credentials. #118 made the release workflow publish for itself — and GitHub does not start workflows from events raised with the automatic `GITHUB_TOKEN`, so the publish became invisible to the trigger.

v0.8.38 shipped that way an hour ago:

| | |
|---|---|
| release run | all jobs green, `publish` included |
| release | published, 8 assets, notes from the changelog |
| `tap-bump` runs for v0.8.38 | **none** |
| `Formula/muxa.rb` | still `version "0.8.37"` |
| anything reporting a failure | **nothing** |

`brew upgrade muxa` kept handing out the previous version, and the pipeline said it was fine. Automating one step had severed the one after it.

The tap for v0.8.38 has already been corrected by hand with `scripts/bump-tap.sh v0.8.38`; formula checksums verified against the release sidecars.

## Fix

The release run now **calls** `tap-bump` as a reusable workflow once `publish` succeeds, passing the tag it just shipped:

```yaml
  tap:
    needs: [publish]
    if: github.event_name == 'push'
    uses: ./.github/workflows/tap-bump.yml
    with: { tag: ${{ github.ref_name }} }
    secrets: inherit
```

`tap-bump` gains a `workflow_call` trigger and resolves its tag from `inputs.tag` when it has one. The `release: published` trigger stays, so a draft published by hand still syncs the tap; the two paths cannot double up, because the automated publish raises no event for the trigger to see.

`CONTRIBUTING` records the `GITHUB_TOKEN` rule next to the step it broke, so the call does not get "simplified" back into a trigger.

## Verification

This one cannot be proven before merge — the path only exists on a tag push, and the failure it fixes is an *absent* run rather than a red one. What is checked here: both workflows parse, the job graph resolves to `create-release → build → publish → tap`, and `tap-bump` still accepts its two existing entry points. The real proof is the next release: a `tap-bump` run whose trigger reads `workflow_call`, and a formula that matches the tag without anyone touching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVQaf1oSAj6ZkgBg2uY2Gk
