### PR TITLE
fix(watch): attach rmux popups to the selected window and pane

### DIFF
--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -3000,17 +3000,18 @@ fn jump_to_pane_rmux_target(socket: &str, session: &str, window: &str, pane: &st
                     "multiple rmux clients share this session: open watch using the popup binding or pass --caller-client"
                 )?
             };
-            selected_session = tmux_work::private_jump_session(&control, &client, session, window)?;
-            // Switch only the client here. Window selection happens below,
-            // after it has its own view and with that view's session id.
+            let view = tmux_work::prepare_jump_view(&control, &client, session, window)?;
+            let target = format!("{}:{window}.{pane}", view.id);
+            // A cross-session switch closes the invoking rmux popup. The
+            // destination must include the window and pane in this last call.
             backend
-                .run_control(&["switch-client", "-c", &client, "-t", &selected_session])
+                .run_control(&["switch-client", "-c", &client, "-t", &target])
                 .map_err(anyhow::Error::msg)
         })();
         if let Err(error) = result {
             eprintln!("muxa: rmux jump failed: {error}");
-            return;
         }
+        return;
     } else if current.is_some() {
         eprintln!("muxa: cannot switch an rmux client across servers; attach to {socket} from a separate terminal");
         return;
@@ -3874,6 +3875,22 @@ mod tests {
             rmux_client_from_context("a\t$1\nb\t$1", "/tmp/socket,10,1"),
             None
         );
+    }
+
+    /// The popup may terminate us during the switch. The external harness
+    /// asserts the final client, window, pane and cleanup state on the server.
+    #[test]
+    #[ignore = "requires scripts/rmux-popup-jump-check.py"]
+    fn popup_rmux_jump() {
+        use muxa::PaneBackend;
+        let socket = std::env::var("MUXA_RMUX_TEST_ENDPOINT").unwrap();
+        let pane = std::env::var("MUXA_RMUX_TEST_PANE").unwrap();
+        CALLER_CLIENT
+            .set(std::env::var("MUXA_RMUX_TEST_CLIENT").unwrap())
+            .unwrap();
+        let backend = muxa::RmuxBackend::with_endpoint(&socket);
+        let pane = backend.resolve_pane(&pane).unwrap();
+        jump_to_topology_pane(&muxa::PaneKey::from_pane(muxa::HostKind::Rmux, &pane));
     }
 
     /// The harness supplies a disposable server with an attached client and

--- a/crates/muxa-cli/src/tmux_work.rs
+++ b/crates/muxa-cli/src/tmux_work.rs
@@ -719,12 +719,12 @@ fn client_suffix(control: &Control, client: &str) -> Result<String> {
 
 /// Choose a private destination before changing the selected window. This
 /// avoids even a transient window switch in another terminal's session.
-pub(crate) fn private_jump_session(
+pub(crate) fn prepare_jump_view(
     control: &Control,
     client: &str,
     session: &str,
     window: &str,
-) -> Result<String> {
+) -> Result<AttachView> {
     let current = resolve_view_session(control, client)?;
     let linked = control.output(&["list-windows", "-t", &current.id, "-F", "#{window_id}"])?;
     let target = if linked.lines().any(|id| id == window) {
@@ -736,20 +736,43 @@ pub(crate) fn private_jump_session(
         .attached
         .saturating_sub(u32::from(current.id == target.id));
     if others == 0 {
-        return Ok(target.id);
+        return Ok(AttachView {
+            id: target.id,
+            control: control.clone(),
+            created: false,
+        });
     }
     let opted_out = control
         .output(&["show-options", "-v", "-t", &target.id, "@no_auto_view"])
         .unwrap_or_default();
     if !opted_out.trim().is_empty() {
-        return Ok(target.id);
+        return Ok(AttachView {
+            id: target.id,
+            control: control.clone(),
+            created: false,
+        });
     }
     let sessions = list_view_sessions(control)?;
     let source = canonical_view_source(&target, &sessions);
     let suffix = client_suffix(control, client)?;
     let view = prepare_view(control, client, &source, &suffix, &sessions)?;
-    activate_view(control, client, &current.id, &view)?;
-    Ok(view.id)
+    let view = AttachView {
+        id: view.id,
+        control: control.clone(),
+        created: view.created,
+    };
+    // Switching sessions can terminate the popup that invoked us. Prepare
+    // cleanup on the server before the caller's one exact switch command.
+    for event in ["client-attached[9001]", "client-session-changed[9001]"] {
+        control.run(&[
+            "set-hook",
+            "-t",
+            &view.id,
+            event,
+            &format!("set-option -t '{}' destroy-unattached on", view.id),
+        ])?;
+    }
+    Ok(view)
 }
 
 /// Keep a bare-terminal attach private as well. The owner is retained until

--- a/scripts/rmux-popup-jump-check.py
+++ b/scripts/rmux-popup-jump-check.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Test the actual Rust jump inside an rmux popup on a disposable server.
+
+Requires rmux, Cargo and Unix PTYs. No user server or config is touched.
+"""
+import fcntl
+import json
+import os
+from pathlib import Path
+import pty
+import select
+import shlex
+import shutil
+import struct
+import subprocess
+import tempfile
+import termios
+import threading
+import time
+
+repo = Path(__file__).resolve().parents[1]
+rmux = shutil.which("rmux")
+if not rmux:
+    raise SystemExit("rmux is required")
+build = subprocess.run(
+    ["cargo", "test", "-p", "muxa-cli", "--no-run", "--message-format=json"],
+    cwd=repo, text=True, stdout=subprocess.PIPE, check=True,
+)
+artifacts = [json.loads(line) for line in build.stdout.splitlines()]
+binary = next(a["executable"] for a in artifacts
+              if a.get("reason") == "compiler-artifact" and a.get("executable")
+              and a["profile"]["test"] and a["target"]["name"] == "muxa")
+
+with tempfile.TemporaryDirectory(prefix="muxa-popup-jump-") as tmp:
+    socket = str(Path(tmp) / "server.sock")
+    env = dict(os.environ, TERM="xterm-256color")
+    for key in ("RMUX", "RMUX_PANE", "TMUX", "TMUX_PANE"):
+        env.pop(key, None)
+    base = [rmux, "-S", socket, "-f", "/dev/null"]
+    clients = []
+    stop = threading.Event()
+
+    def run(*args):
+        return subprocess.run(base + list(args), env=env, text=True,
+                              capture_output=True, timeout=10, check=True).stdout.strip()
+
+    def eventually(check):
+        for _ in range(100):
+            value = check()
+            if value:
+                return value
+            time.sleep(.05)
+        raise AssertionError("server state did not reach the expected value")
+
+    def listing():
+        return dict(line.split("\t") for line in run(
+            "list-clients", "-F", "#{client_name}\t#{session_id}").splitlines())
+
+    def attach(session):
+        before = set(listing())
+        pid, fd = pty.fork()
+        if pid == 0:
+            os.execve(rmux, base + ["attach-session", "-t", session], env)
+        clients.append((pid, fd))
+        fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 30, 120, 0, 0))
+
+        def drain():
+            while not stop.is_set():
+                if select.select([fd], [], [], .1)[0]:
+                    try:
+                        os.read(fd, 65536)
+                    except OSError:
+                        break
+        threading.Thread(target=drain, daemon=True).start()
+        return eventually(lambda: next(iter(set(listing()) - before), None))
+
+    def position(session):
+        return run("display-message", "-p", "-t", session, "#{window_id}.#{pane_id}")
+
+    def jump(client, pane):
+        session = listing()[client].lstrip("$")
+        command = shlex.join([
+            "env", f"RMUX={socket},0,{session}",
+            f"MUXA_RMUX_TEST_ENDPOINT={socket}", f"MUXA_RMUX_TEST_PANE={pane}",
+            f"MUXA_RMUX_TEST_CLIENT={client}", binary,
+            "--exact", "tests::popup_rmux_jump", "--ignored", "--nocapture",
+        ])
+        run("display-popup", "-c", client, "-E", command)
+
+    try:
+        for session in ("origin", "destination"):
+            run("new-session", "-d", "-s", session, "sleep 300")
+            run("new-window", "-d", "-t", session, "-n", "target", "sleep 300")
+            run("split-window", "-d", "-t", session + ":target", "sleep 300")
+        caller = attach("origin")
+        origin_id = listing()[caller]
+        target = run("list-panes", "-t", "destination:target", "-F", "#{pane_id}").splitlines()[-1]
+        target_position = run("display-message", "-p", "-t", target, "#{window_id}.#{pane_id}")
+
+        # A session-only switch kills the popup before select-window can run.
+        jump(caller, target)
+        eventually(lambda: position(listing()[caller]) == target_position)
+        destination_id = listing()[caller]
+        print("PASS cross-session popup jump", flush=True)
+
+        run("select-window", "-t", "destination:0")
+        jump(caller, target)
+        eventually(lambda: position(listing()[caller]) == target_position)
+        print("PASS same-session popup jump", flush=True)
+
+        run("switch-client", "-c", caller, "-t", origin_id)
+        other = attach("destination:0")
+        original_position = position(destination_id)
+        jump(caller, target)
+        view = eventually(lambda: listing()[caller] if listing()[caller] not in
+                          (origin_id, destination_id) else None)
+        eventually(lambda: position(view) == target_position)
+        assert listing()[other] == destination_id
+        assert position(destination_id) == original_position
+        eventually(lambda: run("show-options", "-v", "-t", view, "destroy-unattached") == "on")
+        run("detach-client", "-t", caller)
+        eventually(lambda: view not in run("list-sessions", "-F", "#{session_id}").splitlines())
+        print("PASS private view, other client preserved, view reaped on detach", flush=True)
+        caller = attach("origin")
+
+        run("set-option", "-t", destination_id, "@no_auto_view", "1")
+        jump(caller, target)
+        eventually(lambda: listing()[caller] == destination_id and
+                   position(destination_id) == target_position)
+        print("PASS explicit shared-session opt-out", flush=True)
+    finally:
+        subprocess.run(base + ["kill-server"], env=env, capture_output=True, timeout=10)
+        stop.set()
+        for pid, fd in clients:
+            os.close(fd)
+            os.waitpid(pid, 0)


### PR DESCRIPTION
Opening watch in an rmux popup and selecting a pane in another session moved the client to that session's previously active window. The session-only switch closes the invoking popup before the subsequent select-window and select-pane commands can execute.

Send one switch-client command with the exact session, window and pane. Prepare private grouped views without switching first, and register server-side cleanup hooks before the switch so popup termination cannot skip cleanup setup. A guard removes newly created views on preparation or switch failure.

Validation: 952 CLI tests passed (3 ignored), workspace Clippy with `-D warnings`, and formatting passed. `scripts/rmux-popup-jump-check.py` runs the actual Rust jump inside isolated rmux popups and verifies cross-session and same-session targets, private-view isolation, cleanup on detach, and explicit shared-session opt-out.

Known backend limitation: rmux 0.10 does not reap a destroy-unattached session when its last client switches to another session; it does reap on detach or when the option is explicitly reapplied. This PR fixes the popup interruption that previously left cleanup disabled, but does not fix that separate rmux switch-away cleanup defect.
