### PR TITLE
fix(macos): open surviving inbox context for ended agents

### DIFF
--- a/apps/muxa-macos/Sources/AppModel.swift
+++ b/apps/muxa-macos/Sources/AppModel.swift
@@ -1016,6 +1016,8 @@ final class AppModel: ObservableObject {
     /// Collaboration requests retain the agent's stable session identity even
     /// when tmux reuses or moves its pane. Prefer that identity, then use the
     /// room alias and pane address only as progressively weaker live fallbacks.
+    /// If the agent really ended, keep the historical conversation actionable
+    /// by opening its surviving window, session, or host instead of failing.
     static func operatorSelection(
         for message: MuxaOperatorMessage,
         in snapshot: MuxaExecutionSnapshot
@@ -1060,6 +1062,30 @@ final class AppModel: ObservableObject {
         let roomPanes = panes.filter { matchesRoom($0.pane) }
         if roomPanes.count == 1, let roomPane = roomPanes.first {
             return .pane(roomPane.id)
+        }
+
+        let host = snapshot.watchHosts.first { $0.host.alias == message.host.alias }
+        let windows = host?.sessions.flatMap(\.windows) ?? []
+        let roomWindows = windows.filter { window in
+            window.windowID == participant.room.windowID
+                && (participantSocket == nil || window.socket == participantSocket)
+        }
+        if roomWindows.count == 1, let roomWindow = roomWindows.first {
+            return .fleetWindow(roomWindow.identity)
+        }
+
+        if let sessionID = participant.sessionID, !sessionID.isEmpty {
+            let sessions = host?.sessions.filter { session in
+                session.sessionID == sessionID
+                    && (participantSocket == nil || session.socket == participantSocket)
+            } ?? []
+            if sessions.count == 1, let session = sessions.first {
+                return .fleetSession(session.identity)
+            }
+        }
+
+        if host != nil {
+            return .host(message.host.alias)
         }
         return nil
     }

--- a/apps/muxa-macos/Sources/WorkConsoleViews.swift
+++ b/apps/muxa-macos/Sources/WorkConsoleViews.swift
@@ -1572,6 +1572,19 @@ private struct OperatorMessageDetail: View {
     @ObservedObject var model: AppModel
 
     private var request: MuxaCollaborationRequest { message.request }
+    private var openDestination: MuxaSidebarSelection? {
+        AppModel.operatorSelection(for: message, in: model.executionSnapshot)
+    }
+    private var openDestinationLabel: String {
+        switch openDestination {
+        case .agent, .pane: "Open Agent"
+        case .fleetWindow: "Open Window"
+        case .fleetSession: "Open Session"
+        case .host: "Open Host"
+        case nil: "Agent Ended"
+        default: "Open Context"
+        }
+    }
     private var statusColor: Color {
         if request.reply?.status == "completed" { return .green }
         if ["blocked", "failed", "declined", "expired", "cancelled"].contains(request.status) {
@@ -1608,9 +1621,10 @@ private struct OperatorMessageDetail: View {
                 Button {
                     model.openOperatorMessage(message)
                 } label: {
-                    Label("Open Agent", systemImage: "rectangle.and.hand.point.up.left")
+                    Label(openDestinationLabel, systemImage: "rectangle.and.hand.point.up.left")
                 }
                 .buttonStyle(.borderedProminent)
+                .disabled(openDestination == nil)
             }
             .padding(.horizontal, 16)
             .frame(minHeight: 54)

--- a/apps/muxa-macos/Tests/MuxaIPCTests.swift
+++ b/apps/muxa-macos/Tests/MuxaIPCTests.swift
@@ -852,6 +852,42 @@ struct MuxaIPCTests {
         #expect(selection == .agent("local:agent-17"))
     }
 
+    @Test @MainActor
+    func operatorInboxOpensRecordedSessionWhenAgentAndWindowEnded() async throws {
+        let probe = IPCProbe()
+        let client = MuxaIPCClient(socketPath: "/tmp/muxa-test.sock", request: probe.request)
+        try await client.hello()
+        let execution = try await client.executionSnapshot()
+        let route = try #require(
+            execution.watchHosts.first(where: { $0.host.alias == "local" })?
+                .sessions.first?.windows.first?.panes.first
+        )
+        let request = try JSONDecoder().decode(
+            MuxaCollaborationRequest.self,
+            from: Data(#"""
+            {
+              "id":"request-ended-agent",
+              "from":{"agent_kind":"unknown","agent_session_id":"__muxa_console__","pane":"console","room":{"host":"tmux","window_id":"@4"},"console":true},
+              "to":{"agent_kind":"claude_code","agent_session_id":"ended-agent","pane":"%999","socket":"default","room":{"host":"tmux","socket":"default","window_id":"@999"},"alias":"claude","tmux_session_id":"$4","tmux_session_name":"muxa","window_name":"ended"},
+              "kind":"task","body":"Historical request","expects_reply":true,"work_mode":"read_only","status":"completed","created_at":"2026-08-31T10:00:00Z"
+            }
+            """#.utf8)
+        )
+        let message = MuxaOperatorMessage(
+            host: route.host,
+            routePane: route.pane,
+            request: request
+        )
+
+        let selection = AppModel.operatorSelection(for: message, in: execution)
+
+        #expect(selection == .fleetSession(MuxaWatchSessionIdentity(
+            hostAlias: "local",
+            socket: "default",
+            sessionID: "$4"
+        )))
+    }
+
     @Test
     func operatorInboxSeparatesHumanDecisionsFromOrdinaryReplies() throws {
         func message(replyStatus: String) throws -> MuxaOperatorMessage {


### PR DESCRIPTION
## Summary
- resolve Operator Inbox targets by stable agent identity before weaker context fallbacks
- open a surviving window, session, or host when the original live agent ended
- label the action as Open Agent, Open Window, Open Session, or Open Host

## Test plan
- [x] `xcodebuild -project apps/muxa-macos/Muxa.xcodeproj -scheme Muxa -configuration Debug -destination platform=macOS test` (37 passed)
- [x] Release app build and smoke test
- [x] Verified the real rtzr `@claude` request falls back to its surviving `callabo` session
- [x] Installed and launched the updated Release app locally