### PR TITLE
fix(init): fold each edit onto the plan, not onto disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Selecting two components that share a file no longer throws one of them
+  away.** Each component planned its edit by reading the file from disk, which
+  is right for the first one to touch a path and wrong for every one after it:
+  `apply` writes each result in turn, so the second edit — computed from text
+  that had never seen the first one's block — silently overwrote it. Nothing
+  looked wrong, because every component's own plan was accurate: the dry-run
+  reported `~ edit ~/.tmux.conf (tmux-popup) [+9 lines]`, the user confirmed
+  it, and the block was not there afterwards. A stale `prefix + s` binding
+  could survive any number of reinstalls that way, and `doctor` then blamed a
+  stray `bind-key` that did not exist.
+
+  `~/.tmux.conf` is the reported case (`tmux-popup` with `tmux-statusline`,
+  which `--preset standard` selects together), and `config.toml` has the same
+  shape: `ask`, `collaboration` and `dashboard` each own one table in it. Every
+  planner now folds onto what the plan already holds for that path — which
+  `plan_tmux_env` was alone in doing — and records that as its `before`, so the
+  backup `apply` takes is the file as it stood a moment earlier rather than as
+  it stood before the whole run.
+
 ## [0.8.39] - 2026-08-31
 
 ### Fixed

--- a/crates/muxa-cli/src/init/plan.rs
+++ b/crates/muxa-cli/src/init/plan.rs
@@ -118,8 +118,7 @@ pub fn build(
                 let Some(path) = files::dashboard::default_path() else {
                     continue;
                 };
-                let before = read_to_string_opt(&path)?;
-                let original = before.clone().unwrap_or_default();
+                let (before, original) = file_base(&actions, &path)?;
                 match direction {
                     Direction::Install => {
                         let (after, outcome, token) = files::dashboard::upsert(&original)
@@ -154,8 +153,7 @@ pub fn build(
                 let Some(path) = files::collaboration::default_path() else {
                     continue;
                 };
-                let before = read_to_string_opt(&path)?;
-                let original = before.clone().unwrap_or_default();
+                let (before, original) = file_base(&actions, &path)?;
                 let (after, outcome) = match direction {
                     Direction::Install => files::collaboration::upsert(&original)
                         .context("enabling collaboration in config.toml")?,
@@ -255,20 +253,9 @@ fn plan_tmux_env(
     actions: &mut Vec<Action>,
 ) -> Result<()> {
     let path = tmux_conf.to_path_buf();
-    // Re-read tmux.conf from disk fresh: an earlier `plan_tmux` action
-    // for popup/statusline only carries its post-edit content in the
-    // `Action`, not on disk. Pulling from disk would race with the
-    // earlier edit when apply.rs runs sequentially. Instead, fold our
-    // change on top of that pending content by replaying the earlier
-    // `EditFile` outputs targeting the same path.
-    let mut latest = read_to_string_opt(&path)?.unwrap_or_default();
-    for action in actions.iter() {
-        if let Action::EditFile { path: p, after, .. } = action {
-            if p == &path {
-                latest.clone_from(after);
-            }
-        }
-    }
+    // Folds onto whatever popup/statusline planned for this file, rather than
+    // onto disk — see `file_base`.
+    let (_, latest) = file_base(actions, &path)?;
     let (after, outcome) = match direction {
         Direction::Install if !needs_socket_pin(socket, &muxa::paths::default_socket()) => {
             files::tmux::remove_env(&latest)
@@ -313,6 +300,37 @@ fn needs_socket_pin(socket: &Path, default_socket: &Path) -> bool {
     socket != default_socket
 }
 
+/// The content a file will hold once every edit planned before this point
+/// has been applied, and the `before` to record against the next one.
+///
+/// Planning a component reads its file from disk. That is right for the first
+/// component to touch a path and wrong for every one after it: `apply` writes
+/// each `after` in turn, so a second edit computed from the *original* text
+/// silently overwrites the first one's block. Several components share a file
+/// — `tmux-popup` and `tmux-statusline` both own part of `~/.tmux.conf`, and
+/// `ask`, `collaboration` and `dashboard` each own a table in the same
+/// `config.toml` — so this is the ordinary case, not a corner.
+///
+/// Returning the pending text as `before` also keeps the chain honest: the
+/// backup `apply` takes is the file as it stood a moment earlier, and the
+/// dry-run diff for each component shows only that component's change.
+fn file_base(actions: &[Action], path: &Path) -> Result<(Option<String>, String)> {
+    let pending = actions.iter().rev().find_map(|action| match action {
+        Action::EditFile {
+            path: planned,
+            after,
+            ..
+        } if planned == path => Some(after.clone()),
+        _ => None,
+    });
+    if let Some(pending) = pending {
+        return Ok((Some(pending.clone()), pending));
+    }
+    let before = read_to_string_opt(&path.to_path_buf())?;
+    let original = before.clone().unwrap_or_default();
+    Ok((before, original))
+}
+
 fn plan_tmux(
     direction: Direction,
     c: Component,
@@ -322,8 +340,7 @@ fn plan_tmux(
     let Some(path) = tmux_path.cloned() else {
         return Ok(());
     };
-    let before = read_to_string_opt(&path)?;
-    let original = before.clone().unwrap_or_default();
+    let (before, original) = file_base(actions, &path)?;
     let (after, outcome) = match direction {
         Direction::Install => files::tmux::upsert(&original, c),
         Direction::Uninstall => files::tmux::remove(&original, c),
@@ -344,8 +361,7 @@ fn plan_ask(direction: Direction, component: Component, actions: &mut Vec<Action
     let Some(path) = files::ask::default_path() else {
         return Ok(());
     };
-    let before = read_to_string_opt(&path)?;
-    let original = before.clone().unwrap_or_default();
+    let (before, original) = file_base(actions, &path)?;
     let (after, outcome) = match direction {
         Direction::Install => {
             files::ask::upsert(&original).context("enabling ask in config.toml")?
@@ -580,6 +596,80 @@ mod tests {
         let plan = build(Direction::Install, &[], &d, &fake_socket()).unwrap();
         assert!(plan.actions.is_empty());
         assert!(!plan.has_changes());
+    }
+
+    /// The seam the silent overwrite went through. Several components share
+    /// one file — `tmux-popup` and `tmux-statusline` in `~/.tmux.conf`, `ask`
+    /// / `collaboration` / `dashboard` in one `config.toml` — and planning the
+    /// second from disk gives it text that has never seen the first one's
+    /// block. `apply` then writes them in turn and the first is gone, with
+    /// nothing on screen wrong: each component's own plan was accurate.
+    ///
+    /// Driven directly rather than through `build`, because the planners read
+    /// the operator's real `$HOME`: a machine whose `~/.tmux.conf` already
+    /// carries both blocks passes an end-to-end assertion no matter which way
+    /// the bug goes.
+    #[test]
+    fn a_planned_edit_folds_onto_the_one_already_planned_for_that_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("tmux.conf");
+        std::fs::write(&path, "on disk\n").expect("seed the file");
+
+        let actions = vec![Action::EditFile {
+            component: Component::TmuxPopup,
+            path: path.clone(),
+            before: Some("on disk\n".into()),
+            after: "on disk\nfirst component's block\n".into(),
+            outcome: Outcome::Inserted,
+        }];
+
+        let (before, original) = file_base(&actions, &path).expect("resolve the base");
+        assert_eq!(
+            original, "on disk\nfirst component's block\n",
+            "the next component must build on the pending edit, not the file",
+        );
+        assert_eq!(
+            before.as_deref(),
+            Some("on disk\nfirst component's block\n"),
+            "and record it as `before`, so the backup is the file as it will stand",
+        );
+    }
+
+    /// The first component to touch a file still reads it, including the
+    /// `None` that says it does not exist yet.
+    #[test]
+    fn the_first_planned_edit_reads_the_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("tmux.conf");
+
+        let (before, original) = file_base(&[], &path).expect("resolve the base");
+        assert_eq!(before, None, "a missing file has no `before` to back up");
+        assert!(original.is_empty());
+
+        std::fs::write(&path, "on disk\n").expect("seed the file");
+        let (before, original) = file_base(&[], &path).expect("resolve the base");
+        assert_eq!(before.as_deref(), Some("on disk\n"));
+        assert_eq!(original, "on disk\n");
+    }
+
+    /// An edit planned for a *different* file is not the base for this one.
+    #[test]
+    fn a_pending_edit_elsewhere_is_not_this_file_s_base() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mine = dir.path().join("config.toml");
+        let theirs = dir.path().join("tmux.conf");
+        std::fs::write(&mine, "[ask]\n").expect("seed the file");
+
+        let actions = vec![Action::EditFile {
+            component: Component::TmuxPopup,
+            path: theirs,
+            before: None,
+            after: "someone else's file\n".into(),
+            outcome: Outcome::Inserted,
+        }];
+
+        let (_, original) = file_base(&actions, &mine).expect("resolve the base");
+        assert_eq!(original, "[ask]\n");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #74.

## The bug is a class, not a case

Every planner read its file from disk (`plan.rs`, `plan_tmux` / `Dashboard` / `Collaboration` / `plan_ask`). Right for the first component to touch a path; wrong for every one after it. `apply` writes each `after` in turn, so a second edit computed from text that never saw the first one's block overwrites it.

The report covers `~/.tmux.conf`, where `--preset standard` selects `tmux-popup` and `tmux-statusline` together. **`config.toml` has the same shape and was not in the report:** `files::ask::default_path()`, `files::dashboard::default_path()` and `files::collaboration::default_path()` all resolve to `<config>/muxa/config.toml`, so selecting any two of those components lost one.

What makes it survive reinstalls is that nothing looks wrong. Each component's plan is accurate on its own terms — the dry-run says `~ edit ~/.tmux.conf (tmux-popup) [+9 lines]`, the user confirms, and the block is not there afterwards. `doctor` then reports the stale binding and blames a stray `bind-key` that does not exist.

## Fix

`plan_tmux_env` already folded onto the pending content, with a comment explaining exactly why. That is now `file_base`, and every planner uses it:

```rust
fn file_base(actions: &[Action], path: &Path) -> Result<(Option<String>, String)>
```

It also returns the pending text as `before`, so the backup `apply` writes is the file as it stood a moment earlier rather than as it stood before the whole run — otherwise the second component's backup would be a copy of the pre-run file and the first component's block would be missing from it too.

## About the test

The first version of this test went through `build` and asserted the final text contained both blocks. **It passed with the bug reinstated**, because these planners read the operator's real `$HOME` and this machine's `~/.tmux.conf` already carries both blocks. An end-to-end assertion there proves nothing either way.

The test now drives `file_base` directly against a tempdir: a pending edit is the base for the next one, a first edit still reads the file (including the `None` that says it does not exist), and an edit planned for a different path is not this file's base. Reinstating the bug fails it with `the next component must build on the pending edit, not the file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVQaf1oSAj6ZkgBg2uY2Gk
