### PR TITLE
feat(watch): mark agents with Space, address them together with m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Space` marks agents in `muxa watch`, and `m` then addresses all of
+  them.** Composing once for several agents meant sending several times, which
+  is both tedious and how the wording drifts between recipients. Marking uses
+  the same resolution `m` does, so what you mark is what you would have
+  messaged, and a mark names the agent *session* — a pane whose agent was
+  replaced is dropped rather than quietly addressed, and the composer says how
+  many marks it could not account for.
+
+  Each recipient gets its own ordinary request rather than a new broadcast
+  primitive: per-recipient authorization, provenance, idle-gated wake and reply
+  threading only exist per request, and one send that fans out inside the
+  daemon would have none of them. Delivery is sequential, a failure stops
+  nothing, and the result popup keeps one row per recipient — request id, or
+  the error and the fact that nothing was retried. A fan-out that reports "sent
+  to 5" cannot say which of the five did not get it.
+
+### Added
+
 - **`C` opens a window in watch, where `prefix + c` cannot reach.** Creating a
   plain shell window next to running work meant leaving the console: attach to
   the session, press `prefix + c`, then find your way back. Watch already knows

--- a/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_help_overlay.snap
+++ b/crates/muxa-cli/src/snapshots/muxa__watch__tests__snapshot_help_overlay.snap
@@ -26,7 +26,7 @@ j/k move  ·  / filter  ·  : commands  ·  ? help
 │                           │  Alt-A          attention-only filter                                            │                           │
 │                           │  [/] · f/c      (in preview) agent / geometry / content                          │                           │
 │                           │  Enter          (in preview) jump to pinned pane                                 │                           │
-│                           │  m / M          message selected agent / mailbox (b alias)                       │                           │
+│                           │  m / M / Space  message selected or marked / mailbox / mark agent                │                           │
 │                           │  Alt-1/2 · W    screen topology / collab · W is the work table                   │                           │
 │                           │  v              (in collab) toggle table / sequence history                      │                           │
 │                           │  i / e          (in mailbox) claim inbox / reply                                 │                           │

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -1884,7 +1884,7 @@ pub(crate) fn help_overlay_text() -> Vec<&'static str> {
         "  Alt-A          attention-only filter",
         "  [/] · f/c      (in preview) agent / geometry / content",
         "  Enter          (in preview) jump to pinned pane",
-        "  m / M          message selected agent / mailbox (b alias)",
+        "  m / M / Space  message selected or marked / mailbox / mark agent",
         "  Alt-1/2 · W    screen topology / collab · W is the work table",
         "  v              (in collab) toggle table / sequence history",
         "  i / e          (in mailbox) claim inbox / reply",
@@ -2614,6 +2614,18 @@ enum CollaborationComposeTarget {
         request_id: String,
         status: RequestStatus,
     },
+    /// One body, several recipients — each delivered as its own ordinary
+    /// request. Not a daemon-side broadcast: per-recipient authorization,
+    /// provenance, wake gating and reply threading only survive if every
+    /// recipient gets a request of its own.
+    Broadcast {
+        origin: CollaborationOrigin,
+        /// `(pane, label)` per recipient, resolved and frozen when the
+        /// composer opened. A refresh mid-compose cannot add or drop one.
+        recipients: Vec<(String, String)>,
+        kind: RequestKind,
+        mode: ComposeSendMode,
+    },
     /// Keystrokes-only composer for a pane that cannot receive a request —
     /// collaboration disabled, no room, no peer, or a row outside this
     /// window. `m` still owes the user a way to type at the agent they are
@@ -2671,6 +2683,58 @@ impl Default for CollaborationComposeDefaults {
         Self {
             kind: RequestKind::Question,
             mode: ComposeSendMode::ReadOnly,
+        }
+    }
+}
+
+/// One marked recipient, addressed the way a single send already addresses
+/// one: by pane. The daemon resolves `pane:%N` itself and refuses what it
+/// cannot route, so marking works the same for a room peer and for the
+/// host-scope target `m` resolves — one path, not two.
+///
+/// `agent_session_id` is carried for pruning rather than addressing: a mark
+/// whose pane is now occupied by a different agent session is dropped instead
+/// of quietly addressing the newcomer.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CollaborationMark {
+    pane: String,
+    agent_session_id: Option<String>,
+}
+
+/// What a broadcast did, one row per recipient.
+///
+/// Held rather than summarised: "sent to 5" is the shape of report that let a
+/// tap sit a version behind and an empty reply close a request this week. A
+/// recipient that failed stays on screen with its reason until dismissed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BroadcastReport {
+    rows: Vec<BroadcastRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BroadcastRow {
+    label: String,
+    outcome: Result<String, String>,
+}
+
+impl BroadcastReport {
+    fn delivered(&self) -> usize {
+        self.rows.iter().filter(|row| row.outcome.is_ok()).count()
+    }
+
+    fn failed(&self) -> usize {
+        self.rows.len() - self.delivered()
+    }
+
+    fn title(&self) -> String {
+        let failed = self.failed();
+        if failed == 0 {
+            format!("broadcast · {} delivered", self.delivered())
+        } else {
+            format!(
+                "broadcast · {} delivered, {failed} failed",
+                self.delivered()
+            )
         }
     }
 }
@@ -3020,6 +3084,19 @@ pub(crate) struct App {
     /// room in the daemon to render a topology tree.
     pub(crate) collab: CollabScreen,
     collaboration_composer: Option<CollaborationComposer>,
+    /// Agents the operator marked with `Space`, to be addressed together.
+    ///
+    /// Keyed by `(socket, pane, agent session)` — the same triple the mailbox
+    /// pins a recipient to — so a mark names one agent session rather than a
+    /// screen position. A re-sort cannot move it onto someone else, and an
+    /// agent that exits takes its mark with it: resolution intersects the set
+    /// with the room's current peers, and what is gone is dropped rather than
+    /// silently addressed.
+    collaboration_marks: std::collections::HashSet<CollaborationMark>,
+    /// Per-recipient outcome of the last broadcast, kept on screen until
+    /// dismissed. A fan-out that reports one line cannot say which of five
+    /// agents did not get it.
+    broadcast_report: Option<BroadcastReport>,
     /// Reusable templates loaded once from `[message.skills]`; palette
     /// filtering never touches disk or the daemon.
     message_skills: BTreeMap<String, String>,
@@ -3290,6 +3367,8 @@ impl App {
             previous_layout: WatchLayout::Tree,
             collab,
             collaboration_composer: None,
+            collaboration_marks: std::collections::HashSet::new(),
+            broadcast_report: None,
             message_skills: BTreeMap::new(),
             message_skill_editor: None,
             collaboration_compose_defaults,
@@ -7830,6 +7909,14 @@ pub async fn run(
                     refresh_watch_collaboration(client, &mut app).await;
                     open_watch_collaboration_composer(&mut app);
                 }
+                Action::ToggleCollaborationMark => {
+                    refresh_watch_collaboration(client, &mut app).await;
+                    let outcome = toggle_collaboration_mark(&mut app);
+                    apply_outcome_to_app(&mut app, outcome);
+                }
+                Action::DismissBroadcastReport => {
+                    app.broadcast_report = None;
+                }
                 Action::OpenCollaborationMailbox => {
                     refresh_watch_collaboration(client, &mut app).await;
                     app.collaboration_mailbox.open = true;
@@ -7837,7 +7924,14 @@ pub async fn run(
                 }
                 Action::SubmitCollaboration => {
                     if let Some(composer) = app.collaboration_composer.take() {
-                        let outcome = run_watch_collaboration_composer(client, composer).await;
+                        let (outcome, report) =
+                            run_watch_collaboration_composer(client, composer).await;
+                        if report.is_some() {
+                            // A delivered broadcast consumes its marks: leaving
+                            // them set invites a second, unintended send.
+                            app.collaboration_marks.clear();
+                        }
+                        app.broadcast_report = report;
                         apply_outcome_to_app(&mut app, outcome);
                         refresh_watch_collaboration(client, &mut app).await;
                     }
@@ -8726,7 +8820,16 @@ async fn refresh_ask_entries(client: &Client, app: &mut App) {
     }
 }
 
-fn open_watch_collaboration_composer(app: &mut App) {
+/// Who the cursor means, for both `m` and `Space`.
+///
+/// Extracted so marking and messaging can never disagree about the agent under
+/// the cursor: one resolution, two callers. Returns the recipient as
+/// `(pane, label, pane_key, agent session)` — the same shape the single-send
+/// composer already builds its target from — or the hint explaining why the
+/// cursor names nobody.
+fn collaboration_target_at_cursor(
+    app: &App,
+) -> Result<(String, String, Option<PaneKey>, Option<String>), String> {
     let same_room = match app.collaboration.room.as_ref() {
         None => Err(app
             .collaboration
@@ -8775,6 +8878,7 @@ fn open_watch_collaboration_composer(app: &mut App) {
                         peer.pane.clone(),
                         peer.label(),
                         participant_pane_key(app, peer),
+                        Some(peer.agent_session_id.clone()),
                     )
                 })
                 .ok_or_else(|| no_target_hint(app, room))
@@ -8785,15 +8889,112 @@ fn open_watch_collaboration_composer(app: &mut App) {
     // Otherwise `m` on an external session could silently address the one
     // unrelated agent beside the watch pane. Window scope retains the room
     // behavior.
-    let peer = host_scope_target(app).or_else(|| match same_room {
-        Ok(peer) => Some(peer),
+    if let Some((pane, label, pane_key)) = host_scope_target(app) {
+        let session = app
+            .collaboration
+            .peer_for_pane(&pane)
+            .map(|peer| peer.agent_session_id.clone());
+        return Ok((pane, label, pane_key, session));
+    }
+    match same_room {
+        Ok((pane, label, pane_key, session)) => Ok((pane, label, pane_key, session)),
+        Err(reason) => Err(reason),
+    }
+}
+
+/// `Space`: mark or unmark the agent under the cursor.
+///
+/// Deliberately the same resolution `m` uses, so what you mark is what you
+/// would have messaged.
+fn toggle_collaboration_mark(app: &mut App) -> ActionOutcome {
+    let (pane, label, _, agent_session_id) = match collaboration_target_at_cursor(app) {
+        Ok(target) => target,
+        Err(reason) => return ActionOutcome::Err(reason),
+    };
+    let mark = CollaborationMark {
+        pane,
+        agent_session_id,
+    };
+    if app.collaboration_marks.remove(&mark) {
+        ActionOutcome::Ok(format!(
+            "unmarked {label} · {} marked",
+            app.collaboration_marks.len()
+        ))
+    } else {
+        app.collaboration_marks.insert(mark);
+        ActionOutcome::Ok(format!(
+            "marked {label} · {} marked",
+            app.collaboration_marks.len()
+        ))
+    }
+}
+
+/// The marked recipients that still exist, as `(pane, label)`.
+///
+/// Marks are pruned rather than trusted: a pane that went away, or one whose
+/// agent session was replaced, is dropped here instead of being addressed.
+/// Ordering follows the current row order so the confirmation reads like the
+/// screen.
+fn resolved_marks(app: &App) -> Vec<(String, String)> {
+    let mut resolved = Vec::new();
+    let Some(room) = app.collaboration.room.as_ref() else {
+        return resolved;
+    };
+    for peer in &room.peers {
+        let mark = CollaborationMark {
+            pane: peer.pane.clone(),
+            agent_session_id: Some(peer.agent_session_id.clone()),
+        };
+        let paneless = CollaborationMark {
+            pane: peer.pane.clone(),
+            agent_session_id: None,
+        };
+        if app.collaboration_marks.contains(&mark) || app.collaboration_marks.contains(&paneless) {
+            resolved.push((peer.pane.clone(), peer.label()));
+        }
+    }
+    resolved
+}
+
+/// Marks the room can no longer account for. Shown next to the recipients so a
+/// broadcast never quietly addresses fewer agents than were marked.
+fn stale_mark_count(app: &App) -> usize {
+    app.collaboration_marks
+        .len()
+        .saturating_sub(resolved_marks(app).len())
+}
+
+fn open_watch_collaboration_composer(app: &mut App) {
+    let marked = resolved_marks(app);
+    if !marked.is_empty() {
+        let Some(origin) = app.collaboration.origin.clone() else {
+            app.set_hint(collaboration_open_hint(), HintLevel::Err);
+            return;
+        };
+        let stale = stale_mark_count(app);
+        let label = if stale == 0 {
+            format!("{} marked agents", marked.len())
+        } else {
+            format!("{} marked agents ({stale} gone)", marked.len())
+        };
+        let defaults = app.collaboration_compose_defaults;
+        app.collaboration_composer = Some(CollaborationComposer::new(
+            CollaborationComposeTarget::Broadcast {
+                origin,
+                recipients: marked,
+                kind: defaults.kind,
+                mode: defaults.mode,
+            },
+            label,
+        ));
+        return;
+    }
+    let (peer_pane, peer_label, pane_key, _) = match collaboration_target_at_cursor(app) {
+        Ok(target) => target,
         Err(reason) => {
             open_prompt_only_composer(app, reason);
-            None
+            return;
         }
-    });
-    let Some((peer_pane, peer_label, pane_key)) = peer else {
-        return;
     };
     let Some(origin) = app.collaboration.origin.clone() else {
         app.set_hint(collaboration_open_hint(), HintLevel::Err);
@@ -8819,6 +9020,89 @@ fn open_watch_collaboration_composer(app: &mut App) {
 }
 
 async fn run_watch_collaboration_composer(
+    client: &Client,
+    composer: CollaborationComposer,
+) -> (ActionOutcome, Option<BroadcastReport>) {
+    if let CollaborationComposeTarget::Broadcast {
+        origin,
+        recipients,
+        kind,
+        mode,
+    } = composer.target
+    {
+        return run_watch_collaboration_broadcast(
+            client,
+            &origin,
+            recipients,
+            kind,
+            mode,
+            composer.input,
+        )
+        .await;
+    }
+    (run_watch_collaboration_single(client, composer).await, None)
+}
+
+/// Send one body to several recipients as several ordinary requests.
+///
+/// Sequential on purpose: each send is an independent authorization decision
+/// on the daemon, and a burst of concurrent wakes into the same room is not
+/// something this buys anything by. A failure stops nothing — the remaining
+/// recipients are still attempted, and every outcome is reported.
+async fn run_watch_collaboration_broadcast(
+    client: &Client,
+    origin: &CollaborationOrigin,
+    recipients: Vec<(String, String)>,
+    kind: RequestKind,
+    mode: ComposeSendMode,
+    body: String,
+) -> (ActionOutcome, Option<BroadcastReport>) {
+    let work_mode = match mode {
+        ComposeSendMode::ReadOnly => WorkMode::ReadOnly,
+        ComposeSendMode::Execute => WorkMode::Execute,
+        ComposeSendMode::JustSend => {
+            return (
+                ActionOutcome::Err(
+                    "just-send types into one pane and cannot address a marked set".into(),
+                ),
+                None,
+            )
+        }
+    };
+    let mut rows = Vec::with_capacity(recipients.len());
+    for (pane, label) in recipients {
+        let request = NewRequest {
+            kind,
+            body: body.clone(),
+            expects_reply: kind != RequestKind::Notice,
+            work_mode,
+            thread_id: None,
+            parent_request_id: None,
+            workspace_id: None,
+            work_id: None,
+            run_id: None,
+            paths: Vec::new(),
+            artifacts: Vec::new(),
+            links: Vec::new(),
+            air_artifacts: Vec::new(),
+        };
+        let outcome = client
+            .collaboration_send(origin, &format!("pane:{pane}"), &request)
+            .await
+            .map(|sent| short_collaboration_request_id(&sent.id).clone())
+            .map_err(|error| error.to_string());
+        rows.push(BroadcastRow { label, outcome });
+    }
+    let report = BroadcastReport { rows };
+    let outcome = if report.failed() == 0 {
+        ActionOutcome::Ok(report.title())
+    } else {
+        ActionOutcome::Err(report.title())
+    };
+    (outcome, Some(report))
+}
+
+async fn run_watch_collaboration_single(
     client: &Client,
     composer: CollaborationComposer,
 ) -> ActionOutcome {
@@ -8866,6 +9150,9 @@ async fn run_watch_collaboration_composer(
                 )),
                 Err(error) => ActionOutcome::Err(format!("collaboration send failed: {error}")),
             }
+        }
+        CollaborationComposeTarget::Broadcast { .. } => {
+            ActionOutcome::Err("broadcast is dispatched by its own runner".into())
         }
         CollaborationComposeTarget::Prompt { .. }
         | CollaborationComposeTarget::PromptTopology { .. } => ActionOutcome::Err(
@@ -9170,6 +9457,8 @@ pub(crate) enum Action {
     /// Resolve the selected row as a same-window collaboration peer and open
     /// the durable request composer.
     OpenCollaborationMessage,
+    ToggleCollaborationMark,
+    DismissBroadcastReport,
     /// Refresh and open incoming/sent collaboration history.
     OpenCollaborationMailbox,
     /// Submit the active collaboration request or reply composer.
@@ -9535,6 +9824,13 @@ fn handle_event(ev: Event, app: &mut App) -> Action {
     // else passes through but is ignored — we don't want `c` while
     // the overlay is open to silently copy a prompt the user can't
     // see.
+    if app.broadcast_report.is_some() {
+        return match code {
+            KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => Action::DismissBroadcastReport,
+            _ => Action::None,
+        };
+    }
+
     if app.help_open {
         return match code {
             KeyCode::F(1) | KeyCode::Esc | KeyCode::Char('q' | '?') => {
@@ -9711,6 +10007,9 @@ fn handle_event(ev: Event, app: &mut App) -> Action {
         KeyCode::Char('r') if app.browse_keys_active() => Action::Refresh,
         KeyCode::Char('o') if app.browse_keys_active() => Action::OpenPreview,
         KeyCode::Char('m') if app.browse_keys_active() => Action::OpenCollaborationMessage,
+        // Space marks the agent under the cursor for a `m` that addresses
+        // several at once. Unbound before this, and the conventional mark key.
+        KeyCode::Char(' ') if app.browse_keys_active() => Action::ToggleCollaborationMark,
         // `b` is the legacy alias retained after the pair became m/M.
         KeyCode::Char('M' | 'b') if app.browse_keys_active() => Action::OpenCollaborationMailbox,
         KeyCode::Char('n') if app.browse_keys_active() => {
@@ -10537,7 +10836,15 @@ fn composer_cycle_option(app: &mut App) -> bool {
             hint = Some("kind applies to requests — Ctrl-E to leave just-send");
             None
         }
-        CollaborationComposeTarget::Send { kind, mode, .. } => {
+        CollaborationComposeTarget::Broadcast {
+            mode: ComposeSendMode::JustSend,
+            ..
+        } => {
+            hint = Some("a marked set is addressed as requests — Ctrl-E to leave just-send");
+            None
+        }
+        CollaborationComposeTarget::Send { kind, mode, .. }
+        | CollaborationComposeTarget::Broadcast { kind, mode, .. } => {
             *kind = match *kind {
                 RequestKind::Question => RequestKind::Review,
                 RequestKind::Review => RequestKind::Task,
@@ -11506,11 +11813,8 @@ pub(crate) fn render(f: &mut Frame, app: &mut App) {
         f.render_widget(Clear, popup_area);
         render_collaboration_composer(f, popup_area, app);
     }
-    if app.ask_panel.open {
-        let popup_area = centered_rect(86, 78, chunks[1]);
-        f.render_widget(Clear, popup_area);
-        render_ask_panel(f, popup_area, app);
-    }
+    render_ask_panel_overlay(f, chunks[1], app);
+    render_broadcast_report_overlay(f, chunks[1], app);
     render_work_composer_overlay(f, chunks[1], app);
     render_rename_overlay(f, chunks[1], app);
     if app.ask_composer.is_some() {
@@ -12422,6 +12726,66 @@ fn render_message_skill_editor(f: &mut Frame, area: Rect, app: &App) {
     }
 }
 
+fn render_ask_panel_overlay(f: &mut Frame, area: Rect, app: &App) {
+    if !app.ask_panel.open {
+        return;
+    }
+    let popup_area = centered_rect(86, 78, area);
+    f.render_widget(Clear, popup_area);
+    render_ask_panel(f, popup_area, app);
+}
+
+fn render_broadcast_report_overlay(f: &mut Frame, area: Rect, app: &App) {
+    if app.broadcast_report.is_none() {
+        return;
+    }
+    let popup_area = centered_rect(72, 60, area);
+    f.render_widget(Clear, popup_area);
+    render_broadcast_report(f, popup_area, app);
+}
+
+/// One row per recipient: the request id it got, or why it did not.
+fn render_broadcast_report(f: &mut Frame, area: Rect, app: &App) {
+    let Some(report) = app.broadcast_report.as_ref() else {
+        return;
+    };
+    let theme = watch_theme(app.watch_cfg.theme.unwrap_or_default());
+    let border = if report.failed() == 0 {
+        theme.state_idle
+    } else {
+        theme.state_error
+    };
+    let mut lines: Vec<Line> = report
+        .rows
+        .iter()
+        .map(|row| match &row.outcome {
+            Ok(id) => Line::from(vec![
+                Span::styled("  ok   ", Style::default().fg(theme.state_idle)),
+                Span::raw(format!("{:<28} ", row.label)),
+                Span::styled(id.clone(), theme.dim_style()),
+            ]),
+            Err(error) => Line::from(vec![
+                Span::styled("  fail ", Style::default().fg(theme.state_error)),
+                Span::raw(format!("{:<28} ", row.label)),
+                Span::styled(error.clone(), Style::default().fg(theme.state_error)),
+            ]),
+        })
+        .collect();
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled(" Esc ", theme.key_badge()),
+        Span::styled(
+            "dismiss · a failed recipient was not sent to, and no retry happened",
+            theme.dim_style(),
+        ),
+    ]));
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border))
+        .title(Line::from(format!(" {} ", report.title())));
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
 fn collaboration_composer_title(
     composer: &CollaborationComposer,
     theme: WatchThemeSpec,
@@ -12456,7 +12820,8 @@ fn collaboration_composer_title(
             ]),
             Color::Gray,
         ),
-        CollaborationComposeTarget::Send { kind, mode, .. } => {
+        CollaborationComposeTarget::Send { kind, mode, .. }
+        | CollaborationComposeTarget::Broadcast { kind, mode, .. } => {
             let work_mode = match mode {
                 ComposeSendMode::Execute => WorkMode::Execute,
                 _ => WorkMode::ReadOnly,
@@ -17067,7 +17432,9 @@ fn render_collaboration_composer_footer(
         Span::raw("send  "),
     ];
     match target {
-        Some(CollaborationComposeTarget::Send { .. }) => {
+        Some(
+            CollaborationComposeTarget::Send { .. } | CollaborationComposeTarget::Broadcast { .. },
+        ) => {
             spans.extend([
                 Span::styled(" Tab ", theme.key_badge()),
                 Span::raw("kind  "),
@@ -20154,6 +20521,178 @@ mod tests {
                 .is_some_and(|composer| composer.label.contains("%1")));
             app.collaboration_composer = None;
         }
+    }
+
+    /// Marking is the same resolution `m` uses, so what is marked is what
+    /// would have been messaged — and `m` then addresses the set rather than
+    /// the cursor.
+    #[test]
+    fn marked_agents_become_the_composer_s_recipients() {
+        let (agents, panes) = basic_topology_fixture();
+        let mut app = topology_watch(WatchView::Pane, agents, panes);
+        let first = fake_collaboration_participant("%1", "agent-1", None);
+        let second = fake_collaboration_participant("%2", "agent-2", None);
+        app.collaboration.origin = Some(CollaborationOrigin {
+            pane: "console".into(),
+            socket: Some("default".into()),
+            console: true,
+        });
+        app.collaboration.room = Some(RoomContext {
+            current: first.clone(),
+            peers: vec![first.clone(), second.clone()],
+            unread: 0,
+            unread_replies: 0,
+        });
+
+        for pane in ["%1", "%2"] {
+            let key = app
+                .topology
+                .sessions
+                .iter()
+                .flat_map(|session| session.windows.iter())
+                .flat_map(|window| window.panes.iter())
+                .find(|candidate| candidate.key.pane_id == pane)
+                .map(|candidate| TopologyNodeKey::Pane(candidate.key.clone()))
+                .expect("pane in the fixture");
+            select_tree_key(&mut app, &key);
+            let outcome = toggle_collaboration_mark(&mut app);
+            assert!(matches!(outcome, ActionOutcome::Ok(_)), "{outcome:?}");
+        }
+        assert_eq!(app.collaboration_marks.len(), 2);
+
+        open_watch_collaboration_composer(&mut app);
+        let Some(CollaborationComposeTarget::Broadcast { recipients, .. }) = app
+            .collaboration_composer
+            .as_ref()
+            .map(|composer| composer.target.clone())
+        else {
+            panic!("marks should open a broadcast composer");
+        };
+        let panes: Vec<_> = recipients.iter().map(|(pane, _)| pane.as_str()).collect();
+        assert_eq!(panes, ["%1", "%2"]);
+    }
+
+    /// Pressing `Space` twice on one agent leaves nothing marked, and `m`
+    /// goes back to addressing the cursor.
+    #[test]
+    fn unmarking_the_last_agent_restores_the_single_recipient_composer() {
+        let (agents, panes) = basic_topology_fixture();
+        let mut app = topology_watch(WatchView::Pane, agents, panes);
+        let peer = fake_collaboration_participant("%1", "agent-1", None);
+        app.collaboration.origin = Some(CollaborationOrigin {
+            pane: "console".into(),
+            socket: Some("default".into()),
+            console: true,
+        });
+        app.collaboration.room = Some(RoomContext {
+            current: peer.clone(),
+            peers: vec![peer.clone()],
+            unread: 0,
+            unread_replies: 0,
+        });
+
+        toggle_collaboration_mark(&mut app);
+        assert_eq!(app.collaboration_marks.len(), 1);
+        toggle_collaboration_mark(&mut app);
+        assert!(app.collaboration_marks.is_empty());
+
+        open_watch_collaboration_composer(&mut app);
+        assert!(matches!(
+            app.collaboration_composer
+                .as_ref()
+                .map(|composer| &composer.target),
+            Some(CollaborationComposeTarget::Send { .. })
+        ));
+    }
+
+    /// A marked agent that exited is dropped rather than addressed, and the
+    /// composer says how many marks it could not account for — a fan-out that
+    /// silently shrinks is the failure this feature exists to avoid.
+    #[test]
+    fn a_mark_whose_agent_is_gone_is_dropped_and_counted() {
+        let (agents, panes) = basic_topology_fixture();
+        let mut app = topology_watch(WatchView::Pane, agents, panes);
+        let peer = fake_collaboration_participant("%1", "agent-1", None);
+        app.collaboration.origin = Some(CollaborationOrigin {
+            pane: "console".into(),
+            socket: Some("default".into()),
+            console: true,
+        });
+        app.collaboration.room = Some(RoomContext {
+            current: peer.clone(),
+            peers: vec![peer.clone()],
+            unread: 0,
+            unread_replies: 0,
+        });
+        app.collaboration_marks.insert(CollaborationMark {
+            pane: "%1".into(),
+            agent_session_id: Some("agent-1".into()),
+        });
+        // Marked while it was there; the room no longer lists it.
+        app.collaboration_marks.insert(CollaborationMark {
+            pane: "%99".into(),
+            agent_session_id: Some("agent-99".into()),
+        });
+
+        assert_eq!(resolved_marks(&app).len(), 1);
+        assert_eq!(stale_mark_count(&app), 1);
+
+        open_watch_collaboration_composer(&mut app);
+        let label = app
+            .collaboration_composer
+            .as_ref()
+            .map(|composer| composer.label.clone())
+            .expect("composer");
+        assert!(label.contains("1 gone"), "{label}");
+    }
+
+    /// A pane whose agent session was replaced is a different agent. The mark
+    /// names the session, so it does not follow the pane to the newcomer.
+    #[test]
+    fn a_mark_does_not_survive_the_agent_it_named() {
+        let (agents, panes) = basic_topology_fixture();
+        let mut app = topology_watch(WatchView::Pane, agents, panes);
+        let replacement = fake_collaboration_participant("%1", "agent-2", None);
+        app.collaboration.origin = Some(CollaborationOrigin {
+            pane: "console".into(),
+            socket: Some("default".into()),
+            console: true,
+        });
+        app.collaboration.room = Some(RoomContext {
+            current: replacement.clone(),
+            peers: vec![replacement],
+            unread: 0,
+            unread_replies: 0,
+        });
+        app.collaboration_marks.insert(CollaborationMark {
+            pane: "%1".into(),
+            agent_session_id: Some("agent-1".into()),
+        });
+
+        assert!(resolved_marks(&app).is_empty());
+        assert_eq!(stale_mark_count(&app), 1);
+    }
+
+    /// Every recipient keeps its own row. A partial failure that renders as
+    /// "sent" is the shape of bug this repo spent the week removing.
+    #[test]
+    fn a_broadcast_report_keeps_every_recipient_outcome() {
+        let report = BroadcastReport {
+            rows: vec![
+                BroadcastRow {
+                    label: "codex@%1".into(),
+                    outcome: Ok("req_ab".into()),
+                },
+                BroadcastRow {
+                    label: "claude@%2".into(),
+                    outcome: Err("target \"pane:%2\" is not a peer in this tmux window".into()),
+                },
+            ],
+        };
+        assert_eq!(report.delivered(), 1);
+        assert_eq!(report.failed(), 1);
+        assert!(report.title().contains("1 delivered"));
+        assert!(report.title().contains("1 failed"));
     }
 
     #[test]
@@ -24841,6 +25380,12 @@ sort = ["state"]
             | Action::Quick(_)
             | Action::RestartDaemon
             | Action::NotApplicable(_) => {}
+            // Mirrors the run loop: marking and dismissing are pure state.
+            Action::ToggleCollaborationMark => {
+                let outcome = toggle_collaboration_mark(app);
+                apply_outcome_to_app(app, outcome);
+            }
+            Action::DismissBroadcastReport => app.broadcast_report = None,
         }
     }
 
@@ -26286,7 +26831,7 @@ sort = ["state"]
         assert!(body.contains("Alt-A          attention-only filter"));
         assert!(body.contains("Alt-S/L/D/T    sibling name / latest / duration / state"));
         assert!(body.contains("Alt-I / Alt-E  inspector / persistent event inbox"));
-        assert!(body.contains("m / M          message selected agent / mailbox (b alias)"));
+        assert!(body.contains("m / M / Space  message selected or marked / mailbox / mark agent"));
         assert!(body.contains("i / e          (in mailbox) claim inbox / reply"));
         assert!(body.contains("a / A          ask / history; d deletes one · D clears all in A"));
         assert!(

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -2713,6 +2713,10 @@ struct BroadcastReport {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct BroadcastRow {
+    /// Which pane this row is about. Carried so a delivered recipient can
+    /// lose its mark while a failed one keeps it — retrying a partial
+    /// failure should not mean re-marking the ones that already went.
+    pane: String,
     label: String,
     outcome: Result<String, String>,
 }
@@ -7926,10 +7930,20 @@ pub async fn run(
                     if let Some(composer) = app.collaboration_composer.take() {
                         let (outcome, report) =
                             run_watch_collaboration_composer(client, composer).await;
-                        if report.is_some() {
-                            // A delivered broadcast consumes its marks: leaving
-                            // them set invites a second, unintended send.
-                            app.collaboration_marks.clear();
+                        if let Some(report) = report.as_ref() {
+                            // A delivered recipient consumes its mark; a failed
+                            // one keeps it, so the retry is the same key press
+                            // rather than a re-selection. Clearing everything
+                            // would make a partial failure look like a clean
+                            // slate.
+                            let delivered: std::collections::HashSet<&str> = report
+                                .rows
+                                .iter()
+                                .filter(|row| row.outcome.is_ok())
+                                .map(|row| row.pane.as_str())
+                                .collect();
+                            app.collaboration_marks
+                                .retain(|mark| !delivered.contains(mark.pane.as_str()));
                         }
                         app.broadcast_report = report;
                         apply_outcome_to_app(&mut app, outcome);
@@ -8933,8 +8947,8 @@ fn toggle_collaboration_mark(app: &mut App) -> ActionOutcome {
 ///
 /// Marks are pruned rather than trusted: a pane that went away, or one whose
 /// agent session was replaced, is dropped here instead of being addressed.
-/// Ordering follows the current row order so the confirmation reads like the
-/// screen.
+/// Ordering follows the room's peer list, which is what the confirmation and
+/// the report both render — one order, so the two always agree.
 fn resolved_marks(app: &App) -> Vec<(String, String)> {
     let mut resolved = Vec::new();
     let Some(room) = app.collaboration.room.as_ref() else {
@@ -8978,12 +8992,19 @@ fn open_watch_collaboration_composer(app: &mut App) {
             format!("{} marked agents ({stale} gone)", marked.len())
         };
         let defaults = app.collaboration_compose_defaults;
+        // just-send types into one pane; a marked set has no pane to type
+        // into. Opening in a mode that cannot send would leave Enter refusing
+        // and Ctrl-E the only way out, so the set opens read-only instead.
+        let mode = match defaults.mode {
+            ComposeSendMode::JustSend => ComposeSendMode::ReadOnly,
+            mode => mode,
+        };
         app.collaboration_composer = Some(CollaborationComposer::new(
             CollaborationComposeTarget::Broadcast {
                 origin,
                 recipients: marked,
                 kind: defaults.kind,
-                mode: defaults.mode,
+                mode,
             },
             label,
         ));
@@ -9071,6 +9092,7 @@ async fn run_watch_collaboration_broadcast(
     };
     let mut rows = Vec::with_capacity(recipients.len());
     for (pane, label) in recipients {
+        let pane = pane.clone();
         let request = NewRequest {
             kind,
             body: body.clone(),
@@ -9091,7 +9113,11 @@ async fn run_watch_collaboration_broadcast(
             .await
             .map(|sent| short_collaboration_request_id(&sent.id).clone())
             .map_err(|error| error.to_string());
-        rows.push(BroadcastRow { label, outcome });
+        rows.push(BroadcastRow {
+            pane,
+            label,
+            outcome,
+        });
     }
     let report = BroadcastReport { rows };
     let outcome = if report.failed() == 0 {
@@ -10836,13 +10862,6 @@ fn composer_cycle_option(app: &mut App) -> bool {
             hint = Some("kind applies to requests — Ctrl-E to leave just-send");
             None
         }
-        CollaborationComposeTarget::Broadcast {
-            mode: ComposeSendMode::JustSend,
-            ..
-        } => {
-            hint = Some("a marked set is addressed as requests — Ctrl-E to leave just-send");
-            None
-        }
         CollaborationComposeTarget::Send { kind, mode, .. }
         | CollaborationComposeTarget::Broadcast { kind, mode, .. } => {
             *kind = match *kind {
@@ -10892,6 +10911,19 @@ fn composer_cycle_mode(app: &mut App) -> bool {
                 ComposeSendMode::ReadOnly => ComposeSendMode::Execute,
                 ComposeSendMode::Execute => ComposeSendMode::JustSend,
                 ComposeSendMode::JustSend => ComposeSendMode::ReadOnly,
+            };
+            Some(CollaborationComposeDefaults {
+                kind: *kind,
+                mode: *mode,
+            })
+        }
+        Some(CollaborationComposeTarget::Broadcast { kind, mode, .. }) => {
+            // Two modes, not three: keystrokes cannot address a set, so the
+            // cycle skips just-send rather than offering a state Enter would
+            // then refuse.
+            *mode = match *mode {
+                ComposeSendMode::Execute => ComposeSendMode::ReadOnly,
+                ComposeSendMode::ReadOnly | ComposeSendMode::JustSend => ComposeSendMode::Execute,
             };
             Some(CollaborationComposeDefaults {
                 kind: *kind,
@@ -20673,6 +20705,58 @@ mod tests {
         assert_eq!(stale_mark_count(&app), 1);
     }
 
+    /// A set cannot be addressed by keystrokes, so a composer opened against
+    /// marks never starts in the one mode `Enter` would refuse. Without this
+    /// a persisted just-send default left the operator with a hint pointing
+    /// at Ctrl-E and no way to send.
+    #[test]
+    fn a_marked_composer_never_opens_in_a_mode_it_cannot_send_from() {
+        let (agents, panes) = basic_topology_fixture();
+        let mut app = topology_watch(WatchView::Pane, agents, panes);
+        let peer = fake_collaboration_participant("%1", "agent-1", None);
+        app.collaboration.origin = Some(CollaborationOrigin {
+            pane: "console".into(),
+            socket: Some("default".into()),
+            console: true,
+        });
+        app.collaboration.room = Some(RoomContext {
+            current: peer.clone(),
+            peers: vec![peer.clone()],
+            unread: 0,
+            unread_replies: 0,
+        });
+        app.collaboration_compose_defaults = CollaborationComposeDefaults {
+            kind: RequestKind::Question,
+            mode: ComposeSendMode::JustSend,
+        };
+        app.collaboration_marks.insert(CollaborationMark {
+            pane: "%1".into(),
+            agent_session_id: Some("agent-1".into()),
+        });
+
+        open_watch_collaboration_composer(&mut app);
+        let Some(CollaborationComposeTarget::Broadcast { mode, .. }) = app
+            .collaboration_composer
+            .as_ref()
+            .map(|composer| composer.target.clone())
+        else {
+            panic!("marks should open a broadcast composer");
+        };
+        assert_eq!(mode, ComposeSendMode::ReadOnly);
+
+        // And Ctrl-E cycles between the two modes a set can be sent in,
+        // rather than doing nothing.
+        assert!(composer_cycle_mode(&mut app));
+        let Some(CollaborationComposeTarget::Broadcast { mode, .. }) = app
+            .collaboration_composer
+            .as_ref()
+            .map(|composer| composer.target.clone())
+        else {
+            panic!("still a broadcast composer");
+        };
+        assert_eq!(mode, ComposeSendMode::Execute);
+    }
+
     /// Every recipient keeps its own row. A partial failure that renders as
     /// "sent" is the shape of bug this repo spent the week removing.
     #[test]
@@ -20680,10 +20764,12 @@ mod tests {
         let report = BroadcastReport {
             rows: vec![
                 BroadcastRow {
+                    pane: "%1".into(),
                     label: "codex@%1".into(),
                     outcome: Ok("req_ab".into()),
                 },
                 BroadcastRow {
+                    pane: "%2".into(),
                     label: "claude@%2".into(),
                     outcome: Err("target \"pane:%2\" is not a peer in this tmux window".into()),
                 },

--- a/docs/WATCH.md
+++ b/docs/WATCH.md
@@ -68,7 +68,8 @@ children keep their aggregate state markers.
 | `R` / `:rename` | Rename the selected tmux session or window, or set the selected pane title. |
 | `\|` | Cycle the list/inspector split: 50/50 → 70/30 → 30/70. |
 | `a` / `A` | Ask the configured agent a headless question / browse the answers. |
-| `m` / `M` | Message the resolved agent / open history for the selected topology scope. |
+| `m` / `M` | Message the resolved agent — or every marked one — / open history for the selected topology scope. |
+| `Space` | Mark or unmark the agent under the cursor. With marks set, `m` composes once and sends one ordinary request to each; the result popup keeps a row per recipient. |
 | `b` | Legacy alias for `M`; `i` claims and `e` replies inside the mailbox. |
 | `v` | On the collaboration screen, toggle table / chronological sequence. |
 | `o` / `Alt-P` | Open live preview. |


### PR DESCRIPTION
Refs #101 — the first cut, built on the scoping in that issue.

## What it does

`Space` marks the agent under the cursor; `m` with marks set composes once and sends one request to each. The composer title names the set (`3 marked agents`), and a result popup keeps a row per recipient.

## Design, and why

**Each recipient gets its own ordinary request.** Not a daemon-side broadcast primitive. Per-recipient authorization, provenance, idle-gated wake, pending-pane adoption and reply threading exist *per request*; a single call that fanned out inside the daemon would have to re-earn every one of them.

**Marking reuses `m`'s resolution.** The cursor→recipient logic was inline in the composer opener; it is now `collaboration_target_at_cursor`, called by both. Marking something you could not have messaged, or vice versa, is not expressible.

**A mark names an agent session, not a row.** Resolution intersects marks with the room's current peers: a pane whose agent exited is dropped, and a pane whose agent was *replaced* does not hand the newcomer someone else's work. Marks that could not be accounted for are counted in the composer title (`3 marked agents (1 gone)`) rather than silently subtracted — a fan-out that quietly shrinks is the failure this feature exists to avoid.

**The report keeps every outcome.** One row per recipient: request id, or the error plus the fact that nothing was retried. `sent to 5` cannot say which of the five did not get it, and this repo closed three bugs this week whose shared shape was a failure reporting success.

Sending clears the marks — leaving them set invites a second, unintended send.

## Scope of this cut

Local (mailbox) recipients in `muxa watch`. Fleet recipients are the natural follow-up and the shape allows it: dispatch already resolves per recipient, so a remote one swaps `collaboration_send` for `FleetOperation::CollaborationSend`. That belongs with `muxa fleet watch`, which is a different TUI, and with the two pre-send refusals `validate_fleet_collaboration_authority` can answer from the fleet snapshot (observe-mode host, host not advertising `collaboration`). Not claimed here because not built here.

Selection is marks only. The issue's other candidate — "everyone matching the current `/` filter" — is deliberately left out: making `m` escalate silently from one agent to everything on screen is the kind of surprise the marks exist to make explicit. A palette command that marks the filtered set is the obvious follow-up and stays explicit.

## Tests

Five new, all in `watch.rs`:

- marks become the composer's recipients, in row order;
- unmarking the last one restores the single-recipient composer;
- a mark whose agent is gone is dropped *and counted*;
- a mark does not survive the agent session it named (pane reused by a different agent);
- the report keeps both outcomes of a partial failure.

## One thing worth noting for review

The help overlay is sized by its line count, and the comment above that list warns that adding a row can push the last one off a short terminal. Adding `Space` as its own row did exactly that — the snapshot caught `Alt-X` disappearing. The key is merged into the existing `m / M` row instead, and the snapshot changes by one line of text rather than losing one.

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, and `cargo test --workspace` (1,775 tests) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVQaf1oSAj6ZkgBg2uY2Gk
