### PR TITLE
fix(collab): a pane seen through a session-group view is one pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two terminals on one workspace no longer hide every agent from
+  collaboration.** tmux lists a pane once per session that shows it, and a
+  session *group* shows one window through several sessions — which is exactly
+  what muxa's own `tmux-auto-view` builds, giving each attached client a
+  `<session>~view~<pid>` member of the group. Every pane in such a session was
+  therefore listed twice, and the participant resolver treated the second row
+  as an ambiguity and skipped the pane. With a second terminal attached there
+  were no participants, no origin and no peers: `muxa msg send`, `m` in
+  `muxa watch` and `muxa_call_peer` all refused with *"collaboration origin is
+  not a hook-correlated tracked pane agent"*, advising a restart of an agent
+  that was working fine — and the whole thing healed itself the moment the
+  second terminal detached, which is the worst way for a bug to behave.
+
+  Rows that agree on server, window and pane are now recognised as one pane
+  seen twice, with the durable session naming it rather than a per-client view.
+  The ambiguity that matters — one pane id on two servers — still refuses. The
+  origin resolver, the participant table and the pending-pane resolver all
+  shared the shape and are all fixed.
+
 ### Added
 
 - **`Space` marks agents in `muxa watch`, and `m` then addresses all of

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -2596,10 +2596,9 @@ pub fn participants_from(agents: &[Agent], panes: &[PaneInfo]) -> Vec<Participan
                     }
             })
             .collect();
-        if candidates.len() != 1 {
+        let Some(pane) = same_pane_seen_twice(&candidates) else {
             continue;
-        }
-        let pane = candidates[0];
+        };
         let socket = pane.socket.clone().or(agent_socket);
         let participant = Participant {
             agent_kind: agent.kind,
@@ -2673,25 +2672,28 @@ fn console_participant(
     origin: &CollaborationOrigin,
     panes: &[PaneInfo],
 ) -> Result<Participant, CollaborationError> {
-    let mut matches = panes.iter().filter(|pane| {
-        pane.pane_id == origin.pane
-            && match origin.socket.as_deref() {
-                Some(socket) => pane.socket.as_deref().is_some_and(|candidate| {
-                    crate::backend::pane_endpoints_match(Some(&origin.pane), candidate, socket)
-                }),
-                None => true,
-            }
-    });
-    let Some(pane) = matches.next() else {
+    let matches: Vec<_> = panes
+        .iter()
+        .filter(|pane| {
+            pane.pane_id == origin.pane
+                && match origin.socket.as_deref() {
+                    Some(socket) => pane.socket.as_deref().is_some_and(|candidate| {
+                        crate::backend::pane_endpoints_match(Some(&origin.pane), candidate, socket)
+                    }),
+                    None => true,
+                }
+        })
+        .collect();
+    if matches.is_empty() {
         return Ok(Participant::console(RoomId {
             host: CONSOLE_PANE.to_string(),
             socket: None,
             window_id: CONSOLE_PANE.to_string(),
         }));
-    };
-    if matches.next().is_some() {
-        return Err(CollaborationError::AmbiguousOrigin(origin.pane.clone()));
     }
+    let Some(pane) = same_pane_seen_twice(&matches) else {
+        return Err(CollaborationError::AmbiguousOrigin(origin.pane.clone()));
+    };
     let socket = pane.socket.clone().or_else(|| origin.socket.clone());
     let mut console = Participant::console(pane_room(&origin.pane, pane, socket));
     console.tmux_session_id = (!pane.session_id.is_empty()).then(|| pane.session_id.clone());
@@ -2915,6 +2917,41 @@ pub fn pending_recipient_ready(
     (ready.same_endpoint(to) && ready.room == to.room).then_some(ready)
 }
 
+/// The single pane a candidate list describes, or `None` when the candidates
+/// are genuinely different panes.
+///
+/// tmux lists a pane once per session that shows it, and a session *group*
+/// shows one window through several sessions. muxa's own `tmux-auto-view`
+/// creates exactly that: every attached client gets a `<session>~view~<pid>`
+/// member of the group, so an ordinary two-terminal setup lists every pane
+/// twice. Those rows differ only in the session they were seen through — same
+/// server, same window, same pane — and treating the second one as ambiguity
+/// made every pane in such a session invisible to collaboration: no
+/// participants, no origin, no peers, and an error telling the operator to
+/// restart an agent that was working fine.
+///
+/// The ambiguity that matters is a pane id repeated across *servers*, which
+/// differs by socket. That still refuses.
+///
+/// The base session wins over a view for display: it is the durable name, and
+/// the one the operator recognises.
+fn same_pane_seen_twice<'a>(candidates: &[&'a PaneInfo]) -> Option<&'a PaneInfo> {
+    let first = *candidates.first()?;
+    if !candidates
+        .iter()
+        .all(|pane| pane.socket == first.socket && pane.window_id == first.window_id)
+    {
+        return None;
+    }
+    Some(
+        candidates
+            .iter()
+            .copied()
+            .find(|pane| !pane.session.contains("~view~"))
+            .unwrap_or(first),
+    )
+}
+
 /// The one pane with this id, disambiguated by control endpoint the same way
 /// [`participants_from`] does — pane ids repeat across tmux servers.
 fn unique_pane<'a>(
@@ -2926,20 +2963,20 @@ fn unique_pane<'a>(
         .iter()
         .filter(|pane| pane.pane_id == pane_id)
         .collect();
-    match candidates.as_slice() {
-        [pane] => Some(pane),
-        [] => None,
-        _ => {
-            let socket = socket?;
-            let mut matching = candidates.into_iter().filter(|pane| {
-                pane.socket.as_deref().is_some_and(|candidate| {
-                    crate::backend::pane_endpoints_match(Some(pane_id), candidate, socket)
-                })
-            });
-            let first = matching.next()?;
-            matching.next().is_none().then_some(first)
-        }
+    if let Some(pane) = same_pane_seen_twice(&candidates) {
+        return Some(pane);
     }
+    // Several real panes share the id, so the control endpoint decides.
+    let socket = socket?;
+    let matching: Vec<_> = candidates
+        .into_iter()
+        .filter(|pane| {
+            pane.socket.as_deref().is_some_and(|candidate| {
+                crate::backend::pane_endpoints_match(Some(pane_id), candidate, socket)
+            })
+        })
+        .collect();
+    same_pane_seen_twice(&matching)
 }
 
 /// The live agent row occupying a pane, real or synthetic. Discovery and
@@ -3653,6 +3690,112 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(replied.to.agent_session_id, "codex-session");
+    }
+
+    /// A pane shown through a session group is listed once per session, and
+    /// muxa's own `tmux-auto-view` puts every attached client in one. Two
+    /// terminals on a workspace therefore list every pane twice — which used
+    /// to make all of them invisible to collaboration, with an error telling
+    /// the operator to restart an agent that was working fine.
+    #[tokio::test]
+    async fn a_pane_seen_through_a_view_session_is_one_participant() {
+        let store = crate::Store::shared();
+        store
+            .apply(&crate::event::AgentEvent::Started {
+                id: crate::event::AgentId {
+                    kind: AgentKind::ClaudeCode,
+                    session_id: "real-session".into(),
+                    surface: None,
+                    pane: Some("%1".into()),
+                    tmux_socket: Some("default".into()),
+                    cwd: Some("/repo".into()),
+                },
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+        let agents = store.snapshot().await;
+
+        let mut base = pane_info("%1");
+        base.session = "muxa".into();
+        base.session_group = Some("muxa".into());
+        let mut view = pane_info("%1");
+        view.session = "muxa~view~348778".into();
+        view.session_group = Some("muxa".into());
+        view.session_id = "$99".into();
+
+        let participants = participants_from(&agents, &[base, view]);
+        assert_eq!(participants.len(), 1, "one pane, one participant");
+        assert_eq!(
+            participants[0].tmux_session_name.as_deref(),
+            Some("muxa"),
+            "the durable session names it, not the per-client view",
+        );
+    }
+
+    /// `muxa watch` resolves its origin as a console against the pane list, so
+    /// the same duplication took the operator's own surface out too.
+    #[tokio::test]
+    async fn a_console_origin_resolves_through_a_view_session() {
+        let mut base = pane_info("%1");
+        base.session = "muxa".into();
+        base.session_group = Some("muxa".into());
+        let mut view = pane_info("%1");
+        view.session = "muxa~view~348778".into();
+        view.session_group = Some("muxa".into());
+
+        let origin = CollaborationOrigin {
+            pane: "%1".into(),
+            socket: Some("default".into()),
+            console: true,
+        };
+        let resolved = resolve_origin(&origin, &[], &[base, view]).expect("console resolves");
+        assert!(resolved.console);
+        assert_eq!(resolved.room.window_id, "@1");
+    }
+
+    /// The ambiguity that matters is a pane id repeated across *servers*. It
+    /// still refuses — this fix narrows the check, it does not remove it.
+    #[tokio::test]
+    async fn the_same_pane_id_on_two_servers_is_still_ambiguous() {
+        let mut here = pane_info("%1");
+        here.socket = Some("default".into());
+        let mut elsewhere = pane_info("%1");
+        elsewhere.socket = Some("other".into());
+        elsewhere.window_id = "@7".into();
+
+        let origin = CollaborationOrigin {
+            pane: "%1".into(),
+            socket: None,
+            console: true,
+        };
+        assert!(matches!(
+            resolve_origin(&origin, &[], &[here, elsewhere]),
+            Err(CollaborationError::AmbiguousOrigin(_))
+        ));
+    }
+
+    /// The pending-pane resolver reads the same pane list and had the same
+    /// shape, so a marked or spawned pane vanished under a view too.
+    #[tokio::test]
+    async fn a_pending_pane_resolves_through_a_view_session() {
+        let sender = participant("%2", "sender");
+        let mut base = pane_info("%1");
+        base.session = "muxa".into();
+        base.agent_role = Some("peer".into());
+        let mut view = pane_info("%1");
+        view.session = "muxa~view~348778".into();
+        view.agent_role = Some("peer".into());
+
+        let pending = resolve_pending_pane_target(
+            &sender,
+            "pane:%1",
+            &[],
+            &[],
+            &[base, view, pane_info("%2")],
+            CollaborationScope::Window,
+        )
+        .expect("a launched pane stays addressable through a view");
+        assert_eq!(pending.pane, "%1");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Attaching a second terminal deletes every agent from collaboration

tmux lists a pane once per session that shows it. A session *group* shows one window through several sessions — and muxa's own `tmux-auto-view` (on by default since 0.8.36) gives every attached client a `<session>~view~<pid>` member of the group. So a second terminal is all it takes:

```console
$ tmux list-panes -a -F '#{pane_id} #{session_name} #{session_group} #{window_id}' | grep '^%1356'
%1356 muxa             muxa @30
%1356 muxa~view~348778 muxa @30
```

`participants_from` required exactly one candidate row per pane and `continue`d otherwise. Two rows, so the pane is not a participant — no origin, no peers, nothing addressable:

```console
$ muxa msg send pane:%1557 "…"
Error: collaboration origin is not a hook-correlated tracked pane agent: %1356; trigger an agent event or restart the agent
```

That pane's agent was running and answering at the time. The advice is wrong, the named component is innocent, and the whole thing heals itself when the second terminal detaches and tmux destroys the view — so it reads as flakiness rather than a bug.

I hit it trying to brief two agent panes over the mailbox and being refused by my own pane.

## Fix

Rows that agree on **server, window and pane** are one pane seen twice. They are collapsed, and the durable session names the participant rather than whichever per-client view sorted first.

The ambiguity worth refusing is a pane id repeated across *servers* — that differs by socket and still errors, with its own test.

Three call sites shared the shape:

- `participants_from` — the participant table;
- `console_participant` — the origin behind `muxa watch`, so the operator's own surface was affected too;
- `unique_pane` — the pending-pane resolver added earlier this week, which would have lost a spawned peer the same way.

## Tests

Four, all failing without the change (verified by reverting it):

- a pane listed through a view is one participant, named by the base session;
- a console origin resolves through a view;
- a pending pane resolves through a view;
- one pane id on two servers is still ambiguous.

## Note on verification

The real-world reproduction is intermittent by nature: it exists only while a second client is attached. The duplicate listing above and the refusal were captured in the same moment; by the time the fix was built the second terminal had detached and the shipped daemon was answering normally again. The deterministic proof is the tests, and a patched daemon seeded with the same session resolves the origin where the check previously refused.

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (1,780 tests) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVQaf1oSAj6ZkgBg2uY2Gk
