### PR TITLE
fix(collab): refuse a reply with nothing in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A reply must carry a body.** `create` refuses an empty request body;
+  `reply` refused nothing, so an argument that did not survive its shell closed
+  the request with an empty answer in it — and, the request now being terminal,
+  the real answer could never be posted to that thread. The sender saw
+  `completed` with an empty body, which reads as a reviewer who had nothing to
+  say rather than as a delivery that went missing. A blank or whitespace-only
+  reply is now `EmptyMessage`, leaving the request claimed and still
+  answerable, and the stored body is trimmed the way a request body already
+  was. This holds for every terminal status: a decline with no reason tells the
+  sender as little as an empty completion does.
+
 - **A release syncs the Homebrew tap again.** `tap-bump` listens for
   `release: published`, which worked while a human published each draft and
   stopped the moment the release workflow started publishing for itself:

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -2072,6 +2072,19 @@ impl CollaborationStore {
         ) {
             return Err(CollaborationError::InvalidReplyStatus);
         }
+        // The same guard `create` puts on a request body, for the same reason
+        // and one more: a reply is a terminal write. An empty one — an
+        // argument that did not survive its shell, a variable that expanded to
+        // nothing — closes the request with no answer in it, and the real
+        // answer can never be posted to that thread afterwards. The sender
+        // sees `completed` and an empty body, which reads as a reviewer with
+        // nothing to say rather than as a delivery that went missing.
+        // A refusal without a reason is no more useful than an empty
+        // completion, so this holds for every terminal status.
+        let body = body.trim().to_string();
+        if body.is_empty() {
+            return Err(CollaborationError::EmptyMessage);
+        }
         if body.len() > self.opts.max_message_bytes {
             return Err(CollaborationError::MessageTooLarge(
                 self.opts.max_message_bytes,
@@ -3664,6 +3677,120 @@ mod tests {
         let participants = participants_from(&store.snapshot().await, &panes);
         assert_eq!(participants.len(), 1);
         assert_eq!(participants[0].agent_session_id, "real-session");
+    }
+
+    /// A reply is a terminal write, so an empty one must not spend it. This
+    /// cost a real review round trip: a peer's `muxa msg reply` lost its body
+    /// to the shell, the request closed with nothing in it, and the findings
+    /// that followed were refused as "already terminal".
+    #[tokio::test]
+    async fn an_empty_reply_is_refused_and_leaves_the_request_answerable() {
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let sender = participant("%1", "sender");
+        let recipient = participant("%2", "reviewer");
+        let request = mailbox
+            .create(
+                sender,
+                recipient.clone(),
+                NewRequest {
+                    kind: RequestKind::Review,
+                    body: "review the diff".into(),
+                    expects_reply: true,
+                    work_mode: WorkMode::ReadOnly,
+                    paths: Vec::new(),
+                    air_artifacts: Vec::new(),
+                    ..NewRequest::default()
+                },
+            )
+            .await
+            .unwrap();
+        mailbox.claim_for(&recipient).await.unwrap();
+
+        for blank in ["", "   ", "\n\t "] {
+            let refused = mailbox
+                .reply(
+                    &recipient,
+                    &request.id,
+                    RequestStatus::Completed,
+                    blank.into(),
+                    Vec::new(),
+                    Vec::new(),
+                )
+                .await;
+            assert!(
+                matches!(refused, Err(CollaborationError::EmptyMessage)),
+                "{blank:?} should be refused, got {refused:?}",
+            );
+        }
+
+        // Refusing a terminal write is only worth anything if the request is
+        // still there to answer.
+        let stored = mailbox.get_for(&recipient, &request.id).await.unwrap();
+        assert_eq!(stored.status, RequestStatus::Claimed);
+        assert!(stored.reply.is_none());
+
+        let answered = mailbox
+            .reply(
+                &recipient,
+                &request.id,
+                RequestStatus::Completed,
+                "  no blockers found  ".into(),
+                Vec::new(),
+                Vec::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(answered.status, RequestStatus::Completed);
+        assert_eq!(
+            answered.reply.expect("reply").body,
+            "no blockers found",
+            "stored trimmed, the way a request body is",
+        );
+    }
+
+    /// A decline with no reason tells the sender as little as an empty
+    /// completion does.
+    #[tokio::test]
+    async fn every_terminal_status_needs_a_body() {
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let sender = participant("%1", "sender");
+        let recipient = participant("%2", "reviewer");
+        for status in [
+            RequestStatus::Declined,
+            RequestStatus::Blocked,
+            RequestStatus::Failed,
+        ] {
+            let request = mailbox
+                .create(
+                    sender.clone(),
+                    recipient.clone(),
+                    NewRequest {
+                        kind: RequestKind::Question,
+                        body: "is the release green?".into(),
+                        expects_reply: true,
+                        work_mode: WorkMode::ReadOnly,
+                        paths: Vec::new(),
+                        air_artifacts: Vec::new(),
+                        ..NewRequest::default()
+                    },
+                )
+                .await
+                .unwrap();
+            let refused = mailbox
+                .reply(
+                    &recipient,
+                    &request.id,
+                    status,
+                    String::new(),
+                    Vec::new(),
+                    Vec::new(),
+                )
+                .await;
+            assert!(
+                matches!(refused, Err(CollaborationError::EmptyMessage)),
+                "{status:?} with no body should be refused, got {refused:?}",
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #121.

## The asymmetry

| | empty body |
|---|---|
| `create_with_provenance` (`collaboration.rs:1852`) | trimmed, refused with `EmptyMessage` |
| `reply` (`collaboration.rs:2074`) | accepted, request marked terminal |

A reply is a one-way door. Spending it on an empty body closes the request *and* forecloses the answer, because a terminal request cannot be replied to again.

## How it actually happened

A codex peer reviewing #120 answered through `muxa msg reply`. The body did not reach the CLI's argument, so this was stored:

```json
"status": "completed",
"reply": { "status": "completed", "body": "", "at": "2026-08-31T11:18:59Z" }
```

Its next attempt — the one carrying the findings — was refused with `request … is already terminal`, and the review arrived as a separate `notice`, outside the thread that had asked for it. On the requester's side `muxa msg wait` returned `completed`, so nothing signalled that anything was missing: an empty review reads as a reviewer with nothing to say.

## Fix

`reply` now trims and refuses a blank body with `EmptyMessage`, and stores the trimmed body the way `create` already did. The request stays `Claimed` and answerable, which is the point — the failure mode being fixed is losing the ability to answer, not the empty string itself.

Every terminal status is held to it, `Declined` and `Blocked` included. The issue left that open; a refusal with no reason is no more useful to the sender than an empty completion, and no caller in the tree sends one deliberately (`ipc.rs` passes the body straight through from the CLI and MCP; every other call site is a test).

## Coverage

- `an_empty_reply_is_refused_and_leaves_the_request_answerable` — `""`, spaces, and `\n\t ` are each refused; the request is still `Claimed` with no reply attached; a real answer then goes through and is stored trimmed.
- `every_terminal_status_needs_a_body` — `Declined`, `Blocked`, `Failed` with no body are refused.

Both fail without the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVQaf1oSAj6ZkgBg2uY2Gk
