### PR TITLE
fix(workspace): write session marks to an id, and report when they disagree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`muxa doctor` reports a workspace whose mark and session name disagree.**
+  A workspace's identity is a tmux session option, and the session *name* is
+  the fallback used when nothing claims it. The mark outranks the name on
+  purpose — that is what lets an adopted or renamed session keep working — but
+  when a session carries the workspace's own name *and* another session claims
+  the workspace, a launch passes the named one by and says so only in its
+  result line, after the window is already open. doctor now names both
+  sessions, and separately reports a workspace claimed by more than one
+  session, where a lookup takes whichever tmux lists first. Nothing is refused
+  and nothing lands anywhere new: this is the disagreement said out loud.
+
 - **Marked broadcasts now cross physical hosts in `muxa fleet watch`.** A pane
   row's `Space` mark carries its host alias and complete pane identity, so a
   local `%1` and a remote `%1` are two exact recipients rather than one
@@ -56,6 +67,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Existing dotfile symlinks and locally modified integration files are preserved.
 
 ### Fixed
+
+- **Session marks are written to a session id, not a session name.** tmux
+  resolves a bare name by exact match, then as a pattern, then as a *unique
+  prefix*, and the last of those is silent: with no session named `callabo`
+  and `callabo-set` the only one starting with those letters,
+  `set-option -t callabo` succeeds against `callabo-set`. muxa picked its
+  session by exact match in Rust and then handed the name back to tmux, so
+  that guarantee was lost at the boundary — for the workspace marks and for
+  the `new-window` target that places work. Both now carry the session id
+  from the listing that matched, `adopt_workspace`/`mark_workspace` refuse
+  anything that is not one, and `WorkspaceInfo` exposes the id beside the
+  name it displays. The `=name` spelling is not the fix here: tmux 3.4
+  refuses it for `set-option`, though `kill-session` accepts it, which is why
+  `muxa workspace close` was already safe.
 
 - **The live tour no longer presses Enter on the learner's behalf.** Step 8
   asks them to press Enter, and it completed when the prompt log grew. Splitting

--- a/crates/muxa-cli/src/agent_launch.rs
+++ b/crates/muxa-cli/src/agent_launch.rs
@@ -681,6 +681,14 @@ pub fn start(mut request: StartRequest) -> Result<StartResult> {
     let window = managed
         .then(|| crate::tmux_work::window_id_for_pane(&pane))
         .transpose()?;
+    // The name is what the result reports to a human; the id is what the
+    // marks are written against. They are read from the same pane, so they
+    // describe one session — but only the id still says so once it reaches
+    // tmux, which resolves a bare name by unique prefix as well as by
+    // exact match.
+    let session_id = managed
+        .then(|| crate::tmux_work::session_id_for_pane(&pane))
+        .transpose()?;
 
     let mark = (|| {
         if let (Some(session), Some(workspace)) = (&adopted_session, workspace.as_deref()) {
@@ -688,7 +696,7 @@ pub fn start(mut request: StartRequest) -> Result<StartResult> {
         }
         if created_workspace {
             crate::tmux_work::mark_workspace(
-                session
+                session_id
                     .as_deref()
                     .ok_or_else(|| anyhow::anyhow!("created workspace has no tmux session"))?,
                 workspace
@@ -753,8 +761,8 @@ pub fn start(mut request: StartRequest) -> Result<StartResult> {
 
 struct PreparedLaunch {
     cwd: PathBuf,
-    /// Session muxa put this work into without having created it. It gets a
-    /// workspace identity, never the managed flag.
+    /// Session muxa put this work into without having created it, as a tmux
+    /// session id. It gets a workspace identity, never the managed flag.
     adopted_session: Option<String>,
     workspace: Option<String>,
     work: Option<String>,
@@ -842,7 +850,7 @@ fn prepare_launch(request: &mut StartRequest) -> Result<PreparedLaunch> {
         request.name = Some(existing.window_name.clone());
     } else if let Some(existing) = &existing_workspace {
         request.placement = Placement::Window;
-        request.target = Some(existing.session.clone());
+        request.target = Some(existing.session_id.clone());
         request.name = Some(crate::tmux_work::window_name_for_work(
             work.as_deref().expect("managed work has id"),
         )?);

--- a/crates/muxa-cli/src/doctor.rs
+++ b/crates/muxa-cli/src/doctor.rs
@@ -128,6 +128,11 @@ pub async fn run(socket: PathBuf, config: Option<&Path>) -> Result<()> {
     // path differs per OS and nothing else prints it.
     tally(check_config_file(), &mut issues);
 
+    // 5⅞. Workspace marks vs session names. Reported, never acted on:
+    // the mark legitimately outranks the name, so a disagreement is a thing
+    // to know about rather than a thing to refuse.
+    tally(check_workspace_marks(), &mut issues);
+
     // 6. Recent muxad errors. These are surfaced as warnings (not
     //    failures) — a stale ERROR line from yesterday shouldn't make
     //    the whole doctor run look red.
@@ -155,6 +160,33 @@ pub async fn run(socket: PathBuf, config: Option<&Path>) -> Result<()> {
     };
     let _ = cliclack::outro(summary);
     Ok(())
+}
+
+/// Workspace identity lives in a tmux session option, and the session name is
+/// the fallback muxa uses when nothing claims the workspace. When both exist
+/// and point different ways, a launch goes somewhere the operator did not
+/// name — visible in the result line, but only after the window has opened.
+/// Saying so here is the cheap half: no refusal, no change to where anything
+/// lands, just the one line that turns "why is my agent over there" into a
+/// fact somebody can act on.
+fn check_workspace_marks() -> CheckResult {
+    match crate::tmux_work::workspace_mark_anomalies() {
+        // No server, or a server with no marks, is the ordinary case.
+        Ok(anomalies) if anomalies.is_empty() => {
+            CheckResult::Ok("Workspace marks agree with session names".to_string())
+        }
+        Ok(anomalies) => CheckResult::Warn(format!(
+            "{}. Rebind with `muxa work start --workspace <id>` from the intended \
+             session, or clear the stale mark with `tmux set-option -u -t <session> \
+             @muxa_workspace_id`",
+            anomalies
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("; ")
+        )),
+        Err(error) => CheckResult::Warn(format!("Could not read workspace marks: {error}")),
+    }
 }
 
 /// Internal status — every check folds into one of these so the

--- a/crates/muxa-cli/src/tmux_work.rs
+++ b/crates/muxa-cli/src/tmux_work.rs
@@ -111,6 +111,11 @@ pub struct WorkspaceInfo {
     /// because tmux resolves a bare name by unique prefix as well as by
     /// exact match, and picks the neighbour silently when the exact one is
     /// gone. `session` is for display.
+    ///
+    /// Kept out of `--json`: this is plumbing for addressing the session
+    /// correctly, and putting a new key in a published payload is a decision
+    /// to make on its own rather than a side effect of fixing the addressing.
+    #[serde(skip)]
     pub session_id: String,
     /// Whether muxa created this session, as opposed to adopting one the
     /// operator already had.

--- a/crates/muxa-cli/src/tmux_work.rs
+++ b/crates/muxa-cli/src/tmux_work.rs
@@ -106,6 +106,12 @@ pub struct ExternalItemInfo {
 pub struct WorkspaceInfo {
     pub workspace: String,
     pub session: String,
+    /// The session's tmux id. Anything that acts on the session — placing a
+    /// window in it, writing its marks — uses this rather than `session`,
+    /// because tmux resolves a bare name by unique prefix as well as by
+    /// exact match, and picks the neighbour silently when the exact one is
+    /// gone. `session` is for display.
+    pub session_id: String,
     /// Whether muxa created this session, as opposed to adopting one the
     /// operator already had.
     ///
@@ -1339,6 +1345,104 @@ pub fn find_workspace(raw: &str) -> Result<Option<WorkspaceInfo>> {
         .find(|workspace| workspace.workspace == wanted))
 }
 
+/// A workspace mark that does not agree with the session names around it.
+///
+/// Neither shape is treated as an error. muxa resolves a workspace through
+/// its mark and falls back to the session name, and that order is right: the
+/// mark is the explicit identity, and it is what lets a renamed or adopted
+/// session keep working. These are the states where the two sources disagree
+/// and a human would want to know before wondering why a launch landed
+/// somewhere unexpected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MarkAnomaly {
+    /// The workspace is claimed by one session while a *different* session
+    /// carries the name the workspace would otherwise resolve to. The mark
+    /// wins, so `--workspace callabo` goes to the claiming session even
+    /// though a session named `callabo` is sitting right there.
+    Shadowed {
+        workspace: String,
+        claimed_by: String,
+        named: String,
+    },
+    /// Two or more sessions claim the same workspace. One session is one
+    /// workspace, so this is a state muxa should not be able to reach —
+    /// lookups take the first tmux happens to list.
+    Duplicated {
+        workspace: String,
+        sessions: Vec<String>,
+    },
+}
+
+impl std::fmt::Display for MarkAnomaly {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Shadowed {
+                workspace,
+                claimed_by,
+                named,
+            } => write!(
+                f,
+                "workspace {workspace} is claimed by session {claimed_by}, \
+                 but a different session is named {named} — launches into \
+                 {workspace} go to {claimed_by}"
+            ),
+            Self::Duplicated {
+                workspace,
+                sessions,
+            } => write!(
+                f,
+                "workspace {workspace} is claimed by {} sessions ({}) — \
+                 lookups take whichever tmux lists first",
+                sessions.len(),
+                sessions.join(", ")
+            ),
+        }
+    }
+}
+
+/// Disagreements between the workspace marks and the session names, read from
+/// the live tmux server.
+pub fn workspace_mark_anomalies() -> Result<Vec<MarkAnomaly>> {
+    Ok(mark_anomalies(&list_workspaces()?, &all_session_names()?))
+}
+
+/// The pure half of [`workspace_mark_anomalies`], so the shapes can be tested
+/// without a tmux server.
+pub fn mark_anomalies(workspaces: &[WorkspaceInfo], session_names: &[String]) -> Vec<MarkAnomaly> {
+    let mut anomalies = Vec::new();
+    let mut claimants: Vec<(&str, Vec<&str>)> = Vec::new();
+    for workspace in workspaces {
+        match claimants
+            .iter_mut()
+            .find(|(id, _)| *id == workspace.workspace)
+        {
+            Some((_, sessions)) => sessions.push(&workspace.session),
+            None => claimants.push((&workspace.workspace, vec![&workspace.session])),
+        }
+    }
+    for (workspace, sessions) in &claimants {
+        if sessions.len() > 1 {
+            anomalies.push(MarkAnomaly::Duplicated {
+                workspace: (*workspace).to_string(),
+                sessions: sessions.iter().map(|s| (*s).to_string()).collect(),
+            });
+            continue;
+        }
+        // The name a workspace resolves to when nothing claims it, which is
+        // what `adoptable_session` matches on.
+        let named = sanitize_session_name(&workspace.to_ascii_lowercase());
+        let claimed_by = sessions[0];
+        if claimed_by != named && session_names.iter().any(|name| name == &named) {
+            anomalies.push(MarkAnomaly::Shadowed {
+                workspace: (*workspace).to_string(),
+                claimed_by: claimed_by.to_string(),
+                named,
+            });
+        }
+    }
+    anomalies
+}
+
 pub fn list_works() -> Result<Vec<WorkInfo>> {
     Ok(list_workspaces()?
         .into_iter()
@@ -1354,18 +1458,25 @@ pub fn list_workspaces() -> Result<Vec<WorkspaceInfo>> {
 }
 
 /// A session muxa may put this workspace's work windows into without
-/// having created it: one already named after the workspace.
+/// having created it: one already named after the workspace. Returns its
+/// tmux *session id*, not its name.
 ///
 /// Refusing to adopt splits a workspace across `callabo` and `callabo-2`,
 /// which contradicts the whole model — one session is one workspace. The
 /// safety that mattered was never "do not touch it"; it is that
 /// `close_workspace` refuses a session muxa did not create.
+///
+/// The id comes out of the same listing that matched the name, so nothing
+/// between here and the write has to look the session up again: see
+/// [`adopt_workspace`] for why a name handed back to tmux is not the same
+/// session it came from.
 pub fn adoptable_session(workspace: &str) -> Result<Option<String>> {
     let normalized = normalize_workspace_id(workspace)?;
     let wanted = sanitize_session_name(&normalized.to_ascii_lowercase());
-    Ok(all_session_names()?
+    Ok(all_sessions()?
         .into_iter()
-        .find(|name| name == &wanted))
+        .find(|(name, _)| name == &wanted)
+        .map(|(_, id)| id))
 }
 
 pub fn session_name_for_workspace(workspace: &str) -> Result<String> {
@@ -1496,29 +1607,48 @@ fn set_window_automatic_rename(window: &str, enabled: bool) -> Result<()> {
 /// Deliberately does not set `@muxa_managed_workspace`: that flag is what
 /// `close_workspace` reads, and muxa must not offer to kill a session full
 /// of windows somebody else opened.
-pub fn adopt_workspace(session: &str, workspace: &str) -> Result<()> {
+/// Takes a tmux session *id* (`$5`), never a name.
+///
+/// tmux resolves a bare name by exact match, then as a pattern, then as a
+/// unique prefix — and that last step is silent. So a name that named one
+/// session when muxa looked it up can name a *different* one by the time the
+/// write goes out: with `callabo` gone and `callabo-set` the only session
+/// left starting with those letters, `set-option -t callabo` succeeds against
+/// `callabo-set`, exit 0. The `=name` spelling does not close this, because
+/// tmux 3.4 refuses it for `set-option` (it accepts it for `kill-session`,
+/// which is why `close_workspace` is already safe). An id is the only
+/// spelling that means one session and nothing else.
+pub fn adopt_workspace(session_id: &str, workspace: &str) -> Result<()> {
+    validate_session_id(session_id)?;
     let workspace = normalize_workspace_id(workspace)?;
     set_option(
         OptionScope::Session,
-        session,
+        session_id,
         WORKSPACE_ID_OPTION,
         &workspace,
     )
 }
 
-pub fn mark_workspace(session: &str, workspace: &str, cwd: &Path) -> Result<()> {
+/// Takes a tmux session *id* — see [`adopt_workspace`].
+pub fn mark_workspace(session_id: &str, workspace: &str, cwd: &Path) -> Result<()> {
+    validate_session_id(session_id)?;
     let workspace = normalize_workspace_id(workspace)?;
     let cwd = cwd
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("workspace cwd is not valid UTF-8: {}", cwd.display()))?;
     set_option(
         OptionScope::Session,
-        session,
+        session_id,
         WORKSPACE_ID_OPTION,
         &workspace,
     )?;
-    set_option(OptionScope::Session, session, WORKSPACE_CWD_OPTION, cwd)?;
-    set_option(OptionScope::Session, session, MANAGED_WORKSPACE_OPTION, "1")?;
+    set_option(OptionScope::Session, session_id, WORKSPACE_CWD_OPTION, cwd)?;
+    set_option(
+        OptionScope::Session,
+        session_id,
+        MANAGED_WORKSPACE_OPTION,
+        "1",
+    )?;
     Ok(())
 }
 
@@ -1921,6 +2051,20 @@ pub fn window_id_for_pane(pane: &str) -> Result<String> {
     Ok(window.to_string())
 }
 
+/// The session id owning `pane`. A pane id is exact, so this resolves one
+/// session with no room for tmux's prefix matching — which is what makes it
+/// the right input to [`mark_workspace`].
+pub fn session_id_for_pane(pane: &str) -> Result<String> {
+    validate_pane_id(pane)?;
+    let session = tmux_output(&["display-message", "-p", "-t", pane, "#{session_id}"])?;
+    let session = session.trim();
+    if session.is_empty() {
+        bail!("pane {pane} resolved to an empty session id");
+    }
+    validate_session_id(session)?;
+    Ok(session.to_string())
+}
+
 pub fn session_name_for_pane(pane: &str) -> Result<String> {
     validate_pane_id(pane)?;
     let session = tmux_output(&["display-message", "-p", "-t", pane, "#{session_name}"])?;
@@ -2006,6 +2150,17 @@ fn ensure_managed_agent(pane: &str) -> Result<()> {
     Ok(())
 }
 
+fn validate_session_id(session: &str) -> Result<()> {
+    if session
+        .strip_prefix('$')
+        .is_some_and(|digits| !digits.is_empty() && digits.chars().all(|ch| ch.is_ascii_digit()))
+    {
+        Ok(())
+    } else {
+        bail!("session must be an exact tmux session id such as $5, not {session:?}")
+    }
+}
+
 fn validate_pane_id(pane: &str) -> Result<()> {
     if pane
         .strip_prefix('%')
@@ -2060,6 +2215,7 @@ fn parse_workspaces(sessions: &str, windows: &str, panes: &str) -> Vec<Workspace
         let session = fields[0].to_string();
         let session_id = fields[1];
         let workspace = fields[2].trim().to_ascii_lowercase();
+        let session_id_owned = session_id.to_string();
         let mut works = windows
             .lines()
             .filter_map(|line| parse_work_window(line, session_id, &workspace, panes))
@@ -2068,6 +2224,7 @@ fn parse_workspaces(sessions: &str, windows: &str, panes: &str) -> Vec<Workspace
         workspaces.push(WorkspaceInfo {
             workspace,
             session,
+            session_id: session_id_owned,
             managed: fields[4] == "1",
             cwd: PathBuf::from(fields[3]),
             attached_clients: fields[5].parse().unwrap_or(0),
@@ -2167,6 +2324,20 @@ fn parse_agent_pane(
 
 fn option(value: &str) -> Option<String> {
     (!value.trim().is_empty()).then(|| value.to_string())
+}
+
+/// Every session's name paired with its id, read in one listing so a caller
+/// that matches on the name can act on the id.
+fn all_sessions() -> Result<Vec<(String, String)>> {
+    Ok(
+        tmux_output_allow_no_server(&["list-sessions", "-F", "#{session_name}\t#{session_id}"])?
+            .lines()
+            .filter_map(|line| {
+                let (name, id) = line.split_once('\t')?;
+                Some((name.to_string(), id.to_string()))
+            })
+            .collect(),
+    )
 }
 
 fn all_session_names() -> Result<Vec<String>> {
@@ -2480,6 +2651,78 @@ mod tests {
     #[test]
     fn parse_view_session_refuses_a_malformed_attached_count() {
         assert!(parse_view_session("$1\tbase\tnot-a-number\t\toff").is_err());
+    }
+
+    fn workspace_at(workspace: &str, session: &str, session_id: &str) -> WorkspaceInfo {
+        WorkspaceInfo {
+            workspace: workspace.to_string(),
+            session: session.to_string(),
+            session_id: session_id.to_string(),
+            managed: false,
+            cwd: PathBuf::new(),
+            attached_clients: 0,
+            windows: 1,
+            works: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_mark_on_a_differently_named_session_is_only_reported_when_the_name_is_taken() {
+        // Adoption and renames both leave a mark whose session is named
+        // something else. On its own that is the feature working.
+        let renamed = [workspace_at("callabo", "callabo-set", "$5")];
+        assert!(mark_anomalies(&renamed, &["callabo-set".to_string()]).is_empty());
+
+        // A session carrying the workspace's own name is what makes it
+        // ambiguous: `--workspace callabo` passes it by without a word.
+        let shadowed = mark_anomalies(
+            &renamed,
+            &["callabo-set".to_string(), "callabo".to_string()],
+        );
+        assert_eq!(
+            shadowed,
+            vec![MarkAnomaly::Shadowed {
+                workspace: "callabo".to_string(),
+                claimed_by: "callabo-set".to_string(),
+                named: "callabo".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn two_sessions_claiming_one_workspace_are_reported_together() {
+        let both = [
+            workspace_at("callabo", "callabo", "$2"),
+            workspace_at("callabo", "callabo-set", "$5"),
+        ];
+        // Reported as the duplicate, not as a shadow: which session a lookup
+        // returns is down to tmux's listing order, and naming one of them as
+        // the claimant would imply muxa had chosen.
+        assert_eq!(
+            mark_anomalies(&both, &["callabo".to_string(), "callabo-set".to_string()]),
+            vec![MarkAnomaly::Duplicated {
+                workspace: "callabo".to_string(),
+                sessions: vec!["callabo".to_string(), "callabo-set".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn the_mark_writers_refuse_a_session_name() {
+        // The whole point of the id: a name is what tmux may resolve to a
+        // neighbour, so it must not reach `set-option` at all.
+        let error = adopt_workspace("callabo", "callabo")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("session id"), "unexpected error: {error}");
+        let error = mark_workspace("callabo", "callabo", Path::new("/tmp"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("session id"), "unexpected error: {error}");
+        // And the spellings tmux itself uses are accepted.
+        assert!(validate_session_id("$5").is_ok());
+        assert!(validate_session_id("$").is_err());
+        assert!(validate_session_id("$x").is_err());
     }
 
     #[test]

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -1221,7 +1221,6 @@ pub(crate) trait Effects {
 pub(crate) struct RealEffects;
 
 struct SpawnWorkPlan {
-    session: String,
     created_workspace: bool,
     created_work: bool,
     args: Vec<String>,
@@ -1249,7 +1248,6 @@ fn plan_spawn_work(
             ));
         }
         return Ok(SpawnWorkPlan {
-            session: existing.session,
             created_workspace: false,
             created_work: false,
             args: vec![
@@ -1272,7 +1270,6 @@ fn plan_spawn_work(
         crate::tmux_work::window_name_for_work(work).map_err(|error| error.to_string())?;
     if let Some(existing) = existing_workspace {
         return Ok(SpawnWorkPlan {
-            session: existing.session.clone(),
             created_workspace: false,
             created_work: true,
             args: vec![
@@ -1282,7 +1279,7 @@ fn plan_spawn_work(
                 "-F".into(),
                 "#{pane_id}".into(),
                 "-t".into(),
-                existing.session,
+                existing.session_id,
                 "-n".into(),
                 window_name,
                 "-c".into(),
@@ -1295,7 +1292,6 @@ fn plan_spawn_work(
     let session = crate::tmux_work::session_name_for_workspace(workspace)
         .map_err(|error| error.to_string())?;
     Ok(SpawnWorkPlan {
-        session: session.clone(),
         created_workspace: true,
         created_work: true,
         args: vec![
@@ -1589,7 +1585,10 @@ impl Effects for RealEffects {
             crate::tmux_work::window_id_for_pane(&pane).map_err(|error| error.to_string())?;
         let marked = (|| {
             if plan.created_workspace {
-                crate::tmux_work::mark_workspace(&plan.session, &workspace, &cwd)?;
+                // From the pane, so the mark lands on the session the pane is
+                // actually in — a session *name* can resolve to a neighbour.
+                let session_id = crate::tmux_work::session_id_for_pane(&pane)?;
+                crate::tmux_work::mark_workspace(&session_id, &workspace, &cwd)?;
             }
             if plan.created_work {
                 crate::tmux_work::mark_work(&window, &workspace, &work, &cwd)?;

--- a/crates/muxa-cli/tests/workspace_marks.rs
+++ b/crates/muxa-cli/tests/workspace_marks.rs
@@ -1,0 +1,268 @@
+//! Which session a workspace resolves to, and what muxa says when the two
+//! sources of that answer disagree.
+//!
+//! A workspace's identity is a tmux session option (`@muxa_workspace_id`), and
+//! the session *name* is the fallback used when nothing claims the workspace.
+//! The mark outranks the name deliberately: that is what lets a renamed or
+//! adopted session keep working. The cost is that a stale mark sends a launch
+//! somewhere the operator did not name, and until now nothing said so.
+//!
+//! The tests drive the real `muxa` binary against a private tmux server, with
+//! a stand-in `claude` on `PATH`. They skip when tmux is not installed.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn muxa() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_muxa"))
+}
+
+fn tmux_installed() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
+/// A tmux server of our own: private socket, and `-f /dev/null` so the
+/// operator's `~/.tmux.conf` stays out of the test.
+struct Server {
+    socket: PathBuf,
+    dir: tempfile::TempDir,
+}
+
+impl Server {
+    fn start() -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("tmux.sock");
+        Self { socket, dir }
+    }
+
+    fn session(&self, name: &str) {
+        self.tmux(&[
+            "new-session",
+            "-d",
+            "-s",
+            name,
+            "-x",
+            "80",
+            "-y",
+            "24",
+            "-c",
+            "/tmp",
+        ])
+        .unwrap_or_else(|error| panic!("start session {name}: {error}"));
+    }
+
+    fn tmux(&self, args: &[&str]) -> Result<String, String> {
+        let out = Command::new("tmux")
+            .arg("-f")
+            .arg("/dev/null")
+            .arg("-S")
+            .arg(&self.socket)
+            .args(args)
+            .output()
+            .expect("run tmux");
+        let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if out.status.success() {
+            Ok(stdout)
+        } else {
+            Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
+        }
+    }
+
+    fn query(&self, args: &[&str]) -> String {
+        self.tmux(args).expect("tmux query")
+    }
+
+    /// Session name → workspace mark, for every session on the server.
+    fn marks(&self) -> String {
+        self.query(&[
+            "list-sessions",
+            "-F",
+            "#{session_name} #{@muxa_workspace_id}",
+        ])
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.tmux(&["kill-server"]);
+    }
+}
+
+/// A `claude` that stays in its pane and needs nothing installed.
+fn stub_agent_dir(root: &Path) -> PathBuf {
+    let bin = root.join("bin");
+    std::fs::create_dir_all(&bin).expect("create stub bin dir");
+    let claude = bin.join("claude");
+    std::fs::write(&claude, "#!/bin/sh\nexec sleep 600\n").expect("write stub claude");
+    std::fs::set_permissions(&claude, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod stub claude");
+    bin
+}
+
+fn run_muxa(server: &Server, stub_bin: &Path, args: &[&str]) -> std::process::Output {
+    let path = format!(
+        "{}:{}",
+        stub_bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    Command::new(muxa())
+        .args(args)
+        .env("PATH", path)
+        .env("MUXA_TMUX_SOCKET", &server.socket)
+        // A socket no daemon answers: these paths mark tmux and report, and
+        // must not reach the operator's running muxad.
+        .env("MUXA_SOCKET", server.dir.path().join("muxad.sock"))
+        .env_remove("TMUX")
+        .env_remove("TMUX_PANE")
+        .output()
+        .expect("run muxa")
+}
+
+/// The shape that sent four agents to `callabo-set`: a stale mark on one
+/// session while another carries the workspace's own name.
+///
+/// The mark winning is the intended order — this locks it so a later change
+/// has to be deliberate — but it is also why the launch went somewhere nobody
+/// asked for, which is what the doctor check below exists to say out loud.
+#[test]
+fn a_workspace_mark_outranks_a_session_named_after_the_workspace() {
+    if !tmux_installed() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+    let server = Server::start();
+    server.session("wsmark");
+    server.session("wsmark-set");
+    let claimant = server.query(&["display-message", "-p", "-t", "wsmark-set", "#{session_id}"]);
+    server
+        .tmux(&[
+            "set-option",
+            "-t",
+            &claimant,
+            "@muxa_workspace_id",
+            "wsmark",
+        ])
+        .expect("plant the stale mark");
+    let stub = stub_agent_dir(server.dir.path());
+
+    let out = run_muxa(
+        &server,
+        &stub,
+        &[
+            "work",
+            "start",
+            "probe",
+            "--agent",
+            "claude",
+            "--workspace",
+            "wsmark",
+            "--cwd",
+            "/tmp",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "work start failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let windows = server.query(&[
+        "list-windows",
+        "-a",
+        "-F",
+        "#{session_name} #{@muxa_work_id}",
+    ]);
+    let owner = windows
+        .lines()
+        .find(|line| line.split_whitespace().nth(1) == Some("PROBE"))
+        .and_then(|line| line.split_whitespace().next())
+        .unwrap_or_else(|| panic!("no PROBE window anywhere; windows:\n{windows}"));
+    assert_eq!(
+        owner, "wsmark-set",
+        "the mark decides, not the name; windows:\n{windows}"
+    );
+}
+
+/// The reporting half. muxa still goes where the mark says; `doctor` is where
+/// the disagreement stops being invisible.
+#[test]
+fn doctor_reports_a_workspace_claimed_by_another_session() {
+    if !tmux_installed() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+    let server = Server::start();
+    server.session("wsmark");
+    server.session("wsmark-set");
+    let claimant = server.query(&["display-message", "-p", "-t", "wsmark-set", "#{session_id}"]);
+    server
+        .tmux(&[
+            "set-option",
+            "-t",
+            &claimant,
+            "@muxa_workspace_id",
+            "wsmark",
+        ])
+        .expect("plant the stale mark");
+    let stub = stub_agent_dir(server.dir.path());
+
+    let out = run_muxa(&server, &stub, &["doctor"]);
+    let report = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        report.contains("claimed by session wsmark-set"),
+        "doctor should name the claiming session; report:\n{report}"
+    );
+    assert!(
+        report.contains("named wsmark"),
+        "doctor should name the session the workspace would otherwise resolve to; report:\n{report}"
+    );
+}
+
+/// Why every write muxa makes to a session is addressed by id.
+///
+/// tmux resolves a bare name by exact match, then as a pattern, then as a
+/// *unique prefix* — and the last of those is silent. So a name that named one
+/// session when muxa looked it up can name a different one by the time the
+/// write goes out. `=name` is not an escape: tmux 3.4 refuses that spelling
+/// for `set-option`, even though `kill-session` accepts it.
+#[test]
+fn a_bare_session_name_can_resolve_to_a_neighbour() {
+    if !tmux_installed() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+    let server = Server::start();
+    server.session("wsmark-set");
+
+    // No session is named `wsmark`, and `wsmark-set` is the only one starting
+    // with it, so tmux takes the neighbour and reports success.
+    server
+        .tmux(&["set-option", "-t", "wsmark", "@muxa_workspace_id", "wsmark"])
+        .expect("tmux resolves the bare name to the only prefix match");
+    assert_eq!(
+        server.marks(),
+        "wsmark-set wsmark",
+        "a bare name landed on the neighbour"
+    );
+
+    // A second candidate makes it ambiguous, which tmux refuses — so this is
+    // a hazard that shows up only sometimes, which is the worst kind.
+    server.session("wsmark-other");
+    let refused = server
+        .tmux(&["set-option", "-t", "wsmark", "@muxa_probe", "x"])
+        .expect_err("two prefix candidates are ambiguous");
+    assert!(
+        refused.contains("no such session"),
+        "expected an ambiguity refusal, got {refused:?}"
+    );
+}


### PR DESCRIPTION
`muxa work start --workspace callabo` opened its window in the `callabo-set`
session while a session named `callabo` sat right beside it. This is what was
behind that, and — deliberately — what is not.

## The mark was written to a name, not a session

muxa picks the session for a workspace by exact name match in Rust, then hands
that name back to tmux to write the mark. tmux resolves a bare name by exact
match, then as a pattern, then as a **unique prefix**, and the last of those is
silent:

```console
$ tmux list-sessions -F '#{session_name}'
callabo-set
$ tmux set-option -t callabo @muxa_workspace_id callabo   # no session is named callabo
$ echo $?
0
$ tmux list-sessions -F '#{session_name} #{@muxa_workspace_id}'
callabo-set callabo
```

Two candidates make it ambiguous and tmux refuses — so it is a hazard that
appears only sometimes, which is the worst kind. Both are locked in a test.

The workspace marks and the `new-window` target that places work now carry the
session **id** from the listing that matched. `adopt_workspace` and
`mark_workspace` refuse anything that is not an id, and `WorkspaceInfo` exposes
the id beside the name it displays. `=name` is not the fix here: tmux 3.4
refuses that spelling for `set-option`, though `kill-session` accepts it, which
is why `muxa workspace close` was already safe.

## The disagreement was invisible

The mark outranking the session name is correct and stays: it is what lets an
adopted or renamed session keep working. What was missing is that nobody was
told. `muxa doctor` now says it:

```
⚠ workspace callabo is claimed by 2 sessions (callabo, callabo-set) —
  lookups take whichever tmux lists first. Rebind with `muxa work start
  --workspace <id>` from the intended session, or clear the stale mark with
  `tmux set-option -u -t <session> @muxa_workspace_id`
```

That line is from this branch run against the machine where the original
incident happened. **Nothing is refused and nothing lands anywhere new.** An
earlier draft of this change also refused ambiguous launches and errored on
duplicate marks; that was dropped, because the evidence for it was a single
occurrence of unknown origin, and a refusal that blocks a working launch is
worse than the confusion it replaces.

## What this does not settle

How the stale mark got there. The rename theory has no support — a month of
`activity.ndjson` shows `callabo` and `callabo-set` as separate coexisting
sessions with no session id ever changing name. The mis-target theory does not
fit this server's timeline either: after the tmux restart, `callabo` was created
one second *before* `callabo-set`, so an exact match was always available. No
agent transcript contains a raw `set-option` writing it.

So this ships as detection plus the one mechanism that could produce it. If it
recurs, doctor now names it in one line instead of an afternoon of archaeology
— which it already did: while this branch was being written, a *second* session
picked up the same mark, and the check caught it immediately.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -D
warnings`, `cargo test --workspace` (2,065 passed, 0 failed).

Both new behaviours were mutation-tested rather than trusted:

| mutation | result |
|---|---|
| stale mark not planted | work lands in `wsmark`, precedence test **fails** |
| doctor check removed | report is silent, doctor test **fails** |
| `validate_session_id` removed from the writers | guard test **fails** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ7fm8EusDcVL14i1iNnQy
