### PR TITLE
fix(launchd): stop the macOS app from disabling muxad at login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The macOS app no longer stops muxad from starting at login.** Replacing a
+  running daemon ran `launchctl disable` on the legacy `dev.open330.muxad`
+  label before unloading it. `disable` is not scoped to the session: it writes
+  a persistent override into
+  `/var/db/com.apple.xpc.launchd/disabled.<uid>.plist` that survives the reboot
+  and outranks the plist's own `RunAtLoad`, so a single replace left the agent
+  silently skipped at every later login — a correct plist on disk, muxad absent
+  until the app was opened by hand. The app now only boots the label out, which
+  is scoped to the session the socket race is actually fought in, and tolerates
+  the daemon having already been reaped by that bootout.
+
+  Installing clears the override rather than tripping over it: `muxa init`
+  runs `launchctl enable` before bootstrapping, since a disabled label
+  bootstraps cleanly and then never runs, which made a reinstall look like it
+  had worked. `muxa doctor` reports the override by name ahead of its load
+  check — `launchctl print` fails the same way for "never installed" and
+  "installed but disabled", and only one of those is the installer's to fix.
+
 ## [0.8.46] - 2026-09-09
 
 ### Added

--- a/apps/muxa-macos/Sources/DaemonManager.swift
+++ b/apps/muxa-macos/Sources/DaemonManager.swift
@@ -105,16 +105,16 @@ struct DaemonSocketOwner: Equatable, Sendable {
 
     func stop() async throws {
         // A launchd-managed cargo install is just as persistent as a Homebrew
-        // one. Disable known legacy labels before stopping either executable,
+        // one. Unload known legacy labels before stopping either executable,
         // otherwise KeepAlive can win the socket race against the bundled
         // daemon and leave the app in a restart loop.
-        try await Self.disableLegacyLaunchAgents()
+        try await Self.bootOutLegacyLaunchAgents()
         if let brew = homebrewExecutable {
             try await Self.stopHomebrewService(brew: brew)
-        } else {
-            guard Darwin.kill(pid, SIGTERM) == 0 else {
-                throw MuxaIPCError.posix(operation: "kill", code: errno)
-            }
+        } else if Darwin.kill(pid, SIGTERM) != 0, errno != ESRCH {
+            // ESRCH means the bootout above already reaped the daemon, which
+            // is the state this call is asking for.
+            throw MuxaIPCError.posix(operation: "kill", code: errno)
         }
 
         for _ in 0..<100 {
@@ -145,21 +145,22 @@ struct DaemonSocketOwner: Equatable, Sendable {
         }.value
     }
 
-    private static func disableLegacyLaunchAgents() async throws {
+    /// Unload the legacy `LaunchAgent` for the rest of this login session, so
+    /// its `KeepAlive` cannot resurrect the old daemon while the app brings up
+    /// the bundled one.
+    ///
+    /// Deliberately `bootout` and never `launchctl disable`: `disable` writes a
+    /// persistent override into
+    /// `/var/db/com.apple.xpc.launchd/disabled.<uid>.plist` that survives the
+    /// reboot and outranks the plist's own `RunAtLoad`, so one "replace the
+    /// running daemon" would leave muxad silently absent at every later login
+    /// — and `muxa init` re-bootstraps a label launchd still refuses to run.
+    /// `bootout` is scoped to the current session, which is the only window
+    /// this race is fought in.
+    private static func bootOutLegacyLaunchAgents() async throws {
         try await Task.detached(priority: .userInitiated) {
             let domain = "gui/\(getuid())"
             for label in legacyLaunchAgentLabels {
-                let disable = Process()
-                disable.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-                disable.arguments = ["disable", "\(domain)/\(label)"]
-                disable.standardOutput = FileHandle.nullDevice
-                disable.standardError = FileHandle.nullDevice
-                try disable.run()
-                disable.waitUntilExit()
-                guard disable.terminationStatus == 0 else {
-                    throw MuxaIPCError.server("could not disable legacy service \(label)")
-                }
-
                 let bootout = Process()
                 bootout.executableURL = URL(fileURLWithPath: "/bin/launchctl")
                 bootout.arguments = ["bootout", "\(domain)/\(label)"]
@@ -167,8 +168,8 @@ struct DaemonSocketOwner: Equatable, Sendable {
                 bootout.standardError = FileHandle.nullDevice
                 try bootout.run()
                 bootout.waitUntilExit()
-                // bootout returns non-zero when the label was already unloaded;
-                // the preceding persistent disable is the authoritative action.
+                // A non-zero exit means the label was not loaded to begin
+                // with, which is already the state this call wants.
             }
         }.value
     }

--- a/crates/muxa-cli/src/doctor.rs
+++ b/crates/muxa-cli/src/doctor.rs
@@ -337,6 +337,18 @@ fn check_service_manager() -> CheckResult {
 
 fn check_launchctl() -> CheckResult {
     let uid = uid_string();
+    // Report a disable override ahead of the load probe. `launchctl print`
+    // fails identically for "never installed" and "installed but disabled",
+    // and only the first of those is fixed by re-running the installer — a
+    // disabled label is skipped at every login no matter what the plist says.
+    // `muxa init` clears it now, so this is aimed at hosts that are still
+    // carrying the override an older muxa.app wrote.
+    if launchd::service_disabled() == Some(true) {
+        return CheckResult::Fail(format!(
+            "launchd: muxad agent is disabled and will not start at login — run \
+             `launchctl enable gui/{uid}/{LAUNCHD_LABEL}`, then `muxa init --component muxad-launchd`"
+        ));
+    }
     let target = format!("gui/{uid}/{LAUNCHD_LABEL}");
     let out = Command::new("launchctl").args(["print", &target]).output();
     match out {

--- a/crates/muxa-cli/src/init/files/launchd.rs
+++ b/crates/muxa-cli/src/init/files/launchd.rs
@@ -124,6 +124,17 @@ pub fn enable_service(plist_path: &std::path::Path) -> Result<()> {
     let target = format!("gui/{}", super::super::util::uid_string());
     let label_target = format!("{target}/{LABEL}");
 
+    // Clear any persistent disable override before touching the job.
+    // `launchctl disable` writes to
+    // `/var/db/com.apple.xpc.launchd/disabled.<uid>.plist`, survives reboots,
+    // and outranks the plist's own `RunAtLoad`: a disabled label bootstraps
+    // fine and then never runs, at this install and at every later login.
+    // Older muxa.app builds set exactly this when they replaced a running
+    // daemon, so installing has to be able to undo it.
+    let _ = Command::new("launchctl")
+        .args(["enable", &label_target])
+        .output();
+
     // `bootout` is best-effort: it returns "No such process" (errno 3) when
     // the agent isn't loaded, which is equivalent to the desired state.
     let _ = Command::new("launchctl")
@@ -154,6 +165,44 @@ pub fn enable_service(plist_path: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
+/// Read the label's entry out of `launchctl print-disabled gui/<uid>`,
+/// whose body is one `"<label>" => <state>` line per override.
+///
+/// Both spellings of the state are accepted on purpose. macOS 26 prints
+/// `enabled`/`disabled` while the `true`/`false` of the backing
+/// `/var/db/com.apple.xpc.launchd/disabled.<uid>.plist` is what older
+/// launchctl echoed, and either can turn up depending on the host.
+///
+/// `Some(true)` is the state that makes muxad look broken for no visible
+/// reason: the plist is present and correct, `RunAtLoad` is set, and launchd
+/// skips the job at every login anyway. `None` means launchd holds no opinion
+/// about this label, which is the ordinary case.
+pub fn parse_disabled(output: &str, label: &str) -> Option<bool> {
+    let needle = format!("\"{label}\"");
+    output.lines().find_map(|line| {
+        let rest = line.trim().strip_prefix(&needle)?.trim_start();
+        match rest.strip_prefix("=>")?.trim() {
+            "true" | "disabled" => Some(true),
+            "false" | "enabled" => Some(false),
+            _ => None,
+        }
+    })
+}
+
+/// Ask launchd whether `LABEL` carries a disable override. `None` when
+/// `launchctl` can't be run or says nothing about the label.
+pub fn service_disabled() -> Option<bool> {
+    let target = format!("gui/{}", super::super::util::uid_string());
+    let out = Command::new("launchctl")
+        .args(["print-disabled", &target])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_disabled(&String::from_utf8_lossy(&out.stdout), LABEL)
+}
+
 /// `launchctl bootout gui/<uid>/<label>`. Idempotent — non-zero exit
 /// when the agent isn't loaded is treated as success.
 pub fn disable_service() {
@@ -182,6 +231,39 @@ mod tests {
         // Closing tags + xml prologue
         assert!(body.starts_with("<?xml"));
         assert!(body.trim_end().ends_with("</plist>"));
+    }
+
+    #[test]
+    fn parse_disabled_reads_the_override_table() {
+        // Verbatim shape of `launchctl print-disabled gui/501` on macOS 26.
+        let out = "\
+disabled services = {
+\t\t\"com.apple.Siri.agent\" => disabled
+\t\t\"dev.open330.muxad\" => disabled
+\t\t\"homebrew.mxcl.muxa\" => enabled
+}
+";
+        assert_eq!(parse_disabled(out, LABEL), Some(true));
+        assert_eq!(parse_disabled(out, "homebrew.mxcl.muxa"), Some(false));
+        assert_eq!(parse_disabled(out, "dev.open330.absent"), None);
+    }
+
+    #[test]
+    fn parse_disabled_also_reads_the_boolean_spelling() {
+        // What the backing disabled.<uid>.plist stores, and what older
+        // launchctl builds echo back.
+        let out = "\t\t\"dev.open330.muxad\" => true\n";
+        assert_eq!(parse_disabled(out, LABEL), Some(true));
+        assert_eq!(
+            parse_disabled("\t\t\"dev.open330.muxad\" => false\n", LABEL),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn parse_disabled_ignores_a_label_that_is_only_a_suffix() {
+        let out = "\t\t\"legacy.dev.open330.muxad\" => true\n";
+        assert_eq!(parse_disabled(out, LABEL), None);
     }
 
     #[test]


### PR DESCRIPTION
## What

After a reboot muxad never came up. The plist was correct — `RunAtLoad`, `KeepAlive`, right program path — and launchd skipped it at every login anyway.

`DaemonSocketOwner.stop()` ran `launchctl disable` on `dev.open330.muxad` before unloading it. `disable` is not session-scoped: it writes a persistent override into `/var/db/com.apple.xpc.launchd/disabled.<uid>.plist` which survives the reboot and outranks the plist's own `RunAtLoad`. One "replace the running daemon" was enough to leave muxad absent until the app was opened by hand.

## Changes

- **`DaemonManager.swift`** — `bootout` only, no `disable`. The `KeepAlive` race the call is fighting only exists while the app is running, and bootout wins it for exactly that window. `stop()` also treats `ESRCH` from its `SIGTERM` as success, since the bootout may already have reaped the daemon — a latent path that turned a clean stop into a thrown error.
- **`init/files/launchd.rs`** — `enable_service()` runs `launchctl enable` before bootstrapping. A disabled label bootstraps cleanly and *then* never runs, so reinstalling looked like it had worked while changing nothing.
- **`doctor.rs`** — reports the override by name ahead of the load check. `launchctl print` fails identically for "never installed" and "installed but disabled"; only the first is the installer's to fix.

## Verification

Reproduced the disabled state and drove the whole path on macOS 26:

```
✗ launchd: muxad agent is disabled and will not start at login — run
  `launchctl enable gui/501/dev.open330.muxad`, then `muxa init --component muxad-launchd`
→ muxa init --component muxad-launchd → state = running
✔ muxad responding at /tmp/muxa-501.sock
✔ launchd: muxad agent loaded
```

The parser takes both spellings of the override: macOS 26's `launchctl print-disabled` prints `enabled`/`disabled`, the backing plist stores `true`/`false`. Both are covered by unit tests.

`cargo test -p muxa-cli` 947 passing, clippy clean, `xcodebuild test -scheme Muxa` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)