### PR TITLE
feat(fleet): share event-driven reply waits and request updates

### DIFF
--- a/crates/muxa-cli/src/collab_screen.rs
+++ b/crates/muxa-cli/src/collab_screen.rs
@@ -587,6 +587,8 @@ mod tests {
 
     fn request(id: &str, from: Participant, to: Participant, body: &str) -> CollaborationRequest {
         CollaborationRequest {
+            initiator: None,
+            updates: Vec::new(),
             id: id.into(),
             from,
             to,

--- a/crates/muxa-cli/src/dashboard_tui.rs
+++ b/crates/muxa-cli/src/dashboard_tui.rs
@@ -2909,6 +2909,7 @@ async fn collaboration_send(
     work_id: Option<String>,
 ) -> ActionOutcome {
     let request = NewRequest {
+        initiator: None,
         kind,
         body,
         expects_reply: kind != RequestKind::Notice,
@@ -5287,6 +5288,8 @@ mod tests {
         now: OffsetDateTime,
     ) -> CollaborationRequest {
         CollaborationRequest {
+            initiator: None,
+            updates: Vec::new(),
             id: id.into(),
             from,
             to,

--- a/crates/muxa-cli/src/fleet_watch.rs
+++ b/crates/muxa-cli/src/fleet_watch.rs
@@ -1365,6 +1365,7 @@ fn handle_key(
                             )
                         };
                         let request = NewRequest {
+                            initiator: None,
                             kind: app.message_kind,
                             body: text,
                             expects_reply: app.message_kind != RequestKind::Notice,
@@ -2144,7 +2145,7 @@ fn spawn_collaboration_broadcast(
                             &target.recipient.host_alias,
                             &FleetOperation::CollaborationSend {
                                 pane: target.recipient.pane,
-                                request,
+                                request: Box::new(request),
                             },
                         )
                         .await
@@ -2179,7 +2180,13 @@ fn spawn_collaboration_send(
     let sender = background.clone();
     tokio::spawn(async move {
         let result = client
-            .fleet_execute(&host, &FleetOperation::CollaborationSend { pane, request })
+            .fleet_execute(
+                &host,
+                &FleetOperation::CollaborationSend {
+                    pane,
+                    request: Box::new(request),
+                },
+            )
             .await
             .map_err(|error| error.to_string());
         let _ = sender.send(BackgroundResult::CollaborationSent(result));
@@ -4821,6 +4828,7 @@ mod tests {
 
     fn broadcast_request() -> NewRequest {
         NewRequest {
+            initiator: None,
             kind: RequestKind::Question,
             body: "coordinate this change".into(),
             expects_reply: true,

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -1706,6 +1706,7 @@ async fn cmd_msg(client: &Client, action: MsgCmd) -> Result<()> {
                     &origin,
                     &target,
                     &NewRequest {
+                        initiator: None,
                         kind,
                         body,
                         expects_reply: !no_reply && kind != RequestKind::Notice,
@@ -4272,6 +4273,8 @@ mod tests {
         status: RequestStatus,
     ) -> CollaborationRequest {
         CollaborationRequest {
+            initiator: None,
+            updates: Vec::new(),
             id: id.into(),
             from: collaboration_participant("%1", window),
             to: collaboration_participant("%2", window),

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -61,16 +61,14 @@ const DEFAULT_SPAWN_GRACE_SECS: u64 = 10;
 /// Hard ceiling on `muxa_wait_for_change` so a caller can't pin the stdio
 /// loop forever on a typo'd huge timeout.
 const MAX_WAIT_SECS: u64 = 600;
-/// Fleet commands have their own short IPC/relay deadlines, so remote reply
-/// waits poll exact durable request state instead of pinning one relay frame.
-const FLEET_REPLY_POLL_INTERVAL: Duration = Duration::from_millis(500);
+/// Compatibility polling is used only with controllers lacking shared reply waits.
+const FLEET_REPLY_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Sent to MCP hosts during initialization so collaboration is a first-class
 /// workflow rather than a capability the model has to infer from tool names.
-const MCP_SERVER_INSTRUCTIONS: &str = "muxa is your same-tmux-window peer team control plane. \
-    Use muxa_guide for the user's surface/agent launch preferences, muxa_room_context \
-    for identity/peers, and muxa_collaboration_guide only when detailed collaboration \
-    guidance is needed. Reserved @peer/@muxa-peer requests for new \
+const MCP_SERVER_INSTRUCTIONS: &str = "muxa coordinates same-window peers. \
+    Use muxa_guide for launch preferences, muxa_room_context for identity/peers, \
+    and muxa_collaboration_guide for details. Reserved @peer/@muxa-peer requests for new \
     work use muxa_call_peer; requests for an existing report use muxa_peer_report. \
     Never substitute a GitHub/PR workflow without an explicit PR number or URL. Peer \
     calls default to review + read_only. Never set execute=true or \
@@ -87,7 +85,8 @@ const MCP_SERVER_INSTRUCTIONS: &str = "muxa is your same-tmux-window peer team c
     then read it with muxa_wait_reply. Incoming notifications require muxa_inbox and \
     exactly one terminal muxa_reply. A /name selects a registered message skill. \
     muxa_fleet_call_peer/muxa_fleet_wait_reply are a separate physical-host plane: \
-    name host/pane explicitly and respect observe mode.";
+    name host/pane explicitly and respect observe mode. Use muxa_fleet_update_request/muxa_update_request \
+    for batched guidance/progress; read updates at checkpoints and wait with after_update.";
 
 /// How often `muxa_wait_for_change` reconciles against a fresh daemon
 /// snapshot while blocking on the transition stream. A broadcast lag on the
@@ -643,7 +642,7 @@ fn tool_definitions(config: &muxa::config::Config) -> Vec<Value> {
         }),
         json!({
             "name": "muxa_fleet_send_prompt",
-            "description": "Send literal text to one exact pane on a named Fleet host. Local is always control-capable; remote hosts must use control mode. The daemon never retries this mutation.",
+            "description": "Send literal text to one exact pane on a named Fleet host. Local is always control-capable; remote hosts must use control mode. The daemon never retries this mutation. For ongoing agent work use muxa_fleet_update_request; this tool has no request lifecycle or completion acknowledgement.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -691,6 +690,21 @@ fn tool_definitions(config: &muxa::config::Config) -> Vec<Value> {
             }
         }),
         json!({
+            "name": "muxa_update_request",
+            "description": "Append verified guidance or a progress report to an existing nonterminal request without completing it. Use this instead of sending a new message to pane:console or injecting a prompt. Only existing participants may update; scope and execution authority stay unchanged. Read updates through muxa_list_messages and finish with one muxa_reply.",
+            "inputSchema": {"type":"object", "properties": {
+                "request_id":{"type":"string"}, "body":{"type":"string","description":"One consolidated update, at most 8192 UTF-8 bytes. Link larger artifacts."}
+            }, "required":["request_id","body"], "additionalProperties":false}
+        }),
+        json!({
+            "name": "muxa_fleet_update_request",
+            "description": "Append consolidated guidance to an existing Fleet request using its exact returned host/pane_key/request_id. Does not send another task or inject terminal text. Existing authorized scope is unchanged. The recipient reads updates on the same request; terminal completion still uses muxa_reply.",
+            "inputSchema": {"type":"object", "properties": {
+                "host":{"type":"string"}, "pane_key":{"type":"object"},
+                "request_id":{"type":"string"}, "body":{"type":"string","description":"Verified guidance within the original scope, at most 8192 UTF-8 bytes."}
+            }, "required":["host","pane_key","request_id","body"], "additionalProperties":false}
+        }),
+        json!({
             "name": "muxa_fleet_wait_reply",
             "description": "Continue waiting for the structured reply to a prior muxa_fleet_call_peer request. Pass the exact host, pane_key, and request_id returned by that call. The durable remote request remains readable even if the target pane has since exited. Remote hosts must remain explicitly configured mode='control'.",
             "inputSchema": {
@@ -702,6 +716,7 @@ fn tool_definitions(config: &muxa::config::Config) -> Vec<Value> {
                         "description": "Exact collision-free PaneKey object returned by muxa_fleet_call_peer; do not reconstruct it from a pane id."
                     },
                     "request_id": { "type": "string", "description": "Exact collaboration request id returned by muxa_fleet_call_peer." },
+                    "after_update": {"type":"integer", "minimum":0, "description":"Optionally return when a progress/guidance sequence newer than this value is available, without waiting for terminal completion. Start at 0; resume with next_after_update."},
                     "timeout_secs": { "type": "integer", "minimum": 1, "maximum": 600, "description": "Reply wait timeout. Default 300." }
                 },
                 "required": ["host", "pane_key", "request_id"],
@@ -1336,6 +1351,57 @@ async fn call_tool(
                 Err(error) => error_result(&format!("list_messages failed: {error}")),
             })
         }
+        "muxa_update_request" | "muxa_fleet_update_request" => {
+            let Some(request_id) = args.get("request_id").and_then(Value::as_str) else {
+                return Ok(error_result("request_id is required"));
+            };
+            let Some(body) = args.get("body").and_then(Value::as_str) else {
+                return Ok(error_result("body is required"));
+            };
+            if body.trim().is_empty() || body.len() > 8192 {
+                return Ok(error_result("body must contain 1..8192 UTF-8 bytes"));
+            }
+            if name == "muxa_fleet_update_request" {
+                let Some(host) = args.get("host").and_then(Value::as_str) else {
+                    return Ok(error_result("host is required"));
+                };
+                let pane = match serde_json::from_value::<muxa::PaneKey>(
+                    args.get("pane_key").cloned().unwrap_or(Value::Null),
+                ) {
+                    Ok(pane) => pane,
+                    Err(error) => return Ok(error_result(&format!("invalid pane_key: {error}"))),
+                };
+                return Ok(
+                    match client
+                        .fleet_execute(
+                            host,
+                            &muxa::FleetOperation::CollaborationUpdate {
+                                pane,
+                                request_id: request_id.into(),
+                                body: body.into(),
+                            },
+                        )
+                        .await
+                    {
+                        Ok(result) => match result.collaboration_request {
+                            Some(request) => json_result(&request_update_ack(&request)),
+                            None => error_result("update returned no request"),
+                        },
+                        Err(error) => error_result(&error.to_string()),
+                    },
+                );
+            }
+            let origin = match current_collaboration_origin() {
+                Ok(origin) => origin,
+                Err(error) => return Ok(error_result(&error)),
+            };
+            Ok(
+                match client.collaboration_update(&origin, request_id, body).await {
+                    Ok(request) => json_result(&request_update_ack(&request)),
+                    Err(error) => error_result(&error.to_string()),
+                },
+            )
+        }
         "muxa_reply" => {
             let Some(request_id) = args.get("request_id").and_then(Value::as_str) else {
                 return Ok(error_result("reply requires a `request_id` argument"));
@@ -1578,6 +1644,14 @@ fn collaboration_guide(room: RoomContext, config: &muxa::config::Config) -> Valu
                     "Pass artifact_id, exact AIR 1 profile, and optional display-only locator in air_artifacts.",
                     "Use the same artifact identity in review requests and structured replies so watch/dashboard can visualize the handoff.",
                     "Open the source-bearing artifact in AIR Workbench for graph inspection or editing; muxa transports references and does not validate or execute AIR."
+                ]
+            },
+            "ongoing_fleet_work": {
+                "steps": [
+                    "Consolidate verified guidance with muxa_fleet_update_request on the returned host/pane_key/request_id; do not inject repeated task prompts.",
+                    "Report nonterminal progress with muxa_update_request on the same request, never by addressing pane:console.",
+                    "At agreed checkpoints read muxa_list_messages; updates do not interrupt terminal input or widen execution authority.",
+                    "Wait with after_update=0 for progress, then resume with next_after_update; finish with exactly one terminal reply."
                 ]
             },
             "incoming_request": {
@@ -1892,12 +1966,17 @@ async fn fleet_call_peer(
         Err(error) => return error_result(&error),
     };
     let paths = string_array(args, "paths");
-    let request =
+    let mut request =
         match new_request_from_args(args, kind, body, true, work_mode, paths, air_artifacts) {
             Ok(request) => request,
             Err(error) => return error_result(&error),
         };
 
+    if let Ok(origin) = current_collaboration_origin() {
+        if let Ok(room) = client.collaboration_context(&origin).await {
+            request.initiator = Some(Box::new(room.current));
+        }
+    }
     if let Err(error) = ensure_fleet_collaboration_ready(client, host).await {
         return error_result(&format!("fleet_call_peer refused: {error}"));
     }
@@ -1910,7 +1989,7 @@ async fn fleet_call_peer(
             host,
             &muxa::FleetOperation::CollaborationSend {
                 pane: pane_key.clone(),
-                request,
+                request: Box::new(request),
             },
         )
         .await
@@ -1926,6 +2005,9 @@ async fn fleet_call_peer(
         "host": host,
         "pane_key": pane_key,
         "selected_peer": sent.to,
+        "initiator": sent.initiator,
+        "progress_route": {"tool":"muxa_update_request", "request_id":sent.id},
+        "guidance_route": {"tool":"muxa_fleet_update_request", "host":host, "pane_key":pane_key, "request_id":sent.id},
         "expanded_skill": expanded_skill,
         "request_id": sent.id,
         "thread_id": sent.thread_id,
@@ -1948,7 +2030,9 @@ async fn fleet_call_peer(
         .and_then(Value::as_u64)
         .unwrap_or(300)
         .clamp(1, MAX_WAIT_SECS);
-    match await_fleet_collaboration_reply(client, host, &pane_key, &sent.id, timeout_secs).await {
+    match await_fleet_collaboration_reply(client, host, &pane_key, &sent.id, timeout_secs, None)
+        .await
+    {
         Ok(Some(request)) if request.status.is_terminal() => {
             let mut payload = common;
             payload["completed"] = json!(true);
@@ -2035,7 +2119,16 @@ async fn fleet_wait_reply(client: &Client, args: &Value) -> Value {
         .and_then(Value::as_u64)
         .unwrap_or(300)
         .clamp(1, MAX_WAIT_SECS);
-    match await_fleet_collaboration_reply(client, host, &pane_key, request_id, timeout_secs).await {
+    match await_fleet_collaboration_reply(
+        client,
+        host,
+        &pane_key,
+        request_id,
+        timeout_secs,
+        args.get("after_update").and_then(Value::as_u64),
+    )
+    .await
+    {
         Ok(Some(request)) if request.status.is_terminal() => json_result(&json!({
             "completed": true,
             "host": host,
@@ -2043,7 +2136,21 @@ async fn fleet_wait_reply(client: &Client, args: &Value) -> Value {
             "request_id": request.id,
             "status": request.status,
             "reply": request.reply,
+            "updates": request.updates.iter().filter(|u| args.get("after_update").and_then(Value::as_u64).is_none_or(|seen| u.sequence > seen)).collect::<Vec<_>>(),
         })),
+        Ok(Some(request))
+            if args
+                .get("after_update")
+                .and_then(Value::as_u64)
+                .is_some_and(|seen| request.updates.last().is_some_and(|u| u.sequence > seen)) =>
+        {
+            json_result(&json!({
+                "completed":false, "reason":"updated", "host":host, "pane_key":pane_key,
+                "request_id":request.id, "status":request.status, "updates":request.updates.iter().filter(|u| args.get("after_update").and_then(Value::as_u64).is_none_or(|seen| u.sequence > seen)).collect::<Vec<_>>(),
+                "first_retained_sequence":request.updates.first().map(|u| u.sequence),
+                "next_after_update":request.updates.last().map(|u| u.sequence),
+            }))
+        }
         Ok(current) => json_result(&json!({
             "completed": false,
             "reason": "timeout",
@@ -2100,7 +2207,19 @@ async fn await_fleet_collaboration_reply(
     pane: &muxa::PaneKey,
     request_id: &str,
     timeout_secs: u64,
+    after_update: Option<u64>,
 ) -> std::result::Result<Option<CollaborationRequest>, String> {
+    let hello = client
+        .hello(Duration::from_secs(3))
+        .await
+        .map_err(|e| e.to_string())?;
+    if hello.capabilities.iter().any(|c| c == "fleet_wait_reply") {
+        return client
+            .fleet_wait_reply(host, pane, request_id, timeout_secs, after_update)
+            .await
+            .map_err(|e| e.to_string());
+    }
+    let mut poll_interval = FLEET_REPLY_POLL_INTERVAL;
     let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
     let mut current = None;
     loop {
@@ -2119,14 +2238,20 @@ async fn await_fleet_collaboration_reply(
             .ok_or_else(|| "Fleet collaboration get returned no request".to_string())?;
         let terminal = request.status.is_terminal();
         current = Some(request);
-        if terminal || tokio::time::Instant::now() >= deadline {
+        let updated = after_update.is_some_and(|seen| {
+            current
+                .as_ref()
+                .is_some_and(|r| r.updates.last().is_some_and(|u| u.sequence > seen))
+        });
+        if terminal || updated || tokio::time::Instant::now() >= deadline {
             return Ok(current);
         }
         tokio::time::sleep_until(std::cmp::min(
             deadline,
-            tokio::time::Instant::now() + FLEET_REPLY_POLL_INTERVAL,
+            tokio::time::Instant::now() + poll_interval,
         ))
         .await;
+        poll_interval = (poll_interval * 2).min(Duration::from_secs(30));
     }
 }
 
@@ -2816,6 +2941,7 @@ fn new_request_from_args(
     air_artifacts: Vec<AirArtifactReference>,
 ) -> std::result::Result<NewRequest, String> {
     Ok(NewRequest {
+        initiator: None,
         kind,
         body,
         expects_reply,
@@ -3372,6 +3498,11 @@ fn text_result(text: &str) -> Value {
 /// A compact acknowledgement for mutations. The caller already supplied the
 /// request body and attachments, so echoing the full durable record only
 /// consumes context; retain the correlation and routing fields it needs next.
+fn request_update_ack(request: &CollaborationRequest) -> Value {
+    json!({"request_id":request.id, "status":request.status,
+        "next_after_update":request.updates.last().map(|u| u.sequence)})
+}
+
 fn request_ack(request: &CollaborationRequest) -> Value {
     json!({
         "request_id": request.id,
@@ -3689,6 +3820,8 @@ mod tests {
                 "muxa_fleet_capture",
                 "muxa_fleet_send_prompt",
                 "muxa_fleet_call_peer",
+                "muxa_update_request",
+                "muxa_fleet_update_request",
                 "muxa_fleet_wait_reply",
                 "muxa_wait_for_change",
                 "muxa_collaboration_guide",

--- a/crates/muxa-cli/src/relay.rs
+++ b/crates/muxa-cli/src/relay.rs
@@ -89,6 +89,15 @@ pub(crate) async fn run(client: Client) -> Result<()> {
                 muxa_version: env!("CARGO_PKG_VERSION").into(),
                 capabilities: FLEET_CAPABILITIES
                     .iter()
+                    .filter(|capability| {
+                        (**capability != muxa::fleet::FLEET_MAILBOX_WATCH_CAPABILITY
+                            || mailbox_updates.is_some())
+                            && (**capability != "collaboration_update"
+                                || daemon
+                                    .capabilities
+                                    .iter()
+                                    .any(|c| c == "collaboration_update"))
+                    })
                     .map(|capability| (*capability).to_string())
                     .collect(),
                 daemon_generation: daemon.generation,
@@ -141,8 +150,25 @@ pub(crate) async fn run(client: Client) -> Result<()> {
     let mailbox_task = mailbox_updates.take().map(|mut mailbox_updates| {
         let mailbox_tx = output_tx.clone();
         let mailbox_topology_revision = Arc::clone(&revision);
+        let mailbox_client = client.clone();
         tokio::spawn(async move {
-            while let Ok(Some(mailbox_revision)) = mailbox_updates.recv().await {
+            loop {
+                let mailbox_revision = if let Ok(Some(revision)) = mailbox_updates.recv().await {
+                    revision
+                } else {
+                    loop {
+                        tokio::select! {
+                            () = mailbox_tx.closed() => return,
+                            () = tokio::time::sleep(Duration::from_secs(2)) => {},
+                        }
+                        if let Ok(stream) = mailbox_client.collaboration_subscribe().await {
+                            mailbox_updates = stream;
+                            break;
+                        }
+                    }
+                    // A fresh subscription alone cannot replay changes lost during disconnection.
+                    0
+                };
                 if mailbox_tx
                     .send(RelayFrame::Keepalive {
                         revision: mailbox_topology_revision.load(Ordering::SeqCst),
@@ -461,6 +487,24 @@ async fn handle_request(
             Ok(RelayFrame::Result {
                 request_id,
                 result: FleetCommandResult::collaboration_mailbox(incoming, Vec::new()),
+            })
+        }
+        RelayRequest::CollaborationUpdate {
+            request_id,
+            pane,
+            collaboration_request_id,
+            body,
+        } => {
+            let request = client
+                .collaboration_update(
+                    &collaboration_origin(&pane, true),
+                    &collaboration_request_id,
+                    &body,
+                )
+                .await?;
+            Ok(RelayFrame::Result {
+                request_id,
+                result: FleetCommandResult::collaboration_request(request),
             })
         }
         RelayRequest::CollaborationReply {

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -9264,6 +9264,7 @@ async fn run_watch_collaboration_broadcast(
     for (pane, label) in recipients {
         let pane = pane.clone();
         let request = NewRequest {
+            initiator: None,
             kind,
             body: body.clone(),
             expects_reply: kind != RequestKind::Notice,
@@ -9323,6 +9324,7 @@ async fn run_watch_collaboration_single(
                 }
             };
             let request = NewRequest {
+                initiator: None,
                 kind,
                 body: composer.input,
                 expects_reply: kind != RequestKind::Notice,
@@ -20214,6 +20216,8 @@ mod tests {
     ) -> CollaborationRequest {
         let now = OffsetDateTime::now_utc();
         CollaborationRequest {
+            initiator: None,
+            updates: Vec::new(),
             id: id.into(),
             from,
             to,
@@ -27415,6 +27419,8 @@ sort = ["state"]
 
     fn collab_request(to_pane: &str) -> CollaborationRequest {
         CollaborationRequest {
+            initiator: None,
+            updates: Vec::new(),
             id: "req_1".into(),
             from: collab_participant("%1", "callabo", "CAL-7330"),
             to: collab_participant(to_pane, "callabo", "CAL-7330"),

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -531,11 +531,28 @@ pub struct CollaborationReply {
     pub at: OffsetDateTime,
 }
 
+/// A progress report or guidance update, separate from the one terminal reply.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CollaborationUpdate {
+    pub sequence: u64,
+    pub author: Participant,
+    pub body: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub at: OffsetDateTime,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CollaborationRequest {
     pub id: String,
     pub from: Participant,
     pub to: Participant,
+    /// Advisory identity of the agent initiating a Fleet console request;
+    /// never used for authorization or participant matching.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initiator: Option<Box<Participant>>,
+    /// Bounded nonterminal conversation on this exact request.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub updates: Vec<CollaborationUpdate>,
     /// How the request entered muxad. `from` remains the represented agent;
     /// this field identifies the local caller that exercised that authority.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -654,6 +671,8 @@ pub struct RoomContext {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NewRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initiator: Option<Box<Participant>>,
     pub kind: RequestKind,
     pub body: String,
     pub expects_reply: bool,
@@ -680,6 +699,7 @@ pub struct NewRequest {
 impl Default for NewRequest {
     fn default() -> Self {
         Self {
+            initiator: None,
             kind: RequestKind::Question,
             body: String::new(),
             expects_reply: true,
@@ -1896,6 +1916,8 @@ impl CollaborationStore {
             id,
             from,
             to,
+            initiator: input.initiator,
+            updates: Vec::new(),
             provenance,
             kind: input.kind,
             body,
@@ -2051,6 +2073,68 @@ impl CollaborationStore {
             result?;
         }
         Ok(())
+    }
+
+    /// Append bounded guidance/progress without claiming or completing work.
+    pub async fn update_request(
+        &self,
+        caller: &Participant,
+        request_id: &str,
+        body: String,
+    ) -> Result<CollaborationRequest, CollaborationError> {
+        self.ensure_enabled()?;
+        let body = body.trim().to_string();
+        if body.is_empty() {
+            return Err(CollaborationError::EmptyMessage);
+        }
+        let limit = self.opts.max_message_bytes.min(8192);
+        if body.len() > limit {
+            return Err(CollaborationError::MessageTooLarge(limit));
+        }
+        let _transaction = self.transaction_lock.lock().await;
+        let mut updated = self
+            .requests
+            .read()
+            .await
+            .get(request_id)
+            .cloned()
+            .ok_or_else(|| CollaborationError::NotFound(request_id.into()))?;
+        if !addresses(&updated.from, caller) && !addresses(&updated.to, caller) {
+            return Err(CollaborationError::NotParticipant(request_id.into()));
+        }
+        if updated.status.is_terminal() {
+            return Err(CollaborationError::AlreadyTerminal(request_id.into()));
+        }
+        // Retried identical updates from the same participant are idempotent.
+        if updated
+            .updates
+            .last()
+            .is_some_and(|last| addresses(&last.author, caller) && last.body == body)
+        {
+            return Ok(updated);
+        }
+        let sequence = updated
+            .updates
+            .last()
+            .map_or(1, |last| last.sequence.saturating_add(1));
+        updated.updates.push(CollaborationUpdate {
+            sequence,
+            author: caller.clone(),
+            body,
+            at: OffsetDateTime::now_utc(),
+        });
+        while updated.updates.len() > 32
+            || updated.updates.iter().map(|u| u.body.len()).sum::<usize>() > 32768
+        {
+            updated.updates.remove(0);
+        }
+        self.persist_requests(std::slice::from_ref(&updated))?;
+        self.requests
+            .write()
+            .await
+            .insert(request_id.into(), updated.clone());
+        self.publish_change();
+        Ok(updated)
     }
 
     pub async fn reply(
@@ -3193,6 +3277,93 @@ fn valid_identity_token(value: &str) -> bool {
 mod tests {
     use super::*;
     use crate::config::CollaborationScope;
+
+    #[tokio::test]
+    async fn request_updates_are_durable_bounded_and_do_not_complete_work() {
+        let dir = tempfile::tempdir().unwrap();
+        let options = CollaborationOptions {
+            path: Some(dir.path().join("mailbox.json")),
+            ..CollaborationOptions::default()
+        };
+        let mailbox = CollaborationStore::load(options.clone()).await.unwrap();
+        let sender = participant("%1", "sender");
+        let recipient = participant("%2", "recipient");
+        let initiator = participant("%9", "coordinator");
+        let request = mailbox
+            .create(
+                sender.clone(),
+                recipient.clone(),
+                NewRequest {
+                    body: "bounded task".into(),
+                    initiator: Some(Box::new(initiator.clone())),
+                    ..NewRequest::default()
+                },
+            )
+            .await
+            .unwrap();
+        let mut changes = mailbox.subscribe();
+        mailbox
+            .update_request(&recipient, &request.id, "progress".into())
+            .await
+            .unwrap();
+        assert!(changes.has_changed().unwrap());
+        changes.borrow_and_update();
+        let retried = mailbox
+            .update_request(&recipient, &request.id, "progress".into())
+            .await
+            .unwrap();
+        assert_eq!(retried.updates.len(), 1);
+        assert!(!changes.has_changed().unwrap());
+        // Advisory initiator metadata does not grant participant authority.
+        assert!(matches!(
+            mailbox
+                .update_request(&initiator, &request.id, "spoof".into())
+                .await,
+            Err(CollaborationError::NotParticipant(_))
+        ));
+        assert!(matches!(
+            mailbox
+                .update_request(&sender, &request.id, " ".into())
+                .await,
+            Err(CollaborationError::EmptyMessage)
+        ));
+        assert!(matches!(
+            mailbox
+                .update_request(&sender, &request.id, "x".repeat(8193))
+                .await,
+            Err(CollaborationError::MessageTooLarge(_))
+        ));
+        for i in 0..40 {
+            mailbox
+                .update_request(&sender, &request.id, format!("guidance {i}"))
+                .await
+                .unwrap();
+        }
+        let reloaded = CollaborationStore::load(options).await.unwrap();
+        let restored = reloaded.get_for(&recipient, &request.id).await.unwrap();
+        assert_eq!(restored.initiator, Some(Box::new(initiator)));
+        assert_eq!(restored.updates.len(), 32);
+        assert_eq!(restored.updates.last().unwrap().sequence, 41);
+        assert_eq!(restored.status, RequestStatus::Queued);
+        assert!(restored.reply.is_none());
+        reloaded
+            .reply(
+                &recipient,
+                &request.id,
+                RequestStatus::Completed,
+                "done".into(),
+                vec![],
+                vec![],
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            reloaded
+                .update_request(&sender, &request.id, "late".into())
+                .await,
+            Err(CollaborationError::AlreadyTerminal(_))
+        ));
+    }
 
     fn participant(pane: &str, session: &str) -> Participant {
         Participant {

--- a/crates/muxa/src/collaboration_audit.rs
+++ b/crates/muxa/src/collaboration_audit.rs
@@ -32,6 +32,7 @@ pub enum CollaborationAuditOperation {
     Inbox,
     List,
     Reply,
+    Update,
     Get,
     Wait,
     Cancel,

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -2627,6 +2627,7 @@ mod tests {
                         from.clone(),
                         to.clone(),
                         NewRequest {
+                            initiator: None,
                             kind: RequestKind::Review,
                             body: body.to_string(),
                             expects_reply: true,
@@ -2652,6 +2653,7 @@ mod tests {
                     from,
                     to,
                     NewRequest {
+                        initiator: None,
                         kind: RequestKind::Notice,
                         body: "finalize".to_string(),
                         expects_reply: false,

--- a/crates/muxa/src/fleet.rs
+++ b/crates/muxa/src/fleet.rs
@@ -52,6 +52,7 @@ pub const FLEET_MAX_CAPTURE_BYTES: usize = 256 * 1024;
 /// with its own binary. A controller falls back to a one-shot OpenSSH
 /// command for a relay that does not advertise it.
 pub const FLEET_WORK_COMMAND_CAPABILITY: &str = "work_command";
+pub const FLEET_MAILBOX_WATCH_CAPABILITY: &str = "mailbox_watch";
 pub const FLEET_CAPABILITIES: &[&str] = &[
     "snapshot_watch",
     "capture",
@@ -59,6 +60,8 @@ pub const FLEET_CAPABILITIES: &[&str] = &[
     "send_prompt",
     "collaboration",
     "collaboration_get",
+    "collaboration_update",
+    FLEET_MAILBOX_WATCH_CAPABILITY,
     "exact_pane_ref",
     "labels_v1",
     "raw_capture_base64",
@@ -498,7 +501,7 @@ pub enum RelayRequest {
     CollaborationSend {
         request_id: String,
         pane: PaneKey,
-        request: NewRequest,
+        request: Box<NewRequest>,
     },
     CollaborationMailbox {
         request_id: String,
@@ -512,6 +515,12 @@ pub enum RelayRequest {
     CollaborationClaim {
         request_id: String,
         pane: PaneKey,
+    },
+    CollaborationUpdate {
+        request_id: String,
+        pane: PaneKey,
+        collaboration_request_id: String,
+        body: String,
     },
     CollaborationReply {
         request_id: String,
@@ -542,6 +551,7 @@ impl RelayRequest {
             | Self::CollaborationSend { request_id, .. }
             | Self::CollaborationMailbox { request_id, .. }
             | Self::CollaborationGet { request_id, .. }
+            | Self::CollaborationUpdate { request_id, .. }
             | Self::CollaborationClaim { request_id, .. }
             | Self::CollaborationReply { request_id, .. }
             | Self::WorkCommand { request_id, .. } => request_id,
@@ -606,7 +616,7 @@ pub enum FleetOperation {
     },
     CollaborationSend {
         pane: PaneKey,
-        request: NewRequest,
+        request: Box<NewRequest>,
     },
     CollaborationMailbox {
         pane: PaneKey,
@@ -617,6 +627,11 @@ pub enum FleetOperation {
     },
     CollaborationClaim {
         pane: PaneKey,
+    },
+    CollaborationUpdate {
+        pane: PaneKey,
+        request_id: String,
+        body: String,
     },
     CollaborationReply {
         pane: PaneKey,
@@ -910,6 +925,27 @@ impl FleetStore {
         self.updates.subscribe()
     }
 
+    /// Reply waits need connection metadata, never a cloned topology/agent snapshot.
+    pub(crate) async fn reply_wait_host(
+        &self,
+        alias: &str,
+    ) -> Option<crate::fleet_wait::ReplyHost> {
+        self.hosts
+            .read()
+            .await
+            .get(alias)
+            .map(|host| crate::fleet_wait::ReplyHost {
+                local: host.local,
+                mode: host.mode,
+                state: host.state,
+                generation: host.daemon_generation,
+                event_driven: host
+                    .capabilities
+                    .iter()
+                    .any(|c| c == FLEET_MAILBOX_WATCH_CAPABILITY),
+            })
+    }
+
     /// Return whether the current cached host matches `selector`. A missing
     /// host never matches. Fleet streams use this after receiving an update
     /// so selector-scoped watchers are not woken by unrelated hosts.
@@ -1029,13 +1065,21 @@ struct FleetDispatch {
 pub struct FleetRuntime {
     pub store: Arc<FleetStore>,
     commands: mpsc::Sender<FleetDispatch>,
+    pub(crate) reply_waits: Arc<crate::fleet_wait::ReplyWaits>,
 }
 
 impl FleetRuntime {
     #[must_use]
     pub fn new(store: Arc<FleetStore>) -> (Self, FleetCommandReceiver) {
         let (commands, receiver) = mpsc::channel(128);
-        (Self { store, commands }, FleetCommandReceiver(receiver))
+        (
+            Self {
+                store,
+                commands,
+                reply_waits: Arc::default(),
+            },
+            FleetCommandReceiver(receiver),
+        )
     }
 
     pub async fn execute(
@@ -1426,7 +1470,8 @@ mod tests {
         let request = RelayRequest::CollaborationSend {
             request_id: "relay-1".into(),
             pane: pane.clone(),
-            request: NewRequest {
+            request: Box::new(NewRequest {
+                initiator: None,
                 kind: crate::collaboration::RequestKind::Review,
                 body: "review this change".into(),
                 expects_reply: true,
@@ -1440,7 +1485,7 @@ mod tests {
                 artifacts: Vec::new(),
                 links: Vec::new(),
                 air_artifacts: Vec::new(),
-            },
+            }),
         };
         let encoded = serde_json::to_string(&request).unwrap();
         let decoded: RelayRequest = serde_json::from_str(&encoded).unwrap();

--- a/crates/muxa/src/fleet_wait.rs
+++ b/crates/muxa/src/fleet_wait.rs
@@ -1,0 +1,592 @@
+//! Shared, event-driven Fleet reply waits. No long wait occupies a host command slot.
+use std::collections::HashMap;
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use tokio::sync::{broadcast, watch, Mutex};
+use tokio::time::Instant;
+
+use crate::collaboration::CollaborationRequest;
+use crate::fleet::{FleetHostState, FleetOperation, FleetRuntime, HostAccessMode};
+use crate::topology::PaneKey;
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(20);
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+type WaitValue = Option<Result<CollaborationRequest, String>>;
+type WaitKey = (String, PaneKey, String);
+
+#[derive(Clone, Copy)]
+pub(crate) struct ReplyHost {
+    pub local: bool,
+    pub mode: HostAccessMode,
+    pub state: FleetHostState,
+    pub generation: Option<u64>,
+    pub event_driven: bool,
+}
+
+#[derive(Default)]
+pub(crate) struct ReplyWaits(Mutex<HashMap<WaitKey, Weak<watch::Sender<WaitValue>>>>);
+
+impl FleetRuntime {
+    /// Share reads across IPC clients while retaining each caller's own deadline.
+    pub async fn wait_for_reply(
+        &self,
+        host: String,
+        pane: PaneKey,
+        request_id: String,
+        timeout: Duration,
+        after_update: Option<u64>,
+    ) -> Result<Option<CollaborationRequest>, String> {
+        let deadline = Instant::now() + timeout;
+        let metadata = self
+            .store
+            .reply_wait_host(&host)
+            .await
+            .ok_or_else(|| format!("Fleet host '{host}' is not known"))?;
+        if !metadata.local && metadata.mode != HostAccessMode::Control {
+            return Err(format!("Fleet host '{host}' is observe-only"));
+        }
+        let key = (host, pane, request_id);
+        let mut rx = {
+            let mut waits = self.reply_waits.0.lock().await;
+            waits.retain(|_, sender| sender.strong_count() > 0);
+            if let Some(sender) = waits.get(&key).and_then(Weak::upgrade) {
+                sender.subscribe()
+            } else {
+                let (sender, receiver) = watch::channel(None);
+                let sender = Arc::new(sender);
+                waits.insert(key.clone(), Arc::downgrade(&sender));
+                let runtime = self.clone();
+                tokio::spawn(async move {
+                    // Dropping the last caller cancels both pending IO and the subscription.
+                    let work = runtime.drive_reply_wait(&key, &sender);
+                    tokio::pin!(work);
+                    loop {
+                        tokio::select! {
+                            () = sender.closed() => {
+                                let mut waits = runtime.reply_waits.0.lock().await;
+                                if sender.receiver_count() == 0 {
+                                    waits.remove(&key);
+                                    break;
+                                }
+                            },
+                            () = &mut work => break,
+                        }
+                    }
+                });
+                receiver
+            }
+        };
+        loop {
+            let current = rx.borrow_and_update().clone();
+            match current {
+                Some(Err(error)) => return Err(error),
+                Some(Ok(request)) if request.status.is_terminal() => return Ok(Some(request)),
+                Some(Ok(request))
+                    if after_update.is_some_and(|seen| {
+                        request.updates.last().is_some_and(|u| u.sequence > seen)
+                    }) =>
+                {
+                    return Ok(Some(request))
+                }
+                _ => {}
+            }
+            if tokio::time::timeout_at(deadline, rx.changed())
+                .await
+                .is_err()
+            {
+                return rx.borrow().clone().transpose();
+            }
+            if rx.has_changed().is_err() {
+                return rx.borrow().clone().transpose();
+            }
+        }
+    }
+
+    async fn drive_reply_wait(&self, key: &WaitKey, sender: &watch::Sender<WaitValue>) {
+        // Subscribe before the initial read: completion racing that read stays queued.
+        let mut updates = self.store.subscribe();
+        let mut backoff = Duration::from_secs(1);
+        let mut reads = 0_u64;
+        loop {
+            // Coalesce pending invalidations before the authoritative read.
+            while matches!(
+                updates.try_recv(),
+                Ok(_) | Err(broadcast::error::TryRecvError::Lagged(_))
+            ) {}
+            let Some(host) = self.store.reply_wait_host(&key.0).await else {
+                sender.send_replace(Some(Err(format!("Fleet host '{}' is not known", key.0))));
+                return;
+            };
+            if !host.local && host.mode != HostAccessMode::Control {
+                sender.send_replace(Some(Err(format!("Fleet host '{}' is observe-only", key.0))));
+                return;
+            }
+            let event_driven = host.event_driven;
+            let generation = host.generation;
+            let state = host.state;
+            let result = self
+                .execute(
+                    &key.0,
+                    FleetOperation::CollaborationGet {
+                        pane: key.1.clone(),
+                        request_id: key.2.clone(),
+                    },
+                    COMMAND_TIMEOUT,
+                )
+                .await
+                .and_then(|result| {
+                    result
+                        .collaboration_request
+                        .map(|r| *r)
+                        .ok_or_else(|| "Fleet get returned no collaboration request".to_string())
+                });
+            reads += 1;
+            let mut disconnected = false;
+            match result {
+                Ok(request) => {
+                    let terminal = request.status.is_terminal();
+                    sender.send_replace(Some(Ok(request)));
+                    if terminal {
+                        tracing::debug!(request_id = %key.2, reads, "fleet reply wait completed");
+                        return;
+                    }
+                }
+                Err(error) => {
+                    disconnected = self.store.reply_wait_host(&key.0).await.is_some_and(|h| {
+                        matches!(
+                            h.state,
+                            FleetHostState::Connecting
+                                | FleetHostState::Offline
+                                | FleetHostState::Degraded
+                        )
+                    });
+                    if !disconnected {
+                        sender.send_replace(Some(Err(error)));
+                        return;
+                    }
+                }
+            }
+            let retry_at = Instant::now() + backoff;
+            // A healthy current host is silent until a mailbox invalidation; legacy or
+            // disconnected hosts reconcile with bounded exponential backoff.
+            let retry = disconnected || !event_driven || !matches!(state, FleetHostState::Online);
+            loop {
+                tokio::select! {
+                    () = tokio::time::sleep_until(retry_at), if retry => {
+                        backoff = (backoff * 2).min(MAX_BACKOFF);
+                        break;
+                    }
+                    update = updates.recv() => {
+                        match update {
+                            Ok(update) if update.resync => break,
+                            Ok(update) if update.host == key.0 => {
+                                let changed = self.store.reply_wait_host(&key.0).await
+                                    .is_none_or(|h| h.state != state || h.generation != generation || (!h.local && h.mode != HostAccessMode::Control));
+                                if update.mailbox_revision.is_some() || changed {
+                                    break;
+                                }
+                            }
+                            Err(broadcast::error::RecvError::Lagged(_)) => break,
+                            Err(broadcast::error::RecvError::Closed) => return,
+                            _ => {},
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::collaboration::{
+        CollaborationOptions, CollaborationStore, NewRequest, Participant, RequestStatus,
+    };
+    use crate::fleet::{
+        FleetCommandReceiver, FleetCommandResult, FleetHostSnapshot, FleetStore,
+        FLEET_MAILBOX_WATCH_CAPABILITY,
+    };
+    use serde_json::json;
+
+    async fn fixture(
+        watch: bool,
+    ) -> (
+        FleetRuntime,
+        FleetCommandReceiver,
+        PaneKey,
+        CollaborationRequest,
+    ) {
+        let store = Arc::new(FleetStore::new());
+        let host: FleetHostSnapshot = serde_json::from_value(json!({
+            "alias":"local", "local":true, "ssh_target":"", "labels":{}, "annotations":{},
+            "mode":"control", "state":"online", "capabilities": if watch { vec![FLEET_MAILBOX_WATCH_CAPABILITY] } else { vec![] },
+        })).unwrap();
+        store.upsert_host(host).await;
+        let (runtime, receiver) = FleetRuntime::new(store);
+        let pane = serde_json::from_value(json!({"window":{"session":{"host":"tmux","socket":"default","session_id":"$1"},"window_id":"@1"},"pane_id":"%2"})).unwrap();
+        let participant: Participant = serde_json::from_value(json!({
+            "agent_kind":"codex","agent_session_id":"agent", "pane":"%2", "socket":"default",
+            "room":{"host":"tmux","socket":"default","window_id":"@1"},"state":"idle","roles":[]
+        }))
+        .unwrap();
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let request = mailbox
+            .create(
+                participant.clone(),
+                participant,
+                NewRequest {
+                    body: "work".into(),
+                    ..NewRequest::default()
+                },
+            )
+            .await
+            .unwrap();
+        (runtime, receiver, pane, request)
+    }
+
+    fn wait(
+        runtime: FleetRuntime,
+        pane: PaneKey,
+        request: &CollaborationRequest,
+        seconds: u64,
+    ) -> tokio::task::JoinHandle<Result<Option<CollaborationRequest>, String>> {
+        let id = request.id.clone();
+        tokio::spawn(async move {
+            runtime
+                .wait_for_reply("local".into(), pane, id, Duration::from_secs(seconds), None)
+                .await
+        })
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn quiet_five_minutes_performs_one_read_and_shares_waiters() {
+        let (runtime, mut commands, pane, request) = fixture(true).await;
+        let first = wait(runtime.clone(), pane.clone(), &request, 300);
+        let second = wait(runtime.clone(), pane, &request, 600);
+        let command = commands.recv().await.unwrap();
+        command
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(
+                request.clone(),
+            )))
+            .unwrap();
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(300)).await;
+        assert_eq!(
+            first.await.unwrap().unwrap().unwrap().status,
+            request.status
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(1), commands.recv())
+                .await
+                .is_err()
+        );
+        assert!(!second.is_finished());
+        runtime.store.notify_mailbox("local", 1).await;
+        let command = commands.recv().await.unwrap();
+        let mut completed = request;
+        completed.status = RequestStatus::Completed;
+        command
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(completed)))
+            .unwrap();
+        assert_eq!(
+            second.await.unwrap().unwrap().unwrap().status,
+            RequestStatus::Completed
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn completion_during_initial_read_is_not_lost_and_other_commands_run() {
+        let (runtime, mut commands, pane, request) = fixture(true).await;
+        let waiting = wait(runtime.clone(), pane.clone(), &request, 300);
+        let initial = commands.recv().await.unwrap();
+        runtime.store.notify_mailbox("local", 1).await;
+        initial
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(
+                request.clone(),
+            )))
+            .unwrap();
+        let refresh = commands.recv().await.unwrap();
+        let operation = tokio::spawn(async move {
+            runtime
+                .execute(
+                    "local",
+                    FleetOperation::Capture { pane },
+                    Duration::from_secs(10),
+                )
+                .await
+        });
+        let other = commands.recv().await.unwrap();
+        assert!(matches!(other.operation, FleetOperation::Capture { .. }));
+        other.reply.send(Err("test capture".into())).unwrap();
+        assert!(operation.await.unwrap().is_err());
+        let mut completed = request;
+        completed.status = RequestStatus::Completed;
+        refresh
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(completed)))
+            .unwrap();
+        assert!(waiting
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap()
+            .status
+            .is_terminal());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unrelated_topology_is_ignored_but_reconnect_reconciles() {
+        let (runtime, mut commands, pane, request) = fixture(true).await;
+        let waiting = wait(runtime.clone(), pane, &request, 300);
+        commands
+            .recv()
+            .await
+            .unwrap()
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(
+                request.clone(),
+            )))
+            .unwrap();
+        tokio::task::yield_now().await;
+        runtime.store.mutate_host("local", |_| {}).await;
+        runtime.store.notify_mailbox("unknown", 1).await;
+        assert!(
+            tokio::time::timeout(Duration::from_secs(2), commands.recv())
+                .await
+                .is_err()
+        );
+        runtime
+            .store
+            .mutate_host("local", |h| h.daemon_generation = Some(2))
+            .await;
+        let refresh = commands.recv().await.unwrap();
+        let mut completed = request;
+        completed.status = RequestStatus::Cancelled;
+        refresh
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(completed)))
+            .unwrap();
+        assert_eq!(
+            waiting.await.unwrap().unwrap().unwrap().status,
+            RequestStatus::Cancelled
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn legacy_backoff_and_last_waiter_cancellation_are_bounded() {
+        let (runtime, mut commands, pane, request) = fixture(false).await;
+        let waiting = wait(runtime.clone(), pane, &request, 300);
+        let started = Instant::now();
+        for seconds in [0, 1, 3, 7, 15, 31, 61] {
+            let command = commands.recv().await.unwrap();
+            assert_eq!(
+                Instant::now().duration_since(started),
+                Duration::from_secs(seconds)
+            );
+            command
+                .reply
+                .send(Ok(FleetCommandResult::collaboration_request(
+                    request.clone(),
+                )))
+                .unwrap();
+        }
+        waiting.abort();
+        let _ = waiting.await;
+        tokio::task::yield_now().await;
+        assert!(runtime.reply_waits.0.lock().await.is_empty());
+        assert!(
+            tokio::time::timeout(Duration::from_secs(60), commands.recv())
+                .await
+                .is_err()
+        );
+    }
+    #[tokio::test(start_paused = true)]
+    async fn progress_wait_returns_without_completing_or_duplicating_terminal_wait() {
+        let (runtime, mut commands, pane, request) = fixture(true).await;
+        let terminal = wait(runtime.clone(), pane.clone(), &request, 300);
+        let progress_runtime = runtime.clone();
+        let id = request.id.clone();
+        let progress = tokio::spawn(async move {
+            progress_runtime
+                .wait_for_reply("local".into(), pane, id, Duration::from_secs(300), Some(0))
+                .await
+        });
+        commands
+            .recv()
+            .await
+            .unwrap()
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(
+                request.clone(),
+            )))
+            .unwrap();
+        tokio::task::yield_now().await;
+        runtime.store.notify_mailbox("local", 1).await;
+        let update = commands.recv().await.unwrap();
+        let mut changed = request;
+        changed
+            .updates
+            .push(crate::collaboration::CollaborationUpdate {
+                sequence: 1,
+                author: changed.to.clone(),
+                body: "tests passed".into(),
+                at: time::OffsetDateTime::now_utc(),
+            });
+        update
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(changed)))
+            .unwrap();
+        assert_eq!(
+            progress.await.unwrap().unwrap().unwrap().updates[0].sequence,
+            1
+        );
+        assert!(!terminal.is_finished());
+        terminal.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn upstream_resubscription_and_broadcast_lag_reconcile() {
+        let (runtime, mut commands, pane, request) = fixture(true).await;
+        let waiting = wait(runtime.clone(), pane, &request, 300);
+        let initial = commands.recv().await.unwrap();
+        // Overrun the subscribed receiver while its first read is in flight.
+        for _ in 0..600 {
+            runtime.store.mutate_host("local", |_| {}).await;
+        }
+        initial
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(
+                request.clone(),
+            )))
+            .unwrap();
+        let lagged = commands.recv().await.unwrap();
+        lagged
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(
+                request.clone(),
+            )))
+            .unwrap();
+        tokio::task::yield_now().await;
+        // A reconnect emits a zero revision even if no further writes occur.
+        runtime.store.notify_mailbox("local", 0).await;
+        let resync = commands.recv().await.unwrap();
+        let mut completed = request;
+        completed.status = RequestStatus::Completed;
+        resync
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(completed)))
+            .unwrap();
+        assert!(waiting
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap()
+            .status
+            .is_terminal());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn transient_disconnect_retries_and_observe_mode_revocation_stops_reads() {
+        let (runtime, mut commands, pane, request) = fixture(true).await;
+        runtime
+            .store
+            .mutate_host("local", |h| h.local = false)
+            .await;
+        let waiting = wait(runtime.clone(), pane, &request, 300);
+        let initial = commands.recv().await.unwrap();
+        runtime
+            .store
+            .mutate_host("local", |h| h.state = FleetHostState::Offline)
+            .await;
+        initial
+            .reply
+            .send(Err("relay disconnected".into()))
+            .unwrap();
+        let retry = commands.recv().await.unwrap();
+        runtime
+            .store
+            .mutate_host("local", |h| h.state = FleetHostState::Online)
+            .await;
+        retry
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(
+                request.clone(),
+            )))
+            .unwrap();
+        let restored = commands.recv().await.unwrap();
+        restored
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(request)))
+            .unwrap();
+        tokio::task::yield_now().await;
+        runtime
+            .store
+            .mutate_host("local", |h| h.mode = HostAccessMode::Observe)
+            .await;
+        assert!(waiting.await.unwrap().unwrap_err().contains("observe-only"));
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), commands.recv())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn ipc_wait_disconnect_releases_worker_and_keeps_other_connections_responsive() {
+        use crate::ipc::{Client, Server};
+        let (runtime, mut commands, pane, request) = fixture(true).await;
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("wait.sock");
+        let (shutdown, receiver) = broadcast::channel(1);
+        let server =
+            Server::new(socket.clone(), crate::state::Store::shared()).with_fleet(runtime.clone());
+        let serving = tokio::spawn(async move { server.run(receiver).await.unwrap() });
+        let client = Client::new(socket.clone());
+        for _ in 0..100 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        let other = client.clone();
+        let id = request.id.clone();
+        let waiting = tokio::spawn(async move {
+            client
+                .fleet_wait_reply("local", &pane, &id, 300, None)
+                .await
+        });
+        let command = tokio::time::timeout(Duration::from_secs(2), commands.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        command
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(request)))
+            .unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), other.fleet_snapshot(None))
+                .await
+                .unwrap()
+                .is_ok()
+        );
+        waiting.abort();
+        let _ = waiting.await;
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if runtime.reply_waits.0.lock().await.is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .unwrap();
+        shutdown.send(()).unwrap();
+        serving.await.unwrap();
+    }
+}

--- a/crates/muxa/src/history.rs
+++ b/crates/muxa/src/history.rs
@@ -526,6 +526,14 @@ async fn run_writer(
             }
         }
     }
+    // Tokio's write_all can return while the blocking filesystem write is
+    // still pending. Joining this task must also wait for that write before
+    // callers reopen the history file during restart (flush is not fsync).
+    if let Some(file) = appender.as_mut() {
+        if let Err(error) = file.flush().await {
+            warn!(%error, "history writer shutdown flush failed");
+        }
+    }
 }
 
 /// File mode applied to `prompts.ndjson` — and the tempfile that
@@ -794,7 +802,13 @@ mod tests {
         // Quiesce: shut down the writer so the appended record is durable
         // before we reopen the file.
         let _ = tx.send(());
-        let _ = writer.await;
+        writer.await.unwrap();
+
+        // A synchronous read cannot accidentally wait behind the pending
+        // Tokio write on its blocking pool and hide an incomplete shutdown.
+        let persisted = std::fs::read_to_string(&path).unwrap();
+        let record: HistoryEntry = serde_json::from_str(persisted.trim()).unwrap();
+        assert_eq!(record.prompt, "persisted");
 
         // Re-open: a fresh PromptHistory must hydrate from disk.
         let (tx2, _) = broadcast::channel::<()>(1);

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -268,6 +268,14 @@ enum RequestBody {
         host: String,
         operation: FleetOperation,
     },
+    FleetWaitReply {
+        #[serde(default)]
+        after_update: Option<u64>,
+        host: String,
+        pane: crate::topology::PaneKey,
+        request_id: String,
+        timeout_secs: u64,
+    },
     ByPane {
         pane: String,
     },
@@ -555,6 +563,11 @@ enum RequestBody {
         origin: CollaborationOrigin,
         request_id: String,
     },
+    CollaborationUpdate {
+        origin: CollaborationOrigin,
+        request_id: String,
+        body: String,
+    },
     /// Block on the mailbox's durable revision signal until this exact
     /// participant-visible request becomes terminal, or return its latest
     /// state at the bounded deadline. Unlike `collaboration_get` loops, one
@@ -701,6 +714,8 @@ const CAPABILITIES: &[&str] = &[
     "fleet_v1",
     "fleet_raw_capture_v1",
     "fleet_subscribe",
+    "fleet_wait_reply",
+    "collaboration_update",
     "pipeline_runs_v1",
     "pipeline_subscribe",
     "work_control_v1",
@@ -1647,6 +1662,9 @@ impl Server {
         tracing::info!(socket = %self.socket_path.display(), "listening");
 
         let mut handlers: JoinSet<()> = JoinSet::new();
+        // Sticky signal: a handler entering push mode after shutdown still
+        // observes it. Request mutations themselves are never cancelled by it.
+        let (stopping_tx, stopping_rx) = watch::channel(false);
         // Fixed budget of concurrent handlers. A permit is held for the
         // lifetime of each handler and released when it ends, so live fds
         // from handlers can never exceed `MAX_INFLIGHT_HANDLERS` — keeping
@@ -1722,6 +1740,7 @@ impl Server {
                     let pipeline_runs = self.pipeline_runs.clone();
                     let work_up = self.work_up.clone();
                     let config_path = self.config_path.clone();
+                    let stopping = stopping_rx.clone();
                     handlers.spawn(async move {
                         // Held for the handler's lifetime; released here on exit.
                         let _permit = permit;
@@ -1741,6 +1760,7 @@ impl Server {
                                 pipeline_runs,
                                 work_up,
                                 config_path,
+                                stopping,
                             ))
                             .await
                         {
@@ -1757,6 +1777,8 @@ impl Server {
                 }
             }
         }
+
+        stopping_tx.send_replace(true);
 
         // Drain in-flight handlers with a bounded timeout. Closes the
         // lost-update window where a handler could call `Store::apply`
@@ -1911,6 +1933,19 @@ where
     *line = String::from_utf8(bytes)
         .map_err(|e| RuntimeError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)))?;
     Ok(line.len())
+}
+
+/// Only use at cancellation-safe boundaries: waiting for a new request or
+/// streaming read-only updates. In-flight mutations retain the bounded drain.
+async fn until_server_shutdown<T>(
+    stopping: &mut watch::Receiver<bool>,
+    future: impl std::future::Future<Output = T>,
+) -> Option<T> {
+    tokio::select! {
+        biased;
+        _ = stopping.wait_for(|value| *value) => None,
+        result = future => Some(result),
+    }
 }
 
 /// Encode the `{"event":"lagged","dropped":N}` overflow control frame — but
@@ -2702,6 +2737,7 @@ async fn handle(
     pipeline_runs: Arc<PipelineRunStore>,
     work_up: Arc<WorkUpManager>,
     config_path: Option<PathBuf>,
+    mut stopping: watch::Receiver<bool>,
 ) -> Result<(), RuntimeError> {
     let mut collaboration_actor = observe_collaboration_actor(&stream);
     let (reader, mut writer) = stream.into_split();
@@ -2723,9 +2759,27 @@ async fn handle(
         // persistent client simply reconnects; a half-open one can't leak.
         // (A `Subscribe` connection never reaches a second iteration: it hands
         // off to `stream_transitions` and returns, so streams are unaffected.)
+        let deadline = tokio::time::Instant::now() + IDLE_CONN_TIMEOUT;
+        // fill_buf is cancellation-safe. Once any bytes of a request arrive,
+        // finish reading/processing it under the normal drain budget instead
+        // of dropping a partially received ingest on shutdown.
+        let Some(ready) = until_server_shutdown(
+            &mut stopping,
+            tokio::time::timeout_at(deadline, async {
+                reader.fill_buf().await.map(|bytes| !bytes.is_empty())
+            }),
+        )
+        .await
+        else {
+            return Ok(());
+        };
+        match ready {
+            Ok(Ok(true)) => {}
+            Ok(Err(error)) if !is_client_disconnect(&error) => return Err(error.into()),
+            _ => return Ok(()),
+        }
         let Ok(read_result) =
-            tokio::time::timeout(IDLE_CONN_TIMEOUT, read_limited_line(&mut reader, &mut line))
-                .await
+            tokio::time::timeout_at(deadline, read_limited_line(&mut reader, &mut line)).await
         else {
             tracing::debug!("idle connection timed out; closing");
             return Ok(());
@@ -2872,7 +2926,12 @@ async fn handle(
                     if !write_line_or_closed(&mut writer, &ack_bytes).await? {
                         return Ok(());
                     }
-                    return stream_revision_updates(writer, changes, stream_proto).await;
+                    return until_server_shutdown(
+                        &mut stopping,
+                        stream_revision_updates(writer, changes, stream_proto),
+                    )
+                    .await
+                    .unwrap_or(Ok(()));
                 }
                 RequestBody::WorkUp { request } => {
                     kind = "work_up";
@@ -3061,15 +3120,19 @@ async fn handle(
                         kind,
                         "ipc.handle (fleet stream takeover)",
                     );
-                    return stream_fleet_updates(
-                        writer,
-                        fleet.store.clone(),
-                        updates,
-                        stream_proto,
-                        selector,
-                        visible_hosts,
+                    return until_server_shutdown(
+                        &mut stopping,
+                        stream_fleet_updates(
+                            writer,
+                            fleet.store.clone(),
+                            updates,
+                            stream_proto,
+                            selector,
+                            visible_hosts,
+                        ),
                     )
-                    .await;
+                    .await
+                    .unwrap_or(Ok(()));
                 }
                 RequestBody::FleetCommand { host, operation } => {
                     kind = "fleet_command";
@@ -3082,6 +3145,42 @@ async fn handle(
                             Err(error) => Response::err(error),
                         },
                         None => Response::err("fleet is not enabled in muxad"),
+                    }
+                }
+                RequestBody::FleetWaitReply {
+                    host,
+                    pane,
+                    request_id,
+                    timeout_secs,
+                    after_update,
+                } => {
+                    kind = "fleet_wait_reply";
+                    let response = async {
+                        match &fleet {
+                            Some(fleet) => match fleet
+                                .wait_for_reply(
+                                    host,
+                                    pane,
+                                    request_id,
+                                    Duration::from_secs(
+                                        timeout_secs.clamp(1, MAX_COLLABORATION_WAIT_SECS),
+                                    ),
+                                    after_update,
+                                )
+                                .await
+                            {
+                                Ok(Some(request)) => Response::with_collaboration_request(request),
+                                Ok(None) => Response::ok(),
+                                Err(error) => Response::err(error),
+                            },
+                            None => Response::err("fleet is not enabled in muxad"),
+                        }
+                    };
+                    // A disconnected waiter must release its shared subscription promptly.
+                    tokio::select! {
+                        response = response => response,
+                        _ = reader.fill_buf() => return Ok(()),
+                        _ = stopping.wait_for(|value| *value) => return Ok(()),
                     }
                 }
                 RequestBody::ByPane { pane } => {
@@ -3363,7 +3462,12 @@ async fn handle(
                     if !write_line_or_closed(&mut writer, &ack_bytes).await? {
                         return Ok(());
                     }
-                    return stream_revision_updates(writer, changes, stream_proto).await;
+                    return until_server_shutdown(
+                        &mut stopping,
+                        stream_revision_updates(writer, changes, stream_proto),
+                    )
+                    .await
+                    .unwrap_or(Ok(()));
                 }
                 RequestBody::AskStatus {} => {
                     kind = "ask_status";
@@ -3719,7 +3823,12 @@ async fn handle(
                         kind,
                         "ipc.handle (collaboration stream takeover)",
                     );
-                    return stream_revision_updates(writer, changes, stream_proto).await;
+                    return until_server_shutdown(
+                        &mut stopping,
+                        stream_revision_updates(writer, changes, stream_proto),
+                    )
+                    .await
+                    .unwrap_or(Ok(()));
                 }
                 RequestBody::CollaborationList {
                     origin,
@@ -3745,6 +3854,40 @@ async fn handle(
                             Ok(requests) => {
                                 Response::with_scoped_collaboration_requests(requests, scope)
                             }
+                            Err(error) => Response::err(error.to_string()),
+                        },
+                        Err(error) => Response::err(error.to_string()),
+                    };
+                    record_collaboration_audit(
+                        &collaboration_audit,
+                        &collaboration_actor,
+                        audit_context,
+                        &response,
+                    )
+                    .await;
+                    response
+                }
+                RequestBody::CollaborationUpdate {
+                    origin,
+                    request_id,
+                    body,
+                } => {
+                    kind = "collaboration_update";
+                    collaboration_actor.observe_pane(&backends).await;
+                    let mut audit_context = CollaborationAuditContext::new(
+                        CollaborationAuditOperation::Update,
+                        origin.clone(),
+                    );
+                    audit_context.request_id = Some(request_id.clone());
+                    audit_context.message_bytes = Some(body.len());
+                    let topology =
+                        collaboration_participants(&store, &backends, &collaboration).await;
+                    let response = match topology.resolve_origin(&origin) {
+                        Ok(current) => match collaboration
+                            .update_request(&current, &request_id, body)
+                            .await
+                        {
+                            Ok(request) => Response::with_collaboration_request(request),
                             Err(error) => Response::err(error.to_string()),
                         },
                         Err(error) => Response::err(error.to_string()),
@@ -4029,7 +4172,12 @@ async fn handle(
                     if !write_line_or_closed(&mut writer, &ack).await? {
                         return Ok(());
                     }
-                    return stream_agent_changes(writer, changes, protocol).await;
+                    return until_server_shutdown(
+                        &mut stopping,
+                        stream_agent_changes(writer, changes, protocol),
+                    )
+                    .await
+                    .unwrap_or(Ok(()));
                 }
                 RequestBody::Subscribe { lagged_markers } => {
                     kind = "subscribe";
@@ -4053,8 +4201,12 @@ async fn handle(
                         kind,
                         "ipc.handle (stream takeover)",
                     );
-                    return stream_transitions(writer, transitions, stream_proto, lagged_markers)
-                        .await;
+                    return until_server_shutdown(
+                        &mut stopping,
+                        stream_transitions(writer, transitions, stream_proto, lagged_markers),
+                    )
+                    .await
+                    .unwrap_or(Ok(()));
                 }
             },
             Err(e) => {
@@ -4695,6 +4847,22 @@ impl Client {
 
     /// Execute an exact operation on one configured host. Mutations are
     /// authorized again by the manager's per-host access mode.
+    pub async fn collaboration_update(
+        &self,
+        origin: &CollaborationOrigin,
+        request_id: &str,
+        body: &str,
+    ) -> Result<CollaborationRequest, RuntimeError> {
+        let response = self
+            .call_checked(&serde_json::json!({
+                "protocol": PROTOCOL_VERSION, "kind": "collaboration_update",
+                "origin": origin, "request_id": request_id, "body": body,
+            }))
+            .await?;
+        serde_json::from_value(response["collaboration_request"].clone())
+            .map_err(RuntimeError::Json)
+    }
+
     pub async fn fleet_execute(
         &self,
         host: &str,
@@ -4718,6 +4886,38 @@ impl Client {
             )));
         }
         serde_json::from_value(response["fleet_result"].clone()).map_err(RuntimeError::Json)
+    }
+
+    /// Wait through the controller's shared event subscription, without pinning a relay command.
+    pub async fn fleet_wait_reply(
+        &self,
+        host: &str,
+        pane: &crate::topology::PaneKey,
+        request_id: &str,
+        timeout_secs: u64,
+        after_update: Option<u64>,
+    ) -> Result<Option<CollaborationRequest>, RuntimeError> {
+        let timeout_secs = timeout_secs.clamp(1, MAX_COLLABORATION_WAIT_SECS);
+        let req = serde_json::json!({
+            "protocol": PROTOCOL_VERSION, "kind": "fleet_wait_reply",
+            "host": host, "pane": pane, "request_id": request_id, "timeout_secs": timeout_secs, "after_update":after_update,
+        });
+        let response = self
+            .call_with_timeout(
+                &req,
+                Duration::from_secs(timeout_secs).saturating_add(CLIENT_CALL_TIMEOUT),
+            )
+            .await?;
+        if !response["ok"].as_bool().unwrap_or(false) {
+            return Err(RuntimeError::Json(serde::de::Error::custom(
+                response["error"]
+                    .as_str()
+                    .unwrap_or("fleet reply wait failed")
+                    .to_string(),
+            )));
+        }
+        serde_json::from_value(response["collaboration_request"].clone())
+            .map_err(RuntimeError::Json)
     }
 
     /// Run one allowlisted `muxa work …` argv through the daemon, on its own
@@ -6405,6 +6605,95 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn request_updates_round_trip_between_fleet_console_and_recipient() {
+        let dir = tempdir().unwrap();
+        let socket = dir.path().join("request-updates.sock");
+        let store = Store::shared();
+        add_collaboration_agent(&store, "%1", "recipient", AgentKind::Codex).await;
+        add_collaboration_agent(&store, "%2", "unrelated", AgentKind::ClaudeCode).await;
+        let backend: SharedBackend = Arc::new(CollaborationTestBackend {
+            panes: vec![
+                collaboration_test_pane("%1", "0"),
+                collaboration_test_pane("%2", "1"),
+            ],
+        });
+        let audit = CollaborationAuditLog::in_memory();
+        let server = Server::new(socket.clone(), store)
+            .with_backends(vec![backend])
+            .with_collaboration(CollaborationStore::in_memory(
+                CollaborationOptions::default(),
+            ))
+            .with_collaboration_audit(audit.clone());
+        let (shutdown, rx) = broadcast::channel(1);
+        let serving = tokio::spawn(async move { server.run(rx).await.unwrap() });
+        wait_for_socket(&socket).await;
+        let client = Client::new(socket);
+        let origin = |pane: &str, console| CollaborationOrigin {
+            pane: pane.into(),
+            socket: Some("default".into()),
+            console,
+        };
+        let request = client
+            .collaboration_send(
+                &origin("%1", true),
+                "pane:%1",
+                &NewRequest {
+                    body: "review".into(),
+                    ..NewRequest::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert!(request.from.console);
+        client
+            .collaboration_inbox(&origin("%1", false))
+            .await
+            .unwrap();
+        let progress = client
+            .collaboration_update(&origin("%1", false), &request.id, "Tests running")
+            .await
+            .unwrap();
+        assert_eq!(progress.status, RequestStatus::Claimed);
+        assert!(progress.reply.is_none());
+        let guidance = client
+            .collaboration_update(&origin("%1", true), &request.id, "Include the retry path")
+            .await
+            .unwrap();
+        assert_eq!(guidance.updates.len(), 2);
+        assert!(client
+            .collaboration_update(&origin("%2", false), &request.id, "unrelated")
+            .await
+            .is_err());
+        let completed = client
+            .collaboration_reply(
+                &origin("%1", false),
+                &request.id,
+                RequestStatus::Completed,
+                "verified",
+                &[],
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(completed.updates[0].body, "Tests running");
+        assert_eq!(completed.updates[1].author.pane, "console");
+        assert!(client
+            .collaboration_update(&origin("%1", true), &request.id, "late")
+            .await
+            .is_err());
+        let entries = audit.entries().await;
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|e| e.operation == CollaborationAuditOperation::Update && e.ok)
+                .count(),
+            2
+        );
+        shutdown.send(()).unwrap();
+        serving.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn widening_a_listing_over_ipc_is_console_only() {
         let dir = tempdir().unwrap();
         let sock = dir.path().join("muxa-collaboration-scope.sock");
@@ -6451,6 +6740,7 @@ mod tests {
                         &from,
                         to,
                         &NewRequest {
+                            initiator: None,
                             kind: collaboration::RequestKind::Question,
                             body: body.into(),
                             expects_reply: true,
@@ -6590,6 +6880,7 @@ mod tests {
                 &sender,
                 "role:review",
                 &NewRequest {
+                    initiator: None,
                     kind: collaboration::RequestKind::Question,
                     body: "ambiguous".into(),
                     expects_reply: true,
@@ -6613,6 +6904,7 @@ mod tests {
                 &sender,
                 "@reviewer",
                 &NewRequest {
+                    initiator: None,
                     kind: collaboration::RequestKind::Review,
                     body: "review this".into(),
                     expects_reply: true,
@@ -6701,6 +6993,7 @@ mod tests {
                 &sender,
                 "role:rust",
                 &NewRequest {
+                    initiator: None,
                     kind: collaboration::RequestKind::Question,
                     body: "obsolete question".into(),
                     expects_reply: true,
@@ -6747,6 +7040,7 @@ mod tests {
                 },
                 "pane:%1",
                 &NewRequest {
+                    initiator: None,
                     kind: collaboration::RequestKind::Task,
                     body: "dispatch to launch pane".into(),
                     expects_reply: true,
@@ -7080,10 +7374,9 @@ mod tests {
         // still blocked on its read.
         tx.send(()).unwrap();
 
-        // Now finish the request (newline) so the handler can complete,
-        // then close the stream so the handler's read loop sees EOF and
-        // returns. Without the close, `handle()` would happily wait for
-        // a follow-up request and the drain timeout would fire.
+        // Finish the admitted request after shutdown. The handler must apply
+        // it and close the connection itself rather than waiting for a new
+        // request; the client deliberately remains open while reading EOF.
         stream.write_all(b"\n").await.unwrap();
         stream.flush().await.unwrap();
         // Read the single response so we know the apply landed before
@@ -7119,6 +7412,7 @@ mod tests {
     async fn client_disconnect_before_response_is_clean_handler_exit() {
         let (server_stream, mut client_stream) = tokio::net::UnixStream::pair().unwrap();
         let store = Store::shared();
+        let (_stopping_tx, stopping_rx) = watch::channel(false);
         let handle = tokio::spawn(handle(
             server_stream,
             store,
@@ -7134,6 +7428,7 @@ mod tests {
             PipelineRunStore::in_memory(),
             WorkUpManager::new(PathBuf::from("/tmp/muxa-disconnect-test.sock")),
             None,
+            stopping_rx,
         ));
 
         let req = serde_json::json!({
@@ -7151,6 +7446,62 @@ mod tests {
             .expect("handler should exit promptly")
             .expect("handler task panicked");
         outcome.expect("client disconnect should not be treated as a handler failure");
+    }
+
+    #[tokio::test]
+    async fn shutdown_closes_idle_connections_and_all_local_subscriptions_promptly() {
+        let dir = tempdir().unwrap();
+        let socket = dir.path().join("shutdown-streams.sock");
+        let server = Server::new(socket.clone(), Store::shared());
+        let (stop, receiver) = broadcast::channel(1);
+        let task = tokio::spawn(server.run(receiver));
+        wait_for_socket(&socket).await;
+        let mut connections = Vec::new();
+        for kind in [
+            "subscribe",
+            "subscribe_agent_changes",
+            "pipeline_subscribe",
+            "ask_subscribe",
+            "collaboration_subscribe",
+        ] {
+            let stream = UnixStream::connect(&socket).await.unwrap();
+            let mut reader = BufReader::new(stream);
+            let mut bytes = serde_json::to_vec(
+                &serde_json::json!({"protocol": PROTOCOL_VERSION, "kind": kind}),
+            )
+            .unwrap();
+            bytes.push(b'\n');
+            reader.get_mut().write_all(&bytes).await.unwrap();
+            let mut ack = String::new();
+            reader.read_line(&mut ack).await.unwrap();
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&ack).unwrap()["ok"],
+                true,
+                "{kind}"
+            );
+            connections.push(reader);
+        }
+        // A persistent client has completed its request and is now idle.
+        let mut idle = BufReader::new(UnixStream::connect(&socket).await.unwrap());
+        idle.get_mut()
+            .write_all(
+                format!("{{\"protocol\":{PROTOCOL_VERSION},\"kind\":\"snapshot\"}}\n").as_bytes(),
+            )
+            .await
+            .unwrap();
+        let mut ack = String::new();
+        idle.read_line(&mut ack).await.unwrap();
+        connections.push(idle);
+        stop.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("subscriptions must close without waiting for the five-second drain timeout")
+            .unwrap()
+            .unwrap();
+        for mut reader in connections {
+            let mut line = String::new();
+            assert_eq!(reader.read_line(&mut line).await.unwrap(), 0);
+        }
     }
 
     #[tokio::test]

--- a/crates/muxa/src/lib.rs
+++ b/crates/muxa/src/lib.rs
@@ -48,6 +48,7 @@ pub mod discovery;
 pub mod error;
 pub mod event;
 pub mod fleet;
+mod fleet_wait;
 pub mod history;
 pub mod ipc;
 pub mod metrics;

--- a/crates/muxad/src/fleet_manager.rs
+++ b/crates/muxad/src/fleet_manager.rs
@@ -304,6 +304,10 @@ impl LocalTask {
                 _ = refresh.tick() => self.refresh().await,
                 _ = mailbox_retry.tick(), if mailbox_updates.is_none() => {
                     mailbox_updates = self.client.collaboration_subscribe().await.ok();
+                    if mailbox_updates.is_some() {
+                        // Reconcile replies completed while the upstream stream was down.
+                        self.store.notify_mailbox(LOCAL_HOST_ALIAS, 0).await;
+                    }
                 }
                 mailbox = next_mailbox_update(&mut mailbox_updates), if mailbox_updates.is_some() => {
                     match mailbox {
@@ -473,6 +477,22 @@ impl LocalTask {
                     .collaboration_inbox(&fleet_collaboration_origin(&pane, false))
                     .await
                     .map(|incoming| FleetCommandResult::collaboration_mailbox(incoming, Vec::new()))
+                    .map_err(|error| error.to_string())
+            }
+            FleetOperation::CollaborationUpdate {
+                pane,
+                request_id,
+                body,
+            } => {
+                audit_operation(LOCAL_HOST_ALIAS, "collaboration_update", body.len());
+                self.client
+                    .collaboration_update(
+                        &fleet_collaboration_origin(&pane, true),
+                        &request_id,
+                        &body,
+                    )
+                    .await
+                    .map(FleetCommandResult::collaboration_request)
                     .map_err(|error| error.to_string())
             }
             FleetOperation::CollaborationReply {
@@ -1219,6 +1239,7 @@ impl HostTask {
                             | FleetOperation::CollaborationGet { .. }
                             | FleetOperation::CollaborationClaim { .. }
                             | FleetOperation::CollaborationReply { .. }
+                            | FleetOperation::CollaborationUpdate { .. }
                     )
                         && self.config.mode != HostAccessMode::Control
                     {
@@ -1235,12 +1256,18 @@ impl HostTask {
                             | FleetOperation::CollaborationGet { .. }
                             | FleetOperation::CollaborationClaim { .. }
                             | FleetOperation::CollaborationReply { .. }
+                            | FleetOperation::CollaborationUpdate { .. }
                     ) && !connected.hello.capabilities.iter().any(|capability| capability == "collaboration")
                     {
                         let _ = command.reply.send(Err(format!(
                             "host '{}' does not support Fleet collaboration; upgrade muxa on that host",
                             self.alias
                         )));
+                        continue;
+                    }
+                    if matches!(command.operation, FleetOperation::CollaborationUpdate { .. })
+                        && !connected.hello.capabilities.iter().any(|c| c == "collaboration_update") {
+                        let _ = command.reply.send(Err(format!("host '{}' does not support request updates; upgrade muxa", self.alias)));
                         continue;
                     }
                     if matches!(command.operation, FleetOperation::CollaborationGet { .. })
@@ -1341,6 +1368,11 @@ impl HostTask {
                                 PendingRequest::new(PendingReply::Command(command.reply), command_timeout),
                             );
                             RelayRequest::CollaborationClaim { request_id: id, pane }
+                        }
+                        FleetOperation::CollaborationUpdate { pane, request_id, body } => {
+                            audit_operation(&self.alias, "collaboration_update", body.len());
+                            pending.insert(id.clone(), PendingRequest::new(PendingReply::Command(command.reply), command_timeout));
+                            RelayRequest::CollaborationUpdate { request_id: id, pane, collaboration_request_id: request_id, body }
                         }
                         FleetOperation::CollaborationReply { pane, request_id, status, body } => {
                             audit_operation(&self.alias, "collaboration_reply", body.len());

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -3245,6 +3245,7 @@ mod tests {
                 sender,
                 recipient,
                 NewRequest {
+                    initiator: None,
                     kind: RequestKind::Question,
                     body: "wake from revision".into(),
                     expects_reply: true,
@@ -3387,6 +3388,7 @@ mod tests {
                 sender,
                 pending,
                 NewRequest {
+                    initiator: None,
                     kind: RequestKind::Review,
                     body: "review the pending diff".into(),
                     expects_reply: true,
@@ -3463,6 +3465,7 @@ mod tests {
                 sender.clone(),
                 recipient.clone(),
                 NewRequest {
+                    initiator: None,
                     kind: RequestKind::Task,
                     body: "change only the authorized file".into(),
                     expects_reply: true,
@@ -3515,6 +3518,7 @@ mod tests {
                 sender,
                 recipient.clone(),
                 NewRequest {
+                    initiator: None,
                     kind: RequestKind::Task,
                     body: "unsafe\u{1b}[201~\rsubmit".into(),
                     expects_reply: true,
@@ -3575,6 +3579,7 @@ mod tests {
                 console,
                 recipient.clone(),
                 NewRequest {
+                    initiator: None,
                     kind: RequestKind::Task,
                     body: "operator request body".into(),
                     expects_reply: true,
@@ -3656,6 +3661,7 @@ mod tests {
                 sender,
                 recipient.clone(),
                 NewRequest {
+                    initiator: None,
                     kind: RequestKind::Task,
                     body: "agent delegated body".into(),
                     expects_reply: true,
@@ -3725,6 +3731,7 @@ mod tests {
                     sender.clone(),
                     recipient.clone(),
                     NewRequest {
+                        initiator: None,
                         kind: RequestKind::Task,
                         body: body.into(),
                         expects_reply: true,
@@ -3811,6 +3818,7 @@ mod tests {
                 sender.clone(),
                 recipient.clone(),
                 NewRequest {
+                    initiator: None,
                     kind: RequestKind::Task,
                     body: "do not inject this twice".into(),
                     expects_reply: true,
@@ -3860,6 +3868,7 @@ mod tests {
                 sender,
                 recipient.clone(),
                 NewRequest {
+                    initiator: None,
                     kind: RequestKind::Task,
                     body: "the prompt text is already buffered".into(),
                     expects_reply: true,
@@ -3918,6 +3927,7 @@ mod tests {
                 sender,
                 recipient.clone(),
                 NewRequest {
+                    initiator: None,
                     kind: RequestKind::Review,
                     body: "secret request body".into(),
                     expects_reply: true,
@@ -4035,6 +4045,7 @@ mod tests {
                 console.clone(),
                 recipient.clone(),
                 NewRequest {
+                    initiator: None,
                     kind: RequestKind::Task,
                     body: "dispatched by a human".into(),
                     expects_reply: true,

--- a/docs/FLEET.ko.md
+++ b/docs/FLEET.ko.md
@@ -247,6 +247,25 @@ mutation은 자동 retry하지 않습니다. 결과는 text delivery와 Enter su
 결과의 정확한 `pane_key`와 `request_id`를 wait 도구에 그대로 넘기면 됩니다. 요청과
 구조화된 reply는 선택한 physical node에 남으므로 terminal capture polling이 필요 없습니다.
 
+Fleet 응답 대기는 controller에서 `(host, pane_key, request_id)`별로 공유합니다.
+`mailbox_watch` 지원 호스트는 최초 조회 후 mailbox 변경·연결 복구 때만 다시 읽으며,
+상태 변화 없는 5분 대기는 조회 1회로 끝납니다. 같은 호스트의 다른 요청 변경은
+조회가 발생할 수 있지만, 다른 호스트 이벤트와 일반 topology refresh는 무시합니다.
+대기자별 timeout은 독립적이고 마지막 대기 연결이 종료되면 구독도 정리합니다.
+구형 호스트/controller에만 1→2→4→8→16→30초 간격의 backoff를 적용합니다.
+
+진행 중 보완 지시는 `muxa_fleet_update_request(host, pane_key, request_id, body)`,
+수임자의 진행보고는 `muxa_update_request(request_id, body)`로 기존 요청에 남깁니다.
+`muxa_fleet_wait_reply`에 `after_update: 0`을 주면 완료 전 새 update에도 반환하고,
+이후 `next_after_update`로 이어서 기다릴 수 있습니다. `initiator`는 원래 조율자의
+식별 정보이며 권한을 추가하지 않습니다. `console`을 수신 pane으로 사용하지 않습니다.
+
+update는 작업 완료·새 작업 생성·터미널 입력을 하지 않습니다. 에이전트는 합의한
+검토 시점에 `muxa_list_messages`로 변경사항을 읽고 마지막에 `muxa_reply`를 한 번
+제출합니다. 지시를 검증한 뒤 묶어서 전달하고, 큰 근거는 파일 경로로 연결합니다.
+update당 8 KiB, 요청당 최근 32개/본문 합계 32 KiB를 보관합니다. 원격 update는
+`collaboration_update` capability와 control mode가 필요합니다.
+
 web dashboard를 켜면 read API에 `GET /api/fleet?selector=...`가 추가됩니다.
 `POST /api/fleet/{host}/command`는 serialized `FleetOperation`을 받아 PAT를 요구합니다.
 dashboard `auth = "none"`에서는 기존 정책대로 모든 write가 비활성화됩니다.

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -311,3 +311,14 @@ into keystrokes.
 
 See [CONFIGURATION.md](CONFIGURATION.md) for every setting and
 [MULTI_HOST.md](MULTI_HOST.md) for local multi-backend observation.
+
+### Event-driven replies and progress
+
+Fleet reply waits share a controller-side subscription per exact host/pane/request.
+`mailbox_watch` hosts reconcile on mailbox changes and reconnection rather than
+polling every 500 ms; older hosts use capped exponential backoff. Independent
+waiters retain their deadlines and release the worker when none remain.
+Use `muxa_fleet_update_request` for consolidated guidance and `muxa_update_request`
+for progress on that same durable request. `muxa_fleet_wait_reply(after_update=0)`
+can return progress before terminal completion. See [MCP.md](MCP.md) for sequence,
+retention, authority and compatibility contracts.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -86,7 +86,7 @@ muxa_fleet_status      { "selector": "environment=production" }
 muxa_fleet_capture     { "host": "local", "pane": "%12" }
 muxa_fleet_capture     { "host": "dev", "pane": "%12" }
 muxa_fleet_send_prompt { "host": "dev", "pane": "%12",
-                         "text": "Summarize the result", "submit": true }
+                         "text": "Start the interactive session", "submit": true }
 muxa_fleet_call_peer   { "host": "dev", "pane": "%12",
                          "intent": "review", "body": "Review the current change" }
 muxa_fleet_wait_reply  { "host": "dev", "pane_key": { "window": { ... },
@@ -102,6 +102,43 @@ times out, pass the returned exact `pane_key` and `request_id` to
 `muxa_fleet_wait_reply`. Fleet calls use muxad's cache/control plane; the MCP
 subprocess never opens SSH itself. The remote `muxa` must advertise both
 `collaboration` and `collaboration_get`. See [FLEET.md](FLEET.md).
+
+Reply waits are shared in the controller by `(host, exact pane_key, request_id)`.
+The controller subscribes before its first read, then reconciles mailbox changes,
+stream gaps and host reconnections. An unchanged five-minute wait performs one
+request read; topology refreshes do not cause mailbox reads. The subscription is
+released when its last waiter disconnects or expires, and each waiter has its own
+deadline. Hosts advertising `mailbox_watch` use this event path; older hosts use
+1/2/4/8/16/30-second capped backoff. Older controllers also use capped backoff.
+Mailbox invalidations are host-scoped, so changes to other requests on that host
+can still trigger reads; updates from other hosts are ignored.
+
+For ongoing work, keep guidance and progress on the existing durable request:
+
+```text
+muxa_fleet_update_request { "host": "dev", "pane_key": <returned pane_key>,
+                           "request_id": "req_...", "body": "Verified guidance within the agreed scope" }
+muxa_update_request      { "request_id": "req_...", "body": "Implementation done; running tests" }
+muxa_fleet_wait_reply    { "host": "dev", "pane_key": <returned pane_key>,
+                           "request_id": "req_...", "after_update": 0 }
+```
+
+`after_update` returns `reason: "updated"` for a newer sequence without marking the
+request completed. Resume using `next_after_update`, or omit `after_update` to wait
+only for a terminal reply. Updates do not claim work, widen its execution/path
+scope, or inject terminal prompts. Recipients check their request updates through
+`muxa_list_messages` at agreed checkpoints; urgent interruption remains an explicit
+separate action. Finish with exactly one `muxa_reply`.
+
+Each update is limited to 8 KiB of UTF-8 text; a request retains at most 32 updates
+and 32 KiB of update bodies, with monotonic sequence numbers even after trimming.
+Link larger artifacts. Consecutive identical updates by the same participant are
+idempotent. Only the existing sender/recipient may update a nonterminal request.
+The optional `initiator` records the originating agent when its context resolves;
+it is advisory metadata, not additional authorization or a routable console pane.
+Fleet calls return explicit progress/guidance routes on the original request.
+Remote updates require the `collaboration_update` capability and control mode;
+there is no terminal-text fallback when that capability is absent.
 
 ## Implementation
 
@@ -155,7 +192,9 @@ it:
 | `muxa_fleet_capture` | `host`, `pane` | Capture one exact pane on a named Fleet host. |
 | `muxa_fleet_send_prompt` | `host`, `pane`, `text`, `submit?` | Inject literal text into one exact Fleet pane on a control-authorized host. |
 | `muxa_fleet_call_peer` | `host`, `pane`, `intent?`, `body?`, `skill?`, `context?`, `execute?`, `paths?`, `wait?`, `timeout_secs?` | Send durable structured work to one explicitly selected Fleet agent and optionally wait for its reply. |
-| `muxa_fleet_wait_reply` | `host`, `pane_key`, `request_id`, `timeout_secs?` | Continue an exact remote durable reply wait, including after the target pane exits. |
+| `muxa_update_request` | `request_id`, `body` | Add nonterminal progress/guidance as an existing participant. |
+| `muxa_fleet_update_request` | `host`, `pane_key`, `request_id`, `body` | Add guidance to the original Fleet request without prompt injection. |
+| `muxa_fleet_wait_reply` | `host`, `pane_key`, `request_id`, `timeout_secs?`, `after_update?` | Continue an exact remote durable reply wait, including after the target pane exits. |
 | `muxa_wait_for_change` | `timeout_secs?`, `pane?`, `until?`, `include_capture?` | Wait for any change or a focused settled/idle/blocked/stopped state, optionally returning the screen. |
 | `muxa_collaboration_guide` | — | Show the recommended reviewer, question, delegated-subagent, incoming-work, and AIR handoff contracts. |
 | `muxa_room_context` | — | Identify self, list same-window peers, and report unread request/reply counts. |


### PR DESCRIPTION
## Problem and behavior

Fleet reply waits polled every 500ms; the local audit attributed 8,865 get calls to muxad polling. This change shares one event-driven wait per host, exact pane key, and request across callers. Each caller keeps its own deadline, and the last disconnect releases the subscription. Legacy hosts use bounded exponential backoff.

Progress and follow-up guidance can now be appended to the original durable request through `muxa_update_request` / `muxa_fleet_update_request`. `after_update` waits return new progress without completing the request or injecting another prompt. Participant authorization, bounded retention, adjacent retry deduplication, and SQLite persistence apply; initiator metadata does not grant authority.

IPC shutdown signaling closes idle connections and subscriptions promptly and supports cancellation of the new wait. Fleet/relay capability negotiation and MCP guidance are updated.

## Validation

- Committed tree: 2,127 tests passed, 0 failed, 3 ignored; Clippy across all targets with `-D warnings` and formatting checks passed. The repository pre-push hook also passed workspace-wide Clippy.
- Local installed integration: 2,128 tests passed, 0 failed, 3 ignored; existing Ask and tmux fixes preserved outside this PR.
- Live read-only measurement: two concurrent waits on an existing request for 30 seconds produced one audited get; simultaneous fleet snapshot completed in 1.57ms.
- Covers shared waits, races, reconnects, lag, legacy backoff, cancellation, progress vs terminal replies, update authorization, persistence, and retention limits.

Mailbox invalidations are host-scoped, so another request on the same host can trigger a reread. Existing MCP processes must reconnect to use the installed new code. Updates are passive and must be read at checkpoints or awaited with `after_update`.
