### PR TITLE
feat(macos): drive the workbench from the keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The workbench is fully drivable from the keyboard, with `⌘P` and `⌘⇧P` in
+  front.** `⌘P` opens Quick Open over sessions, windows, panes, native shells,
+  work and agents; `⌘⇧P` opens the command palette for navigating, creating
+  work and shells, refreshing, and managing editor tabs. While either is open
+  the two keys switch between destinations and commands without closing the
+  search field. The **Navigate** and **Editor** menus list every shortcut, so
+  the keyboard surface is discoverable rather than folklore.
+
+  Ranking is defined rather than fuzzy-by-default: exact title, then title
+  prefix and substring, then context substring, then fuzzy — with recency only
+  breaking ties, and an empty query showing recent destinations. An exact pane
+  title outranks a same-named window. Editing the query selects the best
+  *enabled* result while a background refresh preserves whatever the user
+  selected, so a list that updates underneath does not move the target.
+  Identical names on different hosts or tmux sockets stay separate
+  destinations. Opening a result pins its editor — it never sends terminal
+  input or starts a session.
+
+  IME composition keeps its native key handling, including Korean candidate
+  selection and the Enter that confirms a composition, and plain Tab outside
+  the palette still traverses focus normally.
+
+  Editor navigation covers `⌘1`–`⌘9`, `Ctrl-Tab`, editor groups (`⌘⌥←`/`⌘⌥→`),
+  split (`⌘\`), pin (`⌘⌥Enter`) and close (`⌘W`, which never terminates the
+  session). Closing an editor in a background group no longer moves focus out
+  of the group the user is in, and dismissing an exited shell synchronizes to
+  the surviving editor once rather than leaving the model pointing at a
+  removed group.
+
+  Pane and work send results now occupy a fixed-size status area beside Send,
+  so neither a success nor a long error reflows the composer, and a draft
+  edited while a send is in flight survives that send completing. See
+  [Keyboard navigation](docs/MACOS.md#keyboard-navigation).
+
 - **`[automation.rule.ask_condition]` puts a natural-language check in front of
   a rule's fixed action.** The condition runs *after* the deterministic event,
   filters, timing, and guards have already selected a candidate, and it can

--- a/apps/muxa-macos/Resources/Localizable.xcstrings
+++ b/apps/muxa-macos/Resources/Localizable.xcstrings
@@ -1,6 +1,436 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "A shell is being created": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셸을 생성하고 있습니다"
+          }
+        }
+      }
+    },
+    "Ambiguous agent destination; open its pane instead": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트 대상을 구분할 수 없습니다. 해당 패널을 여세요"
+          }
+        }
+      }
+    },
+    "Ask: Open global Ask": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ask: 전역 Ask 열기"
+          }
+        }
+      }
+    },
+    "Daemon is not connected": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "데몬에 연결되어 있지 않습니다"
+          }
+        }
+      }
+    },
+    "Editor: Close active editor": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집기: 활성 편집기 닫기"
+          }
+        }
+      }
+    },
+    "Editor: Keep open (pin)": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집기: 열린 상태로 고정"
+          }
+        }
+      }
+    },
+    "Editor: Next editor": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집기: 다음 편집기"
+          }
+        }
+      }
+    },
+    "Editor: Previous editor": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집기: 이전 편집기"
+          }
+        }
+      }
+    },
+    "Editor: Split right": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집기: 오른쪽으로 분할"
+          }
+        }
+      }
+    },
+    "Native shell": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "네이티브 셸"
+          }
+        }
+      }
+    },
+    "No active editor": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "활성 편집기가 없습니다"
+          }
+        }
+      }
+    },
+    "Search sessions, windows, panes, shells, work, agents": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세션, 윈도우, 패널, 셸, 작업, 에이전트 검색"
+          }
+        }
+      }
+    },
+    "Selected": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택됨"
+          }
+        }
+      }
+    },
+    "Shell: New native shell": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셸: 새 네이티브 셸"
+          }
+        }
+      }
+    },
+    "View: Focus sidebar": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보기: 사이드바에 포커스"
+          }
+        }
+      }
+    },
+    "View: Show Explore": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보기: 탐색 표시"
+          }
+        }
+      }
+    },
+    "View: Show Inbox": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보기: 받은 편지함 표시"
+          }
+        }
+      }
+    },
+    "View: Show Shells": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보기: 셸 표시"
+          }
+        }
+      }
+    },
+    "View: Show Work": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보기: 작업 표시"
+          }
+        }
+      }
+    },
+    "Watch: Open native Live Watch": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Watch: 네이티브 Live Watch 열기"
+          }
+        }
+      }
+    },
+    "Work is starting": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업을 시작하고 있습니다"
+          }
+        }
+      }
+    },
+    "Work: Open Command Center": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업: 명령 센터 열기"
+          }
+        }
+      }
+    },
+    "Work: Start configured Work": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업: 설정된 작업 시작"
+          }
+        }
+      }
+    },
+    "Workspace: Refresh": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "워크스페이스: 새로 고침"
+          }
+        }
+      }
+    },
+    "esc  dismiss": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "esc  닫기"
+          }
+        }
+      }
+    },
+    "↑↓ / ⇧⇥ ⇥  select": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "↑↓ / ⇧⇥ ⇥  선택"
+          }
+        }
+      }
+    },
+    "↵  open": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "↵  열기"
+          }
+        }
+      }
+    },
+    "Command Palette…": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "명령 팔레트…"
+          }
+        }
+      }
+    },
+    "Focus Next Editor Group": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음 편집기 그룹에 포커스"
+          }
+        }
+      }
+    },
+    "Focus Previous Editor Group": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 편집기 그룹에 포커스"
+          }
+        }
+      }
+    },
+    "Focus Sidebar Filter": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사이드바 필터에 포커스"
+          }
+        }
+      }
+    },
+    "Last Editor": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마지막 편집기"
+          }
+        }
+      }
+    },
+    "Open Ask": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ask 열기"
+          }
+        }
+      }
+    },
+    "Open Inbox": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받은 편지함 열기"
+          }
+        }
+      }
+    },
+    "Quick Open…": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빠른 이동…"
+          }
+        }
+      }
+    },
+    "Show prompt status details": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프롬프트 전송 상태 자세히 보기"
+          }
+        }
+      }
+    },
+    "No destinations available": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이동할 대상이 없습니다"
+          }
+        }
+      }
+    },
+    "No matching results": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검색 결과가 없습니다"
+          }
+        }
+      }
+    },
+    "Sessions and work appear here when available.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 가능한 세션과 작업이 여기에 표시됩니다."
+          }
+        }
+      }
+    },
+    "Try a name, host, socket, or a shorter query.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름, 호스트, 소켓 또는 더 짧은 검색어로 검색하세요."
+          }
+        }
+      }
+    },
+    "Editor %lld": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집기 %lld"
+          }
+        }
+      }
+    },
+    "%lld results": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "결과 %lld개"
+          }
+        }
+      }
+    },
+    "Navigate": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이동"
+          }
+        }
+      }
+    },
     "Advanced has unsaved configuration changes. Save or reload it before changing this." : {
       "localizations" : {
         "ko" : {

--- a/apps/muxa-macos/Scripts/smoke-test.sh
+++ b/apps/muxa-macos/Scripts/smoke-test.sh
@@ -23,16 +23,38 @@ SMOKE_DIR=$(mktemp -d)
 SOCKET_PATH="$SMOKE_DIR/muxad.sock"
 APP_LOG="$SMOKE_DIR/muxa.log"
 APP_PID=
+DAEMON_PIDS=
+mkdir -p "$SMOKE_DIR/home" "$SMOKE_DIR/config" "$SMOKE_DIR/data"
+cat >"$SMOKE_DIR/config.toml" <<'TOML'
+[automation]
+enabled = false
+[ask]
+enabled = false
+[discovery]
+enabled = false
+TOML
 
 cleanup() {
     if [ -n "$APP_PID" ] && kill -0 "$APP_PID" 2>/dev/null; then
         kill "$APP_PID" 2>/dev/null || true
         wait "$APP_PID" 2>/dev/null || true
     fi
-    if [ -S "$SOCKET_PATH" ]; then
-        while IFS= read -r daemon_pid; do
-            [ -n "$daemon_pid" ] && kill "$daemon_pid" 2>/dev/null || true
-        done < <(lsof -t "$SOCKET_PATH" 2>/dev/null || true)
+    for daemon_pid in $DAEMON_PIDS; do
+        [ "$daemon_pid" = "$APP_PID" ] || kill "$daemon_pid" 2>/dev/null || true
+    done
+    for attempt in $(seq 1 100); do
+        running=0
+        for daemon_pid in $DAEMON_PIDS; do
+            if [ "$daemon_pid" != "$APP_PID" ] && kill -0 "$daemon_pid" 2>/dev/null; then
+                running=1
+            fi
+        done
+        [ "$running" -eq 0 ] && break
+        sleep 0.1
+    done
+    if [ "$running" -ne 0 ]; then
+        echo "Smoke daemon is still stopping; retained $SMOKE_DIR" >&2
+        return 1
     fi
     rm -rf "$SMOKE_DIR"
 }
@@ -63,7 +85,9 @@ print(json.dumps(response, separators=(",", ":")))
 PY
 }
 
-MUXA_SOCKET="$SOCKET_PATH" "$APP_EXECUTABLE" >"$APP_LOG" 2>&1 &
+HOME="$SMOKE_DIR/home" XDG_CONFIG_HOME="$SMOKE_DIR/config" XDG_DATA_HOME="$SMOKE_DIR/data" \
+    MUXA_CONFIG="$SMOKE_DIR/config.toml" MUXA_HOSTS=herdr MUXA_SOCKET="$SOCKET_PATH" \
+    "$APP_EXECUTABLE" >"$APP_LOG" 2>&1 &
 APP_PID=$!
 
 for _ in $(seq 1 50); do
@@ -75,6 +99,7 @@ for _ in $(seq 1 50); do
     sleep 0.1
 done
 test -S "$SOCKET_PATH"
+DAEMON_PIDS=$(lsof -t "$SOCKET_PATH" 2>/dev/null | sort -u || true)
 
 hello=$(ipc '{"protocol":6,"kind":"hello","client":"muxa-macos-smoke"}')
 python3 - "$hello" <<'PY'
@@ -89,6 +114,8 @@ required = {
     "ask_status_v1",
     "ask_one_turn_credential_v1",
     "ask_conversations_v1",
+    "automation_ask_v1",
+    "config_launch_v1",
 }
 missing = required.difference(response.get("capabilities", []))
 if missing:
@@ -109,4 +136,6 @@ sleep 3
 kill -0 "$APP_PID"
 ipc "{\"protocol\":6,\"kind\":\"terminate_session\",\"session_id\":\"$session_id\"}" >/dev/null
 
+cleanup
+trap - EXIT
 echo "Muxa.app smoke test passed"

--- a/apps/muxa-macos/Sources/AirModule.swift
+++ b/apps/muxa-macos/Sources/AirModule.swift
@@ -282,6 +282,13 @@ final class AirModule: MuxaModule, ObservableObject {
         workbenchURL = nil
     }
 
+    /// Workbench serves until it is stopped, so quitting the app has to stop
+    /// it — otherwise the server outlives the app that started it, still
+    /// holding a loopback port for an artifact nobody can reach.
+    func shutdown() {
+        stopWorkbench()
+    }
+
     // MARK: AIR → pipeline
 
     func importWorkflow(into model: AppModel) {

--- a/apps/muxa-macos/Sources/CommandPaletteView.swift
+++ b/apps/muxa-macos/Sources/CommandPaletteView.swift
@@ -1,0 +1,562 @@
+import AppKit
+import SwiftUI
+
+enum MuxaPaletteMode: String, Identifiable {
+    case navigation
+    case commands
+
+    var id: Self { self }
+
+    static func shortcut(characters: String?, modifiers: NSEvent.ModifierFlags) -> Self? {
+        guard characters?.lowercased() == "p" else { return nil }
+        let flags = modifiers.intersection(.deviceIndependentFlagsMask).subtracting([.capsLock, .numericPad, .function])
+        switch flags {
+        case .command: return .navigation
+        case [.command, .shift]: return .commands
+        default: return nil
+        }
+    }
+}
+
+enum MuxaPaletteAction: Hashable {
+    case navigate(MuxaSidebarSelection)
+    case command(MuxaPaletteCommand)
+}
+
+enum MuxaPaletteCommand: String, CaseIterable, Identifiable {
+    case startWork, workCommandCenter, liveWatch, ask, newShell
+    case showWork, showWatch, showInbox, showShells, refresh
+    case closeEditor, previousEditor, nextEditor, splitEditor, pinEditor, focusSidebar
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .startWork: String(localized: "Work: Start configured Work")
+        case .workCommandCenter: String(localized: "Work: Open Command Center")
+        case .liveWatch: String(localized: "Watch: Open native Live Watch")
+        case .ask: String(localized: "Ask: Open global Ask")
+        case .newShell: String(localized: "Shell: New native shell")
+        case .showWork: String(localized: "View: Show Work")
+        case .showWatch: String(localized: "View: Show Explore")
+        case .showInbox: String(localized: "View: Show Inbox")
+        case .showShells: String(localized: "View: Show Shells")
+        case .refresh: String(localized: "Workspace: Refresh")
+        case .closeEditor: String(localized: "Editor: Close active editor")
+        case .previousEditor: String(localized: "Editor: Previous editor")
+        case .nextEditor: String(localized: "Editor: Next editor")
+        case .splitEditor: String(localized: "Editor: Split right")
+        case .pinEditor: String(localized: "Editor: Keep open (pin)")
+        case .focusSidebar: String(localized: "View: Focus sidebar")
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .startWork: "play.square.stack"
+        case .workCommandCenter, .showWork: "square.stack.3d.up"
+        case .liveWatch: "waveform.path.ecg.rectangle"
+        case .ask: "sparkles"
+        case .newShell, .showShells: "terminal"
+        case .showWatch, .focusSidebar: "sidebar.left"
+        case .showInbox: "tray.full"
+        case .refresh: "arrow.clockwise"
+        case .closeEditor: "xmark"
+        case .previousEditor: "arrow.left"
+        case .nextEditor: "arrow.right"
+        case .splitEditor: "rectangle.split.2x1"
+        case .pinEditor: "pin"
+        }
+    }
+
+    @MainActor
+    func disabledReason(model: AppModel) -> String? {
+        switch self {
+        case .startWork, .newShell, .refresh:
+            guard model.isConnected else { return String(localized: "Daemon is not connected") }
+            if self == .startWork && model.isStartingWork {
+                return String(localized: "Work is starting")
+            }
+            if self == .newShell && model.isCreatingSession {
+                return String(localized: "A shell is being created")
+            }
+        case .closeEditor, .previousEditor, .nextEditor, .splitEditor, .pinEditor:
+            guard let selection = model.sidebarSelection, model.isSelectionAvailable(selection) else {
+                return String(localized: "No active editor")
+            }
+        default:
+            break
+        }
+        return nil
+    }
+}
+
+struct MuxaPaletteID: Hashable {
+    let components: [String?]
+}
+
+struct MuxaPaletteItem: Identifiable, Equatable {
+    let stableID: MuxaPaletteID
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    let action: MuxaPaletteAction
+    var disabledReason: String? = nil
+
+    var id: MuxaPaletteID { stableID }
+    var isEnabled: Bool { disabledReason == nil }
+}
+
+enum MuxaPaletteSearch {
+    private static func matchTier(query: String, item: MuxaPaletteItem) -> Int {
+        let locale = Locale(identifier: "en_US_POSIX")
+        let query = query.trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: locale)
+        guard !query.isEmpty else { return 0 }
+        let title = item.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: locale)
+        if title == query {
+            if case .navigate(.pane) = item.action { return 6 }
+            return 5
+        }
+        if title.hasPrefix(query) { return 4 }
+        if title.contains(query) { return 3 }
+        let subtitle = item.subtitle.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: locale)
+        if subtitle.contains(query) { return 2 }
+        return 1
+    }
+
+    static func score(query: String, text: String) -> Int? {
+        let locale = Locale(identifier: "en_US_POSIX")
+        let foldedText = Array(text.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: locale))
+        let words = query.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: locale)
+            .split(whereSeparator: { $0.isWhitespace })
+        var total = 0
+        for word in words {
+            if String(foldedText).contains(word) {
+                total += 100 + word.count * 18
+                continue
+            }
+            var cursor = 0
+            var previous: Int?
+            for character in word {
+                guard let index = foldedText[cursor...].firstIndex(of: character) else { return nil }
+                total += 10
+                if index == 0 || !foldedText[index - 1].isLetter && !foldedText[index - 1].isNumber {
+                    total += 12
+                }
+                if let previous {
+                    total += index == previous + 1 ? 8 : -min(index - previous - 1, 8)
+                }
+                previous = index
+                cursor = index + 1
+            }
+        }
+        return total
+    }
+
+    static func results(_ items: [MuxaPaletteItem], query: String, recent: [MuxaSidebarSelection]) -> [MuxaPaletteItem] {
+        var seen = Set<MuxaPaletteID>()
+        let unique = items.filter { seen.insert($0.stableID).inserted }
+        return unique.enumerated().compactMap { offset, item -> (MuxaPaletteItem, Int, Int, Int, Int)? in
+            guard let score = score(query: query, text: item.title + " " + item.subtitle) else { return nil }
+            let rank: Int
+            if case .navigate(let selection) = item.action {
+                rank = recent.firstIndex(of: selection) ?? Int.max
+            } else {
+                rank = Int.max
+            }
+            return (item, matchTier(query: query, item: item), score, rank, offset)
+        }.sorted {
+            if $0.1 != $1.1 { return $0.1 > $1.1 }
+            if $0.2 != $1.2 { return $0.2 > $1.2 }
+            if $0.3 != $1.3 { return $0.3 < $1.3 }
+            return $0.4 < $1.4
+        }.map { $0.0 }
+    }
+}
+
+enum MuxaPaletteSelection {
+    static func updated(_ selected: MuxaPaletteID?, previousQuery: String, query: String, in items: [MuxaPaletteItem]) -> MuxaPaletteID? {
+        retained(previousQuery == query ? selected : nil, in: items)
+    }
+
+    static func retained(_ selected: MuxaPaletteID?, in items: [MuxaPaletteItem]) -> MuxaPaletteID? {
+        if let selected, items.contains(where: { $0.stableID == selected && $0.isEnabled }) { return selected }
+        return items.first(where: \.isEnabled)?.stableID
+    }
+
+    static func moved(_ selected: MuxaPaletteID?, by delta: Int, in items: [MuxaPaletteItem]) -> MuxaPaletteID? {
+        let enabled = items.filter(\.isEnabled)
+        guard !enabled.isEmpty else { return nil }
+        guard let index = enabled.firstIndex(where: { $0.stableID == selected }) else {
+            return delta < 0 ? enabled.last?.stableID : enabled.first?.stableID
+        }
+        let step = delta % enabled.count
+        return enabled[(index + step + enabled.count) % enabled.count].stableID
+    }
+
+    static func action(_ selected: MuxaPaletteID?, in items: [MuxaPaletteItem]) -> MuxaPaletteAction? {
+        items.first(where: { $0.stableID == selected && $0.isEnabled })?.action
+    }
+}
+
+enum MuxaPaletteKeyDecision: Equatable {
+    case previous, next, submit, cancel, passThrough
+
+    static func resolve(selector: String, hasMarkedText: Bool, beganWithMarkedText: Bool = false) -> Self {
+        guard !hasMarkedText, !beganWithMarkedText else { return .passThrough }
+        switch selector {
+        case "moveUp:", "insertBacktab:": return .previous
+        case "moveDown:", "insertTab:": return .next
+        case "insertNewline:", "insertNewlineIgnoringFieldEditor:": return .submit
+        case "cancelOperation:": return .cancel
+        default: return .passThrough
+        }
+    }
+}
+
+enum MuxaPaletteItems {
+    static func navigation(
+        watchSections: [MuxaWatchHost], workGroups: [MuxaWorkGroup],
+        sessions: [MuxaSession], agents: [MuxaHostedAgent], localSocket: String
+    ) -> [MuxaPaletteItem] {
+        var items: [MuxaPaletteItem] = []
+        for section in watchSections {
+            for session in section.sessions {
+                let context = [session.hostAlias, session.socket, session.sessionID].joined(separator: " · ")
+                items.append(MuxaPaletteItem(
+                    stableID: MuxaPaletteID(components: ["session", session.hostAlias, session.socket, session.sessionID]),
+                    title: session.name, subtitle: String(localized: "Session") + " · " + context,
+                    systemImage: "rectangle.stack", action: .navigate(.fleetSession(session.identity))
+                ))
+                for window in session.windows {
+                    let components = ["window", window.hostAlias, window.socket, window.sessionID, window.windowID]
+                    let windowContext = [session.name, window.name, context, window.windowID].joined(separator: " · ")
+                    items.append(MuxaPaletteItem(
+                        stableID: MuxaPaletteID(components: components), title: window.name,
+                        subtitle: String(localized: "Window") + " · " + windowContext, systemImage: "macwindow",
+                        action: .navigate(.fleetWindow(window.identity))
+                    ))
+                    for pane in window.panes {
+                        items.append(MuxaPaletteItem(
+                            stableID: MuxaPaletteID(components: [
+                                "pane", pane.host.alias, pane.pane.endpointSocket,
+                                pane.pane.sessionID, pane.pane.windowID, pane.pane.paneID,
+                            ]),
+                            title: pane.pane.title.isEmpty ? pane.pane.currentCommand : pane.pane.title,
+                            subtitle: [String(localized: "Pane"), windowContext, pane.pane.paneID, pane.pane.currentPath].joined(separator: " · "),
+                            systemImage: "rectangle.split.2x1", action: .navigate(.pane(pane.id))
+                        ))
+                    }
+                }
+            }
+        }
+        for session in sessions where !session.exited {
+            items.append(MuxaPaletteItem(
+                stableID: MuxaPaletteID(components: ["shell", "local", localSocket, session.id]),
+                title: session.displayName ?? session.id,
+                subtitle: [String(localized: "Native shell"), "local", localSocket, session.id, session.cwd ?? ""].joined(separator: " · "),
+                systemImage: "terminal", action: .navigate(.shell(session.id))
+            ))
+        }
+        for work in workGroups {
+            items.append(MuxaPaletteItem(
+                stableID: MuxaPaletteID(components: ["work", work.identity.workspaceID, work.identity.workID]),
+                title: work.title,
+                subtitle: ([String(localized: "Work"), work.workspaceID, work.pipelineLabel, work.cwd ?? ""] + work.hostAliases).joined(separator: " · "),
+                systemImage: "square.stack.3d.up", action: .navigate(.work(work.identity))
+            ))
+        }
+        let agentIDs = Dictionary(grouping: agents, by: \.id).mapValues { group in
+            Set(group.map { agentID($0) }).count
+        }
+        for agent in agents {
+            items.append(MuxaPaletteItem(
+                stableID: agentID(agent), title: agent.agent.aiTitle ?? agent.agent.kind,
+                subtitle: [
+                    String(localized: "Agent"), agent.host.alias, agent.agent.tmuxSocket ?? "", agent.agent.tmuxSession ?? "",
+                    agent.agent.id, agent.agent.state, agent.agent.cwd ?? "",
+                ].joined(separator: " · "),
+                systemImage: "sparkles", action: .navigate(.agent(agent.id)),
+                disabledReason: (agentIDs[agent.id] ?? 0) > 1 ? String(localized: "Ambiguous agent destination; open its pane instead") : nil
+            ))
+        }
+        return items
+    }
+
+    private static func agentID(_ agent: MuxaHostedAgent) -> MuxaPaletteID {
+        MuxaPaletteID(components: [
+            "agent", agent.host.alias, agent.pane?.endpointSocket ?? agent.agent.tmuxSocket,
+            agent.pane?.sessionID ?? agent.agent.tmuxSession, agent.pane?.windowID,
+            agent.agent.id, agent.pane?.paneID ?? agent.agent.pane,
+        ])
+    }
+}
+
+struct CommandPaletteView: View {
+    @ObservedObject var model: AppModel
+    @State var mode: MuxaPaletteMode
+    let recent: [MuxaSidebarSelection]
+    let onChoose: (MuxaPaletteAction) -> Void
+    let onCancel: () -> Void
+
+    @State private var query = ""
+    @State private var selectedID: MuxaPaletteID?
+    @State private var didFinish = false
+
+    private var items: [MuxaPaletteItem] {
+        let candidates: [MuxaPaletteItem]
+        switch mode {
+        case .navigation:
+            candidates = MuxaPaletteItems.navigation(
+                watchSections: model.executionSnapshot.watchHosts, workGroups: model.workGroups,
+                sessions: model.sessions, agents: model.hostedAgents, localSocket: model.client.socketPath
+            )
+        case .commands:
+            candidates = MuxaPaletteCommand.allCases.map { command in
+                MuxaPaletteItem(
+                    stableID: MuxaPaletteID(components: ["command", command.rawValue]), title: command.title,
+                    subtitle: command.disabledReason(model: model) ?? "", systemImage: command.systemImage,
+                    action: .command(command), disabledReason: command.disabledReason(model: model)
+                )
+            }
+        }
+        return MuxaPaletteSearch.results(candidates, query: query, recent: recent)
+    }
+
+    var body: some View {
+        let results = items
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: mode == .navigation ? "magnifyingglass" : "chevron.right")
+                    .foregroundStyle(.secondary)
+                MuxaPaletteSearchField(
+                    text: Binding(get: { query }, set: { updateQuery($0) }),
+                    placeholder: mode == .navigation
+                        ? String(localized: "Search sessions, windows, panes, shells, work, agents")
+                        : String(localized: "Type a command"),
+                    onKey: handleKey,
+                    onModeChange: { mode = $0 }
+                )
+                Text(mode == .navigation ? "⌘P" : "⇧⌘P")
+                    .font(.caption.monospaced()).foregroundStyle(.secondary)
+            }
+            .padding(16)
+            Divider()
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 2) {
+                        if results.isEmpty {
+                            VStack(spacing: 8) {
+                                Image(systemName: "magnifyingglass").font(.title2)
+                                Text(query.isEmpty ? "No destinations available" : "No matching results")
+                                Text(query.isEmpty ? "Sessions and work appear here when available." : "Try a name, host, socket, or a shorter query.")
+                                    .font(.caption)
+                            }
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, minHeight: 230)
+                        }
+                        ForEach(results) { item in
+                            row(item)
+                        }
+                    }
+                    .padding(8)
+                }
+                .onChange(of: selectedID) { selected in
+                    if let selected { proxy.scrollTo(selected) }
+                }
+                .onChange(of: results) { updated in
+                    selectedID = MuxaPaletteSelection.retained(selectedID, in: updated)
+                    if let selectedID { proxy.scrollTo(selectedID) }
+                }
+            }
+            Divider()
+            HStack(spacing: 14) {
+                Text("↑↓ / ⇧⇥ ⇥  select")
+                Text("↵  open")
+                Text("esc  dismiss")
+                Spacer()
+                Text("\(results.count) results")
+            }
+            .font(.caption).foregroundStyle(.secondary).padding(12)
+        }
+        .frame(width: 680, height: 430)
+        .background(.regularMaterial)
+        .onAppear { selectedID = MuxaPaletteSelection.retained(selectedID, in: results) }
+        .onChange(of: mode) { _ in
+            query = ""
+            selectedID = MuxaPaletteSelection.retained(nil, in: items)
+        }
+    }
+
+    private func row(_ item: MuxaPaletteItem) -> some View {
+        Button {
+            selectedID = item.stableID
+            choose(item.stableID)
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: item.systemImage).frame(width: 22)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(item.title).font(.body).lineLimit(1)
+                    if !item.subtitle.isEmpty {
+                        Text(item.subtitle).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+                Spacer(minLength: 0)
+                if !item.isEnabled { Image(systemName: "lock").font(.caption) }
+                if item.stableID == selectedID { Image(systemName: "return").font(.caption) }
+            }
+            .padding(.horizontal, 10).padding(.vertical, 9)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(item.stableID == selectedID ? Color.accentColor.opacity(0.18) : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!item.isEnabled)
+        .opacity(item.isEnabled ? 1 : 0.5)
+        .help(item.disabledReason ?? item.subtitle)
+        .accessibilityValue(item.stableID == selectedID ? String(localized: "Selected") : "")
+        .id(item.stableID)
+    }
+
+    private func updateQuery(_ value: String) {
+        let previousQuery = query
+        query = value
+        selectedID = MuxaPaletteSelection.updated(selectedID, previousQuery: previousQuery, query: value, in: items)
+    }
+
+    private func handleKey(_ decision: MuxaPaletteKeyDecision) {
+        guard !didFinish else { return }
+        switch decision {
+        case .previous: selectedID = MuxaPaletteSelection.moved(selectedID, by: -1, in: items)
+        case .next: selectedID = MuxaPaletteSelection.moved(selectedID, by: 1, in: items)
+        case .submit: choose(selectedID)
+        case .cancel:
+            didFinish = true
+            onCancel()
+        case .passThrough: break
+        }
+    }
+
+    private func choose(_ selected: MuxaPaletteID?) {
+        guard !didFinish, let action = MuxaPaletteSelection.action(selected, in: items) else { return }
+        didFinish = true
+        onChoose(action)
+    }
+}
+
+struct MuxaPaletteSearchField: NSViewRepresentable {
+    @Binding var text: String
+    let placeholder: String
+    let onKey: (MuxaPaletteKeyDecision) -> Void
+    let onModeChange: (MuxaPaletteMode) -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeNSView(context: Context) -> NSTextField {
+        let field = MuxaPaletteTextField(frame: .zero)
+        field.cell = MuxaPaletteTextFieldCell(textCell: "")
+        field.isEditable = true
+        field.isSelectable = true
+        field.onModeChange = onModeChange
+        field.isBezeled = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.font = .systemFont(ofSize: 15)
+        field.delegate = context.coordinator
+        field.placeholderString = placeholder
+        field.stringValue = text
+        field.setAccessibilityLabel(placeholder)
+        field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return field
+    }
+
+    func updateNSView(_ field: NSTextField, context: Context) {
+        context.coordinator.parent = self
+        (field as? MuxaPaletteTextField)?.onModeChange = onModeChange
+        field.placeholderString = placeholder
+        field.setAccessibilityLabel(placeholder)
+        if field.stringValue != text, (field.currentEditor() as? NSTextView)?.hasMarkedText() != true {
+            field.stringValue = text
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var parent: MuxaPaletteSearchField
+
+        init(_ parent: MuxaPaletteSearchField) { self.parent = parent }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let field = notification.object as? NSTextField else { return }
+            parent.text = field.stringValue
+        }
+
+        func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            let decision = MuxaPaletteKeyDecision.resolve(
+                selector: NSStringFromSelector(commandSelector), hasMarkedText: textView.hasMarkedText(),
+                beganWithMarkedText: (textView as? MuxaPaletteFieldEditor)?.beganWithMarkedText ?? false
+            )
+            guard decision != .passThrough else { return false }
+            parent.onKey(decision)
+            return true
+        }
+    }
+}
+
+final class MuxaPaletteTextField: NSTextField {
+    var onModeChange: (MuxaPaletteMode) -> Void = { _ in } {
+        didSet { (cell as? MuxaPaletteTextFieldCell)?.editor.onModeChange = onModeChange }
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if let mode = MuxaPaletteMode.shortcut(characters: event.charactersIgnoringModifiers, modifiers: event.modifierFlags) {
+            onModeChange(mode)
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard window != nil else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let window = self.window else { return }
+            window.makeFirstResponder(self)
+        }
+    }
+}
+
+private final class MuxaPaletteTextFieldCell: NSTextFieldCell {
+    let editor = MuxaPaletteFieldEditor(frame: .zero)
+
+    override func fieldEditor(for controlView: NSView) -> NSTextView? {
+        editor.isFieldEditor = true
+        editor.isRichText = false
+        editor.isAutomaticQuoteSubstitutionEnabled = false
+        editor.isAutomaticDashSubstitutionEnabled = false
+        editor.isAutomaticTextReplacementEnabled = false
+        return editor
+    }
+}
+
+private final class MuxaPaletteFieldEditor: NSTextView {
+    private(set) var beganWithMarkedText = false
+    var onModeChange: (MuxaPaletteMode) -> Void = { _ in }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if let mode = MuxaPaletteMode.shortcut(characters: event.charactersIgnoringModifiers, modifiers: event.modifierFlags) {
+            onModeChange(mode)
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        beganWithMarkedText = hasMarkedText()
+        defer { beganWithMarkedText = false }
+        super.keyDown(with: event)
+    }
+}

--- a/apps/muxa-macos/Sources/ContentView.swift
+++ b/apps/muxa-macos/Sources/ContentView.swift
@@ -4,7 +4,10 @@ import SwiftUI
 struct ContentView: View {
     @EnvironmentObject private var model: AppModel
     @StateObject private var tabs = MuxaWorkbenchTabs()
-    @State private var isCommandPalettePresented = false
+    @State private var paletteMode: MuxaPaletteMode?
+    @State private var pendingPaletteAction: MuxaPaletteAction?
+    @State private var sidebarFocusRequest = UUID()
+    @FocusState private var focusedEditorGroup: UUID?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -19,7 +22,8 @@ struct ContentView: View {
                         model.selectWatchPane(id)
                         tabs.openPinned(.pane(id))
                     },
-                    closeShell: dismissExitedShell
+                    closeShell: dismissExitedShell,
+                    focusRequest: sidebarFocusRequest
                 )
                     .frame(minWidth: 260, idealWidth: 300, maxWidth: 380)
                 editorRegion
@@ -49,11 +53,10 @@ struct ContentView: View {
                     .disabled(!model.isConnected)
 
                     Button {
-                        isCommandPalettePresented = true
+                        paletteMode = .commands
                     } label: {
                         Label("Commands", systemImage: "command")
                     }
-                    .keyboardShortcut("p", modifiers: [.command, .shift])
 
                     Button(role: .destructive) {
                         model.terminateSelectedSession()
@@ -84,8 +87,18 @@ struct ContentView: View {
                 "This stops the muxad currently using the socket, disables older background services that could reclaim it, and starts the version bundled with Muxa. Native PTY sessions owned by the old daemon will end; tmux sessions will not be terminated."
             )
         }
-        .sheet(isPresented: $isCommandPalettePresented) {
-            CommandPaletteView(model: model, isPresented: $isCommandPalettePresented)
+        .sheet(item: $paletteMode, onDismiss: performPendingPaletteAction) { mode in
+            CommandPaletteView(
+                model: model,
+                mode: mode,
+                recent: tabs.groups.sorted { $0.id == tabs.focusedGroupID && $1.id != tabs.focusedGroupID }
+                    .flatMap { $0.history.reversed() },
+                onChoose: { action in
+                    pendingPaletteAction = action
+                    paletteMode = nil
+                },
+                onCancel: { paletteMode = nil }
+            )
         }
         .sheet(isPresented: $model.isPresentingWorkStart) {
             WorkStartView(model: model, isPresented: $model.isPresentingWorkStart)
@@ -109,6 +122,11 @@ struct ContentView: View {
             if model.sidebarSelection != tabs.focusedSelection {
                 model.activateEditor(tabs.focusedSelection)
             }
+        }
+        .onChange(of: focusedEditorGroup) { groupID in
+            guard let groupID else { return }
+            tabs.focus(groupID)
+            model.activateEditor(tabs.focusedSelection)
         }
         .background(WorkbenchWindowPresenter())
         .focusedSceneValue(\.muxaEditorCommands, editorCommands)
@@ -134,6 +152,8 @@ struct ContentView: View {
                     maxHeight: .infinity,
                     alignment: .topLeading
                 )
+                .focusable()
+                .focused($focusedEditorGroup, equals: group.id)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -226,12 +246,7 @@ struct ContentView: View {
     /// sidebar hides the row itself.
     private func dismissExitedShell(id: String) {
         let selection = MuxaSidebarSelection.shell(id)
-        for group in tabs.groups where group.tabs.contains(selection) {
-            let focused = tabs.close(selection, groupID: group.id)
-            if tabs.focusedGroupID == group.id {
-                model.activateEditor(focused)
-            }
-        }
+        model.activateEditor(tabs.closeEverywhere(selection))
         Task { await model.refresh() }
     }
 
@@ -262,8 +277,64 @@ struct ContentView: View {
             pin: {
                 guard let selection = tabs.focusedSelection else { return }
                 tabs.pin(selection, groupID: tabs.focusedGroupID)
-            }
+            },
+            quickOpen: { paletteMode = .navigation },
+            commandPalette: { paletteMode = .commands },
+            activateAt: { index in
+                if let selection = tabs.activateAt(index) { model.activateEditor(selection) }
+            },
+            activateLast: {
+                if let selection = tabs.activateLast() { model.activateEditor(selection) }
+            },
+            focusRelativeGroup: { offset in
+                model.activateEditor(tabs.focusRelativeGroup(offset))
+                focusedEditorGroup = tabs.focusedGroupID
+            },
+            openWorkCommandCenter: { openEditor(.workBoard) },
+            openAsk: { openEditor(.ask) },
+            openInbox: { openEditor(.inbox) },
+            selectSidebar: { model.show($0) },
+            focusSidebar: { sidebarFocusRequest = UUID() },
+            isEnabled: paletteMode == nil && !model.isPresentingWorkStart
+                && !model.isPresentingHostRegistration && model.pipelineEditorTarget == nil
+                && !model.isConfirmingDaemonReplacement
         )
+    }
+
+    private func openEditor(_ selection: MuxaSidebarSelection) {
+        guard model.isSelectionAvailable(selection) else { return }
+        tabs.openPinned(selection)
+        model.select(selection)
+        model.activateEditor(selection)
+    }
+
+    private func performPendingPaletteAction() {
+        guard let action = pendingPaletteAction else { return }
+        pendingPaletteAction = nil
+        switch action {
+        case .navigate(let selection):
+            openEditor(selection)
+        case .command(let command):
+            guard command.disabledReason(model: model) == nil else { return }
+            switch command {
+            case .startWork: model.presentWorkStart()
+            case .workCommandCenter: openEditor(.workBoard)
+            case .liveWatch: openEditor(.watch)
+            case .ask: openEditor(.ask)
+            case .newShell: model.createShell()
+            case .showWork: model.show(.work)
+            case .showWatch: model.show(.watch)
+            case .showInbox: model.show(.inbox)
+            case .showShells: model.show(.shells)
+            case .refresh: Task { await model.refresh() }
+            case .closeEditor: editorCommands.close?()
+            case .previousEditor: editorCommands.previous?()
+            case .nextEditor: editorCommands.next?()
+            case .splitEditor: editorCommands.splitRight?()
+            case .pinEditor: editorCommands.pin?()
+            case .focusSidebar: sidebarFocusRequest = UUID()
+            }
+        }
     }
 }
 
@@ -557,117 +628,6 @@ private struct EditorTab: View {
     @Environment(\.colorScheme) private var colorScheme
 }
 
-private struct CommandPaletteView: View {
-    private enum PaletteCommand: CaseIterable, Identifiable {
-        case startWork
-        case workCommandCenter
-        case liveWatch
-        case ask
-        case newShell
-        case showWork
-        case showShells
-        case refresh
-
-        var id: Self { self }
-
-        var title: String {
-            switch self {
-            case .startWork: String(localized: "Start configured Work")
-            case .workCommandCenter: String(localized: "Open Work Command Center")
-            case .liveWatch: String(localized: "Open native Live Watch")
-            case .ask: String(localized: "Open global Ask")
-            case .newShell: String(localized: "New native shell")
-            case .showWork: String(localized: "Show managed work")
-            case .showShells: String(localized: "Show native shells")
-            case .refresh: String(localized: "Refresh workspace")
-            }
-        }
-
-        var systemImage: String {
-            switch self {
-            case .startWork: "play.square.stack"
-            case .workCommandCenter: "rectangle.3.group"
-            case .liveWatch: "waveform.path.ecg.rectangle"
-            case .ask: "sparkles"
-            case .newShell: "plus.rectangle.on.rectangle"
-            case .showWork: "square.stack.3d.up"
-            case .showShells: "terminal"
-            case .refresh: "arrow.clockwise"
-            }
-        }
-    }
-
-    @ObservedObject var model: AppModel
-    @Binding var isPresented: Bool
-    @State private var query = ""
-    @FocusState private var searchFocused: Bool
-
-    private var commands: [PaletteCommand] {
-        guard !query.isEmpty else { return PaletteCommand.allCases }
-        return PaletteCommand.allCases.filter {
-            $0.title.localizedCaseInsensitiveContains(query)
-        }
-    }
-
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 8) {
-                Image(systemName: "command")
-                    .foregroundStyle(.secondary)
-                TextField("Type a command", text: $query)
-                    .textFieldStyle(.plain)
-                    .focused($searchFocused)
-                    .onSubmit {
-                        if let first = commands.first { run(first) }
-                    }
-            }
-            .font(.title3)
-            .padding(14)
-
-            Divider()
-
-            List(commands) { command in
-                Button {
-                    run(command)
-                } label: {
-                    Label(command.title, systemImage: command.systemImage)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .disabled(
-                    (command == .newShell && (!model.isConnected || model.isCreatingSession))
-                        || (command == .startWork && (!model.isConnected || model.isStartingWork))
-                )
-            }
-            .listStyle(.inset)
-        }
-        .frame(width: 520, height: 360)
-        .onAppear { searchFocused = true }
-    }
-
-    private func run(_ command: PaletteCommand) {
-        switch command {
-        case .startWork:
-            model.presentWorkStart()
-        case .workCommandCenter:
-            model.select(.workBoard)
-        case .liveWatch:
-            model.select(.watch)
-        case .ask:
-            model.select(.ask)
-        case .newShell:
-            model.createShell()
-        case .showWork:
-            model.show(.work)
-        case .showShells:
-            model.show(.shells)
-        case .refresh:
-            Task { await model.refresh() }
-        }
-        isPresented = false
-    }
-}
 
 private struct MuxaSidebar: View {
     private enum StatusScope: CaseIterable, Identifiable {
@@ -783,6 +743,8 @@ private struct MuxaSidebar: View {
     let openPinnedSession: (MuxaWatchSessionIdentity) -> Void
     let openPinnedPane: (MuxaWatchPaneIdentity) -> Void
     let closeShell: (String) -> Void
+    let focusRequest: UUID
+    @FocusState private var filterFocused: Bool
     @Environment(\.colorScheme) private var colorScheme
     @State private var filterText = ""
     @State private var statusScope: StatusScope = .all
@@ -876,6 +838,8 @@ private struct MuxaSidebar: View {
                             .foregroundStyle(.secondary)
                         TextField(model.sidebarMode.filterPrompt, text: $filterText)
                             .textFieldStyle(.plain)
+                            .focused($filterFocused)
+                            .onChange(of: focusRequest) { _ in filterFocused = true }
                         Menu {
                             Picker("Status", selection: $statusScope) {
                                 ForEach(StatusScope.allCases) { scope in

--- a/apps/muxa-macos/Sources/MuxaApp.swift
+++ b/apps/muxa-macos/Sources/MuxaApp.swift
@@ -30,9 +30,23 @@ private final class MuxaApplicationDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Look for the enabled modules' tools once, here. Settings › Modules
+        // used to be the only thing that probed, so until it had been opened
+        // every action needing a tool sat disabled saying it was still
+        // looking — for a module the operator had already pointed at a
+        // working install. A module that is switched off is not probed, so
+        // an operator who uses none still pays nothing.
+        Task { await MuxaModuleRegistry.shared.probeEnabled() }
         if UserDefaults.standard.bool(forKey: MuxaPreferences.showWorkbenchOnLaunchKey) {
             presentWorkbench(remainingAttempts: 50)
         }
+    }
+
+    /// A module may be holding a process of its own — AIR Workbench serves a
+    /// loopback page until it is stopped — and quitting must not leave it
+    /// running.
+    func applicationWillTerminate(_ notification: Notification) {
+        MuxaModuleRegistry.shared.shutdown()
     }
 
     func applicationShouldHandleReopen(
@@ -119,6 +133,7 @@ struct MuxaApp: App {
         }
         .defaultSize(width: 1120, height: 760)
         .commands {
+            CommandGroup(replacing: .printItem) {}
             MuxaEditorMenuCommands()
             OnboardingMenuCommands()
             CommandGroup(after: .newItem) {
@@ -147,26 +162,84 @@ struct MuxaApp: App {
 }
 
 private struct MuxaEditorMenuCommands: Commands {
-    @FocusedValue(\.muxaEditorCommands) private var actions
+    @FocusedValue(\.muxaEditorCommands) private var focusedActions
+
+    private var actions: MuxaEditorCommandActions? {
+        guard let focusedActions, focusedActions.isEnabled else { return nil }
+        return focusedActions
+    }
+
+    private var dispatchActions: MuxaEditorCommandActions? {
+        guard NSApp.modalWindow == nil,
+              let window = NSApp.keyWindow,
+              window.attachedSheet == nil,
+              window.sheetParent == nil else { return nil }
+        return actions
+    }
 
     var body: some Commands {
         CommandMenu("Editor") {
-            Button("Close Editor") { actions?.close() }
+            Button("Close Editor") { dispatchActions?.close?() }
                 .keyboardShortcut("w", modifiers: .command)
-                .disabled(actions == nil)
+                .disabled(actions?.close == nil)
             Divider()
-            Button("Previous Editor") { actions?.previous() }
+            Button("Previous Editor") { dispatchActions?.previous?() }
                 .keyboardShortcut(.tab, modifiers: [.control, .shift])
-                .disabled(actions == nil)
-            Button("Next Editor") { actions?.next() }
+                .disabled(actions?.previous == nil)
+            Button("Next Editor") { dispatchActions?.next?() }
                 .keyboardShortcut(.tab, modifiers: .control)
-                .disabled(actions == nil)
+                .disabled(actions?.next == nil)
+            ForEach(1...8, id: \.self) { number in
+                Button("Editor \(number)") { dispatchActions?.activateAt?(number - 1) }
+                    .keyboardShortcut(KeyEquivalent(Character(String(number))), modifiers: .command)
+                    .disabled(actions?.activateAt == nil)
+            }
+            Button("Last Editor") { dispatchActions?.activateLast?() }
+                .keyboardShortcut("9", modifiers: .command)
+                .disabled(actions?.activateLast == nil)
             Divider()
-            Button("Keep Editor Open") { actions?.pin() }
-                .disabled(actions == nil)
-            Button("Split Editor Right") { actions?.splitRight() }
+            Button("Focus Previous Editor Group") { dispatchActions?.focusRelativeGroup?(-1) }
+                .keyboardShortcut(.leftArrow, modifiers: [.command, .option])
+                .disabled(actions?.focusRelativeGroup == nil)
+            Button("Focus Next Editor Group") { dispatchActions?.focusRelativeGroup?(1) }
+                .keyboardShortcut(.rightArrow, modifiers: [.command, .option])
+                .disabled(actions?.focusRelativeGroup == nil)
+            Divider()
+            Button("Keep Editor Open") { dispatchActions?.pin?() }
+                .keyboardShortcut(.return, modifiers: [.command, .option])
+                .disabled(actions?.pin == nil)
+            Button("Split Editor Right") { dispatchActions?.splitRight?() }
                 .keyboardShortcut("\\", modifiers: .command)
-                .disabled(actions == nil)
+                .disabled(actions?.splitRight == nil)
+        }
+        CommandMenu("Navigate") {
+            Button("Quick Open…") { dispatchActions?.quickOpen?() }
+                .keyboardShortcut("p", modifiers: .command)
+                .disabled(actions?.quickOpen == nil)
+            Button("Command Palette…") { dispatchActions?.commandPalette?() }
+                .keyboardShortcut("p", modifiers: [.command, .shift])
+                .disabled(actions?.commandPalette == nil)
+            Divider()
+            Button("Open Work Command Center") { dispatchActions?.openWorkCommandCenter?() }
+                .keyboardShortcut("1", modifiers: [.command, .shift])
+                .disabled(actions?.openWorkCommandCenter == nil)
+            Button("Open Ask") { dispatchActions?.openAsk?() }
+                .keyboardShortcut("2", modifiers: [.command, .shift])
+                .disabled(actions?.openAsk == nil)
+            Button("Open Inbox") { dispatchActions?.openInbox?() }
+                .keyboardShortcut("3", modifiers: [.command, .shift])
+                .disabled(actions?.openInbox == nil)
+            Divider()
+            Menu("Sidebar") {
+                ForEach(MuxaSidebarMode.allCases) { mode in
+                    Button(mode.title) { dispatchActions?.selectSidebar?(mode) }
+                        .disabled(actions?.selectSidebar == nil)
+                }
+            }
+            .disabled(actions?.selectSidebar == nil)
+            Button("Focus Sidebar Filter") { dispatchActions?.focusSidebar?() }
+                .keyboardShortcut("f", modifiers: [.command, .shift])
+                .disabled(actions?.focusSidebar == nil)
         }
     }
 }

--- a/apps/muxa-macos/Sources/MuxaModule.swift
+++ b/apps/muxa-macos/Sources/MuxaModule.swift
@@ -37,12 +37,18 @@ protocol MuxaModule: AnyObject, Identifiable {
     /// importing a file should not wait on a runtime the import never uses.
     /// Default false: most modules are a face on a tool.
     var worksWithoutTool: Bool { get }
+
+    /// Let go of anything held open — a served page, a running helper —
+    /// because the app is quitting. Default: nothing to let go of.
+    func shutdown()
 }
 
 extension MuxaModule {
     nonisolated var id: String { Self.identity.id }
     var identity: MuxaModuleIdentity { Self.identity }
     var worksWithoutTool: Bool { false }
+
+    func shutdown() {}
 
     func actions(for context: MuxaModuleContext, model: AppModel) -> [MuxaModuleAction] {
         _ = (context, model)

--- a/apps/muxa-macos/Sources/MuxaModuleRegistry.swift
+++ b/apps/muxa-macos/Sources/MuxaModuleRegistry.swift
@@ -66,6 +66,12 @@ final class MuxaModuleRegistry: ObservableObject {
         probeGeneration &+= 1
     }
 
+    /// The app is quitting: every enabled module lets go of what it holds
+    /// open. A module that holds nothing does nothing.
+    func shutdown() {
+        for module in enabledModules { module.shutdown() }
+    }
+
     /// Everything the enabled modules offer for this object. A module whose
     /// tool is missing contributes nothing unless it says its actions work
     /// without one — a converter does not need the editor installed.

--- a/apps/muxa-macos/Sources/WorkConsoleViews.swift
+++ b/apps/muxa-macos/Sources/WorkConsoleViews.swift
@@ -3847,11 +3847,112 @@ struct FleetPaneModuleView: View {
     }
 }
 
-/// The outcome line under a prompt composer: the wording and whether the
-/// send succeeded, so the colour never depends on the wording's language.
 struct PromptFeedback: Equatable {
     let message: String
     let succeeded: Bool
+}
+
+enum PromptComposerRules {
+    static func canSend(prompt: String, sending: Bool, hosts: [MuxaFleetHostIdentity]) -> Bool {
+        !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !sending && !hosts.isEmpty
+            && hosts.allSatisfy { $0.local || $0.mode == "control" }
+    }
+
+    static func shouldClearDraft(current: String, submitted: String, revision: UUID, submittedRevision: UUID) -> Bool {
+        current == submitted && revision == submittedRevision
+    }
+
+    static func handlesSendKey(keyCode: UInt16, modifiers: NSEvent.ModifierFlags, focused: Bool, markedText: Bool) -> Bool {
+        focused && !markedText && keyCode == 36
+            && modifiers.intersection(.deviceIndependentFlagsMask).subtracting([.capsLock, .numericPad]) == .command
+    }
+}
+
+struct PromptComposerStatus: View {
+    let feedback: PromptFeedback?
+    @State private var showsDetails = false
+
+    var body: some View {
+        Color.clear
+            .frame(width: 132, height: 24)
+            .overlay(alignment: .trailing) {
+                if let feedback {
+                    Button {
+                        showsDetails.toggle()
+                    } label: {
+                        Label(feedback.message, systemImage: feedback.succeeded ? "checkmark.circle" : "exclamationmark.circle")
+                            .font(.caption2)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                            .foregroundStyle(feedback.succeeded ? Color.green : Color.red)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                    .buttonStyle(.plain)
+                    .help(Text(verbatim: feedback.message))
+                    .accessibilityLabel(Text(verbatim: feedback.message))
+                    .accessibilityHint("Show prompt status details")
+                    .popover(isPresented: $showsDetails) {
+                        ScrollView {
+                            Text(verbatim: feedback.message)
+                                .font(.callout)
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(12)
+                        }
+                        .frame(width: 360, height: 180)
+                    }
+                }
+            }
+            .onChange(of: feedback) { _ in showsDetails = false }
+    }
+}
+
+private struct PromptComposerSendKey: NSViewRepresentable {
+    let focused: Bool
+    let send: () -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        context.coordinator.update(view: view, focused: focused, send: send)
+        context.coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak coordinator = context.coordinator] event in
+            guard let coordinator,
+                  let window = coordinator.view?.window,
+                  window.isKeyWindow, event.window === window,
+                  let editor = window.firstResponder as? NSTextView,
+                  PromptComposerRules.handlesSendKey(
+                    keyCode: event.keyCode, modifiers: event.modifierFlags,
+                    focused: coordinator.focused, markedText: editor.hasMarkedText()
+                  ) else { return event }
+            coordinator.send()
+            return nil
+        }
+        return view
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        context.coordinator.update(view: view, focused: focused, send: send)
+    }
+
+    static func dismantleNSView(_ view: NSView, coordinator: Coordinator) {
+        if let monitor = coordinator.monitor { NSEvent.removeMonitor(monitor) }
+        coordinator.monitor = nil
+    }
+
+    final class Coordinator {
+        weak var view: NSView?
+        var focused = false
+        var send: () -> Void = {}
+        var monitor: Any?
+
+        func update(view: NSView, focused: Bool, send: @escaping () -> Void) {
+            self.view = view
+            self.focused = focused
+            self.send = send
+        }
+    }
 }
 
 private struct PanePromptComposer: View {
@@ -3861,54 +3962,68 @@ private struct PanePromptComposer: View {
     @Binding var prompt: String
     @Binding var sending: Bool
     @Binding var feedback: PromptFeedback?
+    @State private var draftRevision = UUID()
+    @FocusState private var promptFocused: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             ViewThatFits(in: .horizontal) {
                 HStack(spacing: 8) {
                     promptField
-                    sendButton.fixedSize()
+                    sendControls.fixedSize()
                 }
                 VStack(alignment: .trailing, spacing: 8) {
                     promptField
-                    sendButton
+                    sendControls
                 }
             }
             if !host.local && host.mode != "control" {
                 Text("This host is registered in observe mode. Change it to control to send prompts.")
                     .font(.caption2)
                     .foregroundStyle(.orange)
-            } else if let feedback {
-                Text(feedback.message)
-                    .font(.caption2)
-                    .foregroundStyle(feedback.succeeded ? .green : .red)
             }
         }
+        .background(PromptComposerSendKey(focused: promptFocused, send: send))
     }
 
     private var promptField: some View {
-        TextField("Send a prompt to this agent/pane", text: $prompt, axis: .vertical)
+        TextField("Send a prompt to this agent/pane", text: Binding(
+            get: { prompt },
+            set: { prompt = $0; draftRevision = UUID() }
+        ), axis: .vertical)
             .textFieldStyle(.roundedBorder)
             .lineLimit(1...4)
+            .focused($promptFocused)
             .onSubmit(send)
+    }
+
+    private var sendControls: some View {
+        HStack(spacing: 8) {
+            PromptComposerStatus(feedback: feedback)
+            sendButton
+        }
     }
 
     private var sendButton: some View {
         Button("Send", action: send)
             .buttonStyle(.borderedProminent)
-            .disabled(prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || sending || (!host.local && host.mode != "control"))
+            .disabled(!PromptComposerRules.canSend(prompt: prompt, sending: sending, hosts: [host]))
     }
 
     private func send() {
-        let text = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty, !sending else { return }
+        guard PromptComposerRules.canSend(prompt: prompt, sending: sending, hosts: [host]) else { return }
+        let submitted = prompt
+        let submittedRevision = draftRevision
+        let text = submitted.trimmingCharacters(in: .whitespacesAndNewlines)
         sending = true
         feedback = nil
         Task {
             defer { sending = false }
             do {
                 try await client.sendFleetPrompt(host: host, pane: pane, text: text)
-                prompt = ""
+                if PromptComposerRules.shouldClearDraft(current: prompt, submitted: submitted, revision: draftRevision, submittedRevision: submittedRevision) {
+                    prompt = ""
+                }
                 feedback = PromptFeedback(message: String(localized: "Sent and submitted"), succeeded: true)
             } catch {
                 feedback = PromptFeedback(message: error.localizedDescription, succeeded: false)
@@ -3923,6 +4038,12 @@ struct WorkPromptComposer: View {
     @State private var prompt = ""
     @State private var sending = false
     @State private var feedback: PromptFeedback?
+    @State private var draftRevision = UUID()
+    @FocusState private var promptFocused: Bool
+
+    private var promptHosts: [MuxaFleetHostIdentity] {
+        work.participants.filter { $0.pane != nil }.map(\.host)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 7) {
@@ -3931,46 +4052,62 @@ struct WorkPromptComposer: View {
             ViewThatFits(in: .horizontal) {
                 HStack(spacing: 8) {
                     workPromptField
-                    workSendButton.fixedSize()
+                    sendControls.fixedSize()
                 }
                 VStack(alignment: .trailing, spacing: 8) {
                     workPromptField
-                    workSendButton
+                    sendControls
                 }
             }
-            if let feedback {
-                Text(feedback.message)
-                    .font(.caption)
-                    .foregroundStyle(feedback.succeeded ? .green : .red)
+            if promptHosts.contains(where: { !$0.local && $0.mode != "control" }) {
+                Text("This host is registered in observe mode. Change it to control to send prompts.")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
             }
         }
+        .background(PromptComposerSendKey(focused: promptFocused, send: send))
         .padding(14)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
     }
 
     private var workPromptField: some View {
-        TextField("Send the next instruction to every live collaborator", text: $prompt, axis: .vertical)
+        TextField("Send the next instruction to every live collaborator", text: Binding(
+            get: { prompt },
+            set: { prompt = $0; draftRevision = UUID() }
+        ), axis: .vertical)
             .textFieldStyle(.roundedBorder)
             .lineLimit(1...4)
+            .focused($promptFocused)
             .onSubmit(send)
+    }
+
+    private var sendControls: some View {
+        HStack(spacing: 8) {
+            PromptComposerStatus(feedback: feedback)
+            workSendButton
+        }
     }
 
     private var workSendButton: some View {
         Button("Send to \(work.participants.count)", action: send)
             .buttonStyle(.borderedProminent)
-            .disabled(prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || sending || work.participants.isEmpty)
+            .disabled(!PromptComposerRules.canSend(prompt: prompt, sending: sending, hosts: promptHosts))
     }
 
     private func send() {
-        let text = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty, !sending else { return }
+        guard PromptComposerRules.canSend(prompt: prompt, sending: sending, hosts: promptHosts) else { return }
+        let submitted = prompt
+        let submittedRevision = draftRevision
+        let text = submitted.trimmingCharacters(in: .whitespacesAndNewlines)
         sending = true
         feedback = nil
         Task {
             defer { sending = false }
             do {
                 let count = try await model.prompt(work: work, text: text)
-                prompt = ""
+                if PromptComposerRules.shouldClearDraft(current: prompt, submitted: submitted, revision: draftRevision, submittedRevision: submittedRevision) {
+                    prompt = ""
+                }
                 feedback = PromptFeedback(
                     message: String(localized: "Sent to \(count) collaborators"),
                     succeeded: true

--- a/apps/muxa-macos/Sources/WorkbenchTabs.swift
+++ b/apps/muxa-macos/Sources/WorkbenchTabs.swift
@@ -82,6 +82,31 @@ final class MuxaWorkbenchTabs: ObservableObject {
     }
 
     @discardableResult
+    func activateAt(_ index: Int) -> MuxaSidebarSelection? {
+        guard let group = group(id: focusedGroupID),
+              group.tabs.indices.contains(index) else { return nil }
+        let selection = group.tabs[index]
+        activate(selection, groupID: group.id)
+        return selection
+    }
+
+    @discardableResult
+    func activateLast() -> MuxaSidebarSelection? {
+        guard let group = group(id: focusedGroupID) else { return nil }
+        return activateAt(group.tabs.count - 1)
+    }
+
+    @discardableResult
+    func focusRelativeGroup(_ offset: Int) -> MuxaSidebarSelection? {
+        guard !groups.isEmpty,
+              let current = groups.firstIndex(where: { $0.id == focusedGroupID }) else { return nil }
+        let count = groups.count
+        let nextIndex = (current + offset % count + count) % count
+        focus(groups[nextIndex].id)
+        return focusedSelection
+    }
+
+    @discardableResult
     func activateRelative(_ offset: Int) -> MuxaSidebarSelection? {
         guard let group = group(id: focusedGroupID), !group.tabs.isEmpty else { return nil }
         let current = group.active.flatMap { group.tabs.firstIndex(of: $0) } ?? 0
@@ -125,10 +150,18 @@ final class MuxaWorkbenchTabs: ObservableObject {
 
         if groups[groupIndex].tabs.isEmpty, groups.count > 1 {
             groups.remove(at: groupIndex)
-            let fallbackIndex = min(groupIndex, groups.count - 1)
-            focusedGroupID = groups[fallbackIndex].id
-        } else {
-            focusedGroupID = groupID
+            if focusedGroupID == groupID {
+                let fallbackIndex = min(groupIndex, groups.count - 1)
+                focusedGroupID = groups[fallbackIndex].id
+            }
+        }
+        return focusedSelection
+    }
+
+    @discardableResult
+    func closeEverywhere(_ selection: MuxaSidebarSelection) -> MuxaSidebarSelection? {
+        for group in groups where group.tabs.contains(selection) {
+            close(selection, groupID: group.id)
         }
         return focusedSelection
     }
@@ -293,11 +326,22 @@ private extension Array {
 }
 
 struct MuxaEditorCommandActions {
-    let close: () -> Void
-    let next: () -> Void
-    let previous: () -> Void
-    let splitRight: () -> Void
-    let pin: () -> Void
+    var close: (() -> Void)? = nil
+    var next: (() -> Void)? = nil
+    var previous: (() -> Void)? = nil
+    var splitRight: (() -> Void)? = nil
+    var pin: (() -> Void)? = nil
+    var quickOpen: (() -> Void)? = nil
+    var commandPalette: (() -> Void)? = nil
+    var activateAt: ((Int) -> Void)? = nil
+    var activateLast: (() -> Void)? = nil
+    var focusRelativeGroup: ((Int) -> Void)? = nil
+    var openWorkCommandCenter: (() -> Void)? = nil
+    var openAsk: (() -> Void)? = nil
+    var openInbox: (() -> Void)? = nil
+    var selectSidebar: ((MuxaSidebarMode) -> Void)? = nil
+    var focusSidebar: (() -> Void)? = nil
+    var isEnabled: Bool = true
 }
 
 private struct MuxaEditorCommandActionsKey: FocusedValueKey {

--- a/apps/muxa-macos/Tests/CommandPaletteTests.swift
+++ b/apps/muxa-macos/Tests/CommandPaletteTests.swift
@@ -1,0 +1,249 @@
+import Foundation
+import AppKit
+import SwiftUI
+import Testing
+@testable import Muxa
+
+private func paletteItem(_ id: String, title: String = "demo", enabled: Bool = true) -> MuxaPaletteItem {
+    MuxaPaletteItem(
+        stableID: MuxaPaletteID(components: ["session", id]),
+        title: title, subtitle: "host-a /tmp/tmux.sock", systemImage: "terminal",
+        action: .navigate(.shell(id)), disabledReason: enabled ? nil : "Unavailable"
+    )
+}
+
+@Test func paletteSearchSupportsFuzzyWordsAndDiacritics() {
+    #expect(MuxaPaletteSearch.score(query: "cafe HST", text: "Café on host-a") != nil)
+    #expect(MuxaPaletteSearch.score(query: "host demo", text: "demo · host-a") != nil)
+    #expect(MuxaPaletteSearch.score(query: "개발", text: "개발 세션") != nil)
+    #expect(MuxaPaletteSearch.score(query: "missing", text: "demo") == nil)
+    #expect(MuxaPaletteSearch.score(query: "aa", text: "a") == nil)
+    #expect(MuxaPaletteSearch.score(query: "", text: "") == 0)
+    #expect(MuxaPaletteSearch.score(query: "a", text: "") == nil)
+    #expect((MuxaPaletteSearch.score(query: "two.sock", text: "editor Window /tmp/two.sock") ?? 0)
+        > (MuxaPaletteSearch.score(query: "two.sock", text: "editor Window /tmp/one.sock") ?? 0))
+}
+
+@Test func paletteRanksRecentAndPreservesSameNamedDestinations() {
+    let first = paletteItem("first")
+    let second = paletteItem("second")
+    let results = MuxaPaletteSearch.results([first, second, first], query: "", recent: [.shell("second")])
+    #expect(results == [second, first])
+    #expect(MuxaPaletteSearch.results([first, second], query: "nomatch", recent: []).isEmpty)
+    #expect(MuxaPaletteID(components: ["a:b", "c"]) != MuxaPaletteID(components: ["a", "b:c"]))
+    #expect(MuxaPaletteID(components: [nil]) != MuxaPaletteID(components: [""]))
+}
+
+@Test func paletteExactPaneTitleOutranksRecentContextAndFuzzyMatches() {
+    let exact = MuxaPaletteItem(
+        stableID: MuxaPaletteID(components: ["pane", "local", "default", "%7209"]),
+        title: "CAL-7209", subtitle: "Pane · local · default", systemImage: "terminal",
+        action: .navigate(.pane(MuxaWatchPaneIdentity(hostAlias: "local", socket: "default", paneID: "%7209")))
+    )
+    let context = MuxaPaletteItem(
+        stableID: MuxaPaletteID(components: ["shell", "recent"]),
+        title: "Other task", subtitle: "/work/CAL-7209", systemImage: "terminal", action: .navigate(.shell("recent"))
+    )
+    let prefix = paletteItem("prefix", title: "CAL-7209 review")
+    let substring = paletteItem("substring", title: "Review CAL-7209")
+    let fuzzy = paletteItem("fuzzy", title: "CAL-712039")
+    let candidates = [context, fuzzy, substring, prefix, exact]
+    for query in ["CAL-7209", "cal-7209", "  CAL-7209  "] {
+        let results = MuxaPaletteSearch.results(candidates, query: query, recent: [.shell("recent")])
+        #expect(results.map(\.id) == [exact, prefix, substring, context, fuzzy].map(\.id))
+        #expect(MuxaPaletteSelection.action(results.first?.id, in: results) == exact.action)
+    }
+    let results = MuxaPaletteSearch.results(candidates, query: "CAL-7209", recent: [])
+    #expect(MuxaPaletteSelection.updated(context.id, previousQuery: "CAL-720", query: "CAL-7209", in: results) == exact.id)
+    #expect(MuxaPaletteSelection.updated(context.id, previousQuery: "CAL-7209", query: "CAL-7209", in: results) == context.id)
+}
+
+@Test func paletteCAL7209SelectsExactPaneInsteadOfItsWindowOrSibling() {
+    let pane = MuxaPaletteItem(
+        stableID: MuxaPaletteID(components: ["pane", "rtzr", "default", "%78"]),
+        title: "cal-7209", subtitle: "/home/june/workspace-agent/cal-7209", systemImage: "terminal",
+        action: .navigate(.pane(MuxaWatchPaneIdentity(hostAlias: "rtzr", socket: "default", paneID: "%78")))
+    )
+    let window = MuxaPaletteItem(
+        stableID: MuxaPaletteID(components: ["window", "rtzr", "default", "@39"]),
+        title: "CAL-7209", subtitle: "rtzr · default", systemImage: "macwindow",
+        action: .navigate(.fleetWindow(MuxaWatchWindowIdentity(hostAlias: "rtzr", socket: "default", sessionID: "$5", windowID: "@39")))
+    )
+    let sibling = paletteItem("sibling", title: "✳ CAL-7209 callabo-resolve finalize 예외 경로")
+    let results = MuxaPaletteSearch.results([window, sibling, pane], query: "CAL-7209", recent: [])
+    #expect(results.map(\.id) == [pane, window, sibling].map(\.id))
+}
+
+@Test func paletteSelectionSkipsDisabledAndWraps() {
+    let first = paletteItem("first")
+    let disabled = paletteItem("disabled", enabled: false)
+    let last = paletteItem("last")
+    let items = [first, disabled, last]
+    #expect(MuxaPaletteSelection.retained(nil, in: items) == first.id)
+    #expect(MuxaPaletteSelection.retained(last.id, in: items) == last.id)
+    #expect(MuxaPaletteSelection.retained(disabled.id, in: items) == first.id)
+    #expect(MuxaPaletteSelection.moved(first.id, by: 1, in: items) == last.id)
+    #expect(MuxaPaletteSelection.moved(last.id, by: 1, in: items) == first.id)
+    #expect(MuxaPaletteSelection.moved(first.id, by: -1, in: items) == last.id)
+    #expect(MuxaPaletteSelection.moved(nil, by: -1, in: items) == last.id)
+    #expect(MuxaPaletteSelection.action(disabled.id, in: items) == nil)
+    #expect(MuxaPaletteSelection.action(last.id, in: items) == last.action)
+    #expect(MuxaPaletteSelection.action(last.id, in: [first]) == nil)
+    #expect(MuxaPaletteSelection.retained(first.id, in: [disabled]) == nil)
+    #expect(MuxaPaletteSelection.moved(first.id, by: 1, in: []) == nil)
+}
+
+@Test func paletteKeysRespectInputMethodComposition() {
+    let keys: [(String, MuxaPaletteKeyDecision)] = [
+        ("moveUp:", .previous), ("insertBacktab:", .previous),
+        ("moveDown:", .next), ("insertTab:", .next),
+        ("insertNewline:", .submit), ("insertNewlineIgnoringFieldEditor:", .submit),
+        ("cancelOperation:", .cancel),
+    ]
+    for (selector, decision) in keys {
+        #expect(MuxaPaletteKeyDecision.resolve(selector: selector, hasMarkedText: false) == decision)
+        #expect(MuxaPaletteKeyDecision.resolve(selector: selector, hasMarkedText: true) == .passThrough)
+        #expect(MuxaPaletteKeyDecision.resolve(selector: selector, hasMarkedText: false, beganWithMarkedText: true) == .passThrough)
+    }
+    #expect(MuxaPaletteKeyDecision.resolve(selector: "moveLeft:", hasMarkedText: false) == .passThrough)
+}
+
+@Test func paletteDestinationsKeepHostSocketSessionAndWindowIdentity() throws {
+    let host = try JSONDecoder().decode(MuxaFleetHost.self, from: Data(
+        #"{"alias":"local","local":true,"mode":"control","state":"online"}"#.utf8
+    ))
+    let sessions = ["/tmp/one.sock", "/tmp/two.sock"].map { socket in
+        MuxaWatchSession(
+            hostAlias: "local", socket: socket, sessionID: "$1", name: "demo",
+            windows: [MuxaWatchWindow(
+                hostAlias: "local", socket: socket, sessionID: "$1", windowID: "@1",
+                name: "editor", index: "0", panes: []
+            )]
+        )
+    }
+    let items = MuxaPaletteItems.navigation(
+        watchSections: [MuxaWatchHost(host: host, sessions: sessions)],
+        workGroups: [], sessions: [], agents: [], localSocket: "/tmp/muxa.sock"
+    )
+    #expect(items.count == 4)
+    #expect(Set(items.map(\.id)).count == 4)
+    let results = MuxaPaletteSearch.results(items, query: "editor two.sock", recent: [])
+    #expect(results.count == 2)
+    #expect(results.first?.action == .navigate(.fleetWindow(sessions[1].windows[0].identity)))
+    #expect(MuxaPaletteSearch.results(items, query: "demo", recent: []).count == 4)
+}
+
+@Test func paletteModeShortcutsRequireExactCommandModifiers() {
+    #expect(MuxaPaletteMode.shortcut(characters: "p", modifiers: .command) == .navigation)
+    #expect(MuxaPaletteMode.shortcut(characters: "P", modifiers: [.command, .shift]) == .commands)
+    #expect(MuxaPaletteMode.shortcut(characters: "p", modifiers: [.command, .capsLock]) == .navigation)
+    #expect(MuxaPaletteMode.shortcut(characters: "p", modifiers: []) == nil)
+    #expect(MuxaPaletteMode.shortcut(characters: "p", modifiers: [.command, .option]) == nil)
+    #expect(MuxaPaletteMode.shortcut(characters: "q", modifiers: .command) == nil)
+}
+
+@Test(arguments: [false, true]) @MainActor
+func paletteViewSelectsNewBestMatchAndRetainsManualSelectionOnRefresh(refresh: Bool) async throws {
+    func snapshot(title: String) throws -> MuxaExecutionSnapshot {
+        let panes: [[String: String]] = ["%1": "CAL-7200", "%2": title].sorted { $0.key < $1.key }.map { id, title in
+            ["pane_id": id, "title": title, "session_id": "$1", "session": "demo",
+             "window_id": "@1", "window_name": "CAL-7209", "window_index": "0", "pane_index": id,
+             "current_command": "codex", "current_path": "/tmp/CAL-7209", "socket": "default"]
+        }
+        let host = try JSONDecoder().decode(MuxaFleetHost.self, from: JSONSerialization.data(withJSONObject: [
+            "alias": "local", "local": true, "mode": "control", "state": "online",
+            "remote": ["agents": [], "panes": panes],
+        ]))
+        return MuxaExecutionSnapshot(hosts: [host])
+    }
+    let model = AppModel()
+    model.ingestExecutionSnapshotForTesting(try snapshot(title: "CAL-7209"))
+    var chosen: MuxaPaletteAction?
+    let previous = MuxaSidebarSelection.pane(MuxaWatchPaneIdentity(hostAlias: "local", socket: "default", paneID: "%1"))
+    let hosting = NSHostingView(rootView: CommandPaletteView(
+        model: model, mode: .navigation, recent: [previous], onChoose: { chosen = $0 }, onCancel: {}
+    ))
+    let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 680, height: 430), styleMask: [.titled], backing: .buffered, defer: false)
+    window.isReleasedWhenClosed = false
+    window.contentView = hosting
+    window.makeKeyAndOrderFront(nil)
+    defer { window.close() }
+    try await Task.sleep(for: .milliseconds(150))
+    func field(in view: NSView) -> NSTextField? {
+        if let field = view as? MuxaPaletteTextField { return field }
+        return view.subviews.lazy.compactMap { field(in: $0) }.first
+    }
+    let editor = try #require(field(in: hosting)?.currentEditor() as? NSTextView)
+    editor.insertText("CAL", replacementRange: NSRange(location: NSNotFound, length: 0))
+    try await Task.sleep(for: .milliseconds(40))
+    editor.insertText("-7209", replacementRange: NSRange(location: NSNotFound, length: 0))
+    try await Task.sleep(for: .milliseconds(40))
+    if refresh {
+        let tab = try #require(NSEvent.keyEvent(with: .keyDown, location: .zero, modifierFlags: [], timestamp: 0,
+            windowNumber: window.windowNumber, context: nil, characters: "\t", charactersIgnoringModifiers: "\t", isARepeat: false, keyCode: 48))
+        window.sendEvent(tab)
+        model.ingestExecutionSnapshotForTesting(try snapshot(title: "cal-7209"))
+        try await Task.sleep(for: .milliseconds(40))
+    }
+    let enter = try #require(NSEvent.keyEvent(with: .keyDown, location: .zero, modifierFlags: [], timestamp: 0,
+        windowNumber: window.windowNumber, context: nil, characters: "\r", charactersIgnoringModifiers: "\r", isARepeat: false, keyCode: 36))
+    window.sendEvent(enter)
+    let expected: MuxaSidebarSelection = refresh
+        ? .fleetWindow(MuxaWatchWindowIdentity(hostAlias: "local", socket: "default", sessionID: "$1", windowID: "@1"))
+        : .pane(MuxaWatchPaneIdentity(hostAlias: "local", socket: "default", paneID: "%2"))
+    #expect(chosen == .navigate(expected))
+}
+
+@Test @MainActor func paletteNativeSearchAcceptsFocusTypingAndModeShortcuts() async throws {
+    var query = ""
+    var selectedMode: MuxaPaletteMode?
+    var decisions: [MuxaPaletteKeyDecision] = []
+    let hosting = NSHostingView(rootView: MuxaPaletteSearchField(
+        text: Binding(get: { query }, set: { query = $0 }), placeholder: "Search",
+        onKey: { decisions.append($0) }, onModeChange: { selectedMode = $0 }
+    ))
+    let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 680, height: 70), styleMask: [.titled], backing: .buffered, defer: false)
+    let parent = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 900, height: 500), styleMask: [.titled], backing: .buffered, defer: false)
+    window.isReleasedWhenClosed = false
+    parent.isReleasedWhenClosed = false
+    window.contentView = hosting
+    parent.makeKeyAndOrderFront(nil)
+    parent.beginSheet(window, completionHandler: { _ in })
+    defer { parent.endSheet(window); window.close(); parent.close() }
+    try await Task.sleep(for: .milliseconds(350))
+    func searchField(in view: NSView) -> NSTextField? {
+        if let field = view as? NSTextField { return field }
+        return view.subviews.lazy.compactMap { searchField(in: $0) }.first
+    }
+    let field = try #require(searchField(in: hosting))
+    #expect(field.isEditable)
+    #expect(field.isSelectable)
+    #expect(field.acceptsFirstResponder)
+    let editor = try #require(field.currentEditor() as? NSTextView)
+    #expect(window.firstResponder === editor)
+    editor.insertText("session-search", replacementRange: NSRange(location: NSNotFound, length: 0))
+    #expect(editor.string == "session-search")
+    #expect(query == "session-search")
+    for (characters, keyCode, modifiers, expected): (String, UInt16, NSEvent.ModifierFlags, MuxaPaletteKeyDecision) in [
+        ("\t", 48, [], .next), ("\u{19}", 48, .shift, .previous),
+        ("\r", 36, [], .submit), ("\u{1b}", 53, [], .cancel),
+    ] {
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: modifiers, timestamp: 0,
+            windowNumber: window.windowNumber, context: nil, characters: characters,
+            charactersIgnoringModifiers: characters, isARepeat: false, keyCode: keyCode
+        ))
+        window.sendEvent(event)
+        #expect(decisions.last == expected)
+        #expect(window.firstResponder === editor)
+    }
+    for (modifiers, expected): (NSEvent.ModifierFlags, MuxaPaletteMode) in [(.command, .navigation), ([.command, .shift], .commands)] {
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: modifiers, timestamp: 0,
+            windowNumber: window.windowNumber, context: nil, characters: "p",
+            charactersIgnoringModifiers: "p", isARepeat: false, keyCode: 35
+        ))
+        #expect(window.performKeyEquivalent(with: event))
+        #expect(selectedMode == expected)
+    }
+}

--- a/apps/muxa-macos/Tests/KeyboardNavigationTests.swift
+++ b/apps/muxa-macos/Tests/KeyboardNavigationTests.swift
@@ -1,0 +1,199 @@
+import Testing
+@testable import Muxa
+
+@Test @MainActor func keyboardTabActivationUsesZeroBasedVisualOrder() {
+    let tabs = MuxaWorkbenchTabs(persistenceKey: nil)
+    tabs.openPinned(.ask)
+    tabs.openPreview(.inbox)
+    let groupID = tabs.focusedGroupID
+
+    #expect(tabs.activateAt(0) == .workBoard)
+    #expect(tabs.activateAt(1) == .ask)
+    #expect(tabs.group(id: groupID)?.history.last == .ask)
+    #expect(tabs.activateLast() == .inbox)
+    #expect(tabs.group(id: groupID)?.preview == .inbox)
+
+    let before = tabs.groups
+    #expect(tabs.activateAt(-1) == nil)
+    #expect(tabs.activateAt(3) == nil)
+    #expect(tabs.activateAt(Int.max) == nil)
+    #expect(tabs.groups == before)
+
+    tabs.move(tabIdentifier: MuxaSidebarSelection.inbox.tabIdentifier, before: .workBoard, groupID: groupID)
+    #expect(tabs.activateAt(0) == .inbox)
+    #expect(tabs.activateLast() == .ask)
+}
+
+@Test @MainActor func keyboardTabActivationStaysInFocusedGroup() {
+    let tabs = MuxaWorkbenchTabs(persistenceKey: nil)
+    tabs.openPinned(.ask)
+    let firstID = tabs.focusedGroupID
+    let secondID = tabs.splitRight(selection: .inbox, from: firstID)
+
+    #expect(tabs.activateAt(0) == .inbox)
+    #expect(tabs.activateAt(1) == nil)
+    #expect(tabs.activateLast() == .inbox)
+    #expect(tabs.focusedGroupID == secondID)
+    #expect(tabs.group(id: firstID)?.active == .ask)
+}
+
+@Test @MainActor func keyboardNavigationHandlesEmptyWorkbench() {
+    let tabs = MuxaWorkbenchTabs(initial: nil, persistenceKey: nil)
+    let before = tabs.groups
+    let groupID = tabs.focusedGroupID
+
+    #expect(tabs.activateAt(0) == nil)
+    #expect(tabs.activateLast() == nil)
+    #expect(tabs.activateRelative(1) == nil)
+    #expect(tabs.activateRelative(-1) == nil)
+    #expect(tabs.focusRelativeGroup(1) == nil)
+    #expect(tabs.focusRelativeGroup(-1) == nil)
+    #expect(tabs.groups == before)
+    #expect(tabs.focusedGroupID == groupID)
+}
+
+@Test @MainActor func keyboardRelativeEditorNavigationWrapsWithoutClosingSessions() {
+    let tabs = MuxaWorkbenchTabs(initial: .shell("first"), persistenceKey: nil)
+    tabs.openPinned(.shell("second"))
+    tabs.openPinned(.shell("third"))
+
+    #expect(tabs.activateRelative(1) == .shell("first"))
+    #expect(tabs.activateRelative(-1) == .shell("third"))
+    #expect(tabs.activateRelative(4) == .shell("first"))
+    #expect(tabs.activateRelative(-4) == .shell("third"))
+    #expect(tabs.activateRelative(0) == .shell("third"))
+    #expect(tabs.groups[0].tabs == [.shell("first"), .shell("second"), .shell("third")])
+}
+
+@Test @MainActor func keyboardGroupNavigationWrapsAndPreservesEditorState() {
+    let tabs = MuxaWorkbenchTabs(persistenceKey: nil)
+    tabs.openPreview(.ask)
+    let firstID = tabs.focusedGroupID
+    let secondID = tabs.splitRight(selection: .shell("local"), from: firstID)
+    let before = tabs.groups
+
+    #expect(tabs.focusRelativeGroup(1) == .ask)
+    #expect(tabs.focusedGroupID == firstID)
+    #expect(tabs.focusRelativeGroup(-1) == .shell("local"))
+    #expect(tabs.focusedGroupID == secondID)
+    #expect(tabs.focusRelativeGroup(0) == .shell("local"))
+    #expect(tabs.focusRelativeGroup(Int.max) == .ask)
+    #expect(tabs.focusRelativeGroup(Int.min) == .ask)
+    #expect(tabs.groups == before)
+}
+
+@Test @MainActor func keyboardGroupNavigationCanFocusEmptyGroup() {
+    let tabs = MuxaWorkbenchTabs(initial: nil, persistenceKey: nil)
+    let emptyID = tabs.focusedGroupID
+    let populatedID = tabs.splitRight(selection: .inbox, from: emptyID)
+
+    #expect(tabs.focusRelativeGroup(-1) == nil)
+    #expect(tabs.focusedGroupID == emptyID)
+    #expect(tabs.activateLast() == nil)
+    #expect(tabs.focusRelativeGroup(1) == .inbox)
+    #expect(tabs.focusedGroupID == populatedID)
+}
+
+@Test @MainActor func keyboardNavigationSkipsPrunedGroups() {
+    let tabs = MuxaWorkbenchTabs(persistenceKey: nil)
+    let firstID = tabs.focusedGroupID
+    let removedID = tabs.splitRight(selection: .inbox, from: firstID)
+    tabs.prune { $0 != .inbox }
+
+    #expect(tabs.group(id: removedID) == nil)
+    #expect(tabs.focusedGroupID == firstID)
+    tabs.focus(removedID)
+    #expect(tabs.focusRelativeGroup(1) == .workBoard)
+    #expect(tabs.focusRelativeGroup(-1) == .workBoard)
+    #expect(tabs.activateAt(0) == .workBoard)
+    #expect(tabs.activateLast() == .workBoard)
+
+    tabs.prune { _ in false }
+    #expect(tabs.groups.count == 1)
+    #expect(tabs.focusRelativeGroup(1) == nil)
+    #expect(tabs.activateLast() == nil)
+}
+
+@Test func keyboardCommandActionsPreserveExistingInitializer() {
+    var invoked: [String] = []
+    let actions = MuxaEditorCommandActions(
+        close: { invoked.append("close") },
+        next: { invoked.append("next") },
+        previous: { invoked.append("previous") },
+        splitRight: { invoked.append("split") },
+        pin: { invoked.append("pin") }
+    )
+    actions.next?()
+    actions.previous?()
+    actions.splitRight?()
+    actions.pin?()
+    #expect(invoked == ["next", "previous", "split", "pin"])
+    #expect(actions.quickOpen == nil)
+    #expect(actions.commandPalette == nil)
+    #expect(actions.activateAt == nil)
+    #expect(actions.activateLast == nil)
+    #expect(actions.focusRelativeGroup == nil)
+    #expect(actions.openWorkCommandCenter == nil)
+    #expect(actions.openAsk == nil)
+    #expect(actions.openInbox == nil)
+    #expect(actions.selectSidebar == nil)
+    #expect(actions.focusSidebar == nil)
+    #expect(actions.isEnabled)
+    #expect(MuxaEditorCommandActions().close == nil)
+}
+
+@Test @MainActor func closingBackgroundEditorsDoesNotStealGroupFocus() {
+    let tabs = MuxaWorkbenchTabs(persistenceKey: nil)
+    let firstID = tabs.focusedGroupID
+    let backgroundID = tabs.splitRight(selection: .ask, from: firstID)
+    tabs.openPinned(.inbox)
+    tabs.focus(firstID)
+    #expect(tabs.close(.ask, groupID: backgroundID) == .workBoard)
+    #expect(tabs.focusedGroupID == firstID)
+    #expect(tabs.close(.inbox, groupID: backgroundID) == .workBoard)
+    #expect(tabs.focusedGroupID == firstID)
+    #expect(tabs.groups.count == 1)
+}
+
+@Test @MainActor func closingExitedShellEverywhereReturnsSurvivingEditor() {
+    let tabs = MuxaWorkbenchTabs(persistenceKey: nil)
+    let firstID = tabs.focusedGroupID
+    tabs.openPinned(.shell("exited"))
+    tabs.splitRight(selection: .shell("exited"), from: firstID)
+    #expect(tabs.closeEverywhere(.shell("exited")) == .workBoard)
+    #expect(tabs.focusedGroupID == firstID)
+    #expect(tabs.groups.count == 1)
+    #expect(tabs.groups[0].tabs == [.workBoard])
+    #expect(tabs.closeEverywhere(.workBoard) == nil)
+    #expect(tabs.groups.count == 1)
+}
+
+@Test @MainActor func editorOperationsMaintainStateInvariants() {
+    let tabs = MuxaWorkbenchTabs(persistenceKey: nil)
+    let destinations: [MuxaSidebarSelection] = [.workBoard, .ask, .inbox, .watch, .shell("one"), .shell("two")]
+    var seed: UInt64 = 7209
+    for _ in 0..<1200 {
+        seed = seed &* 6364136223846793005 &+ 1442695040888963407
+        let selection = destinations[Int(seed % UInt64(destinations.count))]
+        switch (seed >> 32) % 9 {
+        case 0: tabs.openPreview(selection)
+        case 1: tabs.openPinned(selection)
+        case 2: tabs.splitRight(selection: selection, from: tabs.focusedGroupID)
+        case 3: tabs.closeFocused()
+        case 4: tabs.closeEverywhere(selection)
+        case 5: tabs.prune { $0 != selection }
+        case 6: tabs.activateRelative(1)
+        case 7: tabs.focusRelativeGroup(-1)
+        default: tabs.closeOthers(keeping: selection, groupID: tabs.focusedGroupID)
+        }
+        #expect((1...2).contains(tabs.groups.count))
+        #expect(tabs.groups.contains { $0.id == tabs.focusedGroupID })
+        for group in tabs.groups {
+            #expect(Set(group.tabs).count == group.tabs.count)
+            #expect(Set(group.history).count == group.history.count)
+            #expect(group.history.allSatisfy { group.tabs.contains($0) })
+            #expect(group.active.map { group.tabs.contains($0) } ?? group.tabs.isEmpty)
+            #expect(group.preview.map { group.tabs.contains($0) } ?? true)
+        }
+    }
+}

--- a/apps/muxa-macos/Tests/PromptComposerTests.swift
+++ b/apps/muxa-macos/Tests/PromptComposerTests.swift
@@ -1,0 +1,86 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import Muxa
+
+@Test func promptComposerGuardsHostControlForEverySendPath() {
+    let local = MuxaFleetHostIdentity(alias: "local", local: true, state: "online", mode: "observe")
+    let control = MuxaFleetHostIdentity(alias: "remote", local: false, state: "online", mode: "control")
+    let observe = MuxaFleetHostIdentity(alias: "readonly", local: false, state: "online", mode: "observe")
+    let unknown = MuxaFleetHostIdentity(alias: "unknown", local: false, state: "online", mode: "")
+
+    #expect(PromptComposerRules.canSend(prompt: "다음 작업", sending: false, hosts: [local]))
+    #expect(PromptComposerRules.canSend(prompt: "next", sending: false, hosts: [control]))
+    #expect(PromptComposerRules.canSend(prompt: "next", sending: false, hosts: [local, control]))
+    #expect(!PromptComposerRules.canSend(prompt: "next", sending: false, hosts: [observe]))
+    #expect(!PromptComposerRules.canSend(prompt: "next", sending: false, hosts: [local, observe]))
+    #expect(!PromptComposerRules.canSend(prompt: "next", sending: false, hosts: [unknown]))
+    #expect(!PromptComposerRules.canSend(prompt: "next", sending: false, hosts: []))
+    #expect(!PromptComposerRules.canSend(prompt: "next", sending: true, hosts: [control]))
+    #expect(!PromptComposerRules.canSend(prompt: " \n\t ", sending: false, hosts: [local]))
+}
+
+@Test func promptComposerOnlyClearsTheUneditedSubmittedDraft() {
+    let submittedRevision = UUID()
+    let editedRevision = UUID()
+    let submitted = "  다음 작업\n"
+
+    #expect(PromptComposerRules.shouldClearDraft(
+        current: submitted, submitted: submitted,
+        revision: submittedRevision, submittedRevision: submittedRevision
+    ))
+    #expect(!PromptComposerRules.shouldClearDraft(
+        current: "새 초안", submitted: submitted,
+        revision: editedRevision, submittedRevision: submittedRevision
+    ))
+    #expect(!PromptComposerRules.shouldClearDraft(
+        current: submitted, submitted: submitted,
+        revision: editedRevision, submittedRevision: submittedRevision
+    ))
+    #expect(!PromptComposerRules.shouldClearDraft(
+        current: "external replacement", submitted: submitted,
+        revision: submittedRevision, submittedRevision: submittedRevision
+    ))
+}
+
+@Test func promptComposerCommandReturnRequiresFocusAndNoIMEComposition() {
+    #expect(PromptComposerRules.handlesSendKey(keyCode: 36, modifiers: .command, focused: true, markedText: false))
+    #expect(!PromptComposerRules.handlesSendKey(keyCode: 36, modifiers: .command, focused: false, markedText: false))
+    #expect(!PromptComposerRules.handlesSendKey(keyCode: 36, modifiers: .command, focused: true, markedText: true))
+    #expect(PromptComposerRules.handlesSendKey(keyCode: 36, modifiers: [.command, .capsLock], focused: true, markedText: false))
+}
+
+@Test func promptComposerLeavesEnterAndFocusTraversalToTheNativeEditor() {
+    let returnModifiers: [NSEvent.ModifierFlags] = [[], .shift, .option, .control, [.command, .shift], [.command, .option]]
+    for modifiers in returnModifiers {
+        #expect(!PromptComposerRules.handlesSendKey(keyCode: 36, modifiers: modifiers, focused: true, markedText: false))
+    }
+    let tabModifiers: [NSEvent.ModifierFlags] = [[], .shift, .command]
+    for modifiers in tabModifiers {
+        #expect(!PromptComposerRules.handlesSendKey(keyCode: 48, modifiers: modifiers, focused: true, markedText: false))
+    }
+    #expect(!PromptComposerRules.handlesSendKey(keyCode: 0, modifiers: .command, focused: true, markedText: false))
+}
+
+@Test func promptComposerFeedbackPreservesActionableMultilineDetails() {
+    let message = "remote/%12: Permission denied.\nChange the host to control mode, then retry.\n" + String(repeating: "Diagnostic detail. ", count: 100)
+    let feedback = PromptFeedback(message: message, succeeded: false)
+    #expect(feedback.message == message)
+    #expect(!feedback.succeeded)
+    #expect(PromptFeedback(message: "전송 완료", succeeded: true).succeeded)
+}
+
+@Test @MainActor func promptComposerStatusKeepsTheSameBoundsForEveryOutcome() {
+    let outcomes: [PromptFeedback?] = [
+        nil,
+        PromptFeedback(message: "Sent and submitted", succeeded: true),
+        PromptFeedback(message: "Sent to 12 collaborators", succeeded: true),
+        PromptFeedback(message: String(repeating: "오류: 호스트 설정을 확인하세요.\n", count: 100), succeeded: false),
+    ]
+    for feedback in outcomes {
+        let status = NSHostingView(rootView: PromptComposerStatus(feedback: feedback))
+        status.layoutSubtreeIfNeeded()
+        #expect(status.fittingSize == NSSize(width: 132, height: 24))
+    }
+}

--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -389,6 +389,46 @@ focus an arbitrary application. Because any process running as the same user
 can reach this QA bridge, quit the helper when UI automation is finished; it is
 intended for local development, not distribution.
 
+## Keyboard navigation
+
+The workbench's **Navigate** and **Editor** menus list the available shortcuts:
+
+| Shortcut | Action |
+| --- | --- |
+| `⌘P` | Quick Open: search sessions, windows, panes, native shells, work, and agents |
+| `⌘⇧P` | Command palette: navigate, create work/shells, refresh, or manage editor tabs |
+| `↑` / `↓`, `Tab` / `Shift-Tab` | Select the previous/next enabled palette result |
+| `Enter` / `Esc` | Open the selected result / dismiss the palette |
+| `⌘1` … `⌘8`, `⌘9` | Activate an editor by position / activate the last editor |
+| `Ctrl-Tab` / `Ctrl-Shift-Tab` | Next / previous editor |
+| `⌘⌥←` / `⌘⌥→` | Focus the previous / next editor group |
+| `⌘\` | Split the active editor to the right |
+| `⌘⌥Enter` | Keep the preview editor open (pin) |
+| `⌘W` | Close the editor, without terminating its session |
+| `⌘⇧1` / `⌘⇧2` / `⌘⇧3` | Open Work Command Center / Ask / Inbox |
+| `⌘⇧F` | Focus the sidebar filter |
+| `⌘Enter` | Send from the focused pane/work prompt composer |
+
+Quick Open searches names and host/socket context with multiword fuzzy matching.
+While the palette is open, `⌘P` and `⌘⇧P` switch between destinations and commands
+without closing the search field; typing is focused automatically.
+Recent destinations rank first when the query is empty. Nonempty searches rank
+by exact title, title prefix/substring, context substring,
+then fuzzy match, with recent history only breaking ties. Exact pane titles take
+precedence over same-named windows. Editing the query selects the best enabled
+result; background refreshes preserve the user's selection. Identical names on
+different hosts or tmux sockets remain separate destinations. Opening a result
+pins its editor; it does not send terminal input or start another session.
+Unavailable commands are shown disabled and skipped by keyboard selection.
+IME composition keeps its native key handling, including Korean candidate
+selection and composition-confirming Enter. Plain Tab outside the palette keeps
+normal focus traversal; macOS Keyboard Navigation controls tabbing to all controls.
+
+Pane/work send results occupy a fixed-size status area immediately left of Send,
+so success or a long error never adds a row or shifts the layout. Hover or open
+the status to read the complete details. A draft edited during an in-flight send
+is preserved when the earlier send completes.
+
 ## Reproducible libghostty supply chain
 
 [`apps/muxa-macos/Dependencies.lock`](../apps/muxa-macos/Dependencies.lock)

--- a/docs/MACOS_AUDIT.md
+++ b/docs/MACOS_AUDIT.md
@@ -1,0 +1,48 @@
+# macOS workbench regression audit
+
+## Scope
+
+Reviewed the workbench's search ranking, destination identity, query and selection
+updates, native search-field input, command dispatch, editor tab/group lifecycle,
+prompt send guards, draft preservation, configuration write/conflict handling,
+and Ask automation judgment boundaries. Ran the complete macOS test target and
+the muxa, muxad, and muxa-cli Rust test suites, plus Rust Clippy.
+
+This is a regression review of these paths, not a claim that every application
+state, platform combination, or production integration is free of bugs.
+
+## Corrected findings
+
+| Finding | Correction | Regression coverage |
+| --- | --- | --- |
+| Closing an editor in a background split group changed the focused group. | Preserve the focused group unless that group itself is removed. | Close both a background tab and its final tab without moving focus. |
+| Dismissing an exited shell could remove the focused group without synchronizing the model's active editor. | Close the shell everywhere, then synchronize once to the surviving editor. | Remove the same shell from both groups and check the surviving editor and empty-workbench case. |
+
+Previously corrected palette defects remain covered: editable native search,
+Command-P/Command-Shift-P dispatch, exact pane-title precedence, and selecting the
+new best match when the query changes rather than retaining a weaker old result.
+
+## Expanded verification
+
+- Native full-palette view: type a partial ticket ID, extend it to an exact ID,
+  press Enter, and verify the chosen pane identity rather than just its score.
+- Native full-palette view: move to a different result with Tab, refresh the
+  execution snapshot, then verify Enter still opens the manually selected item.
+- Editor state: 1,200 deterministic mixed operations covering previews, pinned
+  tabs, splits, closing, pruning, and keyboard cycling. Check group count, focused
+  group membership, unique tabs/history, and active/preview membership after
+  every operation.
+- Existing coverage includes cross-host/socket identities, duplicate names,
+  disabled commands, IME key routing, fixed-size prompt feedback, in-flight draft
+  edits, config conflicts and round trips, and automation safety/budget rules.
+
+Validation: 200 Swift tests pass; 2,105 Rust tests pass with one ignored;
+Clippy with warnings denied passes. Production signing and bundle smoke tests
+are checked separately during packaging.
+
+## Boundaries
+
+No real prompts, paid Ask requests, or user configuration writes are used for
+this audit. The running daemon and its sessions are retained during app updates.
+Live remote failures, every keyboard layout/input method, and every possible
+multi-window workflow still require dedicated manual or integration testing.


### PR DESCRIPTION
The macOS half of the split; #135 was the daemon/IPC half. Swift, docs and the localization catalog only — no Rust changes.

## Quick Open and the command palette

`⌘P` opens Quick Open over sessions, windows, panes, native shells, work and agents. `⌘⇧P` opens the command palette for navigating, creating work and shells, refreshing, and managing editor tabs. While either is open the two keys switch between destinations and commands without closing the search field. The **Navigate** and **Editor** menus list every shortcut, so the keyboard surface is discoverable rather than folklore.

**Ranking is defined, not fuzzy-by-default:** exact title → title prefix/substring → context substring → fuzzy, with recency only breaking ties and an empty query showing recent destinations. An exact pane title outranks a same-named window. Editing the query selects the best *enabled* result, while a background refresh preserves whatever the user selected — a list updating underneath must not move the target. Identical names on different hosts or tmux sockets stay separate destinations. Opening a result pins its editor; it never sends terminal input or starts a session.

IME composition keeps its native key handling, including Korean candidate selection and the Enter that confirms a composition. Plain Tab outside the palette still traverses focus normally.

## Editor navigation

`⌘1`–`⌘9`, `Ctrl-Tab`, editor groups (`⌘⌥←`/`⌘⌥→`), split (`⌘\`), pin (`⌘⌥Enter`), close (`⌘W` — never terminates the session).

Two focus bugs fixed along the way: closing an editor in a background split group changed the focused group, and dismissing an exited shell could remove the focused group without synchronizing the model's active editor. Both are covered by regression tests.

## Prompt composer

Pane and work send results occupy a fixed-size status area beside Send, so neither a success nor a long error reflows the composer. A draft edited while a send is in flight survives that send completing.

## Verification

- `xcodebuild test -scheme Muxa` — 200 tests, TEST SUCCEEDED
- `cargo test --workspace` unaffected and green (no Rust changes in this PR)
- Editor state exercised with 1,200 deterministic mixed operations over previews, pinned tabs, splits, closing, pruning and keyboard cycling, checking group count, focused-group membership, unique tabs/history, and active/preview membership after every operation
- `Localizable.xcstrings` carries only this change's 43 keys
- `docs/MACOS_AUDIT.md` records the scope, the corrected findings and the boundaries of that review

🤖 Generated with [Claude Code](https://claude.com/claude-code)