### PR TITLE
feat(ipc): carry the local protocol over a transport, not a socket type

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Line endings are pinned rather than left to each contributor's
+# `core.autocrlf`, because two of this repo's own checks break on CRLF and
+# neither failure names its cause:
+#
+#   * `scripts/install.sh` is documented as `curl … | sh`, and `sh` is dash on
+#     Debian/Ubuntu. dash rejects a CRLF script outright — "Syntax error: word
+#     unexpected" on the first `case`, pointing at a line that is fine.
+#   * `rustfmt.toml` sets `newline_style = "Unix"`, so `cargo fmt --all --
+#     --check` reports "Incorrect newline style" for every file in the tree.
+#
+# A Windows checkout with the default `core.autocrlf=true` produces exactly
+# that, so a contributor there cannot run the CI checks locally until they
+# reconfigure git. Pinning costs nothing: git already stores LF in both cases.
+
+* text=auto eol=lf
+
+# Fixtures and captures whose bytes are the point.
+*.gif binary
+*.png binary
+*.tape text eol=lf

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -20,16 +20,41 @@ Post-1.0: the protocol is stable within a major version; breaking changes bump
 
 ## Transport
 
+- A local, owner-private, full-duplex byte stream addressed by a path that
+  both ends derive independently. `crates/muxa/src/transport.rs` owns the
+  platform-specific half; nothing above it names a socket type.
+- Encoding: **line-delimited JSON** (one UTF-8 JSON object per line, `\n`
+  terminated). `serde_json` does not emit raw newlines inside values, so
+  embedded newlines in string fields are escaped per RFC 8259. The encoding
+  is transport-independent — Fleet carries the same shape over SSH stdio.
+
+Each connection is full-duplex: a client may issue multiple
+request/response pairs over the same stream.
+
+On Unix, the supported host:
+
 - Unix-domain stream socket.
 - Default path: `$XDG_RUNTIME_DIR/muxa.sock`, falling back to
   `/tmp/muxa-<uid>.sock`.
 - Permissions: `0600` (owner-only). The daemon `chmod`s after bind.
-- Encoding: **line-delimited JSON** (one UTF-8 JSON object per line, `\n`
-  terminated). `serde_json` does not emit raw newlines inside values, so
-  embedded newlines in string fields are escaped per RFC 8259.
+- Peer credentials via `SO_PEERCRED`; collaboration provenance records them
+  as `caller_pid` / `caller_uid` / `caller_gid`.
 
-Each connection is full-duplex: a client may issue multiple
-request/response pairs over the same stream.
+On Windows — **not** a supported host (see `docs/WINDOWS.md`), but no longer
+blocked by the transport — the same protocol runs over a named pipe. The
+differences are not cosmetic:
+
+- Address: `\\.\pipe\muxa-<stem>-<digest>`, derived from the same path.
+  `$XDG_RUNTIME_DIR` being unset, that path defaults under `%LOCALAPPDATA%`.
+- Exclusivity comes from `first_pipe_instance`, not from a bind failing on an
+  existing file. `reject_remote_clients` keeps the pipe off SMB.
+- Protection is the creating token's default DACL, which is **weaker than
+  `0600`**: an administrator can connect. A pipe's DACL is fixed at creation,
+  and setting a custom one needs an unsafe call the workspace forbids.
+- No peer credentials, so provenance records `None` for all three fields.
+- A pipe instance serves one client, and the daemon creates its successor only
+  once a client has claimed the pending one. Clients retry `ERROR_PIPE_BUSY`
+  briefly to cover that window, which a socket's backlog would hide.
 
 Physical-host Fleet uses a second, versioned JSON-lines protocol over an
 OpenSSH stdio channel. It is intentionally not a network service. The remote
@@ -407,11 +432,12 @@ They back muxa's control plane — the `muxa mcp` MCP server exposes each as a
 tool so a coding agent can orchestrate the others (see `docs/MCP.md`).
 
 **Safety.** `send_prompt` injects keystrokes into another agent's pane — a
-control action, not a read. The IPC socket is already owner-only (`0600`,
-chmod'd after bind — see [Transport](#transport)), so only the daemon's own
-user can invoke it; there is no network exposure and no additional
-authentication layer. Treat socket access as equivalent to shell access for
-that user.
+control action, not a read. The IPC endpoint is already owner-only on Unix
+(`0600`, chmod'd after bind — see [Transport](#transport)), so only the
+daemon's own user can invoke it; there is no network exposure and no
+additional authentication layer. Treat endpoint access as equivalent to shell
+access for that user. The Windows named pipe is additionally reachable by
+administrators, which is one of the reasons Windows is not a supported host.
 
 **Pre-1.0 evolution.** These methods are additive (they do not bump
 `PROTOCOL_VERSION`). Like the rest of the pre-1.0 surface they may change

--- a/README.ko.md
+++ b/README.ko.md
@@ -96,6 +96,13 @@ workflow까지 하나의 시나리오로 익히게 합니다. 기존 tmux server
 
 필요 조건: tmux 3.x(또는 herdr), Unix-like OS.
 
+**Windows에서는 WSL2 안에 설치하세요.** tmux는 Windows 네이티브 빌드가 없어
+WSL 밖에서는 Muxa가 관측할 대상 자체가 없습니다. WSL2에서는 Muxa가 온전한
+제품 그대로 동작하며, Windows Terminal이 해당 배포판에 다른 셸과 똑같이
+붙으므로 `muxa watch`를 Windows Terminal 탭에서 그대로 띄울 수 있습니다.
+빌드가 몇 배 느린 `/mnt/c` 대신 WSL 파일시스템(`~/`)에 클론하세요.
+자세한 내용은 [docs/WINDOWS.md](docs/WINDOWS.md).
+
 Homebrew(프리빌트 바이너리, Rust 툴체인 불필요):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ If you decide to keep Muxa, install it with one of the following methods.
 
 Requires tmux 3.x (or herdr) and a Unix-like OS.
 
+**On Windows, install inside WSL2** — tmux has no native Windows build, so
+there is nothing for Muxa to observe outside it. Under WSL2 Muxa is the
+complete product, and Windows Terminal attaches to the distribution like any
+other shell, so `muxa watch` runs in a Windows Terminal tab. Clone into the WSL
+filesystem (`~/`) rather than `/mnt/c`, which is several times slower to build
+in. See [docs/WINDOWS.md](docs/WINDOWS.md).
+
 Homebrew (pre-built binaries, no Rust toolchain needed):
 
 ```bash

--- a/crates/muxa/src/adapters/proc_ancestry.rs
+++ b/crates/muxa/src/adapters/proc_ancestry.rs
@@ -39,7 +39,7 @@ pub fn parent_pid(pid: u32) -> Option<u32> {
 /// for the MCP ancestry recovery; hook reconciliation already takes a shared
 /// one-shot process snapshot on macOS/BSD. A failed or unavailable `ps`
 /// degrades cleanly to no ancestry match.
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 pub fn parent_pid(pid: u32) -> Option<u32> {
     let output = std::process::Command::new("ps")
         .args(["-o", "ppid=", "-p", &pid.to_string()])
@@ -49,6 +49,17 @@ pub fn parent_pid(pid: u32) -> Option<u32> {
         return None;
     }
     String::from_utf8(output.stdout).ok()?.trim().parse().ok()
+}
+
+/// No ancestry source on non-Unix hosts.
+///
+/// Spelled out rather than left to `not(target_os = "linux")`, which would
+/// otherwise select the `ps` arm above and fail at runtime. Returning `None`
+/// degrades exactly like an unavailable `ps`: the caller falls back to the
+/// pane env var and gives up quietly. See `docs/WINDOWS.md`.
+#[cfg(not(unix))]
+pub fn parent_pid(_pid: u32) -> Option<u32> {
+    None
 }
 
 /// Parse the `PPid:` field out of `/proc/<pid>/status` content.

--- a/crates/muxa/src/backend/cmux.rs
+++ b/crates/muxa/src/backend/cmux.rs
@@ -6,9 +6,9 @@
 //! JSON fixture; until then observations are deliberately partial so the
 //! reconciler never treats an absent cmux row as proof that an agent exited.
 
+use super::unix_socket::UnixStream;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
-use std::os::unix::net::UnixStream;
 use std::time::Duration;
 
 use serde_json::json;

--- a/crates/muxa/src/backend/cmux.rs
+++ b/crates/muxa/src/backend/cmux.rs
@@ -269,6 +269,7 @@ mod tests {
         assert!(caps.send_text);
     }
 
+    #[cfg(unix)]
     #[test]
     fn send_text_uses_the_exact_surface_and_socket_endpoint() {
         let dir = tempfile::tempdir().unwrap();
@@ -294,6 +295,7 @@ mod tests {
         server.join().unwrap();
     }
 
+    #[cfg(unix)]
     #[test]
     fn oversized_socket_response_is_rejected() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -90,7 +90,8 @@ impl HerdrBackend {
     /// Shorten the per-call timeout. Test-only so the "server accepts
     /// then hangs" case exercises the real timeout path without a
     /// full-second wait in the suite.
-    #[cfg(test)]
+    // Gated with its only consumer: the suite below needs a Unix socket.
+    #[cfg(all(test, unix))]
     fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
         self
@@ -608,7 +609,7 @@ struct HerdrProcess {
     name: String,
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use std::os::unix::net::UnixListener;
     use std::path::Path;

--- a/crates/muxa/src/backend/herdr.rs
+++ b/crates/muxa/src/backend/herdr.rs
@@ -32,9 +32,9 @@
 //!
 //! See `docs/HERDR.md` for the full design.
 
+use super::unix_socket::UnixStream;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
-use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};

--- a/crates/muxa/src/backend/mod.rs
+++ b/crates/muxa/src/backend/mod.rs
@@ -56,6 +56,7 @@ pub mod cmux;
 pub mod herdr;
 pub mod rmux;
 pub mod tmux;
+pub(crate) mod unix_socket;
 pub mod zellij;
 
 use std::collections::HashMap;

--- a/crates/muxa/src/backend/unix_socket.rs
+++ b/crates/muxa/src/backend/unix_socket.rs
@@ -1,0 +1,86 @@
+//! `UnixStream` for the cmux and herdr clients, with a non-Unix stand-in.
+//!
+//! Both backends speak a line-delimited JSON protocol to a daemon that only
+//! ships for Unix — cmux and herdr have no Windows build. muxa still has to
+//! *compile* on Windows (see `docs/WINDOWS.md`), and `HostKind` matches over
+//! all five hosts exhaustively, so removing the modules there would ripple
+//! through `default_backend`, `backend_of`, and `active_kinds_from`.
+//!
+//! Re-exporting the real type on Unix and a stand-in elsewhere keeps both
+//! clients' bodies byte-for-byte identical across platforms: the shipping
+//! platform's behavior cannot regress, because its code did not change.
+//!
+//! The stand-in is deliberately **uninhabited** — it wraps [`Infallible`], so
+//! no value of it can ever exist and the compiler proves every method body
+//! below is unreachable. `connect` is the only constructor and it always
+//! fails, which lands both clients on paths they already handle:
+//!
+//! - herdr's `request` stats the socket path first, gets "absent", and
+//!   returns `SocketMissing` — authoritatively no panes, which is correct and
+//!   reap-safe on a host where herdr cannot run.
+//! - herdr's `server_reachable` and cmux's `rpc` return `false`.
+//!
+//! So the Windows answer is "this host is not present", reached through the
+//! backends' own logic rather than a parallel set of stubbed return values.
+
+#[cfg(unix)]
+pub(crate) use std::os::unix::net::UnixStream;
+
+#[cfg(not(unix))]
+pub(crate) use stub::UnixStream;
+
+#[cfg(not(unix))]
+mod stub {
+    use std::convert::Infallible;
+    use std::io::{self, Read, Write};
+    use std::path::Path;
+    use std::time::Duration;
+
+    /// See the module docs. Uninhabited: `Infallible` has no values, so this
+    /// struct has none either, and `match self.0 {}` discharges every method.
+    pub(crate) struct UnixStream(Infallible);
+
+    impl UnixStream {
+        /// Always fails. `NotFound` is the same error a Unix host reports for
+        /// a socket path with no daemon behind it, so callers need no
+        /// platform-specific branch.
+        pub(crate) fn connect<P: AsRef<Path>>(_path: P) -> io::Result<Self> {
+            Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "unix-socket backends (cmux, herdr) are not available on this platform",
+            ))
+        }
+
+        pub(crate) fn set_read_timeout(&self, _timeout: Option<Duration>) -> io::Result<()> {
+            match self.0 {}
+        }
+
+        pub(crate) fn set_write_timeout(&self, _timeout: Option<Duration>) -> io::Result<()> {
+            match self.0 {}
+        }
+    }
+
+    impl Read for UnixStream {
+        fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+            match self.0 {}
+        }
+    }
+
+    // herdr wraps a borrow (`BufReader::new(&stream)`); std's `UnixStream`
+    // implements `Read` for both forms, so the stand-in must too.
+    impl Read for &UnixStream {
+        fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+            match self.0 {}
+        }
+    }
+
+    impl Write for UnixStream {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            match self.0 {}
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            match self.0 {}
+        }
+    }
+}

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -2908,6 +2908,7 @@ mod tests {
     /// not the (empty-on-herdr) tmux scanner. We stand up a minimal herdr
     /// mock socket, point a real `HerdrBackend` at it, and assert the pane
     /// surfaces with the herdr synthetic socket identity.
+    #[cfg(unix)]
     #[tokio::test]
     async fn panes_endpoint_sources_from_herdr_backend_when_host_is_herdr() {
         use std::io::{BufRead, BufReader, Write};

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -50,6 +50,7 @@ use crate::session::{
 };
 use crate::state::{Agent, SharedStore};
 use crate::tmux::PaneInfo;
+use crate::transport::{self, Listener, ReadHalf, Stream, WriteHalf};
 use crate::work::WorkIdentity;
 use crate::work_compose::{self, WorkComposeOutput, WorkComposeRequest};
 use crate::work_control::{
@@ -58,14 +59,11 @@ use crate::work_control::{
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet, VecDeque};
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering as AtomicOrdering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::unix::OwnedWriteHalf;
-use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{broadcast, watch};
 use tokio::task::JoinSet;
 
@@ -1642,8 +1640,7 @@ impl Server {
     #[allow(clippy::too_many_lines)] // accept loop plus bounded drain and socket cleanup
     pub async fn run(self, mut shutdown: broadcast::Receiver<()>) -> Result<(), RuntimeError> {
         self.bind_with_perms()?;
-        let listener = UnixListener::bind(&self.socket_path)?;
-        harden_permissions(&self.socket_path)?;
+        let listener = Listener::bind(&self.socket_path)?;
         tracing::info!(socket = %self.socket_path.display(), "listening");
 
         let mut handlers: JoinSet<()> = JoinSet::new();
@@ -1682,7 +1679,7 @@ impl Server {
                     break;
                 }
                 accept = listener.accept() => {
-                    let (stream, _) = match accept {
+                    let stream = match accept {
                         Ok(pair) => pair,
                         Err(e) if is_fd_exhaustion(&e) => {
                             // Out of file descriptors. Do NOT propagate: a
@@ -1779,21 +1776,20 @@ impl Server {
         }
 
         // Remove our own socket file so next startup is clean.
-        let _ = std::fs::remove_file(&self.socket_path);
+        transport::remove_endpoint(&self.socket_path);
         Ok(())
     }
 
     /// Pre-bind sequence: if a stale socket exists, remove it; then the
     /// caller binds and immediately chmods 0600 in `run`.
     fn bind_with_perms(&self) -> Result<(), RuntimeError> {
-        if self.socket_path.exists() {
-            // Probe: is anything listening?
-            if std::os::unix::net::UnixStream::connect(&self.socket_path).is_ok() {
-                return Err(RuntimeError::SocketInUse(self.socket_path.clone()));
-            }
-            // Stale socket, safe to remove.
-            std::fs::remove_file(&self.socket_path)?;
+        // A live endpoint means a daemon is already serving this path. Anything
+        // else that occupies it — an orphaned socket file from an abnormal exit —
+        // is ours to clear, and clearing a path that was never there succeeds.
+        if transport::endpoint_is_live(&self.socket_path) {
+            return Err(RuntimeError::SocketInUse(self.socket_path.clone()));
         }
+        transport::clear_endpoint(&self.socket_path)?;
         if let Some(parent) = self.socket_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -1866,10 +1862,7 @@ fn is_client_disconnect(e: &std::io::Error) -> bool {
     )
 }
 
-async fn write_line_or_closed(
-    writer: &mut OwnedWriteHalf,
-    bytes: &[u8],
-) -> Result<bool, RuntimeError> {
+async fn write_line_or_closed(writer: &mut WriteHalf, bytes: &[u8]) -> Result<bool, RuntimeError> {
     match writer.write_all(bytes).await {
         Ok(()) => {}
         Err(e) if is_client_disconnect(&e) => return Ok(false),
@@ -1945,7 +1938,7 @@ fn lagged_marker_bytes(
 /// disconnecting them. The next snapshot the client takes (via the
 /// fallback polling tick) will reconcile any holes.
 async fn stream_transitions(
-    mut writer: tokio::net::unix::OwnedWriteHalf,
+    mut writer: WriteHalf,
     mut rx: broadcast::Receiver<crate::state::Transition>,
     protocol: u32,
     emit_lagged: bool,
@@ -2014,7 +2007,7 @@ async fn stream_transitions(
 /// channel retains only a pending bit; sustained activity cannot grow a queue
 /// or postpone delivery indefinitely. Idle streams only send keepalives.
 async fn stream_agent_changes(
-    mut writer: OwnedWriteHalf,
+    mut writer: WriteHalf,
     mut changes: watch::Receiver<()>,
     protocol: u32,
 ) -> Result<(), RuntimeError> {
@@ -2041,7 +2034,7 @@ async fn stream_agent_changes(
 /// coherent selector-filtered snapshot. This keeps one busy remote agent from
 /// making the central TUI clone and redraw every host on a fixed timer.
 async fn stream_fleet_updates(
-    mut writer: tokio::net::unix::OwnedWriteHalf,
+    mut writer: WriteHalf,
     store: Arc<crate::fleet::FleetStore>,
     mut rx: broadcast::Receiver<FleetUpdate>,
     protocol: u32,
@@ -2119,7 +2112,7 @@ async fn stream_fleet_updates(
 /// no request content or participant identity; it is safe to propagate
 /// through Fleet as a cache invalidation while mailbox reads remain scoped.
 async fn stream_revision_updates(
-    mut writer: tokio::net::unix::OwnedWriteHalf,
+    mut writer: WriteHalf,
     mut changes: watch::Receiver<u64>,
     protocol: u32,
 ) -> Result<(), RuntimeError> {
@@ -2482,14 +2475,11 @@ impl CollaborationConnectionActor {
 }
 
 #[allow(clippy::similar_names)] // PID/UID/GID are the exact peer credential fields
-fn observe_collaboration_actor(stream: &UnixStream) -> CollaborationConnectionActor {
-    let credentials = stream.peer_cred().ok();
-    let caller_pid = credentials
-        .as_ref()
-        .and_then(tokio::net::unix::UCred::pid)
-        .and_then(|pid| u32::try_from(pid).ok());
-    let caller_uid: Option<u32> = credentials.as_ref().map(tokio::net::unix::UCred::uid);
-    let caller_gid: Option<u32> = credentials.as_ref().map(tokio::net::unix::UCred::gid);
+fn observe_collaboration_actor(stream: &Stream) -> CollaborationConnectionActor {
+    let peer = stream.peer_identity();
+    let caller_pid = peer.pid;
+    let caller_uid = peer.uid;
+    let caller_gid = peer.gid;
     let (executable, process_kind) =
         caller_pid.map_or((None, CollaborationClientKind::Unknown), process_identity);
     CollaborationConnectionActor {
@@ -2688,7 +2678,7 @@ async fn record_collaboration_audit(
 )]
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)] // IPC dispatch table and its shared daemon state
 async fn handle(
-    stream: UnixStream,
+    stream: Stream,
     store: SharedStore,
     backend: SharedBackend,
     backends: Vec<SharedBackend>,
@@ -4110,9 +4100,7 @@ pub fn blocking_call(
     deadline: Duration,
 ) -> Option<serde_json::Value> {
     use std::io::{BufRead, BufReader as SyncBufReader, Write};
-    let mut stream = std::os::unix::net::UnixStream::connect(socket_path).ok()?;
-    stream.set_read_timeout(Some(deadline)).ok()?;
-    stream.set_write_timeout(Some(deadline)).ok()?;
+    let mut stream = transport::blocking_connect(socket_path, deadline).ok()?;
     let mut bytes = serde_json::to_vec(req).ok()?;
     bytes.push(b'\n');
     stream.write_all(&bytes).ok()?;
@@ -4161,8 +4149,7 @@ pub fn blocking_reserve_handle(
 }
 
 pub fn harden_permissions(socket_path: &Path) -> std::io::Result<()> {
-    let perms = std::fs::Permissions::from_mode(0o600);
-    std::fs::set_permissions(socket_path, perms)
+    transport::harden_permissions(socket_path)
 }
 
 /// Client-side helper. Single-shot request/response.
@@ -4263,7 +4250,7 @@ pub struct SendPromptOutcome {
 /// connection (shutdown) or `Err(_)` on a parse / IO failure that
 /// the caller will probably want to handle by reconnecting.
 pub struct TransitionStream {
-    reader: BufReader<tokio::net::unix::OwnedReadHalf>,
+    reader: BufReader<ReadHalf>,
     line: String,
 }
 
@@ -4271,13 +4258,13 @@ pub struct TransitionStream {
 /// [`Client::fleet_subscribe`]. Callers fetch a coherent snapshot after
 /// coalescing one or more updates.
 pub struct FleetUpdateStream {
-    reader: BufReader<tokio::net::unix::OwnedReadHalf>,
+    reader: BufReader<ReadHalf>,
     line: String,
 }
 
 /// Content-free durable mailbox revision stream.
 pub struct CollaborationUpdateStream {
-    reader: BufReader<tokio::net::unix::OwnedReadHalf>,
+    reader: BufReader<ReadHalf>,
     line: String,
 }
 
@@ -4582,14 +4569,15 @@ impl Client {
         &self,
         selector: Option<&str>,
     ) -> Result<FleetUpdateStream, RuntimeError> {
-        let stream = UnixStream::connect(&self.socket_path)
-            .await
-            .map_err(|error| match error.kind() {
-                std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound => {
-                    RuntimeError::NotConnected(self.socket_path.clone())
-                }
-                _ => RuntimeError::Io(error),
-            })?;
+        let stream =
+            Stream::connect(&self.socket_path)
+                .await
+                .map_err(|error| match error.kind() {
+                    std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound => {
+                        RuntimeError::NotConnected(self.socket_path.clone())
+                    }
+                    _ => RuntimeError::Io(error),
+                })?;
         let (reader, mut writer) = stream.into_split();
         let mut reader = BufReader::new(reader);
         self.send_hello(&mut reader, &mut writer).await?;
@@ -4657,14 +4645,15 @@ impl Client {
         &self,
         kind: &str,
     ) -> Result<CollaborationUpdateStream, RuntimeError> {
-        let stream = UnixStream::connect(&self.socket_path)
-            .await
-            .map_err(|error| match error.kind() {
-                std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound => {
-                    RuntimeError::NotConnected(self.socket_path.clone())
-                }
-                _ => RuntimeError::Io(error),
-            })?;
+        let stream =
+            Stream::connect(&self.socket_path)
+                .await
+                .map_err(|error| match error.kind() {
+                    std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound => {
+                        RuntimeError::NotConnected(self.socket_path.clone())
+                    }
+                    _ => RuntimeError::Io(error),
+                })?;
         let (reader, mut writer) = stream.into_split();
         let mut reader = BufReader::new(reader);
         self.send_hello(&mut reader, &mut writer).await?;
@@ -5737,7 +5726,7 @@ impl Client {
     }
 
     async fn subscribe_inner(&self, kind: &str) -> Result<TransitionStream, RuntimeError> {
-        let stream = UnixStream::connect(&self.socket_path)
+        let stream = Stream::connect(&self.socket_path)
             .await
             .map_err(|e| match e.kind() {
                 std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound => {
@@ -6010,7 +5999,7 @@ impl Client {
         // or nothing is listening — surface a friendly message that names the
         // socket path. Other IO errors (timeouts, permission denied, …) keep
         // their existing display via the `Io(#[from] _)` impl.
-        let stream = UnixStream::connect(&self.socket_path)
+        let stream = Stream::connect(&self.socket_path)
             .await
             .map_err(|e| match e.kind() {
                 std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound => {
@@ -6274,7 +6263,7 @@ mod tests {
     async fn collaboration_wait_falls_back_for_legacy_daemon() {
         let dir = tempdir().unwrap();
         let socket = dir.path().join("legacy-collaboration.sock");
-        let listener = UnixListener::bind(&socket).unwrap();
+        let listener = Listener::bind(&socket).unwrap();
         let terminal_request = serde_json::json!({
             "id": "legacy-request",
             "from": {
@@ -6307,7 +6296,7 @@ mod tests {
         });
         let server = tokio::spawn(async move {
             for expected_kind in ["collaboration_wait", "collaboration_get"] {
-                let (stream, _) = listener.accept().await.unwrap();
+                let stream = listener.accept().await.unwrap();
                 let (reader, mut writer) = stream.into_split();
                 let mut reader = BufReader::new(reader);
                 let mut line = String::new();
@@ -6635,6 +6624,11 @@ mod tests {
         assert_eq!(request.run_id.as_deref(), Some("tmux:default:@1"));
         let provenance = request.provenance.as_ref().unwrap();
         assert_eq!(provenance.client_kind, CollaborationClientKind::Watch);
+        // Peer credentials come from `SO_PEERCRED`; a host whose transport
+        // cannot report them leaves this `None` by design — see
+        // `transport::PeerIdentity`. `client_kind` above is declared by the
+        // client itself, so it holds either way.
+        #[cfg(unix)]
         assert_eq!(provenance.caller_pid, Some(std::process::id()));
         assert_eq!(
             provenance.origin_match,
@@ -7053,7 +7047,7 @@ mod tests {
         // the trailing newline so the handler is stuck inside
         // `read_line`. This simulates an in-flight handler at the moment
         // shutdown lands.
-        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        let mut stream = Stream::connect(&sock).await.unwrap();
         let req = serde_json::json!({
             "protocol": PROTOCOL_VERSION,
             "kind": "ingest",
@@ -7117,7 +7111,7 @@ mod tests {
 
     #[tokio::test]
     async fn client_disconnect_before_response_is_clean_handler_exit() {
-        let (server_stream, mut client_stream) = tokio::net::UnixStream::pair().unwrap();
+        let (server_stream, mut client_stream) = Stream::pair().await.unwrap();
         let store = Store::shared();
         let handle = tokio::spawn(handle(
             server_stream,
@@ -7163,12 +7157,12 @@ mod tests {
         let handle = tokio::spawn(async move { server.run(rx).await.unwrap() });
         wait_for_socket(&sock).await;
 
-        let mut holder = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        let mut holder = Stream::connect(&sock).await.unwrap();
         holder.write_all(b"{").await.unwrap();
         holder.flush().await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-        let mut second = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        let mut second = Stream::connect(&sock).await.unwrap();
         let req = serde_json::json!({
             "protocol": PROTOCOL_VERSION,
             "kind": "snapshot",
@@ -7222,7 +7216,7 @@ mod tests {
     /// the legacy strict-match path and the negotiated downgrade path
     /// in isolation.
     async fn raw_call(sock: &Path, req: &serde_json::Value) -> serde_json::Value {
-        let mut stream = tokio::net::UnixStream::connect(sock).await.unwrap();
+        let mut stream = Stream::connect(sock).await.unwrap();
         let mut bytes = serde_json::to_vec(req).unwrap();
         bytes.push(b'\n');
         stream.write_all(&bytes).await.unwrap();
@@ -8396,7 +8390,7 @@ mod tests {
 
         // Get a handler accepted and parked mid-request before the stop. This
         // is the exact ordering that could re-arm the old AtomicBool design.
-        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        let mut stream = Stream::connect(&sock).await.unwrap();
         let mut request = serde_json::to_vec(&serde_json::json!({
             "protocol": PROTOCOL_VERSION,
             "kind": "restart",
@@ -8480,14 +8474,14 @@ mod tests {
             .await
             .expect_err("embedded server refuses restart");
         assert!(error.to_string().contains("restart"));
-        assert!(UnixStream::connect(&sock).await.is_ok());
+        assert!(Stream::connect(&sock).await.is_ok());
 
         let error = client
             .stop(Duration::from_secs(2))
             .await
             .expect_err("embedded server refuses stop");
         assert!(error.to_string().contains("stop"));
-        assert!(UnixStream::connect(&sock).await.is_ok());
+        assert!(Stream::connect(&sock).await.is_ok());
 
         tx.send(()).unwrap();
         handle.await.unwrap();
@@ -8531,7 +8525,7 @@ mod tests {
             .await;
 
         // Open one connection: hello v1, then snapshot.
-        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        let mut stream = Stream::connect(&sock).await.unwrap();
         let mut hello = serde_json::to_vec(&serde_json::json!({
             "protocol": 1, "kind": "hello", "client": "v1-test",
         }))
@@ -8586,7 +8580,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        let mut stream = Stream::connect(&sock).await.unwrap();
         let mut hello = serde_json::to_vec(&serde_json::json!({
             "protocol": 2, "kind": "hello", "client": "v2-test",
         }))
@@ -8650,7 +8644,7 @@ mod tests {
             })
             .await;
 
-        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        let mut stream = Stream::connect(&sock).await.unwrap();
         let mut hello = serde_json::to_vec(&serde_json::json!({
             "protocol": 2, "kind": "hello", "client": "v2-test",
         }))
@@ -9293,7 +9287,7 @@ mod tests {
         use tokio::io::AsyncBufReadExt;
         let store = crate::state::Store::shared();
         let mut other = store.subscribe_changes();
-        let (client, server) = UnixStream::pair().unwrap();
+        let (client, server) = Stream::pair().await.unwrap();
         let (_, writer) = server.into_split();
         let pump = tokio::spawn(stream_agent_changes(
             writer,
@@ -9416,7 +9410,7 @@ mod tests {
         let transition_json = serde_json::to_string(&transition).unwrap();
 
         // Wire the marker + transition into a TransitionStream's reader.
-        let (client_side, server_side) = UnixStream::pair().unwrap();
+        let (client_side, server_side) = Stream::pair().await.unwrap();
         let (cr, _cw) = client_side.into_split();
         let mut ts = TransitionStream {
             reader: BufReader::new(cr),

--- a/crates/muxa/src/lib.rs
+++ b/crates/muxa/src/lib.rs
@@ -69,6 +69,7 @@ pub mod state;
 pub mod timeline;
 pub mod tmux;
 pub mod topology;
+pub mod transport;
 pub mod work;
 pub mod work_compose;
 #[doc(hidden)]

--- a/crates/muxa/src/paths.rs
+++ b/crates/muxa/src/paths.rs
@@ -22,7 +22,21 @@ pub fn default_socket() -> PathBuf {
     if let Some(dir) = dirs::runtime_dir() {
         return dir.join(SOCKET_FILENAME);
     }
-    PathBuf::from(format!("/tmp/muxa-{}.sock", posix_uid()))
+    #[cfg(unix)]
+    {
+        PathBuf::from(format!("/tmp/muxa-{}.sock", posix_uid()))
+    }
+    // No `$XDG_RUNTIME_DIR` and no `/tmp` worth writing to: fall back to the
+    // per-user local data directory. On Windows the path is not bound to a
+    // filesystem object anyway — the transport derives a pipe name from it —
+    // but it is still what `create_dir_all` runs against, and creating a
+    // `	mp` at the drive root would be a surprising thing for a daemon to do.
+    #[cfg(not(unix))]
+    {
+        dirs::data_local_dir()
+            .map(|d| d.join(CONFIG_DIRNAME).join(SOCKET_FILENAME))
+            .unwrap_or_else(|| PathBuf::from(SOCKET_FILENAME))
+    }
 }
 
 /// Default config file path: `$XDG_CONFIG_HOME/muxa/config.toml`, falling
@@ -95,6 +109,7 @@ pub fn default_pipeline_run_file() -> Option<PathBuf> {
     dirs::data_dir().map(|d| d.join(CONFIG_DIRNAME).join(PIPELINE_RUN_FILENAME))
 }
 
+#[cfg(unix)]
 fn posix_uid() -> u32 {
     std::process::Command::new("id")
         .arg("-u")

--- a/crates/muxa/src/process_snapshot.rs
+++ b/crates/muxa/src/process_snapshot.rs
@@ -30,7 +30,7 @@ pub(crate) struct ProcessTable {
     children_by_parent: HashMap<u32, Vec<u32>>,
 }
 
-#[cfg_attr(target_os = "linux", allow(dead_code))]
+#[cfg_attr(any(target_os = "linux", not(unix)), allow(dead_code))]
 impl ProcessTable {
     pub(crate) fn from_processes(processes: impl IntoIterator<Item = ProcessInfo>) -> Self {
         let mut table = Self::default();

--- a/crates/muxa/src/process_snapshot.rs
+++ b/crates/muxa/src/process_snapshot.rs
@@ -1,8 +1,13 @@
 //! Lightweight process-table snapshot shared by OS process-tree scanners.
 //!
-//! On non-Linux hosts the cheapest portable primitive is a single `ps` pass
-//! over the whole process table. Callers then walk this in memory instead of
-//! spawning `ps`/`pgrep` once per pane.
+//! On Unix hosts that are not Linux the cheapest portable primitive is a
+//! single `ps` pass over the whole process table. Callers then walk this in
+//! memory instead of spawning `ps`/`pgrep` once per pane.
+//!
+//! Windows has neither `/proc` nor `ps`. Rather than let it fall into the
+//! `ps` arm and fail at runtime with an empty table, the non-Unix arm is
+//! spelled out below and returns empty *deliberately*. See
+//! `docs/WINDOWS.md` for what wiring a real Windows process source needs.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
@@ -88,7 +93,7 @@ impl ProcessTable {
 /// hooks only need parent IDs, and may run many times during an agent turn.
 /// One small `ps` snapshot is both cheaper and avoids needlessly reading
 /// command-line arguments that can contain sensitive values.
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 pub(crate) fn read_parent_pid_map() -> HashMap<u32, u32> {
     let output = std::process::Command::new("ps")
         .args(["-axo", "pid=,ppid="])
@@ -101,7 +106,7 @@ pub(crate) fn read_parent_pid_map() -> HashMap<u32, u32> {
     parse_parent_pid_map(&String::from_utf8_lossy(&output.stdout))
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn parse_parent_pid_map(stdout: &str) -> HashMap<u32, u32> {
     stdout
         .lines()
@@ -115,7 +120,7 @@ fn parse_parent_pid_map(stdout: &str) -> HashMap<u32, u32> {
         .collect()
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 pub(crate) fn read_current_process_table() -> ProcessTable {
     let output = std::process::Command::new("ps")
         .args(["-axo", "pid=,ppid=,args="])
@@ -131,7 +136,7 @@ pub(crate) fn read_current_process_table() -> ProcessTable {
     parse_ps_table(&String::from_utf8_lossy(&output.stdout))
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn parse_ps_table(stdout: &str) -> ProcessTable {
     let processes = stdout.lines().filter_map(|line| {
         let mut parts = line.split_whitespace();
@@ -155,6 +160,30 @@ fn parse_ps_table(stdout: &str) -> ProcessTable {
         })
     });
     ProcessTable::from_processes(processes)
+}
+
+// --- Non-Unix (Windows) -----------------------------------------------------
+//
+// Windows exposes neither `/proc` nor `ps`. These arms exist so that the
+// absence of a process source is one visible place in the tree, rather than an
+// accident of `not(target_os = "linux")` quietly selecting the `ps` code path
+// and failing at runtime with an empty table and a debug line nobody reads.
+//
+// Returning empty is honest rather than lossy: without a Windows `PaneBackend`
+// there are no panes whose descendants could be attributed anyway. Wiring a
+// real source (Toolhelp32 / WTS) is only worth doing once such a backend
+// exists to give the PIDs meaning. See `docs/WINDOWS.md`.
+
+#[cfg(not(unix))]
+pub(crate) fn read_parent_pid_map() -> HashMap<u32, u32> {
+    tracing::debug!("parent-pid snapshot unavailable: no process source on this platform");
+    HashMap::new()
+}
+
+#[cfg(not(unix))]
+pub(crate) fn read_current_process_table() -> ProcessTable {
+    tracing::debug!("process-table snapshot unavailable: no process source on this platform");
+    ProcessTable::default()
 }
 
 #[cfg(test)]
@@ -197,7 +226,7 @@ mod tests {
         assert_eq!(table.descendants(1, 3, 1).len(), 1);
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(all(unix, not(target_os = "linux")))]
     #[test]
     fn parses_ps_table_rows() {
         let table = parse_ps_table(
@@ -221,7 +250,7 @@ mod tests {
         );
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(all(unix, not(target_os = "linux")))]
     #[test]
     fn parses_parent_pid_rows_without_command_arguments() {
         let parents = parse_parent_pid_map("  10   1\n  20  10\nmalformed\n 30 nope\n");

--- a/crates/muxa/src/tmux/scanner.rs
+++ b/crates/muxa/src/tmux/scanner.rs
@@ -25,6 +25,8 @@
 use crate::backend::HostKind;
 use crate::tmux::{PaneInfo, PANE_FMT};
 use serde::Serialize;
+// Only the Unix socket-directory walk dedupes by canonical path.
+#[cfg(unix)]
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -240,8 +242,18 @@ fn enumerate_sockets_with(scoped: Option<PathBuf>, dirs: &[PathBuf]) -> Vec<Path
 /// error (e.g. permission denied) keeps the socket so we never hide one we
 /// merely failed to probe — the worst case there is the old per-socket cost
 /// for that single file.
+#[cfg(unix)]
 fn socket_is_live(path: &Path) -> bool {
     classify_socket_connect(std::os::unix::net::UnixStream::connect(path).map(|_| ()))
+}
+
+/// No tmux server sockets exist on a non-Unix host, so nothing can be live.
+///
+/// `classify_socket_connect` stays shared and unit-tested on every platform;
+/// only the syscall that feeds it is Unix-only.
+#[cfg(not(unix))]
+fn socket_is_live(_path: &Path) -> bool {
+    false
 }
 
 fn classify_socket_connect(result: std::io::Result<()>) -> bool {
@@ -268,6 +280,7 @@ fn default_socket_dirs() -> Vec<PathBuf> {
 
 /// Inner enumerator with the search dirs injected — the unit tests use
 /// this to point at a temp fixture instead of the real `/tmp`.
+#[cfg(unix)]
 fn enumerate_sockets_in(dirs: &[PathBuf]) -> Vec<PathBuf> {
     use std::os::unix::fs::FileTypeExt;
     let mut out = Vec::new();
@@ -291,6 +304,18 @@ fn enumerate_sockets_in(dirs: &[PathBuf]) -> Vec<PathBuf> {
         }
     }
     out
+}
+
+/// tmux does not run natively on Windows, so there is no socket directory to
+/// walk and no `SOCK_STREAM` file type to test for.
+///
+/// Returning empty makes [`scan`] yield an empty [`ScanResult`] rather than
+/// failing — the honest answer for a host with no tmux server. A Windows user
+/// runs muxa inside WSL, where this is the Unix arm above. See
+/// `docs/WINDOWS.md`.
+#[cfg(not(unix))]
+fn enumerate_sockets_in(_dirs: &[PathBuf]) -> Vec<PathBuf> {
+    Vec::new()
 }
 
 /// Get the current user's UID. Cached for the process lifetime — stable
@@ -609,6 +634,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn enumerate_sockets_in_filters_to_socket_files() {
         let dir = tempfile::tempdir().unwrap();
@@ -625,6 +651,7 @@ mod tests {
         assert_eq!(found[0], sock_path);
     }
 
+    #[cfg(unix)]
     #[test]
     fn enumerate_sockets_with_scopes_to_a_single_socket() {
         let dir = tempfile::tempdir().unwrap();
@@ -652,6 +679,7 @@ mod tests {
         assert!(event_in_scope_with(None, None));
     }
 
+    #[cfg(unix)]
     #[test]
     fn event_in_scope_drops_foreign_socket_but_keeps_scoped_and_paneless() {
         let dir = tempfile::tempdir().unwrap();
@@ -683,6 +711,7 @@ mod tests {
         ));
     }
 
+    #[cfg(unix)]
     #[test]
     fn enumerate_sockets_in_dedupes_canonical_paths() {
         // /tmp and /private/tmp resolve to the same dir on macOS — the
@@ -697,6 +726,7 @@ mod tests {
         assert_eq!(found.len(), 1);
     }
 
+    #[cfg(unix)]
     #[test]
     fn enumerate_sockets_in_skips_missing_dirs() {
         // Non-existent dirs should not panic or short-circuit later
@@ -713,6 +743,7 @@ mod tests {
         assert_eq!(found, vec![sock]);
     }
 
+    #[cfg(unix)]
     #[test]
     fn socket_is_live_distinguishes_listening_from_orphan() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/muxa/src/tmux/scanner.rs
+++ b/crates/muxa/src/tmux/scanner.rs
@@ -256,6 +256,7 @@ fn socket_is_live(_path: &Path) -> bool {
     false
 }
 
+#[cfg_attr(not(unix), allow(dead_code))]
 fn classify_socket_connect(result: std::io::Result<()>) -> bool {
     use std::io::ErrorKind;
     match result {

--- a/crates/muxa/src/transport.rs
+++ b/crates/muxa/src/transport.rs
@@ -1,0 +1,522 @@
+//! Local IPC transport: a Unix-domain socket, or a Windows named pipe.
+//!
+//! [`crate::ipc`] speaks line-delimited JSON (see `PROTOCOL.md`) and never
+//! needed a *socket* specifically — it needs a local, owner-private,
+//! full-duplex byte stream that a client can address by a path the daemon also
+//! knows. Fleet already carries the same shape of protocol over an SSH stdio
+//! channel, so the encoding was never the coupled part. The types were:
+//! `UnixStream` and `OwnedWriteHalf` appeared directly in handler signatures.
+//!
+//! This module is that coupling, isolated. It deliberately exposes **one**
+//! `Stream`/`ReadHalf`/`WriteHalf` family rather than a generic parameter, so
+//! `ipc.rs` keeps concrete types in its signatures and gains no type
+//! parameters — its dispatch table is unchanged apart from the names it
+//! mentions.
+//!
+//! # Differences a caller can observe
+//!
+//! | | Unix | Windows |
+//! | --- | --- | --- |
+//! | Address | the socket path | a pipe name derived from that path |
+//! | Exclusivity | bind fails on an existing path | `first_pipe_instance` |
+//! | Protection | `chmod 0600` after bind | creation flags + the default DACL |
+//! | Peer identity | `SO_PEERCRED` | none — see [`PeerIdentity`] |
+//! | Teardown | unlink the socket file | the pipe dies with its last handle |
+//! | Blocking client | a second synchronous socket | unsupported |
+//!
+//! Windows is not a supported host (see `docs/WINDOWS.md`). This exists so the
+//! transport stops being the reason it cannot be, and so the differences above
+//! live in one place instead of being rediscovered later.
+
+use std::io;
+use std::path::Path;
+use std::time::Duration;
+
+pub use imp::{BlockingStream, Listener, ReadHalf, Stream, WriteHalf};
+
+/// Credentials of the process on the other end of a connection.
+///
+/// Populated from `SO_PEERCRED` on Unix. Every field is `None` on Windows:
+/// recovering the client pid needs `GetNamedPipeClientProcessId`, and the
+/// workspace sets `unsafe_code = "forbid"`, so calling it would take a new
+/// dependency. Callers already treat missing credentials as an unknown actor —
+/// `observe_collaboration_actor` maps `None` to
+/// `CollaborationClientKind::Unknown` — so this is the existing degradation
+/// rather than a new path. It does leave collaboration provenance weaker on
+/// Windows, which is one more reason it is not a supported host.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PeerIdentity {
+    pub pid: Option<u32>,
+    pub uid: Option<u32>,
+    pub gid: Option<u32>,
+}
+
+/// Restrict an already-bound endpoint to its owner.
+///
+/// Kept as a standalone entry point because `muxad` re-applies it after the
+/// listener appears. A no-op on Windows, where protection is fixed at creation
+/// time — see [`Listener::bind`].
+pub fn harden_permissions(endpoint: &Path) -> io::Result<()> {
+    imp::harden(endpoint)
+}
+
+/// Whether a daemon is currently accepting on `endpoint`.
+///
+/// Used to tell a live daemon from a leftover socket file before binding. A
+/// live endpoint means "already running"; anything else is clearable.
+pub fn endpoint_is_live(endpoint: &Path) -> bool {
+    imp::probe_live(endpoint)
+}
+
+/// Remove a dead endpoint so a bind can succeed.
+///
+/// Only Unix leaves a file behind; a named pipe vanishes with its last handle,
+/// so there is nothing to clear.
+pub fn clear_endpoint(endpoint: &Path) -> io::Result<()> {
+    imp::clear(endpoint)
+}
+
+/// Best-effort teardown on daemon shutdown. Failures are the caller's to
+/// ignore — the next startup clears a stale endpoint anyway.
+pub fn remove_endpoint(endpoint: &Path) {
+    let _ = imp::clear(endpoint);
+}
+
+/// Connect a synchronous client, with `deadline` applied to reads and writes.
+///
+/// For callers with no runtime to await on. Returns
+/// [`io::ErrorKind::Unsupported`] on Windows: a named pipe opened as a file has
+/// no way to bound a read without an unsafe `SetCommTimeouts`, and a transport
+/// that can hang the caller forever is worse than one that declines. The single
+/// caller ([`crate::ipc::blocking_call`]) already degrades every failure to
+/// `None`.
+pub fn blocking_connect(endpoint: &Path, deadline: Duration) -> io::Result<BlockingStream> {
+    imp::blocking_connect(endpoint, deadline)
+}
+
+// --- Unix -------------------------------------------------------------------
+
+#[cfg(unix)]
+mod imp {
+    use super::{io, Duration, Path, PeerIdentity};
+
+    /// The daemon's listening socket.
+    pub struct Listener(tokio::net::UnixListener);
+
+    /// One accepted or connected byte stream.
+    pub struct Stream(tokio::net::UnixStream);
+
+    pub type ReadHalf = tokio::net::unix::OwnedReadHalf;
+    pub type WriteHalf = tokio::net::unix::OwnedWriteHalf;
+    pub type BlockingStream = std::os::unix::net::UnixStream;
+
+    impl Listener {
+        /// Bind, then immediately restrict the socket to its owner.
+        ///
+        /// The caller must have cleared a stale path first: `bind(2)` fails
+        /// with `EADDRINUSE` on any existing file, live or not.
+        pub fn bind(endpoint: &Path) -> io::Result<Self> {
+            let listener = tokio::net::UnixListener::bind(endpoint)?;
+            harden(endpoint)?;
+            Ok(Self(listener))
+        }
+
+        /// Cancel-safe, as required by the daemon's `select!` accept loop.
+        pub async fn accept(&self) -> io::Result<Stream> {
+            let (stream, _addr) = self.0.accept().await?;
+            Ok(Stream(stream))
+        }
+    }
+
+    impl tokio::io::AsyncRead for Stream {
+        fn poll_read(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<io::Result<()>> {
+            std::pin::Pin::new(&mut self.0).poll_read(cx, buf)
+        }
+    }
+
+    impl tokio::io::AsyncWrite for Stream {
+        fn poll_write(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> std::task::Poll<io::Result<usize>> {
+            std::pin::Pin::new(&mut self.0).poll_write(cx, buf)
+        }
+
+        fn poll_flush(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<io::Result<()>> {
+            std::pin::Pin::new(&mut self.0).poll_flush(cx)
+        }
+
+        fn poll_shutdown(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<io::Result<()>> {
+            std::pin::Pin::new(&mut self.0).poll_shutdown(cx)
+        }
+    }
+
+    impl Stream {
+        pub async fn connect(endpoint: &Path) -> io::Result<Self> {
+            tokio::net::UnixStream::connect(endpoint).await.map(Self)
+        }
+
+        /// A connected pair, for tests that drive a handler without a daemon.
+        ///
+        /// Nothing here needs to await; it is async only so the signature
+        /// matches the Windows counterpart, which has a handshake to finish.
+        #[cfg(test)]
+        #[allow(clippy::unused_async)] // parity with the Windows counterpart
+        pub async fn pair() -> io::Result<(Self, Self)> {
+            let (a, b) = tokio::net::UnixStream::pair()?;
+            Ok((Self(a), Self(b)))
+        }
+
+        /// Lock-free owned halves, exactly as before this module existed.
+        pub fn into_split(self) -> (ReadHalf, WriteHalf) {
+            self.0.into_split()
+        }
+
+        pub fn peer_identity(&self) -> PeerIdentity {
+            let Ok(cred) = self.0.peer_cred() else {
+                return PeerIdentity::default();
+            };
+            PeerIdentity {
+                pid: cred.pid().and_then(|pid| u32::try_from(pid).ok()),
+                uid: Some(cred.uid()),
+                gid: Some(cred.gid()),
+            }
+        }
+    }
+
+    pub(super) fn harden(endpoint: &Path) -> io::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(endpoint, std::fs::Permissions::from_mode(0o600))
+    }
+
+    pub(super) fn probe_live(endpoint: &Path) -> bool {
+        // A connect refuses instantly on an orphaned socket file and succeeds
+        // only when a server is accepting, so this costs one syscall.
+        std::os::unix::net::UnixStream::connect(endpoint).is_ok()
+    }
+
+    pub(super) fn clear(endpoint: &Path) -> io::Result<()> {
+        match std::fs::remove_file(endpoint) {
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            other => other,
+        }
+    }
+
+    pub(super) fn blocking_connect(
+        endpoint: &Path,
+        deadline: Duration,
+    ) -> io::Result<BlockingStream> {
+        let stream = std::os::unix::net::UnixStream::connect(endpoint)?;
+        stream.set_read_timeout(Some(deadline))?;
+        stream.set_write_timeout(Some(deadline))?;
+        Ok(stream)
+    }
+}
+
+// --- Windows ----------------------------------------------------------------
+
+#[cfg(not(unix))]
+mod imp {
+    use super::{io, Duration, Path, PeerIdentity};
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+    use tokio::net::windows::named_pipe::{
+        ClientOptions, NamedPipeClient, NamedPipeServer, ServerOptions,
+    };
+
+    /// A named pipe has no `accept(2)`. The server pre-creates one *instance*,
+    /// waits for a client on it, and must create the next instance before it
+    /// can take another connection — so the pending instance is state the
+    /// listener carries, unlike a `UnixListener`.
+    ///
+    /// The mutex serialises that swap. A tokio mutex because the wait happens
+    /// inside it; serialising costs nothing, as the daemon runs exactly one
+    /// accept loop.
+    pub struct Listener {
+        name: std::ffi::OsString,
+        pending: tokio::sync::Mutex<NamedPipeServer>,
+    }
+
+    /// Server- and client-side pipes are distinct types on Windows, unlike
+    /// `UnixStream`. Erasing them behind one enum keeps `ipc.rs` to a single
+    /// `Stream` type, matching the Unix shape it was written against.
+    pub enum Stream {
+        Server(NamedPipeServer),
+        Client(NamedPipeClient),
+    }
+
+    pub type ReadHalf = tokio::io::ReadHalf<Stream>;
+    pub type WriteHalf = tokio::io::WriteHalf<Stream>;
+
+    /// A named pipe opened as a file would be a synchronous byte stream, which
+    /// is the shape [`crate::ipc::blocking_call`] wants. The type is named so
+    /// the signature stays honest; [`blocking_connect`] declines to build one.
+    pub type BlockingStream = std::fs::File;
+
+    impl Listener {
+        /// `first_pipe_instance` is the exclusivity guarantee: a second process
+        /// creating the same name fails rather than silently joining the pipe
+        /// and racing for its clients. It doubles as the "already running"
+        /// signal, standing in for a live socket file.
+        ///
+        /// `reject_remote_clients` keeps the pipe off SMB. That is tokio's
+        /// default; it is set explicitly because a local-only transport quietly
+        /// becoming network-reachable is exactly the mistake worth spelling
+        /// out at the call site.
+        ///
+        /// There is no post-create hardening step. A pipe's DACL is fixed at
+        /// creation and setting a custom one needs the raw unsafe entry point
+        /// the workspace forbids, so it inherits the creating token's default
+        /// DACL — owner plus SYSTEM/Administrators. That is weaker than `0600`
+        /// (an administrator can connect) and is recorded in `docs/WINDOWS.md`.
+        pub fn bind(endpoint: &Path) -> io::Result<Self> {
+            let name = pipe_name(endpoint);
+            let first = ServerOptions::new()
+                .first_pipe_instance(true)
+                .reject_remote_clients(true)
+                .create(&name)?;
+            Ok(Self {
+                name,
+                pending: tokio::sync::Mutex::new(first),
+            })
+        }
+
+        pub async fn accept(&self) -> io::Result<Stream> {
+            let mut pending = self.pending.lock().await;
+            pending.connect().await?;
+            // Create the successor before handing this one out, so the name is
+            // never momentarily unserved: a client connecting in that gap would
+            // see FILE_NOT_FOUND instead of waiting for an instance.
+            let next = ServerOptions::new()
+                .reject_remote_clients(true)
+                .create(&self.name)?;
+            Ok(Stream::Server(std::mem::replace(&mut *pending, next)))
+        }
+    }
+
+    impl Stream {
+        /// Connect, absorbing the window in which no instance is free.
+        ///
+        /// A pipe instance serves exactly one client, and [`Listener::accept`]
+        /// creates the successor only once a client has taken the pending one.
+        /// A connect landing in that window fails with `ERROR_PIPE_BUSY`, which
+        /// is transient and says nothing about whether the daemon is up — where
+        /// a Unix socket's backlog absorbs the same burst invisibly. Two
+        /// requests in quick succession are enough to hit it.
+        ///
+        /// So `ERROR_PIPE_BUSY` is retried briefly, to give callers the Unix
+        /// behaviour they were written against. Every other error returns
+        /// immediately, so an absent daemon is still reported at once.
+        pub async fn connect(endpoint: &Path) -> io::Result<Self> {
+            let name = pipe_name(endpoint);
+            let deadline = std::time::Instant::now() + BUSY_RETRY_BUDGET;
+            loop {
+                match ClientOptions::new().open(&name) {
+                    Ok(client) => return Ok(Stream::Client(client)),
+                    Err(e)
+                        if e.raw_os_error() == Some(ERROR_PIPE_BUSY)
+                            && std::time::Instant::now() < deadline =>
+                    {
+                        tokio::time::sleep(BUSY_RETRY_BACKOFF).await;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+
+        /// `tokio::io::split` rather than owned halves: `NamedPipeServer` has
+        /// no `into_split`. Costs a `BiLock` per poll, which is noise beside
+        /// the JSON parse on the same line.
+        pub fn into_split(self) -> (ReadHalf, WriteHalf) {
+            tokio::io::split(self)
+        }
+
+        /// Always empty — see [`PeerIdentity`].
+        pub fn peer_identity(&self) -> PeerIdentity {
+            PeerIdentity::default()
+        }
+
+        /// A connected pair, for tests that drive a handler without a daemon.
+        ///
+        /// Windows has no `socketpair`, so this brokers a real single-instance
+        /// pipe under a name unique to this process and call, then connects to
+        /// it. The name is never reused, so concurrent tests cannot collide.
+        #[cfg(test)]
+        pub async fn pair() -> io::Result<(Self, Self)> {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static SEQ: AtomicU64 = AtomicU64::new(0);
+
+            let name = format!(
+                r"\\.\pipe\muxa-test-{}-{}",
+                std::process::id(),
+                SEQ.fetch_add(1, Ordering::Relaxed)
+            );
+            let server = ServerOptions::new()
+                .first_pipe_instance(true)
+                .reject_remote_clients(true)
+                .create(&name)?;
+            let client = ClientOptions::new().open(&name)?;
+            // A server instance holds no connection until `ConnectNamedPipe`
+            // completes, and reads on it block until one arrives. The client
+            // above is already attached, so this returns immediately — but
+            // omitting it deadlocks the first read, which is the whole reason
+            // this function is async.
+            server.connect().await?;
+            Ok((Stream::Server(server), Stream::Client(client)))
+        }
+    }
+
+    // Both pipe types are `Unpin`, so `get_mut` projects without `unsafe`.
+    impl AsyncRead for Stream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            match self.get_mut() {
+                Stream::Server(s) => Pin::new(s).poll_read(cx, buf),
+                Stream::Client(c) => Pin::new(c).poll_read(cx, buf),
+            }
+        }
+    }
+
+    impl AsyncWrite for Stream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            match self.get_mut() {
+                Stream::Server(s) => Pin::new(s).poll_write(cx, buf),
+                Stream::Client(c) => Pin::new(c).poll_write(cx, buf),
+            }
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            match self.get_mut() {
+                Stream::Server(s) => Pin::new(s).poll_flush(cx),
+                Stream::Client(c) => Pin::new(c).poll_flush(cx),
+            }
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            match self.get_mut() {
+                Stream::Server(s) => Pin::new(s).poll_shutdown(cx),
+                Stream::Client(c) => Pin::new(c).poll_shutdown(cx),
+            }
+        }
+    }
+
+    /// Protection is set at creation; there is nothing to re-apply after.
+    pub(super) fn harden(_endpoint: &Path) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub(super) fn probe_live(endpoint: &Path) -> bool {
+        // An instance exists only while the daemon holds it, so a successful
+        // open is the liveness answer. `ERROR_PIPE_BUSY` means every instance
+        // is momentarily taken — also live.
+        match ClientOptions::new().open(pipe_name(endpoint)) {
+            Ok(_) => true,
+            Err(e) => e.raw_os_error() == Some(ERROR_PIPE_BUSY),
+        }
+    }
+
+    /// Nothing to clear: the pipe is gone once the daemon drops its handles.
+    pub(super) fn clear(_endpoint: &Path) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub(super) fn blocking_connect(
+        _endpoint: &Path,
+        _deadline: Duration,
+    ) -> io::Result<BlockingStream> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "synchronous IPC needs a read timeout, which a named pipe cannot \
+             set without an unsafe SetCommTimeouts call",
+        ))
+    }
+
+    /// `ERROR_PIPE_BUSY` — all instances are in use, so the server is up.
+    const ERROR_PIPE_BUSY: i32 = 231;
+
+    /// How long [`Stream::connect`] keeps retrying a busy pipe. Generous
+    /// against the microseconds the daemon needs to create a successor
+    /// instance, and still far below any caller's own request deadline.
+    const BUSY_RETRY_BUDGET: Duration = Duration::from_secs(1);
+
+    /// Short enough that the common case — losing a race by a few
+    /// microseconds — costs one sleep rather than a visible stall.
+    const BUSY_RETRY_BACKOFF: Duration = Duration::from_millis(2);
+
+    /// Map an endpoint path onto a pipe name.
+    ///
+    /// Pipe names live in a flat namespace and may not contain a backslash, so
+    /// the path cannot be used as-is. The file stem keeps the name readable
+    /// when someone lists pipes; the digest keeps two daemons on different
+    /// paths (a test fixture and a login daemon, say) from colliding on it.
+    ///
+    /// FNV-1a rather than `DefaultHasher`: the client and the daemon derive
+    /// this name independently, so it has to be stable across builds, and
+    /// `DefaultHasher`'s algorithm is explicitly not guaranteed to be.
+    fn pipe_name(endpoint: &Path) -> std::ffi::OsString {
+        let full = endpoint.to_string_lossy();
+        let stem: String = endpoint
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default()
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+            .take(32)
+            .collect();
+        format!(r"\\.\pipe\muxa-{stem}-{:016x}", fnv1a64(full.as_bytes())).into()
+    }
+
+    fn fnv1a64(bytes: &[u8]) -> u64 {
+        const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+        const PRIME: u64 = 0x0000_0100_0000_01b3;
+        bytes.iter().fold(OFFSET, |hash, byte| {
+            (hash ^ u64::from(*byte)).wrapping_mul(PRIME)
+        })
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn pipe_name_is_stable_and_path_specific() {
+            let a = pipe_name(Path::new(r"C:\Users\dev\AppData\Local\Temp\muxa.sock"));
+            let b = pipe_name(Path::new(r"C:\Users\dev\AppData\Local\Temp\muxa.sock"));
+            let c = pipe_name(Path::new(r"C:\other\muxa.sock"));
+
+            assert_eq!(a, b, "same path must derive the same pipe");
+            assert_ne!(a, c, "different paths must not collide");
+            assert!(a.to_string_lossy().starts_with(r"\\.\pipe\muxa-muxa-"));
+        }
+
+        #[test]
+        fn pipe_name_drops_characters_a_pipe_name_cannot_carry() {
+            let name = pipe_name(Path::new(r"C:\tmp\od d\mu xa!.sock"));
+            let text = name.to_string_lossy();
+
+            assert!(text.starts_with(r"\\.\pipe\muxa-"));
+            // Only the leading `\\.\pipe\` may contain backslashes.
+            assert_eq!(text.matches('\\').count(), 4);
+            assert!(!text.contains(' '));
+        }
+    }
+}

--- a/crates/muxa/src/transport.rs
+++ b/crates/muxa/src/transport.rs
@@ -169,13 +169,14 @@ mod imp {
 
         /// A connected pair, for tests that drive a handler without a daemon.
         ///
-        /// Nothing here needs to await; it is async only so the signature
-        /// matches the Windows counterpart, which has a handshake to finish.
+        /// A socketpair is connected the moment it exists, so there is nothing
+        /// to await — but the signature has to match the Windows counterpart,
+        /// which has a handshake to finish. Returning a ready future says that
+        /// honestly, where an `async fn` with no `.await` only looks like an
+        /// oversight.
         #[cfg(test)]
-        #[allow(clippy::unused_async)] // parity with the Windows counterpart
-        pub async fn pair() -> io::Result<(Self, Self)> {
-            let (a, b) = tokio::net::UnixStream::pair()?;
-            Ok((Self(a), Self(b)))
+        pub fn pair() -> impl std::future::Future<Output = io::Result<(Self, Self)>> {
+            std::future::ready(tokio::net::UnixStream::pair().map(|(a, b)| (Self(a), Self(b))))
         }
 
         /// Lock-free owned halves, exactly as before this module existed.

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -1,0 +1,117 @@
+# Windows
+
+Status: **not a supported host. Use WSL2.** muxa observes and drives agents
+running in multiplexer panes, and no Windows-native multiplexer exposes the
+control surface [`PaneBackend`] requires. Under WSL2 muxa is the complete
+product, unchanged.
+
+This document records what is true today, why, and what the platform gates in
+the tree are protecting — so that a future port starts from measurements
+rather than from a fresh survey.
+
+## Use WSL2
+
+```bash
+# inside your WSL distribution
+curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/install.sh | sh
+```
+
+Requirements are the ordinary Linux ones: tmux, and Rust `1.89+` to build.
+Windows Terminal attaches to the WSL distribution like any other shell, so
+`muxa watch` runs in a Windows Terminal tab with no bridge in between.
+
+Clone into the WSL filesystem (`~/`) rather than building from `/mnt/<drive>`.
+The 9p mount that backs `/mnt` makes cargo builds several times slower.
+
+## Why not native
+
+Four independent reasons, in increasing order of how hard they are to remove.
+
+### 1. No host to observe
+
+[`PaneBackend`] requires `list_panes`, `resolve_pane`, `capture_pane`,
+`pane_pid_map`, `current_pane`, `focus_pane`, and `send_text`. Windows Terminal
+provides none of them: `wt.exe` accepts split-pane arguments at launch and
+returns, with no pane enumeration, no stable pane ids, no screen capture, and
+no way to send input to a pane it is not focused on. ConPTY is a pseudoconsole
+API, not a multiplexer.
+
+[`BackendCaps`] can already describe a host with gaps — that is how the zellij
+CLI baseline is modelled — but `list_panes` has no capability flag because
+every host must answer it. A Windows backend could not.
+
+This is the blocker. The three below are ordinary work; this one has no known
+solution, so the other three should not be started on its account.
+
+### 2. IPC is a Unix-domain socket
+
+`crates/muxa/src/ipc.rs` binds a `UnixListener`, `chmod`s it to `0600`, and
+threads `tokio::net::unix::OwnedWriteHalf` through handler signatures. See
+[PROTOCOL.md](../PROTOCOL.md#transport).
+
+The encoding itself is transport-agnostic — line-delimited JSON — and Fleet
+already runs the same shape of protocol over an SSH stdio byte stream
+(`crates/muxa-cli/src/relay.rs`), so there is precedent for carrying it on
+something other than a Unix socket. The security model is the part that does
+not port directly: `0600` on a socket file has no exact named-pipe equivalent,
+and a pipe's protection comes from creation-time flags and its DACL instead.
+
+### 3. No process source
+
+Linux reads `/proc`. Every other platform took one `ps` snapshot. Windows has
+neither.
+
+Until recently the second arm was spelled `#[cfg(not(target_os = "linux"))]`,
+which meant Windows *silently* selected the `ps` implementation and got an
+empty table with one `tracing::debug!` line. Those arms are now
+`#[cfg(all(unix, not(target_os = "linux")))]` with explicit `#[cfg(not(unix))]`
+counterparts, so the absence is visible in the tree instead of being an
+accident of cfg arithmetic:
+
+| File | Unix arm | Non-Unix arm |
+| --- | --- | --- |
+| `process_snapshot.rs` | `/proc` or `ps` | empty table |
+| `adapters/proc_ancestry.rs` | `/proc` or `ps` | `None` |
+| `tmux/scanner.rs` | walk `$TMUX_TMPDIR`, probe sockets | no sockets |
+| `backend/unix_socket.rs` | `std::os::unix::net::UnixStream` | uninhabited stand-in whose `connect` always fails |
+
+Returning empty is the honest answer while reason 1 stands: with no Windows
+backend there are no panes whose descendants could be attributed. Wiring a real
+source (Toolhelp32, WTS) is only worth doing once those PIDs mean something.
+
+Note that `unsafe_code = "forbid"` is set workspace-wide, so a future process
+source cannot call the Win32 APIs directly — it needs a safe wrapper crate.
+
+### 4. Unix assumptions throughout the CLI
+
+`muxa-cli` depends on `nix` and `signal-hook`, neither of which builds for a
+Windows target, so the CLI fails at dependency resolution rather than at
+compile time. Service installation shells out to `launchctl` and `systemctl`,
+and roughly twenty other call sites invoke `sh`, `bash`, `id`, `kill`, `ps`,
+or `nohup`.
+
+## What compiles today
+
+`cargo check -p muxa --target x86_64-pc-windows-msvc`.
+
+The whole dependency tree builds on Windows, including `rusqlite` (bundled
+SQLite, so a C toolchain is exercised), `portable-pty` (ConPTY), `axum`,
+`reqwest`, `tokio`, and `notify-rust` (which pulls `tauri-winrt-notification`
+for toasts). The dependencies are not the obstacle; muxa's own code is.
+
+Remaining errors are confined to `ipc.rs`.
+
+A caution for anyone reading that error count as an estimate: they are `E0432`
+/ `E0433` name-resolution failures, and rustc stops before type-checking. The
+9,921 lines of `ipc.rs` have not been checked at all. Stubbing the imports
+reveals a considerably larger second wave.
+
+## If the blocker ever lifts
+
+Sequence the work as 1 → 2 → 3 → 4, not the reverse. Reasons 2 through 4 are
+tractable and individually reviewable, but they buy nothing on their own: a
+daemon that starts on Windows and observes no panes is not a product. Settle
+what a Windows `PaneBackend` would talk to first.
+
+[`PaneBackend`]: ../crates/muxa/src/backend/mod.rs
+[`BackendCaps`]: ../crates/muxa/src/backend/mod.rs

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -26,6 +26,8 @@ The 9p mount that backs `/mnt` makes cargo builds several times slower.
 ## Why not native
 
 Four independent reasons, in increasing order of how hard they are to remove.
+The second has since been removed — it is kept here, marked, because what it
+cost and what it could not recover are the useful part of the record.
 
 ### 1. No host to observe
 
@@ -41,20 +43,41 @@ CLI baseline is modelled — but `list_panes` has no capability flag because
 every host must answer it. A Windows backend could not.
 
 This is the blocker. The three below are ordinary work; this one has no known
-solution, so the other three should not be started on its account.
+solution, so the other three should not be started on its account — and
+finishing one of them, as the next section did, changes nothing here.
 
-### 2. IPC is a Unix-domain socket
+### 2. IPC was a Unix-domain socket — resolved
 
-`crates/muxa/src/ipc.rs` binds a `UnixListener`, `chmod`s it to `0600`, and
-threads `tokio::net::unix::OwnedWriteHalf` through handler signatures. See
-[PROTOCOL.md](../PROTOCOL.md#transport).
+`ipc.rs` used to bind a `UnixListener` and thread
+`tokio::net::unix::OwnedWriteHalf` through handler signatures. It now goes
+through `crates/muxa/src/transport.rs`, which resolves to a Unix socket or a
+Windows named pipe. See [PROTOCOL.md](../PROTOCOL.md#transport).
 
-The encoding itself is transport-agnostic — line-delimited JSON — and Fleet
-already runs the same shape of protocol over an SSH stdio byte stream
-(`crates/muxa-cli/src/relay.rs`), so there is precedent for carrying it on
-something other than a Unix socket. The security model is the part that does
-not port directly: `0600` on a socket file has no exact named-pipe equivalent,
-and a pipe's protection comes from creation-time flags and its DACL instead.
+The encoding was never the coupled part — line-delimited JSON, which Fleet
+already carries over an SSH stdio byte stream (`crates/muxa-cli/src/relay.rs`).
+The types were. Rather than make the dispatch table generic, the module exposes
+one `Stream`/`ReadHalf`/`WriteHalf` family whose definition is platform-chosen,
+so `ipc.rs` gained no type parameters.
+
+What did **not** port cleanly, and is why this is a compile story rather than a
+support story:
+
+- **Protection is weaker.** `0600` on a socket file has no named-pipe
+  equivalent. A pipe's DACL is fixed at creation and setting a custom one needs
+  an unsafe raw call `unsafe_code = "forbid"` rules out, so the pipe inherits
+  the creating token's default DACL — an administrator can connect.
+  `first_pipe_instance` and `reject_remote_clients` cover name squatting and
+  SMB reachability, which are the other two exposures.
+- **No peer credentials.** `SO_PEERCRED` has no safe counterpart, so
+  collaboration provenance records `None` for pid/uid/gid on Windows.
+- **No synchronous client.** `blocking_call` needs a bounded read, and a pipe
+  opened as a file cannot set one without `SetCommTimeouts`. It returns
+  `Unsupported` rather than risk hanging the caller — which lands on the
+  "daemon unavailable" path the function already documents.
+- **Accept has a gap a socket does not have.** One pipe instance serves one
+  client, and the successor is created only once the pending instance is
+  claimed. A client connecting in that window gets `ERROR_PIPE_BUSY`, so
+  clients retry it briefly; a socket's backlog hides the same burst.
 
 ### 3. No process source
 
@@ -90,28 +113,46 @@ compile time. Service installation shells out to `launchctl` and `systemctl`,
 and roughly twenty other call sites invoke `sh`, `bash`, `id`, `kill`, `ps`,
 or `nohup`.
 
-## What compiles today
+## What builds and runs today
 
-`cargo check -p muxa --target x86_64-pc-windows-msvc`.
+The `muxa` library crate compiles clean for `x86_64-pc-windows-msvc`, warnings
+included, and its test suite runs:
 
-The whole dependency tree builds on Windows, including `rusqlite` (bundled
-SQLite, so a C toolchain is exercised), `portable-pty` (ConPTY), `axum`,
-`reqwest`, `tokio`, and `notify-rust` (which pulls `tauri-winrt-notification`
-for toasts). The dependencies are not the obstacle; muxa's own code is.
+```
+cargo check -p muxa --all-targets     # clean
+cargo test  -p muxa --lib             # 995 passed, 8 failed
+```
 
-Remaining errors are confined to `ipc.rs`.
+The whole dependency tree builds, including `rusqlite` (bundled SQLite, so a C
+toolchain is exercised), `portable-pty` (ConPTY), `axum`, `reqwest`, `tokio`,
+and `notify-rust` (which pulls `tauri-winrt-notification` for toasts). The
+dependencies were never the obstacle.
 
-A caution for anyone reading that error count as an estimate: they are `E0432`
-/ `E0433` name-resolution failures, and rustc stops before type-checking. The
-9,921 lines of `ipc.rs` have not been checked at all. Stubbing the imports
-reveals a considerably larger second wave.
+The eight failures are all pre-existing Unix assumptions in test fixtures, none
+in transport or IPC:
+
+| Test | Assumption |
+| --- | --- |
+| `ipc::work_command_tests` (4) | fixture cwd `/tmp/...`, which `Path::is_absolute` rejects without a drive prefix |
+| `work_control::tests::native_work_request_...` | same |
+| `adapters::antigravity::tests` (2) | transcript path shape |
+| `state::tests::reap_dead_pids_...` | Unix process liveness |
+
+They are left alone deliberately. Making them pass means teaching fixtures a
+second path grammar, which is only worth doing for a host muxa intends to
+support.
+
+`muxa-cli` still does not build — `nix` fails at dependency resolution. `muxad`
+has no such dependency and is the natural next crate, if anyone wants one.
 
 ## If the blocker ever lifts
 
-Sequence the work as 1 → 2 → 3 → 4, not the reverse. Reasons 2 through 4 are
-tractable and individually reviewable, but they buy nothing on their own: a
-daemon that starts on Windows and observes no panes is not a product. Settle
-what a Windows `PaneBackend` would talk to first.
+Sequence the remaining work as 1 → 3 → 4, and settle 1 first. Reasons 3 and 4
+are tractable and individually reviewable, but they buy nothing on their own: a
+daemon that starts on Windows and observes no panes is not a product. Reason 2
+was worth doing early only because it was the load-bearing one for *compiling*
+at all, and because writing the transport down forced the security differences
+above into one reviewable place.
 
 [`PaneBackend`]: ../crates/muxa/src/backend/mod.rs
 [`BackendCaps`]: ../crates/muxa/src/backend/mod.rs

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -39,6 +39,35 @@ need() {
   }
 }
 
+# Git Bash, MSYS2 and Cygwin all report a Windows-family `uname -s` while
+# providing a POSIX shell, so this script runs happily and then spends several
+# minutes compiling before dying inside `nix`, which has no Windows target.
+# Answer the question up front instead: muxa has no Windows host, and WSL is
+# not a workaround there but the actual supported environment.
+case "$(uname -s 2>/dev/null)" in
+  MINGW* | MSYS* | CYGWIN* | Windows_NT)
+    cat >&2 <<'WINDOWS_NOTICE'
+muxa-install: this is a Windows shell, and muxa has no Windows host.
+
+muxa observes agents running in tmux panes, and tmux does not run natively on
+Windows. Install inside WSL2, where muxa is the complete product:
+
+  wsl --install                 # once, if you have no distribution yet
+  wsl                           # then, inside it:
+  curl -fsSL https://raw.githubusercontent.com/Open330/muxa/main/scripts/install.sh | sh
+
+Windows Terminal attaches to that distribution like any other shell, so
+`muxa watch` runs in a Windows Terminal tab with nothing bridging in between.
+
+Clone into the WSL filesystem (~/) rather than /mnt/c — the 9p mount makes
+cargo builds several times slower.
+
+See docs/WINDOWS.md for why native support is not planned.
+WINDOWS_NOTICE
+    exit 1
+    ;;
+esac
+
 need cargo
 need git
 


### PR DESCRIPTION
## What this is

Two commits that make Windows a *compilable* target for the `muxa` library
crate, and write down what that does and does not buy.

**It does not make Windows a supported host, and does not try to.** muxa
observes agents in tmux panes; tmux has no native Windows build, and no
Windows multiplexer offers the control surface `PaneBackend` requires
(`list_panes`, `capture_pane`, `send_text`, …). WSL2 remains the answer, and
is now documented as such.

What it buys is that the platform boundary stops being implicit. Two things
were true before this branch and are worth stating plainly:

- `#[cfg(not(target_os = "linux"))]` was being used to mean *"macOS/BSD, where
  `ps` exists"*. Windows satisfies that cfg too, so it selected the `ps`
  implementation, found no such binary, and returned an empty process table
  behind one `tracing::debug!` line. Hook ancestry recovery would have degraded
  to nothing with no compile error and no visible failure.
- `ipc.rs` named `UnixStream` and `OwnedWriteHalf` in handler signatures, so
  the transport could not be reasoned about separately from the dispatch table
  built on top of it.

## Commits

### 1. `refactor(platform)` — make the non-Unix arms explicit

Splits the accidental arms into `all(unix, not(target_os = "linux"))` plus a
spelled-out `not(unix)` counterpart, so the absence of a Windows process source
is one readable place rather than a consequence of cfg arithmetic.

The cmux and herdr clients keep their bodies **unchanged**. Both talk to
Unix-only daemons, and `HostKind` is matched exhaustively in three places, so
dropping the modules would ripple through the backend factory. Instead
`UnixStream` resolves through a new `backend::unix_socket`: the real type on
Unix, and elsewhere an *uninhabited* stand-in whose `connect` always fails. The
compiler proves its method bodies unreachable, and both clients reach their
existing "no server" paths — herdr via `SocketMissing`, which is authoritative
and reap-safe.

### 2. `feat(ipc)` — carry the protocol over a transport, not a socket type

New `crates/muxa/src/transport.rs`. It exposes **one**
`Stream`/`ReadHalf`/`WriteHalf` family whose definition is platform-chosen,
rather than a generic parameter — so `ipc.rs` gained no type parameters and no
monomorphisation, and changed only the names it mentions.

Unix keeps every syscall it had, in the same order: bind then `chmod 0600`,
`into_split` for lock-free owned halves, `SO_PEERCRED` for provenance.

## Where a pipe is not a socket

The point of writing the transport down is that these had to be decided rather
than discovered. Three are load-bearing:

| | Unix | Windows |
| --- | --- | --- |
| Protection | `chmod 0600` | creating token's default DACL — **an administrator can connect** |
| Peer identity | `SO_PEERCRED` | none; provenance records `None` for pid/uid/gid |
| Accept | backlog absorbs bursts | one instance per client; a connect in the successor-creation window gets `ERROR_PIPE_BUSY` |

The DACL gap is real and unfixable here: a pipe's DACL is fixed at creation and
setting a custom one needs an unsafe raw call `unsafe_code = "forbid"` rules
out. `first_pipe_instance` and `reject_remote_clients` cover name squatting and
SMB reachability; nothing covers this one. It is recorded in `PROTOCOL.md`
under Safety and in `docs/WINDOWS.md`.

`ERROR_PIPE_BUSY` was not theory — it failed
`lifecycle_control_is_refused_without_a_controller` on the second request of
the test. Clients now retry it briefly.

`blocking_call` returns `Unsupported` on Windows rather than risk hanging: a
pipe opened as a file cannot bound a read without an unsafe `SetCommTimeouts`,
and the function already documents every failure as "the daemon could not
referee".

## Verification

Both platforms, every commit:

| | Linux (WSL2, rustc 1.92) | Windows (x86_64-pc-windows-msvc) |
| --- | --- | --- |
| `cargo clippy -p muxa --all-targets` | clean | clean |
| `cargo fmt --all -- --check` | clean | — |
| `cargo test -p muxa --lib` | **1050 passed, 0 failed** | **995 passed, 8 failed** |

No Linux regression: the suite count and result are identical to `main`.

The 8 Windows failures are pre-existing Unix assumptions in *fixtures*, none in
transport or IPC:

- `ipc::work_command_tests` (4) and `work_control::tests::native_work_request_…`
  — fixture cwd `/tmp/…`, which `Path::is_absolute` rejects without a drive
  prefix
- `adapters::antigravity::tests` (2) — transcript path shape
- `state::tests::reap_dead_pids_…` — Unix process liveness

Left alone deliberately: teaching fixtures a second path grammar is only worth
doing for a host muxa intends to support. `docs/WINDOWS.md` lists them.

`muxa-cli` still does not build — `nix` fails at dependency resolution, before
any of our code. `muxad` has no such dependency and is the natural next crate
if anyone wants one.

## Also: `.gitattributes`

Both of these were hit while doing the work, on a normal Windows checkout with
the default `core.autocrlf=true`:

- `cargo fmt --all -- --check` reports "Incorrect newline style" for **every
  file in the tree** (`rustfmt.toml` sets `newline_style = "Unix"`).
- `sh scripts/install.sh` dies in dash with `Syntax error: word unexpected`,
  pointing at a line that is fine.

So a Windows contributor cannot run CI's own checks locally until they
reconfigure git. Pinning costs nothing — git already stores LF in both cases —
and the staged diff confirms no tree-wide churn.

`scripts/install.sh` also now detects Git Bash / MSYS / Cygwin up front and
prints the WSL instructions, instead of spending several minutes compiling
before dying inside `nix`. Verified in both directions: it fires in Git Bash,
and `uname -s` in WSL is `Linux`, which does not match.

## Reviewing this

The Unix diff is small and mostly renames; `transport.rs` is where the thinking
is, and its module docs carry the platform-difference table. Worth a close look:

- `Listener::accept` on Windows (the instance swap, and why `next` is created
  before the connected instance is handed out)
- `harden` being a no-op there, and whether the DACL gap is acceptable to state
  in docs rather than solve
- whether `blocking_call` declining is preferable to a thread-plus-timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEHfiC4GaFR8tiUep1hd7K
