### PR TITLE
feat(collaboration): surface human decisions and recover interrupted peers

### DIFF
--- a/apps/muxa-macos/Sources/MuxaIPC.swift
+++ b/apps/muxa-macos/Sources/MuxaIPC.swift
@@ -804,6 +804,10 @@ struct MuxaCollaborationReply: Decodable, Hashable, Sendable {
 }
 
 struct MuxaCollaborationRequest: Decodable, Identifiable, Hashable, Sendable {
+    var humanAction: String? = nil
+    var needsHumanResponse: Bool {
+        to.console == true && expectsReply && kind != "notice" && ["queued", "claimed"].contains(status)
+    }
     let id: String
     let from: MuxaCollaborationParticipant
     let to: MuxaCollaborationParticipant
@@ -824,6 +828,7 @@ struct MuxaCollaborationRequest: Decodable, Identifiable, Hashable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case id, from, to, kind, body, status, reply
+        case humanAction = "human_action"
         case expectsReply = "expects_reply"
         case workMode = "work_mode"
         case createdAt = "created_at"

--- a/apps/muxa-macos/Sources/MuxaIPC.swift
+++ b/apps/muxa-macos/Sources/MuxaIPC.swift
@@ -803,7 +803,28 @@ struct MuxaCollaborationReply: Decodable, Hashable, Sendable {
     let at: String
 }
 
+struct MuxaPeerInterruption: Decodable, Hashable, Sendable {
+    let requestID: String
+    let reason: String
+    let active: Bool
+    let observedAt: String
+    let resetAt: String?
+    let actionRequestID: String?
+    let decision: MuxaCollaborationReply?
+    enum CodingKeys: String, CodingKey {
+        case reason, active, decision
+        case requestID = "request_id"
+        case observedAt = "observed_at"
+        case resetAt = "reset_at"
+        case actionRequestID = "action_request_id"
+    }
+}
+
 struct MuxaCollaborationRequest: Decodable, Identifiable, Hashable, Sendable {
+    var interruption: MuxaPeerInterruption? = nil
+    var peerInterrupted: Bool {
+        interruption?.active == true && interruption?.requestID == id && ["queued", "claimed"].contains(status)
+    }
     var humanAction: String? = nil
     var needsHumanResponse: Bool {
         to.console == true && expectsReply && kind != "notice" && ["queued", "claimed"].contains(status)
@@ -828,6 +849,7 @@ struct MuxaCollaborationRequest: Decodable, Identifiable, Hashable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case id, from, to, kind, body, status, reply
+        case interruption
         case humanAction = "human_action"
         case expectsReply = "expects_reply"
         case workMode = "work_mode"

--- a/apps/muxa-macos/Sources/WorkConsoleViews.swift
+++ b/apps/muxa-macos/Sources/WorkConsoleViews.swift
@@ -2627,9 +2627,9 @@ private struct CollaborationFlowGraph: View {
                     let start = step * (CGFloat(from) + 0.5)
                     let end = step * (CGFloat(to) + 0.5)
                     let y = CGFloat(index) * 48 + 42
-                    let color: Color = request.needsHumanResponse ? .orange : .blue
+                    let color: Color = (request.needsHumanResponse || request.peerInterrupted) ? .orange : .blue
                     context.stroke(arrow(from: start, to: end, y: y), with: .color(color), lineWidth: 1.5)
-                    let label = request.needsHumanResponse ? "Need you: \(request.humanAction ?? "information")" : request.kind
+                    let label = request.needsHumanResponse ? "Need you: \(request.humanAction ?? "information")" : (request.peerInterrupted ? "Interrupted: \(request.interruption?.reason ?? "unknown")" : request.kind)
                     context.draw(Text(label).font(.caption2).foregroundColor(color), at: CGPoint(x: (start + end) / 2, y: y - 9))
                     if request.reply != nil {
                         context.stroke(arrow(from: end, to: start, y: y + 18), with: .color(.green), style: StrokeStyle(lineWidth: 1, dash: [4, 2]))
@@ -2683,6 +2683,20 @@ private struct CollaborationRequestCard: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
+            if let recovery = request.interruption {
+                VStack(alignment: .leading, spacing: 4) {
+                    Label(recovery.active ? "Peer interrupted: \(recovery.reason)" : "Peer interruption cleared", systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(recovery.active ? .orange : .secondary)
+                    Text("Original request: \(recovery.requestID)").textSelection(.enabled)
+                    Text("Reset: \(recovery.resetAt ?? "unknown")")
+                    if let action = recovery.actionRequestID {
+                        Text("Recovery decision: \(action)").textSelection(.enabled)
+                    }
+                    if let decision = recovery.decision { Text("Decision (\(decision.status)): \(decision.body)") }
+                    Text("A decision does not automatically restart or reassign work.")
+                        .foregroundStyle(.secondary)
+                }.font(.caption)
+            }
             MarkdownContent(source: request.body, lineLimit: compact ? 2 : nil)
             if let response = request.reply {
                 if !compact {
@@ -2733,6 +2747,14 @@ private struct CollaborationReplyView: View {
             MarkdownContent(source: request.body)
                 .padding(10)
                 .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 7))
+            if request.needsHumanResponse && request.interruption != nil {
+                HStack {
+                    Button("Wait and recheck") { replyText = "Wait and recheck the original peer. Verify fresh health and progress before resuming." }
+                    Button("Safe handoff") { replyText = "Arrange a safe handoff within the existing scope. Verify no overlapping execution before reassignment." }
+                    Button("Stop attempt") { replyText = "Stop this work attempt using authorized controls and preserve existing artifacts." }
+                }
+                Text("Choose a draft, edit it, then Reply. This records your decision only.").font(.caption)
+            }
             Picker("Outcome", selection: $status) {
                 Text("Completed").tag("completed")
                 Text("Blocked").tag("blocked")

--- a/apps/muxa-macos/Sources/WorkConsoleViews.swift
+++ b/apps/muxa-macos/Sources/WorkConsoleViews.swift
@@ -2367,6 +2367,7 @@ private struct MuxaCollaborationView: View {
     }
 
     private enum MailboxTab: CaseIterable, Identifiable {
+        case human
         case incoming
         case sent
         var id: Self { self }
@@ -2390,7 +2391,7 @@ private struct MuxaCollaborationView: View {
     let mailboxRevision: UInt64?
     @State private var mailbox = MuxaCollaborationMailbox(incoming: [], sent: [])
     @State private var module: ModuleTab = .activity
-    @State private var tab: MailboxTab = .sent
+    @State private var tab: MailboxTab = .human
     @State private var displayMode: DisplayMode = .compact
     @State private var kind = "question"
     @State private var workMode = "read_only"
@@ -2401,7 +2402,11 @@ private struct MuxaCollaborationView: View {
     @State private var replyingTo: MuxaCollaborationRequest?
 
     private var requests: [MuxaCollaborationRequest] {
-        tab == .incoming ? mailbox.incoming : mailbox.sent
+        switch tab {
+        case .human: mailbox.incoming.filter { $0.needsHumanResponse }
+        case .incoming: mailbox.incoming.filter { $0.to.console != true }
+        case .sent: mailbox.sent
+        }
     }
 
     var body: some View {
@@ -2431,12 +2436,13 @@ private struct MuxaCollaborationView: View {
             case .activity:
                 HStack(spacing: 10) {
                     Picker("Mailbox", selection: $tab) {
-                        Text("Incoming \(mailbox.incoming.count)").tag(MailboxTab.incoming)
+                        Text("Need you \(mailbox.incoming.filter { $0.needsHumanResponse }.count)").tag(MailboxTab.human)
+                        Text("Agent inbox").tag(MailboxTab.incoming)
                         Text("Sent \(mailbox.sent.count)").tag(MailboxTab.sent)
                     }
                     .labelsHidden()
                     .pickerStyle(.segmented)
-                    .frame(width: 220)
+                    .frame(width: 310)
                     Spacer()
                     Picker("Density", selection: $displayMode) {
                         ForEach(DisplayMode.allCases) { item in Text(item.title).tag(item) }
@@ -2453,15 +2459,30 @@ private struct MuxaCollaborationView: View {
 
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: displayMode == .compact ? 4 : 9) {
+                        CollaborationFlowGraph(requests: mailbox.incoming + mailbox.sent)
                         if requests.isEmpty {
-                            Text(tab == .incoming ? "No incoming requests for this agent." : "No requests sent from the operator in this room.")
+                            Text(tab == .human ? "No requests need your response." : "No messages in this mailbox.")
                                 .foregroundStyle(.secondary)
                                 .frame(maxWidth: .infinity, minHeight: 90, alignment: .center)
                         } else {
                             ForEach(requests) { request in
+                                HStack {
+                                    Text(request.from.label)
+                                    Image(systemName: "arrow.right")
+                                    Text(request.to.label)
+                                    if request.reply != nil {
+                                        Image(systemName: "arrow.turn.down.left")
+                                        Text("Reply to \(request.from.label)")
+                                    }
+                                    if request.needsHumanResponse {
+                                        Label(request.humanAction ?? "information", systemImage: "person.crop.circle.badge.exclamationmark")
+                                            .foregroundStyle(.orange)
+                                    }
+                                }
+                                .font(.caption)
                                 CollaborationRequestCard(
                                     request: request,
-                                    incoming: tab == .incoming,
+                                    incoming: tab != .sent,
                                     compact: displayMode == .compact,
                                     claim: { Task { await claim() } },
                                     reply: { replyingTo = request }
@@ -2569,6 +2590,75 @@ private struct MuxaCollaborationView: View {
     }
 }
 
+/// A chronological participant graph. Request and reply arrows stay paired;
+/// human attention is a live property, not an interpretation of message text.
+private struct CollaborationFlowGraph: View {
+    let requests: [MuxaCollaborationRequest]
+
+    private var uniqueRequests: [MuxaCollaborationRequest] {
+        var seen = Set<String>()
+        return requests.sorted { $0.createdAt < $1.createdAt }
+            .filter { seen.insert($0.id).inserted }
+            .suffix(20).map { $0 }
+    }
+
+    var body: some View {
+        let rows = uniqueRequests
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Conversation flow · latest 20 requests")
+                .font(.caption).foregroundStyle(.secondary)
+            ScrollView(.horizontal) {
+            Canvas { context, size in
+                let participants = rows.flatMap { [$0.from, $0.to] }
+                var seen = Set<String>()
+                let nodes = participants.filter { seen.insert(identity($0)).inserted }
+                let step = size.width / CGFloat(max(nodes.count, 1))
+                for (index, node) in nodes.enumerated() {
+                    let x = step * (CGFloat(index) + 0.5)
+                    context.draw(Text(node.label).font(.caption2), at: CGPoint(x: x, y: 12))
+                    var lane = Path()
+                    lane.move(to: CGPoint(x: x, y: 25))
+                    lane.addLine(to: CGPoint(x: x, y: size.height))
+                    context.stroke(lane, with: .color(.gray.opacity(0.3)), style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
+                }
+                for (index, request) in rows.enumerated() {
+                    guard let from = nodes.firstIndex(where: { identity($0) == identity(request.from) }),
+                          let to = nodes.firstIndex(where: { identity($0) == identity(request.to) }) else { continue }
+                    let start = step * (CGFloat(from) + 0.5)
+                    let end = step * (CGFloat(to) + 0.5)
+                    let y = CGFloat(index) * 48 + 42
+                    let color: Color = request.needsHumanResponse ? .orange : .blue
+                    context.stroke(arrow(from: start, to: end, y: y), with: .color(color), lineWidth: 1.5)
+                    let label = request.needsHumanResponse ? "Need you: \(request.humanAction ?? "information")" : request.kind
+                    context.draw(Text(label).font(.caption2).foregroundColor(color), at: CGPoint(x: (start + end) / 2, y: y - 9))
+                    if request.reply != nil {
+                        context.stroke(arrow(from: end, to: start, y: y + 18), with: .color(.green), style: StrokeStyle(lineWidth: 1, dash: [4, 2]))
+                    }
+                }
+            }
+            .frame(width: CGFloat(max(Set(rows.flatMap { [identity($0.from), identity($0.to)] }).count, 2)) * 140, height: CGFloat(rows.count) * 48 + 30)
+            .accessibilityLabel("Request arrows point to recipients; dashed replies return to senders. Orange requests need your response.")
+            }
+        }
+    }
+
+    private func identity(_ participant: MuxaCollaborationParticipant) -> String {
+        if participant.console == true { return "operator" }
+        return "\(participant.room.host)|\(participant.socket ?? participant.room.socket ?? "default")|\(participant.agentSessionID)"
+    }
+
+    private func arrow(from: CGFloat, to: CGFloat, y: CGFloat) -> Path {
+        let direction: CGFloat = to >= from ? 1 : -1
+        var path = Path()
+        path.move(to: CGPoint(x: from, y: y))
+        path.addLine(to: CGPoint(x: to, y: y))
+        path.move(to: CGPoint(x: to - direction * 6, y: y - 4))
+        path.addLine(to: CGPoint(x: to, y: y))
+        path.addLine(to: CGPoint(x: to - direction * 6, y: y + 4))
+        return path
+    }
+}
+
 private struct CollaborationRequestCard: View {
     let request: MuxaCollaborationRequest
     let incoming: Bool
@@ -2606,10 +2696,10 @@ private struct CollaborationRequestCard: View {
             if incoming, request.reply == nil {
                 HStack {
                     Spacer()
-                    if request.status == "queued" {
+                    if request.status == "queued" && !request.needsHumanResponse {
                         Button("Claim", action: claim)
                     }
-                    if request.status == "claimed" {
+                    if request.status == "claimed" || request.needsHumanResponse {
                         Button("Reply…", action: reply)
                             .buttonStyle(.borderedProminent)
                     }

--- a/apps/muxa-macos/Tests/MuxaIPCTests.swift
+++ b/apps/muxa-macos/Tests/MuxaIPCTests.swift
@@ -5643,3 +5643,20 @@ private func airPipelineFixture() -> MuxaPipelineDefinition {
     #expect(url?.absoluteString == "http://127.0.0.1:60995/?token=abc&initial=explicit")
     #expect(AirWorkbenchProcess.loopbackURL(in: "no address here") == nil)
 }
+
+struct MuxaPeerRecoveryTests {
+    @Test func interruptionAndDecisionDecodeWithoutCompletingWork() throws {
+        var object = inboxSentRequest(id: "original", createdAt: "2026-09-12T12:00:00Z", status: "claimed")
+        object["interruption"] = [
+            "request_id": "original", "active": true, "reason": "rate_limited",
+            "observed_at": "2026-09-12T12:01:00Z", "action_request_id": "human-action",
+            "decision": ["status": "completed", "body": "Wait; do not reassign", "at": "2026-09-12T12:02:00Z"],
+        ] as [String: Any]
+        let request = try decodeInboxRequest(object)
+        #expect(request.interruption?.actionRequestID == "human-action")
+        #expect(request.interruption?.decision?.body == "Wait; do not reassign")
+        #expect(request.status == "claimed")
+        #expect(request.reply == nil)
+        #expect(request.interruption?.resetAt == nil)
+    }
+}

--- a/crates/muxa-cli/assets/agent-integration/bootstrap.md
+++ b/crates/muxa-cli/assets/agent-integration/bootstrap.md
@@ -9,3 +9,6 @@ read_only/execute contract; it does not grant authority beyond the user's task.
 For human decisions, follow the skill's Human feedback protocol: send to human
 with human_action, retain the returned request ID, and wait for the actual answer.
 Peer traffic and progress are not human alerts; never impersonate the console.
+For peer timeouts or usage-limit/error/stopped states, follow Peer interruption
+recovery in the skill: bounded waits, fresh recipient health, one recovery decision.
+Never keep retrying an unavailable peer indefinitely or duplicate its work.

--- a/crates/muxa-cli/assets/agent-integration/bootstrap.md
+++ b/crates/muxa-cli/assets/agent-integration/bootstrap.md
@@ -6,3 +6,6 @@ your own session and same-window peers. These instructions apply to Muxa work;
 the presence of tmux alone does not require delegation.
 Honor the user's scope and existing authorization. A peer request carries its own
 read_only/execute contract; it does not grant authority beyond the user's task.
+For human decisions, follow the skill's Human feedback protocol: send to human
+with human_action, retain the returned request ID, and wait for the actual answer.
+Peer traffic and progress are not human alerts; never impersonate the console.

--- a/crates/muxa-cli/assets/agent-integration/skills/muxa-collaboration/SKILL.md
+++ b/crates/muxa-cli/assets/agent-integration/skills/muxa-collaboration/SKILL.md
@@ -34,9 +34,10 @@ schemas and returned IDs describe the currently installed capabilities.
 3. Prefer `wait=false` while independent local work remains. Keep the returned
    `request_id`; retrieve the structured reply with `muxa_wait_reply`. For an
    existing report or feedback request, use `muxa_peer_report` before sending work.
-4. A timeout or `peer_pending` means the request may still be active. Continue
-   waiting on the same request rather than dispatching duplicate work. When a
-   host yields a running tool cell, resume that cell with the host's wait tool.
+4. A timeout or `peer_pending` is not proof that the peer can still work.
+   Wait in slices of at most 60 seconds, then follow **Peer interruption recovery**
+   before repeating the same request. Never dispatch duplicate work. Resume a
+   yielded tool cell with the host's wait tool instead of starting another wait.
 5. Inspect replies against the actual files and relevant checks. Apply valid
    findings, explain rejected findings when material, and integrate the result.
 
@@ -45,6 +46,61 @@ kind/work_mode/paths, and finish with one terminal `muxa_reply` (`completed`,
 `blocked`, `declined`, or `failed`). Include useful artifacts and verification.
 Do not treat idle status or terminal text as a durable completion report. Use
 `muxa_wait_for_change` for process state waits and mailbox tools for peer results.
+
+## Peer interruption recovery
+
+The coordinator owns recovery: a usage-limited agent may be unable to send any
+final reply. Before dispatch, retain the exact recipient identity and agree on
+an overall wait budget/checkpoint. Prefer `wait=false` and independent work;
+when awaiting results use `timeout_secs=60` or less, locally and in Fleet.
+A bounded call does not bound an unlimited sequence of repeated calls.
+
+After a timeout, or on an error/stopped notification, read the durable request
+first: a terminal reply wins. For an open request check fresh `muxa_status` for
+the recipient pane, matching its original agent kind/session and socket; use
+`muxa_fleet_status` for the exact returned host/pane_key on Fleet. The request's
+`to.state` is a dispatch-time snapshot, not a live health check. A reused pane
+is not the original recipient. Missing/offline observations mean unknown
+availability, not proof of a provider cap or that the remote process stopped.
+
+Use recorded `rate_limit_scope`, `rate_limit_source`, `rate_limited_until`, state
+and attention/error evidence. A utilization percentage alone is not proof that
+execution stopped. Do not classify every `error` as quota exhaustion or invent
+a reset time. `waiting_input`/`waiting_choice` may require an action; idle alone
+is neither completion nor proof of interruption. Known caps, errors, stopped
+sessions, repeated unavailability, or reaching the overall wait budget stop
+blind reply waits and require a recovery decision.
+
+Record one consolidated update on the original request with observed evidence,
+last progress/artifacts, reset time if known, and the next action. Do not send
+repeated prompts to the capped agent. If already authorized, continue independent
+work, arrange one bounded recheck near a known reset, or use a healthy peer.
+A reset timestamp is a recheck hint, not evidence of recovery: verify fresh state
+and actual progress before resuming. Do not leave a long blocking tool cell open
+until reset or claim to have scheduled a recheck without a real scheduler.
+
+Prevent duplicate execution before reassignment. Cancel a still-queued local
+request with `muxa_cancel_message` and verify success. Claimed requests cannot be
+cancelled by that tool; error/cap/offline status does not prevent later resumption.
+Use supported, authorized stop/handoff controls and verify the old worker cannot
+resume overlapping writes, or isolate the replacement in a separate worktree.
+Keep the old/new request IDs and artifacts linked in the thread. Never fabricate
+a reply as the unavailable peer or treat its failure as a successful review.
+
+If recovery needs a real user decision (wait, change provider, restart, or adjust
+scope/cost), send one `target="human"` request using the Human feedback protocol,
+with the original `parent_request_id` when supported. Include evidence, impact,
+options and recommendation. Reuse its ID while unresolved; do not create an alert
+for every timeout. Existing authorization counts; do not require another approval
+for an already-authorized recovery. On Fleet preserve the remote endpoint and use
+its supported transport; do not pass a remote request ID to local tools.
+
+If the coordinator is itself a recipient and can no longer complete its own work,
+reply `blocked` on that incoming request with the unavailable dependency and
+handoff evidence. Only do this when ending that attempt; keep it open during an
+active human decision. Never submit a terminal reply for someone else's work.
+If the coordinator is also capped, these instructions cannot execute; daemon
+notification/escalation is required for unattended recovery.
 
 ## Human feedback protocol
 

--- a/crates/muxa-cli/assets/agent-integration/skills/muxa-collaboration/SKILL.md
+++ b/crates/muxa-cli/assets/agent-integration/skills/muxa-collaboration/SKILL.md
@@ -99,8 +99,13 @@ If the coordinator is itself a recipient and can no longer complete its own work
 reply `blocked` on that incoming request with the unavailable dependency and
 handoff evidence. Only do this when ending that attempt; keep it open during an
 active human decision. Never submit a terminal reply for someone else's work.
-If the coordinator is also capped, these instructions cannot execute; daemon
-notification/escalation is required for unattended recovery.
+On upgraded daemons, `reason="peer_interrupted"` releases local/Fleet waits while
+keeping the work open. Read `interruption.action_request_id` and reuse that human
+request instead of creating another; `interruption.decision` carries the recorded
+answer, including refusals. The daemon escalates once if the coordinator is also
+unavailable or has not acknowledged with an update within two minutes. Recovery
+clears the interruption and withdraws unanswered daemon actions. Unknown/missing
+identities are not classified as caps; older hosts still need bounded checks.
 
 ## Human feedback protocol
 

--- a/crates/muxa-cli/assets/agent-integration/skills/muxa-collaboration/SKILL.md
+++ b/crates/muxa-cli/assets/agent-integration/skills/muxa-collaboration/SKILL.md
@@ -101,8 +101,11 @@ handoff evidence. Only do this when ending that attempt; keep it open during an
 active human decision. Never submit a terminal reply for someone else's work.
 On upgraded daemons, `reason="peer_interrupted"` releases local/Fleet waits while
 keeping the work open. Read `interruption.action_request_id` and reuse that human
-request instead of creating another; `interruption.decision` carries the recorded
-answer, including refusals. The daemon escalates once if the coordinator is also
+request instead of creating another. Original participants may read/wait for that
+action using `muxa_wait_reply` (or the matching Fleet endpoint), but may not answer
+it. Its completed reply is the human decision, not completion of the parent work.
+`interruption.decision` on the parent also carries the recorded answer, including
+refusals. The daemon escalates once if the coordinator is also
 unavailable or has not acknowledged with an update within two minutes. Recovery
 clears the interruption and withdraws unanswered daemon actions. Unknown/missing
 identities are not classified as caps; older hosts still need bounded checks.

--- a/crates/muxa-cli/assets/agent-integration/skills/muxa-collaboration/SKILL.md
+++ b/crates/muxa-cli/assets/agent-integration/skills/muxa-collaboration/SKILL.md
@@ -46,6 +46,43 @@ kind/work_mode/paths, and finish with one terminal `muxa_reply` (`completed`,
 Do not treat idle status or terminal text as a durable completion report. Use
 `muxa_wait_for_change` for process state waits and mailbox tools for peer results.
 
+## Human feedback protocol
+
+Separate agent communication from operator decisions. A pending peer request,
+review, retry, progress update, or a human-initiated task is not by itself a
+reason to notify the human. Use `muxa_update_request` for progress on the same
+request and the existing peer tools for agent work.
+
+When progress actually requires a human's approval, choice, or missing
+information, use `muxa_send_message` with `target="human"`, `kind="question"`,
+`expects_reply=true`, and `human_action="approval"`, `"choice"`, or
+`"information"`. Explain the exact decision, why it is required, available
+options, and your recommendation. Reuse existing authorization; never create
+an approval request for work the user already authorized.
+
+If this follows a collaboration request you participate in, include its exact
+`parent_request_id`; muxa inherits the thread. Otherwise omit the parent.
+Preserve work/workspace/run identity when known. Do not invent IDs. Keep the
+returned human `request_id` and wait with `muxa_wait_reply`; a timeout is not
+an answer, consent, or permission to send a duplicate question. Continue
+independent authorized work while waiting, but not work dependent on the answer.
+
+The operator answers in mailbox **Need you** (`e` in watch). Read the structured
+reply and its body: `completed` means an answer was submitted, not necessarily
+approval. Honor a refusal or cancellation. Resume only the work the answer
+permits and eventually reply on the original peer request. Do not mark that
+parent `blocked` merely to represent a temporary human wait: blocked is terminal.
+Agents must not impersonate the operator console, claim its inbox, or answer
+their own human request. Never use terminal input to simulate a human reply.
+
+Check installed tool schemas for `human_action`/`target="human"` support. If
+unavailable, ask through the user's existing conversation and report the missing
+capability; do not redirect the question to an agent or silently drop it.
+The CLI equivalent is `muxa msg send human "decision and context" --human-action
+choice --parent REQUEST_ID --json` (omit `--parent` when there is none).
+For a remote host, use the installed host's supported message transport and keep
+its endpoint with the request ID; do not assume a local ID resolves remotely.
+
 ## Authority and unavailable capabilities
 
 Existing explicit user authorization remains valid within the same scope; do not

--- a/crates/muxa-cli/assets/agent-integration/skills/muxa-collaboration/references/workflows.md
+++ b/crates/muxa-cli/assets/agent-integration/skills/muxa-collaboration/references/workflows.md
@@ -67,6 +67,18 @@ If a missing prerequisite ends this work attempt, return `blocked` and name it.
 While awaiting a human decision within an active attempt, keep the request open
 and use the Human decision protocol above instead of a terminal `blocked` reply.
 If asked to summarize "the peer's report", retrieve `muxa_peer_report`; do not
-ask the peer to repeat work. Long waits keep the same durable request ID even if
-the target pane disappears. Remote Fleet requests require an explicit host and
+ask the peer to repeat work. Keep the same durable request ID, but if the
+target disappears, follow Peer interruption recovery instead of blindly waiting. Remote Fleet requests require an explicit host and
 pane and obey the host's observe/control mode.
+
+## Interrupted peer example
+
+After `muxa_wait_reply(request_id=R, timeout_secs=60)` times out, check the durable
+record and fresh state for R's exact recipient. If it is capped, record the
+observed scope/reset and last artifacts with `muxa_update_request`. A reset time
+may be unknown. Use an already-authorized recovery when possible. Otherwise send
+one human choice request explaining "wait for reset / use a healthy provider",
+with `parent_request_id=R`, and retain its returned ID. Keep R open during that
+decision; a claimed R still requires verified stop/handoff or isolated work before
+reassignment. Resume only after checking fresh state and the operator's answer.
+For Fleet use its returned host/pane_key and the remote message endpoint.

--- a/crates/muxa-cli/assets/agent-integration/skills/muxa-collaboration/references/workflows.md
+++ b/crates/muxa-cli/assets/agent-integration/skills/muxa-collaboration/references/workflows.md
@@ -1,5 +1,35 @@
 # Workflow examples
 
+## Human decision during peer work
+
+While handling `req_review`, a reviewer discovers two mutually exclusive product
+requirements that the authorized task does not resolve. Send:
+
+```json
+{
+  "target": "human",
+  "kind": "question",
+  "expects_reply": true,
+  "human_action": "choice",
+  "parent_request_id": "req_review",
+  "body": "Choose A (preserve compatibility) or B (remove the legacy API). This changes the public contract, so I need your choice. Recommend A for this release."
+}
+```
+
+Use `muxa_send_message`, retain its returned ID (for example `req_decision`),
+then call `muxa_wait_reply(request_id="req_decision")`. Keep the original review
+open; continue independent checks. On timeout, wait on `req_decision` again.
+When the operator answers, inspect both status and body, implement only what
+the answer authorizes, then complete `req_review` with the verified result.
+These IDs are illustrative: always use actual returned IDs.
+
+Do not use `muxa_call_peer(target="human")`, `pane:console`, or `console=true`
+to create or answer an operator decision. A failed review, missing peer, or
+routine permission already granted by the user does not justify this flow.
+`approval` and `information` use the same protocol with their corresponding
+`human_action`. The dashboard/app shows the linked request and return reply;
+orange/Need you identifies an unresolved human request, not agent activity.
+
 ## Independent review
 
 For "@peer review the current changes", retrieve room context, then call
@@ -33,7 +63,9 @@ read-only review returns findings without changing files. An execute task edits
 only within its delegated scope and reports the checks run. Use `muxa_reply`
 once with the original request ID, terminal status, result, and artifacts.
 
-If prerequisites are missing, return `blocked` with the missing prerequisite.
+If a missing prerequisite ends this work attempt, return `blocked` and name it.
+While awaiting a human decision within an active attempt, keep the request open
+and use the Human decision protocol above instead of a terminal `blocked` reply.
 If asked to summarize "the peer's report", retrieve `muxa_peer_report`; do not
 ask the peer to repeat work. Long waits keep the same durable request ID even if
 the target pane disappears. Remote Fleet requests require an explicit host and

--- a/crates/muxa-cli/src/collab_screen.rs
+++ b/crates/muxa-cli/src/collab_screen.rs
@@ -587,6 +587,7 @@ mod tests {
 
     fn request(id: &str, from: Participant, to: Participant, body: &str) -> CollaborationRequest {
         CollaborationRequest {
+            interruption: None,
             human_action: None,
             initiator: None,
             updates: Vec::new(),

--- a/crates/muxa-cli/src/collab_screen.rs
+++ b/crates/muxa-cli/src/collab_screen.rs
@@ -587,6 +587,7 @@ mod tests {
 
     fn request(id: &str, from: Participant, to: Participant, body: &str) -> CollaborationRequest {
         CollaborationRequest {
+            human_action: None,
             initiator: None,
             updates: Vec::new(),
             id: id.into(),

--- a/crates/muxa-cli/src/dashboard_tui.rs
+++ b/crates/muxa-cli/src/dashboard_tui.rs
@@ -2909,6 +2909,7 @@ async fn collaboration_send(
     work_id: Option<String>,
 ) -> ActionOutcome {
     let request = NewRequest {
+        human_action: None,
         initiator: None,
         kind,
         body,
@@ -5288,6 +5289,7 @@ mod tests {
         now: OffsetDateTime,
     ) -> CollaborationRequest {
         CollaborationRequest {
+            human_action: None,
             initiator: None,
             updates: Vec::new(),
             id: id.into(),

--- a/crates/muxa-cli/src/dashboard_tui.rs
+++ b/crates/muxa-cli/src/dashboard_tui.rs
@@ -5289,6 +5289,7 @@ mod tests {
         now: OffsetDateTime,
     ) -> CollaborationRequest {
         CollaborationRequest {
+            interruption: None,
             human_action: None,
             initiator: None,
             updates: Vec::new(),

--- a/crates/muxa-cli/src/fleet_watch.rs
+++ b/crates/muxa-cli/src/fleet_watch.rs
@@ -144,12 +144,14 @@ enum InputMode {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 enum MailboxTab {
     #[default]
+    Human,
     Incoming,
     Sent,
 }
 
 #[derive(Debug, Clone, Default)]
 struct MailboxState {
+    human: Vec<CollaborationRequest>,
     open: bool,
     loading: bool,
     host: Option<String>,
@@ -872,6 +874,7 @@ impl App {
 
     fn mailbox_requests(&self) -> &[CollaborationRequest] {
         match self.mailbox.tab {
+            MailboxTab::Human => &self.mailbox.human,
             MailboxTab::Incoming => &self.mailbox.incoming,
             MailboxTab::Sent => &self.mailbox.sent,
         }
@@ -1172,6 +1175,12 @@ pub(crate) async fn run(
                     app.mailbox.loading = false;
                     match result {
                         Ok(result) => {
+                            app.mailbox.human = result
+                                .collaboration_incoming
+                                .iter()
+                                .filter(|request| request.needs_human_response())
+                                .cloned()
+                                .collect();
                             app.mailbox.incoming = result.collaboration_incoming;
                             app.mailbox.sent = result.collaboration_sent;
                             app.clamp_mailbox();
@@ -1365,6 +1374,7 @@ fn handle_key(
                             )
                         };
                         let request = NewRequest {
+                            human_action: None,
                             initiator: None,
                             kind: app.message_kind,
                             body: text,
@@ -1583,8 +1593,9 @@ fn handle_key(
             }
             KeyCode::Tab | KeyCode::BackTab => {
                 app.mailbox.tab = match app.mailbox.tab {
+                    MailboxTab::Human => MailboxTab::Incoming,
                     MailboxTab::Incoming => MailboxTab::Sent,
-                    MailboxTab::Sent => MailboxTab::Incoming,
+                    MailboxTab::Sent => MailboxTab::Human,
                 };
                 app.mailbox.selected = 0;
             }
@@ -2261,7 +2272,7 @@ fn claim_mailbox(
 }
 
 fn open_reply_composer(app: &mut App) {
-    if app.mailbox.tab != MailboxTab::Incoming {
+    if app.mailbox.tab == MailboxTab::Sent {
         app.status("switch to incoming requests to reply");
         return;
     }
@@ -2269,7 +2280,7 @@ fn open_reply_composer(app: &mut App) {
         app.status("no incoming request selected");
         return;
     };
-    if request.status == RequestStatus::Queued {
+    if request.status == RequestStatus::Queued && !request.needs_human_response() {
         app.status("press i to claim the request before replying");
         return;
     }
@@ -4027,6 +4038,14 @@ fn render_mailbox(frame: &mut Frame, area: Rect, app: &App) {
         .title(Line::from(vec![
             Span::styled(" mailbox ", theme.accent_badge()),
             Span::styled(
+                format!(" need you {} ", app.mailbox.human.len()),
+                if app.mailbox.tab == MailboxTab::Human {
+                    theme.action_badge()
+                } else {
+                    theme.dim_style()
+                },
+            ),
+            Span::styled(
                 format!(" incoming {} ", app.mailbox.incoming.len()),
                 if app.mailbox.tab == MailboxTab::Incoming {
                     theme.action_badge()
@@ -4045,7 +4064,9 @@ fn render_mailbox(frame: &mut Frame, area: Rect, app: &App) {
             ),
             Span::styled(format!(" · {target} "), theme.table_header_style()),
         ]))
-        .title_bottom(" Tab inbox/sent · j/k move · i claim · e reply · r refresh · M/Esc close ")
+        .title_bottom(
+            " Tab need you/agent inbox/sent · j/k move · e reply · r refresh · M/Esc close ",
+        )
         .borders(Borders::ALL)
         .border_type(theme.border_type)
         .border_style(theme.border_style());
@@ -4081,7 +4102,7 @@ fn render_mailbox(frame: &mut Frame, area: Rect, app: &App) {
                 "  "
             };
             let peer = match app.mailbox.tab {
-                MailboxTab::Incoming => request.from.label(),
+                MailboxTab::Human | MailboxTab::Incoming => request.from.label(),
                 MailboxTab::Sent => request.to.label(),
             };
             Row::new(vec![
@@ -4828,6 +4849,7 @@ mod tests {
 
     fn broadcast_request() -> NewRequest {
         NewRequest {
+            human_action: None,
             initiator: None,
             kind: RequestKind::Question,
             body: "coordinate this change".into(),

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -4280,6 +4280,7 @@ mod tests {
         status: RequestStatus,
     ) -> CollaborationRequest {
         CollaborationRequest {
+            interruption: None,
             human_action: None,
             initiator: None,
             updates: Vec::new(),

--- a/crates/muxa-cli/src/main.rs
+++ b/crates/muxa-cli/src/main.rs
@@ -393,6 +393,9 @@ enum MsgCmd {
     Send {
         target: String,
         body: String,
+        /// Decision required from the operator; use with target `human`.
+        #[arg(long, value_parser = ["approval", "choice", "information"])]
+        human_action: Option<String>,
         #[arg(long, default_value = "question")]
         kind: String,
         /// Stable conversation id used to group related requests and replies.
@@ -1685,6 +1688,7 @@ async fn cmd_msg(client: &Client, action: MsgCmd) -> Result<()> {
         MsgCmd::Send {
             target,
             body,
+            human_action,
             kind,
             thread,
             parent,
@@ -1706,6 +1710,9 @@ async fn cmd_msg(client: &Client, action: MsgCmd) -> Result<()> {
                     &origin,
                     &target,
                     &NewRequest {
+                        human_action: human_action
+                            .map(|value| serde_json::from_value(serde_json::Value::String(value)))
+                            .transpose()?,
                         initiator: None,
                         kind,
                         body,
@@ -4273,6 +4280,7 @@ mod tests {
         status: RequestStatus,
     ) -> CollaborationRequest {
         CollaborationRequest {
+            human_action: None,
             initiator: None,
             updates: Vec::new(),
             id: id.into(),

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -76,12 +76,12 @@ const MCP_SERVER_INSTRUCTIONS: &str = "Use muxa_guide for launch preferences, mu
     Use one muxa_wait_for_change(until=settled, include_capture). Resume yielded Codex cells with \
     host wait yield_time_ms=60000; never duplicate waits. Prefer muxa_call_peer(wait=false); \
     read the wake with muxa_wait_reply. Incoming: muxa_inbox, then one terminal muxa_reply. \
-    /name selects a message skill. Fleet tools address physical hosts: name host/pane and respect observe mode. \
+    /name selects a message skill. muxa_fleet_call_peer/muxa_fleet_wait_reply address hosts: name host/pane and respect observe mode. \
     Batch progress via muxa_update_request/muxa_fleet_update_request; read at checkpoints, wait with after_update. \
     Human decisions: muxa_send_message(target=human, kind=question, expects_reply=true, \
     human_action=approval|choice|information). Read the guide for threading and options. \
     Keep the request ID and parent open; muxa_wait_reply, then read the answer. \
-    Timeout/completion is not consent. Never impersonate the console or escalate routine peer traffic.";
+    Timeout/completion is not consent; never impersonate the console or escalate routine peer traffic.";
 
 /// How often `muxa_wait_for_change` reconciles against a fresh daemon
 /// snapshot while blocking on the transition stream. A broadcast lag on the

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -66,33 +66,22 @@ const FLEET_REPLY_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Sent to MCP hosts during initialization so collaboration is a first-class
 /// workflow rather than a capability the model has to infer from tool names.
-const MCP_SERVER_INSTRUCTIONS: &str = "muxa coordinates same-window peers. \
-    Use muxa_guide for launch preferences, muxa_room_context for identity/peers, \
-    and muxa_collaboration_guide for details. Reserved @peer/@muxa-peer requests for new \
-    work use muxa_call_peer; requests for an existing report use muxa_peer_report. \
-    Never substitute a GitHub/PR workflow without an explicit PR number or URL. Peer \
-    calls default to review + read_only. Never set execute=true or \
-    spawn_if_missing=true without explicit user authorization. Prior authorization within \
-    scope counts; do not ask again. Keep primary ownership \
-    and verify replies. Use muxa_start_work for a configured Work pipeline, \
-    muxa_start_agent for one agent, and muxa_manage_tmux for lifecycle; never invent \
-    raw tmux commands. Prefer pane-scoped muxa_status; no-argument status is compact \
-    unless full=true. For pane work, use one muxa_wait_for_change with until=settled \
-    and include_capture instead of polling status/capture. On Codex, if a long call \
-    yields a background cell, resume that same cell with the host wait function using \
-    yield_time_ms=60000; never start a second Muxa wait. For durable peer work prefer \
-    muxa_call_peer with wait=false: muxa wakes the idle sender when the reply is ready, \
-    then read it with muxa_wait_reply. Incoming notifications require muxa_inbox and \
-    exactly one terminal muxa_reply. A /name selects a registered message skill. \
-    muxa_fleet_call_peer/muxa_fleet_wait_reply are a separate physical-host plane: \
-    name host/pane explicitly and respect observe mode. Use muxa_fleet_update_request/muxa_update_request \
-    for batched guidance/progress; read updates at checkpoints and wait with after_update. \
-    Human decisions use muxa_send_message(target=human, kind=question, expects_reply=true, \
-    human_action=approval|choice|information), with parent_request_id when following an actual request. \
-    Explain the decision, options and recommendation. Keep the returned ID and use muxa_wait_reply; \
-    timeout is not consent and completed is not necessarily approval: read the answer. \
-    Peer traffic/progress must not trigger human requests. Reuse existing authorization, \
-    never impersonate the console, and keep the parent open while awaiting a human answer.";
+const MCP_SERVER_INSTRUCTIONS: &str = "Use muxa_guide for launch preferences, muxa_room_context for identity, \
+    muxa_collaboration_guide for protocols. @peer/@muxa-peer: new work uses muxa_call_peer; \
+    existing reports use muxa_peer_report. No GitHub/PR substitution without an explicit PR number or URL. \
+    Defaults: review + read_only. execute=true/spawn_if_missing=true require explicit user authorization; \
+    existing authorization counts. Retain ownership and verify replies. \
+    Use muxa_start_work for Work, muxa_start_agent for agents, muxa_manage_tmux for lifecycle; \
+    never invent raw tmux commands. Prefer pane-scoped muxa_status. \
+    Use one muxa_wait_for_change(until=settled, include_capture). Resume yielded Codex cells with \
+    host wait yield_time_ms=60000; never duplicate waits. Prefer muxa_call_peer(wait=false); \
+    read the wake with muxa_wait_reply. Incoming: muxa_inbox, then one terminal muxa_reply. \
+    /name selects a message skill. Fleet tools address physical hosts: name host/pane and respect observe mode. \
+    Batch progress via muxa_update_request/muxa_fleet_update_request; read at checkpoints, wait with after_update. \
+    Human decisions: muxa_send_message(target=human, kind=question, expects_reply=true, \
+    human_action=approval|choice|information). Read the guide for threading and options. \
+    Keep the request ID and parent open; muxa_wait_reply, then read the answer. \
+    Timeout/completion is not consent. Never impersonate the console or escalate routine peer traffic.";
 
 /// How often `muxa_wait_for_change` reconciles against a fresh daemon
 /// snapshot while blocking on the transition stream. A broadcast lag on the

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -70,7 +70,7 @@ const MCP_SERVER_INSTRUCTIONS: &str = "Use muxa_guide for launch preferences, mu
     muxa_collaboration_guide for protocols. @peer/@muxa-peer: new work uses muxa_call_peer; \
     existing reports use muxa_peer_report. No GitHub/PR substitution without an explicit PR number or URL. \
     Defaults: review + read_only. execute=true/spawn_if_missing=true require explicit user authorization; \
-    existing authorization counts. Retain ownership and verify replies. \
+    existing authorization counts. Cap/error recovery: read the guide; peer waits <=60s. \
     Use muxa_start_work for Work, muxa_start_agent for agents, muxa_manage_tmux for lifecycle; \
     never invent raw tmux commands. Prefer pane-scoped muxa_status. \
     Use one muxa_wait_for_change(until=settled, include_capture). Resume yielded Codex cells with \
@@ -701,7 +701,7 @@ fn tool_definitions(config: &muxa::config::Config) -> Vec<Value> {
         }),
         json!({
             "name": "muxa_fleet_wait_reply",
-            "description": "Continue waiting for the structured reply to a prior muxa_fleet_call_peer request. Pass the exact host, pane_key, and request_id returned by that call. The durable remote request remains readable even if the target pane has since exited. Remote hosts must remain explicitly configured mode='control'.",
+            "description": "Continue waiting for the structured reply to a prior muxa_fleet_call_peer request. Pass the exact host, pane_key, and request_id returned by that call. The durable remote request remains readable even if the target pane has since exited. Remote hosts must remain explicitly configured mode='control'. Use <=60-second waits and check fresh recipient/host health after timeout; follow peer_interruption in muxa_collaboration_guide.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -877,7 +877,7 @@ fn tool_definitions(config: &muxa::config::Config) -> Vec<Value> {
         }),
         json!({
             "name": "muxa_wait_reply",
-            "description": "Wait until a peer reviewer/subagent request reaches a terminal status and return its structured reply. Verify findings or edits before integrating them. Default 30 seconds, max 600.",
+            "description": "Wait until a peer reviewer/subagent request reaches a terminal status and return its structured reply. Verify findings or edits before integrating them. Default 30 seconds, max 600. Prefer <=60 seconds; after timeout check fresh recipient health and follow peer_interruption in muxa_collaboration_guide. Never repeat waits indefinitely.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -1601,6 +1601,18 @@ fn collaboration_guide(room: RoomContext, config: &muxa::config::Config) -> Valu
         "user_launch_preferences": launch_guide_value(config),
         "next_step": next_step,
         "workflows": {
+            "peer_interruption": {
+                "wait_slice_secs": 60,
+                "owner": "The coordinator owns recovery; a capped peer may never send a reply. Set an overall wait budget; never renew timed-out waits blindly.",
+                "health": "Read the durable reply first, then fresh muxa_status for the exact recipient agent/session/socket or muxa_fleet_status for the returned host/pane_key. Request to.state is stale. Missing/offline is unknown availability, not proof of a cap or process exit.",
+                "evidence": ["state", "rate_limit_scope", "rate_limit_source", "rate_limited_until", "last_notification"],
+                "trigger": "Known cap/error/stopped, repeated unavailability, or exhausted overall budget requires a recovery decision. Utilization alone is insufficient; reset time is only a recheck hint.",
+                "recovery": "Record one update with evidence/artifacts. Use authorized independent work, one bounded reset recheck, or a healthy peer. Verify current health and progress; do not repeatedly prompt the capped agent.",
+                "handoff": "Cancel queued local requests with muxa_cancel_message and verify success. Claimed requests need supported authorized stop/handoff or isolated replacement work; a cap/offline state does not prevent resumption. Preserve request/thread identities and never impersonate the peer.",
+                "human": "Only if a real choice/approval/information is needed, follow human_feedback with one linked request; reuse its ID and existing authorization. Preserve remote endpoint identity.",
+                "completion": "Do not fabricate the peer reply. If ending your own incoming attempt, reply blocked with dependency/handoff evidence; keep it open during an active human decision.",
+                "limitation": "Waits currently observe durable replies, not live health. Instructions require a running coordinator; if it is capped too, unattended recovery needs daemon escalation."
+            },
             "human_feedback": {
                 "when": "Only when an actual operator approval, choice, or missing information is required; never for routine peer traffic or already-authorized work.",
                 "tool": "muxa_send_message",
@@ -4007,6 +4019,21 @@ mod tests {
         .unwrap();
 
         let guide = collaboration_guide(room, &muxa::config::Config::default());
+        let recovery = &guide["workflows"]["peer_interruption"];
+        assert_eq!(recovery["wait_slice_secs"], 60);
+        assert!(recovery["health"]
+            .as_str()
+            .unwrap()
+            .contains("to.state is stale"));
+        assert!(recovery["handoff"]
+            .as_str()
+            .unwrap()
+            .contains("Claimed requests"));
+        assert!(recovery["human"].as_str().unwrap().contains("reuse its ID"));
+        assert!(recovery["limitation"]
+            .as_str()
+            .unwrap()
+            .contains("running coordinator"));
         let human = &guide["workflows"]["human_feedback"];
         assert_eq!(human["tool"], "muxa_send_message");
         assert_eq!(human["request"]["target"], "human");

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -86,7 +86,13 @@ const MCP_SERVER_INSTRUCTIONS: &str = "muxa coordinates same-window peers. \
     exactly one terminal muxa_reply. A /name selects a registered message skill. \
     muxa_fleet_call_peer/muxa_fleet_wait_reply are a separate physical-host plane: \
     name host/pane explicitly and respect observe mode. Use muxa_fleet_update_request/muxa_update_request \
-    for batched guidance/progress; read updates at checkpoints and wait with after_update.";
+    for batched guidance/progress; read updates at checkpoints and wait with after_update. \
+    Human decisions use muxa_send_message(target=human, kind=question, expects_reply=true, \
+    human_action=approval|choice|information), with parent_request_id when following an actual request. \
+    Explain the decision, options and recommendation. Keep the returned ID and use muxa_wait_reply; \
+    timeout is not consent and completed is not necessarily approval: read the answer. \
+    Peer traffic/progress must not trigger human requests. Reuse existing authorization, \
+    never impersonate the console, and keep the parent open while awaiting a human answer.";
 
 /// How often `muxa_wait_for_change` reconciles against a fresh daemon
 /// snapshot while blocking on the transition stream. A broadcast lag on the
@@ -818,10 +824,11 @@ fn tool_definitions(config: &muxa::config::Config) -> Vec<Value> {
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "target": { "type": "string", "description": "peer, pane:%N, %N, @alias, or role:<name>" },
+                    "target": { "type": "string", "description": "peer, pane:%N, %N, @alias, role:<name>, or human for an operator decision" },
                     "kind": { "type": "string", "enum": ["question", "review", "task", "notice"] },
                     "body": { "type": "string" },
                     "expects_reply": { "type": "boolean", "description": "Default true except notice." },
+                    "human_action": { "type": "string", "enum": ["approval", "choice", "information"], "description": "Use target human only when an operator decision is required. Explain the question, choices and recommendation in body. Internal agent requests must omit this." },
                     "work_mode": { "type": "string", "enum": ["read_only", "execute"], "description": "Default read_only." },
                     "paths": { "type": "array", "items": { "type": "string" }, "description": "Advisory path scope for execute work." },
                     "thread_id": { "type": "string", "description": "Stable id shared by one causal conversation. Omit for a root request; muxa assigns its request id. When parent_request_id is set, this must match the parent's canonical thread." },
@@ -1605,6 +1612,17 @@ fn collaboration_guide(room: RoomContext, config: &muxa::config::Config) -> Valu
         "user_launch_preferences": launch_guide_value(config),
         "next_step": next_step,
         "workflows": {
+            "human_feedback": {
+                "when": "Only when an actual operator approval, choice, or missing information is required; never for routine peer traffic or already-authorized work.",
+                "tool": "muxa_send_message",
+                "request": { "target": "human", "kind": "question", "expects_reply": true, "human_action": "choice" },
+                "actions": ["approval", "choice", "information"],
+                "context": "Include the exact decision, why required, options and recommendation. Include parent_request_id only for an existing request you participate in; inherit its thread and preserve known work identity.",
+                "wait": "Retain the returned request_id and use muxa_wait_reply. Continue independent work; never treat a timeout as consent or create duplicate questions. Keep the original peer request open while waiting.",
+                "answer": "The human answers in Need you (watch: e). Read status and body; completed is not necessarily approval. Honor refusal/cancellation and complete the original peer request after authorized work.",
+                "identity": "Never use console=true or claim/answer the operator inbox as an agent.",
+                "fallback": "If the installed schema lacks human_action, ask in the existing user conversation. Do not silently drop the question or redirect it to a peer."
+            },
             "reviewer": {
                 "when": "After implementation, self-review, and relevant tests; before declaring important work complete.",
                 "request": {
@@ -2941,6 +2959,13 @@ fn new_request_from_args(
     air_artifacts: Vec<AirArtifactReference>,
 ) -> std::result::Result<NewRequest, String> {
     Ok(NewRequest {
+        human_action: args
+            .get("human_action")
+            .map(|value| {
+                serde_json::from_value(value.clone())
+                    .map_err(|error| format!("invalid human_action: {error}"))
+            })
+            .transpose()?,
         initiator: None,
         kind,
         body,
@@ -3993,6 +4018,26 @@ mod tests {
         .unwrap();
 
         let guide = collaboration_guide(room, &muxa::config::Config::default());
+        let human = &guide["workflows"]["human_feedback"];
+        assert_eq!(human["tool"], "muxa_send_message");
+        assert_eq!(human["request"]["target"], "human");
+        assert_eq!(human["request"]["expects_reply"], true);
+        let input = new_request_from_args(
+            &human["request"],
+            RequestKind::Question,
+            "Choose A or B".into(),
+            true,
+            WorkMode::ReadOnly,
+            vec![],
+            vec![],
+        )
+        .unwrap();
+        assert_eq!(
+            input.human_action,
+            Some(muxa::collaboration::HumanAction::Choice)
+        );
+        assert!(human["wait"].as_str().unwrap().contains("muxa_wait_reply"));
+        assert!(MCP_SERVER_INSTRUCTIONS.contains("never impersonate the console"));
         assert_eq!(guide["room"]["peers"][0]["pane"], "%2");
         assert_eq!(guide["workflows"]["reviewer"]["request"]["kind"], "review");
         assert_eq!(

--- a/crates/muxa-cli/src/mcp.rs
+++ b/crates/muxa-cli/src/mcp.rs
@@ -1611,7 +1611,7 @@ fn collaboration_guide(room: RoomContext, config: &muxa::config::Config) -> Valu
                 "handoff": "Cancel queued local requests with muxa_cancel_message and verify success. Claimed requests need supported authorized stop/handoff or isolated replacement work; a cap/offline state does not prevent resumption. Preserve request/thread identities and never impersonate the peer.",
                 "human": "Only if a real choice/approval/information is needed, follow human_feedback with one linked request; reuse its ID and existing authorization. Preserve remote endpoint identity.",
                 "completion": "Do not fabricate the peer reply. If ending your own incoming attempt, reply blocked with dependency/handoff evidence; keep it open during an active human decision.",
-                "limitation": "Waits currently observe durable replies, not live health. Instructions require a running coordinator; if it is capped too, unattended recovery needs daemon escalation."
+                "limitation": "Upgraded daemons return peer_interrupted without completing work. A running coordinator handles recovery first; if unavailable or unacknowledged for two minutes the daemon creates one durable human action. Reuse interruption.action_request_id; inspect interruption.decision without interpreting completion as consent. Older hosts still need bounded health checks."
             },
             "human_feedback": {
                 "when": "Only when an actual operator approval, choice, or missing information is required; never for routine peer traffic or already-authorized work.",
@@ -1922,7 +1922,13 @@ async fn call_peer(client: &Client, args: &Value, config: &muxa::config::Config)
     match await_collaboration_reply(client, &origin, &sent.id, timeout_secs).await {
         Ok(Some(request)) => {
             let mut payload = common;
-            payload["completed"] = json!(true);
+            payload["completed"] = json!(request.status.is_terminal());
+            payload["interruption"] = json!(request.interruption);
+            payload["reason"] = json!(if request.peer_interrupted() {
+                "peer_interrupted"
+            } else {
+                "terminal"
+            });
             payload["status"] = json!(request.status);
             payload["reply"] = json!(request.reply);
             json_result(&payload)
@@ -2052,9 +2058,21 @@ async fn fleet_call_peer(
     match await_fleet_collaboration_reply(client, host, &pane_key, &sent.id, timeout_secs, None)
         .await
     {
+        Ok(Some(request)) if request.peer_interrupted() && !request.status.is_terminal() => {
+            let mut payload = request_outcome(&request);
+            payload["host"] = json!(host);
+            payload["pane_key"] = json!(pane_key);
+            json_result(&payload)
+        }
         Ok(Some(request)) if request.status.is_terminal() => {
             let mut payload = common;
-            payload["completed"] = json!(true);
+            payload["completed"] = json!(request.status.is_terminal());
+            payload["interruption"] = json!(request.interruption);
+            payload["reason"] = json!(if request.peer_interrupted() {
+                "peer_interrupted"
+            } else {
+                "terminal"
+            });
             payload["status"] = json!(request.status);
             payload["reply"] = json!(request.reply);
             json_result(&payload)
@@ -2148,6 +2166,12 @@ async fn fleet_wait_reply(client: &Client, args: &Value) -> Value {
     )
     .await
     {
+        Ok(Some(request)) if request.peer_interrupted() && !request.status.is_terminal() => {
+            let mut payload = request_outcome(&request);
+            payload["host"] = json!(host);
+            payload["pane_key"] = json!(pane_key);
+            json_result(&payload)
+        }
         Ok(Some(request)) if request.status.is_terminal() => json_result(&json!({
             "completed": true,
             "host": host,
@@ -2255,7 +2279,7 @@ async fn await_fleet_collaboration_reply(
         let request = *result
             .collaboration_request
             .ok_or_else(|| "Fleet collaboration get returned no request".to_string())?;
-        let terminal = request.status.is_terminal();
+        let terminal = request.status.is_terminal() || request.peer_interrupted();
         current = Some(request);
         let updated = after_update.is_some_and(|seen| {
             current
@@ -2830,7 +2854,7 @@ async fn await_collaboration_reply(
         .collaboration_wait(origin, request_id, timeout_secs)
         .await
         .map_err(|error| error.to_string())?;
-    Ok(request.status.is_terminal().then_some(request))
+    Ok((request.status.is_terminal() || request.peer_interrupted()).then_some(request))
 }
 
 fn current_collaboration_origin() -> std::result::Result<CollaborationOrigin, String> {
@@ -3019,7 +3043,9 @@ async fn wait_for_reply(client: &Client, args: &Value) -> Value {
         .collaboration_wait(&origin, request_id, timeout_secs)
         .await
     {
-        Ok(request) if request.status.is_terminal() => json_result(&request_outcome(&request)),
+        Ok(request) if request.status.is_terminal() || request.peer_interrupted() => {
+            json_result(&request_outcome(&request))
+        }
         Ok(_) => json_result(&json!({
             "completed": false,
             "reason": "timeout",
@@ -3546,7 +3572,12 @@ fn request_ack(request: &CollaborationRequest) -> Value {
 /// provenance, and timestamps. The structured reply is the new information.
 fn request_outcome(request: &CollaborationRequest) -> Value {
     let mut value = request_ack(request);
-    value["completed"] = json!(true);
+    value["completed"] = json!(request.status.is_terminal());
+    if request.peer_interrupted() {
+        value["reason"] = json!("peer_interrupted");
+        value["interruption"] = json!(request.interruption);
+        value["next_step"] = json!("Stop blind waits. Read the existing human action/decision if present; otherwise follow peer_interruption recovery and acknowledge via muxa_update_request. Do not duplicate work or impersonate the peer.");
+    }
     value["reply"] = json!(request.reply);
     value
 }

--- a/crates/muxa-cli/src/relay.rs
+++ b/crates/muxa-cli/src/relay.rs
@@ -452,11 +452,13 @@ async fn handle_request(
             exact_backend(&backends, &pane).await?;
             let agent = collaboration_origin(&pane, false);
             let console = collaboration_origin(&pane, true);
-            let (incoming, sent) = tokio::try_join!(
+            let (mut incoming, sent, human) = tokio::try_join!(
                 client.collaboration_list(&agent, RequestMailbox::Incoming),
                 client.collaboration_list(&console, RequestMailbox::Sent),
+                client.collaboration_list(&console, RequestMailbox::Incoming),
             )
             .context("reading collaboration mailbox")?;
+            incoming.extend(human);
             Ok(RelayFrame::Result {
                 request_id,
                 result: FleetCommandResult::collaboration_mailbox(incoming, sent),
@@ -516,6 +518,17 @@ async fn handle_request(
         } => {
             exact_backend(&backends, &pane).await?;
             let agent = collaboration_origin(&pane, false);
+            let stored = client
+                .collaboration_get(
+                    &collaboration_origin(&pane, true),
+                    &collaboration_request_id,
+                )
+                .await?;
+            let agent = if stored.to.console {
+                collaboration_origin(&pane, true)
+            } else {
+                agent
+            };
             let request = client
                 .collaboration_reply(&agent, &collaboration_request_id, status, &body, &[], &[])
                 .await

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -20298,6 +20298,7 @@ mod tests {
     ) -> CollaborationRequest {
         let now = OffsetDateTime::now_utc();
         CollaborationRequest {
+            interruption: None,
             human_action: None,
             initiator: None,
             updates: Vec::new(),
@@ -27532,6 +27533,7 @@ sort = ["state"]
 
     fn collab_request(to_pane: &str) -> CollaborationRequest {
         CollaborationRequest {
+            interruption: None,
             human_action: None,
             initiator: None,
             updates: Vec::new(),

--- a/crates/muxa-cli/src/watch.rs
+++ b/crates/muxa-cli/src/watch.rs
@@ -2529,6 +2529,7 @@ fn persist_watch_collab_layout(
 
 #[derive(Debug, Clone, Default)]
 struct WatchCollaboration {
+    human: Vec<CollaborationRequest>,
     origin: Option<CollaborationOrigin>,
     room: Option<RoomContext>,
     /// The agent whose inbox `incoming` holds — the row under the cursor when
@@ -2630,6 +2631,7 @@ impl WatchCollaboration {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 enum CollaborationMailboxTab {
     #[default]
+    Human,
     Incoming,
     Sent,
 }
@@ -7680,6 +7682,7 @@ pub async fn run(
     // forces the first in-loop frame; `Instant::now()` seeds the cadence.
     let mut needs_render = true;
     let mut last_render = std::time::Instant::now();
+    let mut last_mailbox_refresh = std::time::Instant::now();
 
     loop {
         // Animate on a fast cadence only while there's something to move:
@@ -8417,6 +8420,14 @@ pub async fn run(
             }
         }
 
+        if app.collaboration_mailbox.open
+            && last_mailbox_refresh.elapsed() >= Duration::from_secs(2)
+        {
+            refresh_watch_collaboration(client, &mut app).await;
+            last_mailbox_refresh = std::time::Instant::now();
+            needs_render = true;
+        }
+
         if quit {
             break;
         }
@@ -8606,6 +8617,10 @@ async fn refresh_watch_collaboration(client: &Client, app: &mut App) {
                 | None => None,
             };
             app.collaboration = WatchCollaboration {
+                human: requests
+                    .into_iter()
+                    .filter(CollaborationRequest::needs_human_response)
+                    .collect(),
                 origin: Some(origin),
                 room: Some(room),
                 history_scope,
@@ -8614,7 +8629,7 @@ async fn refresh_watch_collaboration(client: &Client, app: &mut App) {
                 sent,
                 unavailable: None,
             };
-            if aggregate {
+            if aggregate && app.collaboration_mailbox.tab != CollaborationMailboxTab::Human {
                 app.collaboration_mailbox.tab = CollaborationMailboxTab::Incoming;
             }
         }
@@ -9264,6 +9279,7 @@ async fn run_watch_collaboration_broadcast(
     for (pane, label) in recipients {
         let pane = pane.clone();
         let request = NewRequest {
+            human_action: None,
             initiator: None,
             kind,
             body: body.clone(),
@@ -9324,6 +9340,7 @@ async fn run_watch_collaboration_single(
                 }
             };
             let request = NewRequest {
+                human_action: None,
                 initiator: None,
                 kind,
                 body: composer.input,
@@ -9376,6 +9393,7 @@ async fn run_watch_collaboration_single(
 
 fn collaboration_requests(app: &App) -> &[CollaborationRequest] {
     match app.collaboration_mailbox.tab {
+        CollaborationMailboxTab::Human => &app.collaboration.human,
         CollaborationMailboxTab::Incoming => &app.collaboration.incoming,
         CollaborationMailboxTab::Sent => &app.collaboration.sent,
     }
@@ -9409,8 +9427,9 @@ fn move_collaboration_mailbox(app: &mut App, delta: isize) {
 
 fn toggle_collaboration_mailbox(app: &mut App) {
     app.collaboration_mailbox.tab = match app.collaboration_mailbox.tab {
+        CollaborationMailboxTab::Human => CollaborationMailboxTab::Incoming,
         CollaborationMailboxTab::Incoming => CollaborationMailboxTab::Sent,
-        CollaborationMailboxTab::Sent => CollaborationMailboxTab::Incoming,
+        CollaborationMailboxTab::Sent => CollaborationMailboxTab::Human,
     };
     app.collaboration_mailbox.selected = 0;
 }
@@ -11629,10 +11648,13 @@ fn handle_collaboration_mailbox_event(code: KeyCode, app: &mut App) -> Action {
         }
         KeyCode::Char('m') => Action::OpenCollaborationMessage,
         KeyCode::Tab | KeyCode::BackTab if aggregate => {
-            app.set_hint(
-                "aggregate history already includes both directions",
-                HintLevel::Ok,
-            );
+            app.collaboration_mailbox.tab =
+                if app.collaboration_mailbox.tab == CollaborationMailboxTab::Human {
+                    CollaborationMailboxTab::Incoming
+                } else {
+                    CollaborationMailboxTab::Human
+                };
+            app.collaboration_mailbox.selected = 0;
             Action::None
         }
         KeyCode::Tab | KeyCode::BackTab => {
@@ -11654,10 +11676,19 @@ fn handle_collaboration_mailbox_event(code: KeyCode, app: &mut App) -> Action {
             app.set_hint(format!("mailbox detail: {label}"), HintLevel::Ok);
             Action::None
         }
-        KeyCode::Char('i' | 'e') if aggregate => {
+        KeyCode::Char('i' | 'e')
+            if aggregate && app.collaboration_mailbox.tab != CollaborationMailboxTab::Human =>
+        {
             app.set_hint(
                 "session/window history is read-only; select an exact recipient pane",
                 HintLevel::Warn,
+            );
+            Action::None
+        }
+        KeyCode::Char('i') if app.collaboration_mailbox.tab == CollaborationMailboxTab::Human => {
+            app.set_hint(
+                "press e to answer the selected human request",
+                HintLevel::Ok,
             );
             Action::None
         }
@@ -11672,6 +11703,25 @@ fn handle_collaboration_mailbox_event(code: KeyCode, app: &mut App) -> Action {
 }
 
 fn open_watch_collaboration_reply_composer(app: &mut App) {
+    if app.collaboration_mailbox.tab == CollaborationMailboxTab::Human {
+        if let (Some(request), Some(origin)) = (
+            selected_collaboration_request(app),
+            app.collaboration.origin.clone(),
+        ) {
+            app.collaboration_composer = Some(CollaborationComposer::new(
+                CollaborationComposeTarget::Reply {
+                    origin: CollaborationOrigin {
+                        console: true,
+                        ..origin
+                    },
+                    request_id: request.id.clone(),
+                    status: RequestStatus::Completed,
+                },
+                format!("reply to {}", request.from.label()),
+            ));
+        }
+        return;
+    }
     if app.collaboration_mailbox.tab != CollaborationMailboxTab::Incoming {
         app.set_hint("switch to incoming requests to reply", HintLevel::Err);
         return;
@@ -13488,6 +13538,15 @@ fn render_collaboration_mailbox(f: &mut Frame, area: Rect, app: &App) {
 
 fn collaboration_mailbox_title(app: &App, theme: WatchThemeSpec) -> Line<'static> {
     let tab = app.collaboration_mailbox.tab;
+    if tab == CollaborationMailboxTab::Human {
+        return Line::from(vec![
+            Span::styled(
+                format!(" need your response {} ", app.collaboration.human.len()),
+                theme.action_badge(),
+            ),
+            Span::raw(" Tab: agent traffic · e: reply "),
+        ]);
+    }
     let owner = app
         .collaboration
         .history_scope
@@ -13500,6 +13559,17 @@ fn collaboration_mailbox_title(app: &App, theme: WatchThemeSpec) -> Line<'static
         .is_some_and(MailboxHistoryScope::aggregate);
     let mut spans = vec![
         Span::styled(" messages ", theme.accent_badge()),
+        Span::styled(
+            format!(
+                " need you {} · Tab to switch ",
+                app.collaboration.human.len()
+            ),
+            if tab == CollaborationMailboxTab::Human {
+                theme.action_badge()
+            } else {
+                theme.dim_style()
+            },
+        ),
         Span::raw(" "),
     ];
     if read_only {
@@ -13606,6 +13676,7 @@ fn collaboration_mailbox_request_lines(
     if painted.is_empty() {
         return vec![Line::from(Span::styled(
             match tab {
+                CollaborationMailboxTab::Human => "no requests need your response",
                 CollaborationMailboxTab::Incoming => "no incoming requests",
                 CollaborationMailboxTab::Sent => "no sent requests",
             },
@@ -13699,7 +13770,9 @@ fn collaboration_mailbox_request_lines_for_request(
         format!("{} → {}", request.from.label(), request.to.label())
     } else {
         match tab {
-            CollaborationMailboxTab::Incoming => request.from.label(),
+            CollaborationMailboxTab::Human | CollaborationMailboxTab::Incoming => {
+                request.from.label()
+            }
             CollaborationMailboxTab::Sent => request.to.label(),
         }
     };
@@ -17863,6 +17936,15 @@ fn render_contextual_footer(f: &mut Frame, area: Rect, app: &App, theme: WatchTh
     }
 
     if app.collaboration_mailbox.open {
+        if app.collaboration_mailbox.tab == CollaborationMailboxTab::Human {
+            f.render_widget(
+                Paragraph::new(
+                    "j/k select · e reply as operator · Tab agent traffic · r refresh · M close",
+                ),
+                area,
+            );
+            return true;
+        }
         let aggregate = app
             .collaboration
             .history_scope
@@ -20216,6 +20298,7 @@ mod tests {
     ) -> CollaborationRequest {
         let now = OffsetDateTime::now_utc();
         CollaborationRequest {
+            human_action: None,
             initiator: None,
             updates: Vec::new(),
             id: id.into(),
@@ -20363,6 +20446,7 @@ mod tests {
     #[test]
     fn session_mailbox_leads_with_human_window_names_and_message_summaries() {
         let mut app = collaboration_watch_app();
+        app.collaboration_mailbox.tab = CollaborationMailboxTab::Incoming;
         app.collaboration.history_scope = Some(MailboxHistoryScope::Session {
             key: SessionKey {
                 endpoint: BackendEndpoint {
@@ -22298,8 +22382,36 @@ mod tests {
     }
 
     #[test]
+    fn human_mailbox_defaults_to_operator_and_replies_without_agent_claim() {
+        let mut app = collaboration_watch_app();
+        assert_eq!(
+            app.collaboration_mailbox.tab,
+            CollaborationMailboxTab::Human
+        );
+        let room = app.collaboration.room.as_ref().unwrap();
+        let mut request = fake_watch_collaboration_request(
+            "human_question",
+            room.peers[0].clone(),
+            Participant::console(room.current.room.clone()),
+            RequestStatus::Queued,
+        );
+        request.expects_reply = true;
+        app.collaboration.human.push(request);
+        open_watch_collaboration_reply_composer(&mut app);
+        assert!(
+            matches!(app.collaboration_composer.as_ref().map(|c| &c.target), Some(CollaborationComposeTarget::Reply { origin, request_id, .. }) if origin.console && request_id == "human_question")
+        );
+        toggle_collaboration_mailbox(&mut app);
+        assert_eq!(
+            app.collaboration_mailbox.tab,
+            CollaborationMailboxTab::Incoming
+        );
+    }
+
+    #[test]
     fn watch_mailbox_opens_reply_for_claimed_incoming_request() {
         let mut app = collaboration_watch_app();
+        app.collaboration_mailbox.tab = CollaborationMailboxTab::Incoming;
         let room = app.collaboration.room.as_ref().unwrap();
         app.collaboration
             .incoming
@@ -22338,6 +22450,7 @@ mod tests {
     #[test]
     fn watch_mailbox_render_contains_request_and_peer() {
         let mut app = collaboration_watch_app();
+        app.collaboration_mailbox.tab = CollaborationMailboxTab::Incoming;
         let room = app.collaboration.room.as_ref().unwrap();
         let mut request = fake_watch_collaboration_request(
             "req_watch_render_123456",
@@ -27419,6 +27532,7 @@ sort = ["state"]
 
     fn collab_request(to_pane: &str) -> CollaborationRequest {
         CollaborationRequest {
+            human_action: None,
             initiator: None,
             updates: Vec::new(),
             id: "req_1".into(),

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -543,6 +543,8 @@ pub struct CollaborationUpdate {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CollaborationRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interruption: Option<PeerInterruption>,
     /// Explicit operator decision. Never inferred from prose or the sender.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub human_action: Option<HumanAction>,
@@ -1946,6 +1948,7 @@ impl CollaborationStore {
             Some(supplied_thread_id.unwrap_or_else(|| id.clone()))
         };
         let request = CollaborationRequest {
+            interruption: None,
             human_action: input.human_action,
             id,
             from,
@@ -2293,7 +2296,7 @@ impl CollaborationStore {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
             let request = self.get_for(caller, request_id).await?;
-            if request.status.is_terminal() {
+            if request.status.is_terminal() || request.peer_interrupted() {
                 return Ok(request);
             }
             match tokio::time::timeout_at(deadline, changes.changed()).await {
@@ -6134,3 +6137,6 @@ mod tests {
         );
     }
 }
+
+mod recovery;
+pub use recovery::PeerInterruption;

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -543,6 +543,9 @@ pub struct CollaborationUpdate {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CollaborationRequest {
+    /// Explicit operator decision. Never inferred from prose or the sender.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub human_action: Option<HumanAction>,
     pub id: String,
     pub from: Participant,
     pub to: Participant,
@@ -628,6 +631,23 @@ pub struct CollaborationRequest {
     pub reply: Option<CollaborationReply>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HumanAction {
+    Approval,
+    Choice,
+    Information,
+}
+
+impl CollaborationRequest {
+    pub fn needs_human_response(&self) -> bool {
+        self.to.console
+            && self.expects_reply
+            && self.kind != RequestKind::Notice
+            && matches!(self.status, RequestStatus::Queued | RequestStatus::Claimed)
+    }
+}
+
 /// A handle the daemon has promised to one pane, pending the scan that will
 /// show the pane holding it.
 #[derive(Debug, Clone)]
@@ -672,6 +692,8 @@ pub struct RoomContext {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NewRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub human_action: Option<HumanAction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub initiator: Option<Box<Participant>>,
     pub kind: RequestKind,
     pub body: String,
@@ -699,6 +721,7 @@ pub struct NewRequest {
 impl Default for NewRequest {
     fn default() -> Self {
         Self {
+            human_action: None,
             initiator: None,
             kind: RequestKind::Question,
             body: String::new(),
@@ -1870,6 +1893,13 @@ impl CollaborationStore {
     ) -> Result<CollaborationRequest, CollaborationError> {
         self.ensure_enabled()?;
         let body = input.body.trim().to_string();
+        if input.human_action.is_some()
+            && (!to.console || !input.expects_reply || input.kind == RequestKind::Notice)
+        {
+            return Err(CollaborationError::UnknownTarget(
+                "human_action requires target human and a reply-bearing request".into(),
+            ));
+        }
         if body.is_empty() {
             return Err(CollaborationError::EmptyMessage);
         }
@@ -1890,7 +1920,10 @@ impl CollaborationStore {
             let parent = requests
                 .get(parent_request_id)
                 .ok_or_else(|| CollaborationError::ParentNotFound(parent_request_id.to_string()))?;
-            if !same_participant_pair(parent, &from, &to) {
+            let human_escalation = to.console
+                && input.human_action.is_some()
+                && (addresses(&parent.from, &from) || addresses(&parent.to, &from));
+            if !same_participant_pair(parent, &from, &to) && !human_escalation {
                 return Err(CollaborationError::InvalidParentScope(
                     parent_request_id.to_string(),
                 ));
@@ -1913,6 +1946,7 @@ impl CollaborationStore {
             Some(supplied_thread_id.unwrap_or_else(|| id.clone()))
         };
         let request = CollaborationRequest {
+            human_action: input.human_action,
             id,
             from,
             to,
@@ -2456,13 +2490,26 @@ impl CollaborationStore {
             .await
             .values()
             .filter(|request| {
-                request.notified_at.is_none()
+                !request.to.console
+                    && request.notified_at.is_none()
                     && (request.status == RequestStatus::Queued || request.wake_delivery.is_some())
             })
             .cloned()
             .collect();
         requests.sort_by_key(|request| request.created_at);
         requests
+    }
+
+    /// Human attention has its own delivery queue; never wake a pane for it.
+    pub async fn pending_human_notifications(&self) -> Vec<CollaborationRequest> {
+        let _transaction = self.transaction_lock.lock().await;
+        self.requests
+            .read()
+            .await
+            .values()
+            .filter(|request| request.needs_human_response() && request.notified_at.is_none())
+            .cloned()
+            .collect()
     }
 
     /// Replies still owed a wake to their sender.
@@ -2496,7 +2543,9 @@ impl CollaborationStore {
             let mut requests = self.requests.write().await;
             requests.get_mut(request_id).and_then(|request| {
                 if request.notified_at.is_none()
-                    && (request.status == RequestStatus::Queued || request.wake_delivery.is_some())
+                    && (request.status == RequestStatus::Queued
+                        || request.wake_delivery.is_some()
+                        || request.needs_human_response())
                 {
                     request.notified_at = Some(OffsetDateTime::now_utc());
                     request.wake_delivery = None;
@@ -2828,6 +2877,9 @@ pub fn resolve_target(
     // alias is only unique among live peers of one room, and matching it
     // host-wide would deliver to whichever unrelated agent happens to share
     // the name.
+    if selector == "human" {
+        return Ok(Participant::console(sender.room.clone()));
+    }
     if scope == crate::config::CollaborationScope::Host {
         let pane = selector.strip_prefix("pane:").unwrap_or(selector);
         if pane.starts_with('%') {
@@ -3277,6 +3329,86 @@ fn valid_identity_token(value: &str) -> bool {
 mod tests {
     use super::*;
     use crate::config::CollaborationScope;
+
+    #[tokio::test]
+    async fn human_escalation_is_separate_durable_and_resolved_by_operator() {
+        let dir = tempfile::tempdir().unwrap();
+        let options = CollaborationOptions {
+            path: Some(dir.path().join("human.json")),
+            ..CollaborationOptions::default()
+        };
+        let mailbox = CollaborationStore::load(options.clone()).await.unwrap();
+        let sender = participant("%1", "sender");
+        let peer = participant("%2", "peer");
+        let human = resolve_target(&peer, "human", &[], CollaborationScope::Window).unwrap();
+        let parent = mailbox
+            .create(
+                sender.clone(),
+                peer.clone(),
+                NewRequest {
+                    body: "review".into(),
+                    ..NewRequest::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert!(!parent.needs_human_response());
+        let request = mailbox
+            .create(
+                peer.clone(),
+                human.clone(),
+                NewRequest {
+                    body: "Choose A or B; recommend A because it preserves compatibility".into(),
+                    human_action: Some(HumanAction::Choice),
+                    parent_request_id: Some(parent.id.clone()),
+                    ..NewRequest::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(request.thread_id, parent.thread_id);
+        assert!(request.needs_human_response());
+        assert_eq!(mailbox.pending_human_notifications().await.len(), 1);
+        assert!(mailbox
+            .pending_unnotified()
+            .await
+            .iter()
+            .all(|r| r.id != request.id));
+        // Reading/claiming is not an answer and must not cause repeat alerts.
+        let claimed = mailbox.claim_for(&human).await.unwrap();
+        assert!(claimed[0].needs_human_response());
+        mailbox.mark_notified(&request.id).await.unwrap();
+        let reloaded = CollaborationStore::load(options).await.unwrap();
+        assert!(reloaded.pending_human_notifications().await.is_empty());
+        assert!(reloaded
+            .reply(
+                &sender,
+                &request.id,
+                RequestStatus::Completed,
+                "spoof".into(),
+                vec![],
+                vec![]
+            )
+            .await
+            .is_err());
+        let resolved = reloaded
+            .reply(
+                &human,
+                &request.id,
+                RequestStatus::Completed,
+                "A".into(),
+                vec![],
+                vec![],
+            )
+            .await
+            .unwrap();
+        assert!(!resolved.needs_human_response());
+        assert_eq!(reloaded.pending_reply_unnotified().await.len(), 1);
+        let legacy = serde_json::to_value(&parent).unwrap();
+        assert!(!serde_json::from_value::<CollaborationRequest>(legacy)
+            .unwrap()
+            .needs_human_response());
+    }
 
     #[tokio::test]
     async fn request_updates_are_durable_bounded_and_do_not_complete_work() {

--- a/crates/muxa/src/collaboration.rs
+++ b/crates/muxa/src/collaboration.rs
@@ -2255,11 +2255,26 @@ impl CollaborationStore {
         let mut changed = false;
         let request = {
             let mut requests = self.requests.write().await;
+            // Participants may await the daemon's linked human decision, but
+            // this grants no authority to answer/cancel the service request.
+            let recovery_observer = requests
+                .get(request_id)
+                .filter(|r| r.to.console && r.from.agent_session_id == "muxa:peer-recovery")
+                .and_then(|r| r.interruption.as_ref())
+                .filter(|i| i.action_request_id.as_deref() == Some(request_id))
+                .and_then(|i| requests.get(&i.request_id))
+                .is_some_and(|parent| {
+                    parent
+                        .interruption
+                        .as_ref()
+                        .is_some_and(|i| i.action_request_id.as_deref() == Some(request_id))
+                        && (addresses(&parent.from, caller) || addresses(&parent.to, caller))
+                });
             let request = requests
                 .get_mut(request_id)
                 .ok_or_else(|| CollaborationError::NotFound(request_id.to_string()))?;
             let is_sender = request.from.same_endpoint(caller);
-            if !is_sender && !addresses(&request.to, caller) {
+            if !is_sender && !addresses(&request.to, caller) && !recovery_observer {
                 return Err(CollaborationError::NotParticipant(request_id.to_string()));
             }
             if is_sender && request.reply.is_some() && request.reply_read_at.is_none() {

--- a/crates/muxa/src/collaboration/recovery.rs
+++ b/crates/muxa/src/collaboration/recovery.rs
@@ -130,7 +130,7 @@ impl CollaborationStore {
                     .map(|t| t.to_string());
                 // A healthy coordinator gets an immediate wait result first. If it
                 // cannot act, or has not acknowledged within two minutes, escalate.
-                let coordinator_unavailable = parent.from.console
+                let coordinator_unavailable = (parent.from.console && parent.initiator.is_none())
                     || exact_agent(&parent.from, agents).is_some_and(|a| reason(a).is_some());
                 let acknowledged = parent
                     .updates
@@ -323,6 +323,57 @@ mod tests {
             .unwrap()
             .peer_interrupted());
         assert!(restored.pending_human_notifications().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fleet_initiator_gets_recovery_grace_without_gaining_authority() {
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let (initiator, _) = actor("%1", "controller-agent").await;
+        let (recipient, mut peer) = actor("%2", "peer").await;
+        let console = Participant::console(recipient.room.clone());
+        let request = mailbox
+            .create(
+                console.clone(),
+                recipient,
+                NewRequest {
+                    initiator: Some(Box::new(initiator.clone())),
+                    body: "remote review".into(),
+                    ..NewRequest::default()
+                },
+            )
+            .await
+            .unwrap();
+        peer.state = AgentState::Error;
+        mailbox
+            .reconcile_peer_interruptions(&[peer.clone()])
+            .await
+            .unwrap();
+        assert!(mailbox
+            .get_for(&console, &request.id)
+            .await
+            .unwrap()
+            .peer_interrupted());
+        assert!(mailbox.pending_human_notifications().await.is_empty());
+        assert!(mailbox
+            .update_request(&initiator, &request.id, "spoof".into())
+            .await
+            .is_err());
+        mailbox
+            .requests
+            .write()
+            .await
+            .get_mut(&request.id)
+            .unwrap()
+            .interruption
+            .as_mut()
+            .unwrap()
+            .observed_at -= time::Duration::minutes(3);
+        mailbox
+            .update_request(&console, &request.id, "Controller handling recovery".into())
+            .await
+            .unwrap();
+        mailbox.reconcile_peer_interruptions(&[peer]).await.unwrap();
+        assert!(mailbox.pending_human_notifications().await.is_empty());
     }
 
     #[tokio::test]

--- a/crates/muxa/src/collaboration/recovery.rs
+++ b/crates/muxa/src/collaboration/recovery.rs
@@ -165,13 +165,21 @@ impl CollaborationStore {
                     .and_then(|id| snapshot.get(id))
                 {
                     info.decision.clone_from(&action.reply);
-                    if !info.active
-                        && !action.status.is_terminal()
-                        && action.from.agent_session_id == "muxa:peer-recovery"
-                    {
-                        let mut obsolete = action.clone();
-                        obsolete.status = RequestStatus::Cancelled;
-                        changed.push(obsolete);
+                    if action.from.agent_session_id == "muxa:peer-recovery" {
+                        let mut refreshed = action.clone();
+                        refreshed.interruption = Some(info.clone());
+                        if !info.active && !action.status.is_terminal() {
+                            refreshed.status = RequestStatus::Cancelled;
+                        }
+                        if action.reply.is_some() {
+                            // The daemon has delivered its own request's answer
+                            // to the parent; there is no service pane to wake.
+                            refreshed.reply_read_at.get_or_insert(now);
+                            refreshed.reply_notified_at.get_or_insert(now);
+                        }
+                        if refreshed != *action {
+                            changed.push(refreshed);
+                        }
                     }
                 }
             }
@@ -224,6 +232,8 @@ mod tests {
         (participant, agent)
     }
 
+    // Keep the restart, authorization and recovery assertions on one episode.
+    #[allow(clippy::too_many_lines)]
     #[tokio::test]
     async fn interrupted_wait_durable_action_decision_and_recovery() {
         let dir = tempfile::tempdir().unwrap();
@@ -273,6 +283,9 @@ mod tests {
             Some(request.id.as_str())
         );
         assert_eq!(action.thread_id, request.thread_id);
+        assert!(mailbox.get_for(&sender, &action.id).await.is_ok());
+        let (unrelated, _) = actor("%9", "unrelated").await;
+        assert!(mailbox.get_for(&unrelated, &action.id).await.is_err());
         assert!(!action.peer_interrupted());
         let restored = CollaborationStore::load(options).await.unwrap();
         restored
@@ -302,6 +315,11 @@ mod tests {
             )
             .await
             .unwrap();
+        let answer = restored
+            .wait_for_terminal(&sender, &action.id, Duration::from_secs(1))
+            .await
+            .unwrap();
+        assert_eq!(answer.reply.as_ref().unwrap().body, "Wait; do not reassign");
         restored
             .reconcile_peer_interruptions(&[coordinator.clone(), peer.clone()])
             .await
@@ -322,6 +340,10 @@ mod tests {
             .await
             .unwrap()
             .peer_interrupted());
+        let archived_action = restored.get_for(&action.to, &action.id).await.unwrap();
+        assert!(!archived_action.interruption.unwrap().active);
+        assert!(archived_action.reply_read_at.is_some());
+        assert!(restored.pending_reply_unnotified().await.is_empty());
         assert!(restored.pending_human_notifications().await.is_empty());
     }
 

--- a/crates/muxa/src/collaboration/recovery.rs
+++ b/crates/muxa/src/collaboration/recovery.rs
@@ -1,0 +1,399 @@
+//! Daemon-owned recovery records. No synthetic agent reply or automatic execution.
+use super::{
+    addresses, next_request_id, CollaborationError, CollaborationReply, CollaborationRequest,
+    CollaborationStore, HumanAction, Participant, RequestKind, RequestStatus, WorkMode,
+};
+use crate::{Agent, AgentKind, AgentState};
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PeerInterruption {
+    pub request_id: String,
+    pub reason: String,
+    pub active: bool,
+    #[serde(with = "time::serde::rfc3339")]
+    pub observed_at: OffsetDateTime,
+    pub reset_at: Option<String>,
+    pub action_request_id: Option<String>,
+    pub decision: Option<CollaborationReply>,
+}
+
+impl CollaborationRequest {
+    pub fn peer_interrupted(&self) -> bool {
+        !self.status.is_terminal()
+            && self
+                .interruption
+                .as_ref()
+                .is_some_and(|i| i.active && i.request_id == self.id)
+    }
+}
+
+fn exact_agent<'a>(participant: &Participant, agents: &'a [Agent]) -> Option<&'a Agent> {
+    if participant.console {
+        return None;
+    }
+    agents.iter().find(|a| {
+        a.kind == participant.agent_kind
+            && a.session_id == participant.agent_session_id
+            && a.pane.as_deref() == Some(&participant.pane)
+            && match (a.tmux_socket.as_deref(), participant.socket.as_deref()) {
+                (Some(a), Some(b)) => {
+                    crate::backend::pane_endpoints_match(Some(&participant.pane), a, b)
+                }
+                (None, None) => true,
+                _ => false,
+            }
+    })
+}
+
+fn reason(agent: &Agent) -> Option<&'static str> {
+    match agent.state {
+        AgentState::Error if agent.rate_limit_scope.is_some() => Some("rate_limited"),
+        AgentState::Error => Some("error"),
+        AgentState::Stopped => Some("stopped"),
+        _ => None,
+    }
+}
+
+fn recovery_action(
+    parent: &CollaborationRequest,
+    id: String,
+    now: OffsetDateTime,
+    current_reason: &str,
+) -> CollaborationRequest {
+    let mut action = parent.clone();
+    action.id = id;
+    action.from = Participant::console(parent.from.room.clone());
+    action.from.console = false;
+    action.from.agent_kind = AgentKind::Task;
+    action.from.agent_session_id = "muxa:peer-recovery".into();
+    action.from.pane = "muxa-recovery".into();
+    action.from.alias = Some("Muxa recovery".into());
+    action.to = Participant::console(parent.from.room.clone());
+    action.initiator = None;
+    action.provenance = None;
+    action.parent_request_id = Some(parent.id.clone());
+    action.kind = RequestKind::Question;
+    action.work_mode = WorkMode::ReadOnly;
+    action.human_action = Some(HumanAction::Choice);
+    action.body = format!("Muxa detected an interrupted peer: {} ({}).\nOriginal request: {}\nReset: {}\nChoose: wait and recheck, arrange a safe handoff, or stop this work attempt. Recommendation: inspect existing work before reassignment; a capped agent may resume. Your answer records a decision; it does not restart, cancel, or spend automatically.", parent.to.agent_session_id, current_reason, parent.id, parent.interruption.as_ref().and_then(|i| i.reset_at.as_deref()).unwrap_or("unknown"));
+    action.status = RequestStatus::Queued;
+    action.created_at = now;
+    action.claimed_at = None;
+    action.notified_at = None;
+    action.reply_notified_at = None;
+    action.reply_read_at = None;
+    action.wake_delivery = None;
+    action.reply = None;
+    action.updates.clear();
+    action
+}
+
+impl CollaborationStore {
+    /// Reconcile a local authoritative registry. Unknown/missing identities never
+    /// imply death or quota exhaustion. Updates and human actions persist together.
+    pub async fn reconcile_peer_interruptions(
+        &self,
+        agents: &[Agent],
+    ) -> Result<(), CollaborationError> {
+        self.ensure_enabled()?;
+        let _transaction = self.transaction_lock.lock().await;
+        let now = OffsetDateTime::now_utc();
+        let snapshot = self.requests.read().await.clone();
+        let mut changed = Vec::new();
+        for original in snapshot
+            .values()
+            .filter(|r| !r.to.console && r.expects_reply && r.kind != RequestKind::Notice)
+        {
+            let agent = exact_agent(&original.to, agents);
+            let current_reason = agent.and_then(reason);
+            let mut parent = original.clone();
+            if let Some(current_reason) = current_reason.filter(|_| !parent.status.is_terminal()) {
+                if !parent.peer_interrupted() {
+                    parent.interruption = Some(PeerInterruption {
+                        request_id: parent.id.clone(),
+                        reason: current_reason.into(),
+                        active: true,
+                        observed_at: now,
+                        reset_at: agent
+                            .and_then(|a| a.rate_limited_until)
+                            .map(|t| t.to_string()),
+                        action_request_id: None,
+                        decision: None,
+                    });
+                }
+                let info = parent.interruption.as_mut().expect("initialized");
+                info.reason = current_reason.into();
+                info.reset_at = agent
+                    .and_then(|a| a.rate_limited_until)
+                    .map(|t| t.to_string());
+                // A healthy coordinator gets an immediate wait result first. If it
+                // cannot act, or has not acknowledged within two minutes, escalate.
+                let coordinator_unavailable = parent.from.console
+                    || exact_agent(&parent.from, agents).is_some_and(|a| reason(a).is_some());
+                let acknowledged = parent
+                    .updates
+                    .iter()
+                    .any(|u| u.at >= info.observed_at && addresses(&parent.from, &u.author));
+                let overdue = now - info.observed_at >= time::Duration::minutes(2) && !acknowledged;
+                if info.action_request_id.is_none() {
+                    info.action_request_id = snapshot
+                        .values()
+                        .find(|r| {
+                            r.needs_human_response()
+                                && r.parent_request_id.as_deref() == Some(parent.id.as_str())
+                        })
+                        .map(|r| r.id.clone());
+                }
+                if info.action_request_id.is_none() && (coordinator_unavailable || overdue) {
+                    let id = next_request_id(now);
+                    info.action_request_id = Some(id.clone());
+                    changed.push(recovery_action(&parent, id, now, current_reason));
+                }
+            } else if parent.status.is_terminal()
+                || agent.is_some_and(|a| matches!(a.state, AgentState::Working | AgentState::Idle))
+            {
+                if let Some(info) = &mut parent.interruption {
+                    info.active = false;
+                }
+            }
+            if let Some(info) = &mut parent.interruption {
+                if let Some(action) = info
+                    .action_request_id
+                    .as_ref()
+                    .and_then(|id| snapshot.get(id))
+                {
+                    info.decision.clone_from(&action.reply);
+                    if !info.active
+                        && !action.status.is_terminal()
+                        && action.from.agent_session_id == "muxa:peer-recovery"
+                    {
+                        let mut obsolete = action.clone();
+                        obsolete.status = RequestStatus::Cancelled;
+                        changed.push(obsolete);
+                    }
+                }
+            }
+            if parent != *original {
+                changed.push(parent);
+            }
+        }
+        if !changed.is_empty() {
+            self.persist_requests(&changed)?;
+            let mut requests = self.requests.write().await;
+            for request in changed {
+                requests.insert(request.id.clone(), request);
+            }
+            drop(requests);
+            self.publish_change();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::collaboration::{CollaborationOptions, NewRequest};
+    use crate::event::{AgentEvent, AgentId, RateLimitScope};
+    use std::time::Duration;
+
+    async fn actor(pane: &str, session: &str) -> (Participant, Agent) {
+        let store = crate::state::Store::shared();
+        store
+            .apply(&AgentEvent::Started {
+                id: AgentId {
+                    kind: AgentKind::Codex,
+                    session_id: session.into(),
+                    surface: None,
+                    pane: Some(pane.into()),
+                    tmux_socket: Some("default".into()),
+                    cwd: None,
+                },
+                at: OffsetDateTime::now_utc(),
+            })
+            .await;
+        let mut agent = store.snapshot().await.remove(0);
+        agent.state = AgentState::Working;
+        let participant = serde_json::from_value(serde_json::json!({
+            "agent_kind":"codex", "agent_session_id":session, "pane":pane, "socket":"default",
+            "room":{"host":"tmux","socket":"default","window_id":"@1"}, "state":"working"
+        }))
+        .unwrap();
+        (participant, agent)
+    }
+
+    #[tokio::test]
+    async fn interrupted_wait_durable_action_decision_and_recovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let options = CollaborationOptions {
+            path: Some(dir.path().join("mailbox.json")),
+            ..CollaborationOptions::default()
+        };
+        let mailbox = CollaborationStore::load(options.clone()).await.unwrap();
+        let (sender, mut coordinator) = actor("%1", "sender").await;
+        let (recipient, mut peer) = actor("%2", "peer").await;
+        let request = mailbox
+            .create(
+                sender.clone(),
+                recipient.clone(),
+                NewRequest {
+                    body: "review".into(),
+                    ..NewRequest::default()
+                },
+            )
+            .await
+            .unwrap();
+        mailbox.claim_for(&recipient).await.unwrap();
+        peer.state = AgentState::Error;
+        peer.rate_limit_scope = Some(RateLimitScope::FiveHour);
+        mailbox
+            .reconcile_peer_interruptions(&[coordinator.clone(), peer.clone()])
+            .await
+            .unwrap();
+        let waiting = mailbox.wait_for_terminal(&sender, &request.id, Duration::from_secs(300));
+        let interrupted = tokio::time::timeout(Duration::from_secs(1), waiting)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(interrupted.peer_interrupted());
+        assert_eq!(interrupted.status, RequestStatus::Claimed);
+        assert!(interrupted.reply.is_none());
+        assert!(mailbox.pending_human_notifications().await.is_empty());
+        coordinator.state = AgentState::Error;
+        mailbox
+            .reconcile_peer_interruptions(&[coordinator.clone(), peer.clone()])
+            .await
+            .unwrap();
+        let action = mailbox.pending_human_notifications().await.remove(0);
+        assert_eq!(action.from.agent_session_id, "muxa:peer-recovery");
+        assert_eq!(
+            action.parent_request_id.as_deref(),
+            Some(request.id.as_str())
+        );
+        assert_eq!(action.thread_id, request.thread_id);
+        assert!(!action.peer_interrupted());
+        let restored = CollaborationStore::load(options).await.unwrap();
+        restored
+            .reconcile_peer_interruptions(&[coordinator.clone(), peer.clone()])
+            .await
+            .unwrap();
+        assert_eq!(restored.pending_human_notifications().await.len(), 1);
+        assert!(restored
+            .reply(
+                &recipient,
+                &action.id,
+                RequestStatus::Completed,
+                "spoof".into(),
+                vec![],
+                vec![]
+            )
+            .await
+            .is_err());
+        restored
+            .reply(
+                &action.to,
+                &action.id,
+                RequestStatus::Completed,
+                "Wait; do not reassign".into(),
+                vec![],
+                vec![],
+            )
+            .await
+            .unwrap();
+        restored
+            .reconcile_peer_interruptions(&[coordinator.clone(), peer.clone()])
+            .await
+            .unwrap();
+        let parent = restored.get_for(&sender, &request.id).await.unwrap();
+        assert_eq!(
+            parent.interruption.unwrap().decision.unwrap().body,
+            "Wait; do not reassign"
+        );
+        assert_eq!(parent.status, RequestStatus::Claimed);
+        peer.state = AgentState::Working;
+        restored
+            .reconcile_peer_interruptions(&[coordinator, peer])
+            .await
+            .unwrap();
+        assert!(!restored
+            .get_for(&sender, &request.id)
+            .await
+            .unwrap()
+            .peer_interrupted());
+        assert!(restored.pending_human_notifications().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn grace_ack_identity_and_obsolete_action() {
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        let (sender, coordinator) = actor("%1", "sender").await;
+        let (recipient, mut peer) = actor("%2", "peer").await;
+        let request = mailbox
+            .create(
+                sender.clone(),
+                recipient,
+                NewRequest {
+                    body: "task".into(),
+                    ..NewRequest::default()
+                },
+            )
+            .await
+            .unwrap();
+        peer.state = AgentState::Stopped;
+        let mut reused = peer.clone();
+        reused.session_id = "another-session".into();
+        mailbox
+            .reconcile_peer_interruptions(&[coordinator.clone(), reused])
+            .await
+            .unwrap();
+        assert!(!mailbox
+            .get_for(&sender, &request.id)
+            .await
+            .unwrap()
+            .peer_interrupted());
+        mailbox
+            .reconcile_peer_interruptions(&[coordinator.clone(), peer.clone()])
+            .await
+            .unwrap();
+        mailbox
+            .requests
+            .write()
+            .await
+            .get_mut(&request.id)
+            .unwrap()
+            .interruption
+            .as_mut()
+            .unwrap()
+            .observed_at -= time::Duration::minutes(3);
+        mailbox
+            .update_request(&sender, &request.id, "Handling recovery".into())
+            .await
+            .unwrap();
+        mailbox
+            .reconcile_peer_interruptions(&[coordinator.clone(), peer.clone()])
+            .await
+            .unwrap();
+        assert!(mailbox.pending_human_notifications().await.is_empty());
+        mailbox
+            .requests
+            .write()
+            .await
+            .get_mut(&request.id)
+            .unwrap()
+            .updates
+            .clear();
+        mailbox
+            .reconcile_peer_interruptions(&[coordinator.clone(), peer.clone()])
+            .await
+            .unwrap();
+        assert_eq!(mailbox.pending_human_notifications().await.len(), 1);
+        peer.state = AgentState::Working;
+        mailbox
+            .reconcile_peer_interruptions(&[coordinator, peer])
+            .await
+            .unwrap();
+        assert!(mailbox.pending_human_notifications().await.is_empty());
+    }
+}

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -2627,6 +2627,7 @@ mod tests {
                         from.clone(),
                         to.clone(),
                         NewRequest {
+                            human_action: None,
                             initiator: None,
                             kind: RequestKind::Review,
                             body: body.to_string(),
@@ -2653,6 +2654,7 @@ mod tests {
                     from,
                     to,
                     NewRequest {
+                        human_action: None,
                         initiator: None,
                         kind: RequestKind::Notice,
                         body: "finalize".to_string(),

--- a/crates/muxa/src/dashboard/server.rs
+++ b/crates/muxa/src/dashboard/server.rs
@@ -955,6 +955,14 @@ fn redact_collaboration_details(request: &mut serde_json::Value) {
     ] {
         request.remove(field);
     }
+    if let Some(info) = request
+        .get_mut("interruption")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        info.remove("decision");
+    }
+    // Progress bodies are also private message content.
+    request.remove("updates");
     if let Some(reply) = request
         .get_mut("reply")
         .and_then(serde_json::Value::as_object_mut)
@@ -2425,6 +2433,15 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn recovery_decisions_and_progress_are_redacted() {
+        let mut value = serde_json::json!({"interruption":{"reason":"error","decision":{"body":"private choice"}},"updates":[{"body":"private progress"}]});
+        super::redact_collaboration_details(&mut value);
+        assert!(value["interruption"].get("decision").is_none());
+        assert!(value.get("updates").is_none());
+        assert_eq!(value["interruption"]["reason"], "error");
+    }
+
     use super::*;
     use crate::backend::{BackendCaps, PaneBackend};
     use crate::event::{AgentEvent, AgentId, AgentKind};

--- a/crates/muxa/src/dashboard/web/collaboration-model.mjs
+++ b/crates/muxa/src/dashboard/web/collaboration-model.mjs
@@ -4,6 +4,12 @@
 
 const SEP = "\u001f";
 
+// Recipient and live request state determine attention, never sender/prose.
+export function needsHumanResponse(request) {
+  return request?.to?.console === true && request.expects_reply === true
+    && request.kind !== "notice" && ["queued", "claimed"].includes(request.status);
+}
+
 export function normalizeCollaborationPayload(payload) {
   if (Array.isArray(payload)) {
     return {
@@ -125,6 +131,7 @@ export function projectCollaboration(requests) {
         to: to.id,
         count: 0,
         replyCount: 0,
+        humanCount: 0,
         replyStatuses: {},
         kinds: {},
         statuses: {},
@@ -134,6 +141,7 @@ export function projectCollaboration(requests) {
     }
     const edge = edges.get(key);
     edge.count += 1;
+    if (needsHumanResponse(request)) edge.humanCount += 1;
     increment(edge.kinds, request.kind || "unknown");
     increment(edge.statuses, request.status || "unknown");
     if (request.reply) {
@@ -167,6 +175,7 @@ export function projectCollaboration(requests) {
 
   return {
     nodes: [...nodes.values()].sort((left, right) => left.label.localeCompare(right.label)),
+    humanCount: (requests || []).filter(needsHumanResponse).length,
     edges: [...edges.values()].sort((left, right) => right.count - left.count || left.key.localeCompare(right.key)),
     rooms: [...rooms.values()].sort((left, right) => right.count - left.count || left.label.localeCompare(right.label)),
     works: [...works].sort(),

--- a/crates/muxa/src/dashboard/web/main.js
+++ b/crates/muxa/src/dashboard/web/main.js
@@ -3012,6 +3012,7 @@ function renderCollaborationDetail(request) {
     </div>
     <dl class="collaboration-detail-meta">
       <dt>response needed</dt><dd>${needsHumanResponse(request) ? `you · ${esc(request.human_action || "information")}` : ["queued", "claimed"].includes(request.status) && request.expects_reply ? "agent" : "none"}</dd>
+      ${request.interruption ? `<dt>peer recovery</dt><dd>${esc(request.interruption.reason)} · ${request.interruption.active ? "active" : "cleared"}</dd><dt>original request</dt><dd>${esc(request.interruption.request_id)}</dd><dt>reset</dt><dd>${esc(request.interruption.reset_at || "unknown")}</dd><dt>action request</dt><dd>${esc(request.interruption.action_request_id || "coordinator notified")}</dd>` : ""}
       <dt>id</dt><dd>${esc(request.id)}</dd>
       <dt>room</dt><dd>${esc(roomLabel(request))}</dd>
       ${work ? `<dt>work</dt><dd>${esc(work)}</dd>` : ""}

--- a/crates/muxa/src/dashboard/web/main.js
+++ b/crates/muxa/src/dashboard/web/main.js
@@ -1,6 +1,7 @@
 import { logicalWorkKey, normalizeAgent, validateWorkSnapshot, WORK_STAGES } from "./work-model.mjs";
 import {
   collaborationSequence,
+  needsHumanResponse,
   dominantCount,
   normalizeCollaborationPayload,
   participantIdentity,
@@ -2771,7 +2772,7 @@ function renderCollaboration() {
   const projection = projectCollaboration(data.requests);
   store.cache.collaborationProjection = projection;
   const page = data.pagination;
-  dom.collaborationMeta.textContent = `${projection.nodes.length} participants · ${data.requests.length} messages`;
+  dom.collaborationMeta.textContent = `${projection.humanCount} need your response (loaded) · ${projection.nodes.length} participants · ${data.requests.length} messages`;
   dom.collaborationPageMeta.textContent = page.has_more
     ? `${data.requests.length} of ${page.total || "many"} loaded · graph is partial`
     : `${data.requests.length} retained messages loaded`;
@@ -2871,7 +2872,7 @@ function renderCollaborationGraph(projection) {
         <title>${edge.count} requests · ${edge.replyCount} replies · ${dominant}</title>
       </path>
       ${replyPath}
-      <text class="collaboration-edge-label" x="${midpoint.x}" y="${midpoint.y}">${edge.count} req${edge.replyCount ? ` · ${edge.replyCount} reply` : ""}</text>
+      <text class="collaboration-edge-label" x="${midpoint.x}" y="${midpoint.y}">${edge.count} req${edge.replyCount ? ` · ${edge.replyCount} reply` : ""}${edge.humanCount ? ` · ${edge.humanCount} need you` : ""}</text>
     </g>`;
   }).join("");
   const nodes = projection.nodes.map((node) => {
@@ -3010,6 +3011,7 @@ function renderCollaborationDetail(request) {
       <button class="icon-btn" type="button" data-close-collaboration-detail aria-label="Close message detail">×</button>
     </div>
     <dl class="collaboration-detail-meta">
+      <dt>response needed</dt><dd>${needsHumanResponse(request) ? `you · ${esc(request.human_action || "information")}` : ["queued", "claimed"].includes(request.status) && request.expects_reply ? "agent" : "none"}</dd>
       <dt>id</dt><dd>${esc(request.id)}</dd>
       <dt>room</dt><dd>${esc(roomLabel(request))}</dd>
       ${work ? `<dt>work</dt><dd>${esc(work)}</dd>` : ""}

--- a/crates/muxa/src/fleet.rs
+++ b/crates/muxa/src/fleet.rs
@@ -1471,6 +1471,7 @@ mod tests {
             request_id: "relay-1".into(),
             pane: pane.clone(),
             request: Box::new(NewRequest {
+                human_action: None,
                 initiator: None,
                 kind: crate::collaboration::RequestKind::Review,
                 body: "review this change".into(),

--- a/crates/muxa/src/fleet_wait.rs
+++ b/crates/muxa/src/fleet_wait.rs
@@ -81,7 +81,9 @@ impl FleetRuntime {
             let current = rx.borrow_and_update().clone();
             match current {
                 Some(Err(error)) => return Err(error),
-                Some(Ok(request)) if request.status.is_terminal() => return Ok(Some(request)),
+                Some(Ok(request)) if request.status.is_terminal() || request.peer_interrupted() => {
+                    return Ok(Some(request))
+                }
                 Some(Ok(request))
                     if after_update.is_some_and(|seen| {
                         request.updates.last().is_some_and(|u| u.sequence > seen)
@@ -145,7 +147,7 @@ impl FleetRuntime {
             let mut disconnected = false;
             match result {
                 Ok(request) => {
-                    let terminal = request.status.is_terminal();
+                    let terminal = request.status.is_terminal() || request.peer_interrupted();
                     sender.send_replace(Some(Ok(request)));
                     if terminal {
                         tracing::debug!(request_id = %key.2, reads, "fleet reply wait completed");
@@ -258,6 +260,32 @@ mod tests {
                 .wait_for_reply("local".into(), pane, id, Duration::from_secs(seconds), None)
                 .await
         })
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn interruption_releases_shared_wait_without_fabricating_reply() {
+        let (runtime, mut commands, pane, mut request) = fixture(true).await;
+        let waiting = wait(runtime.clone(), pane, &request, 300);
+        request.interruption = Some(crate::collaboration::PeerInterruption {
+            request_id: request.id.clone(),
+            reason: "rate_limited".into(),
+            active: true,
+            observed_at: time::OffsetDateTime::now_utc(),
+            reset_at: None,
+            action_request_id: Some("human-action".into()),
+            decision: None,
+        });
+        commands
+            .recv()
+            .await
+            .unwrap()
+            .reply
+            .send(Ok(FleetCommandResult::collaboration_request(request)))
+            .unwrap();
+        let result = waiting.await.unwrap().unwrap().unwrap();
+        assert!(result.peer_interrupted());
+        assert!(!result.status.is_terminal());
+        assert!(result.reply.is_none());
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -6740,6 +6740,7 @@ mod tests {
                         &from,
                         to,
                         &NewRequest {
+                            human_action: None,
                             initiator: None,
                             kind: collaboration::RequestKind::Question,
                             body: body.into(),
@@ -6880,6 +6881,7 @@ mod tests {
                 &sender,
                 "role:review",
                 &NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: collaboration::RequestKind::Question,
                     body: "ambiguous".into(),
@@ -6904,6 +6906,7 @@ mod tests {
                 &sender,
                 "@reviewer",
                 &NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: collaboration::RequestKind::Review,
                     body: "review this".into(),
@@ -6993,6 +6996,7 @@ mod tests {
                 &sender,
                 "role:rust",
                 &NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: collaboration::RequestKind::Question,
                     body: "obsolete question".into(),
@@ -7040,6 +7044,7 @@ mod tests {
                 },
                 "pane:%1",
                 &NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: collaboration::RequestKind::Task,
                     body: "dispatch to launch pane".into(),

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -716,6 +716,7 @@ const CAPABILITIES: &[&str] = &[
     "fleet_subscribe",
     "fleet_wait_reply",
     "collaboration_update",
+    "collaboration_peer_recovery",
     "pipeline_runs_v1",
     "pipeline_subscribe",
     "work_control_v1",

--- a/crates/muxa/src/notify.rs
+++ b/crates/muxa/src/notify.rs
@@ -61,6 +61,36 @@ pub struct Notifier {
 }
 
 impl Notifier {
+    /// Persist the receipt so redraws, progress updates and daemon re-execs
+    /// do not repeatedly notify the operator about the same decision.
+    pub async fn run_human_requests(
+        self,
+        collaboration: std::sync::Arc<crate::collaboration::CollaborationStore>,
+    ) {
+        let mut tick = tokio::time::interval(Duration::from_secs(2));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tick.tick().await;
+            for request in collaboration.pending_human_notifications().await {
+                let title = format!("muxa: your response needed ({})", request.from.label());
+                // Notification bodies can support markup; escape untrusted text.
+                let body = request
+                    .body
+                    .chars()
+                    .take(240)
+                    .collect::<String>()
+                    .replace('&', "&amp;")
+                    .replace('<', "&lt;")
+                    .replace('>', "&gt;");
+                if post(&self.app_name, &title, &body, false).is_ok() {
+                    if let Err(error) = collaboration.mark_notified(&request.id).await {
+                        tracing::warn!(%error, "could not persist human notification receipt");
+                    }
+                }
+            }
+        }
+    }
+
     pub fn new() -> Self {
         Self {
             app_name: "muxa".into(),

--- a/crates/muxa/tests-js/dashboard-collaboration-model.test.mjs
+++ b/crates/muxa/tests-js/dashboard-collaboration-model.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   collaborationSequence,
+  needsHumanResponse,
   edgeIdentity,
   normalizeCollaborationPayload,
   participantIdentity,
@@ -33,6 +34,23 @@ const request = (id, createdAt, extra = {}) => ({
   thread_id: "CAL-7345/review",
   work_id: "CAL-7345",
   ...extra,
+});
+
+test("human attention follows recipient and lifecycle, never initiator or blocked prose", () => {
+  const human = { console: true };
+  const waiting = request("h", "2026-09-12", { to: human, status: "queued", expects_reply: true });
+  assert.equal(needsHumanResponse(waiting), true);
+  assert.equal(needsHumanResponse({ ...waiting, status: "claimed" }), true);
+  for (const status of ["completed", "cancelled", "expired", "blocked", "failed", "declined"]) {
+    assert.equal(needsHumanResponse({ ...waiting, status }), false);
+  }
+  assert.equal(needsHumanResponse({ ...waiting, kind: "notice" }), false);
+  assert.equal(needsHumanResponse({ ...waiting, expects_reply: false }), false);
+  assert.equal(needsHumanResponse({ ...waiting, from: human, to: reviewer }), false);
+  const graph = projectCollaboration([waiting, { ...waiting, id: "done", status: "completed", reply: { status: "completed" } }]);
+  assert.equal(graph.humanCount, 1);
+  assert.equal(graph.edges[0].humanCount, 1);
+  assert.equal(graph.edges[0].replyCount, 1);
 });
 
 test("accepts both the paged API envelope and a legacy bare array", () => {

--- a/crates/muxad/src/fleet_manager.rs
+++ b/crates/muxad/src/fleet_manager.rs
@@ -453,13 +453,16 @@ impl LocalTask {
                 audit_operation(LOCAL_HOST_ALIAS, "collaboration_mailbox", 0);
                 let agent = fleet_collaboration_origin(&pane, false);
                 let console = fleet_collaboration_origin(&pane, true);
-                let (incoming, sent) = tokio::try_join!(
+                let (mut incoming, sent, human) = tokio::try_join!(
                     self.client
                         .collaboration_list(&agent, RequestMailbox::Incoming),
                     self.client
                         .collaboration_list(&console, RequestMailbox::Sent),
+                    self.client
+                        .collaboration_list(&console, RequestMailbox::Incoming),
                 )
                 .map_err(|error| error.to_string())?;
+                incoming.extend(human);
                 Ok(FleetCommandResult::collaboration_mailbox(incoming, sent))
             }
             FleetOperation::CollaborationGet { pane, request_id } => {
@@ -503,9 +506,14 @@ impl LocalTask {
             } => {
                 exact_local_backend(&self.backends, &pane).await?;
                 audit_operation(LOCAL_HOST_ALIAS, "collaboration_reply", body.len());
+                let request = self
+                    .client
+                    .collaboration_get(&fleet_collaboration_origin(&pane, true), &request_id)
+                    .await
+                    .map_err(|error| error.to_string())?;
                 self.client
                     .collaboration_reply(
-                        &fleet_collaboration_origin(&pane, false),
+                        &fleet_collaboration_origin(&pane, request.to.console),
                         &request_id,
                         status,
                         &body,

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -316,6 +316,7 @@ async fn main() -> Result<()> {
     // Desktop notifier: spawned only when opted in. We subscribe BEFORE
     // the server starts accepting events so no early transition is lost.
     if cfg.notifier.enabled && matches!(cfg.notifier.backend, NotifierBackend::Libnotify) {
+        tokio::spawn(Notifier::new().run_human_requests(collaboration.clone()));
         let rx = store.subscribe();
         tokio::spawn(async move {
             if let Err(e) = Notifier::new().run(rx).await {
@@ -3245,6 +3246,7 @@ mod tests {
                 sender,
                 recipient,
                 NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: RequestKind::Question,
                     body: "wake from revision".into(),
@@ -3388,6 +3390,7 @@ mod tests {
                 sender,
                 pending,
                 NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: RequestKind::Review,
                     body: "review the pending diff".into(),
@@ -3465,6 +3468,7 @@ mod tests {
                 sender.clone(),
                 recipient.clone(),
                 NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: RequestKind::Task,
                     body: "change only the authorized file".into(),
@@ -3518,6 +3522,7 @@ mod tests {
                 sender,
                 recipient.clone(),
                 NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: RequestKind::Task,
                     body: "unsafe\u{1b}[201~\rsubmit".into(),
@@ -3579,6 +3584,7 @@ mod tests {
                 console,
                 recipient.clone(),
                 NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: RequestKind::Task,
                     body: "operator request body".into(),
@@ -3661,6 +3667,7 @@ mod tests {
                 sender,
                 recipient.clone(),
                 NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: RequestKind::Task,
                     body: "agent delegated body".into(),
@@ -3731,6 +3738,7 @@ mod tests {
                     sender.clone(),
                     recipient.clone(),
                     NewRequest {
+                        human_action: None,
                         initiator: None,
                         kind: RequestKind::Task,
                         body: body.into(),
@@ -3796,6 +3804,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::too_many_lines)] // Full crash-recovery scenario, including request metadata.
     async fn full_wake_recovers_without_reinjecting_the_request_body() {
         let store = muxa::Store::shared();
         add_agent(&store, "%1", "sender", AgentKind::Codex).await;
@@ -3818,6 +3827,7 @@ mod tests {
                 sender.clone(),
                 recipient.clone(),
                 NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: RequestKind::Task,
                     body: "do not inject this twice".into(),
@@ -3868,6 +3878,7 @@ mod tests {
                 sender,
                 recipient.clone(),
                 NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: RequestKind::Task,
                     body: "the prompt text is already buffered".into(),
@@ -3927,6 +3938,7 @@ mod tests {
                 sender,
                 recipient.clone(),
                 NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: RequestKind::Review,
                     body: "secret request body".into(),
@@ -4045,6 +4057,7 @@ mod tests {
                 console.clone(),
                 recipient.clone(),
                 NewRequest {
+                    human_action: None,
                     initiator: None,
                     kind: RequestKind::Task,
                     body: "dispatched by a human".into(),

--- a/crates/muxad/src/main.rs
+++ b/crates/muxad/src/main.rs
@@ -1468,7 +1468,7 @@ fn spawn_collaboration_waker_task(
     backends: Vec<muxa::SharedBackend>,
     shutdown_tx: &broadcast::Sender<()>,
 ) -> Option<tokio::task::JoinHandle<()>> {
-    if !cfg.collaboration.enabled || cfg.collaboration.wake == CollaborationWake::Never {
+    if !cfg.collaboration.enabled {
         return None;
     }
     let mut shutdown_rx = shutdown_tx.subscribe();
@@ -1478,16 +1478,25 @@ fn spawn_collaboration_waker_task(
     let mut mailbox_changes = collaboration.subscribe();
     let mut agent_transitions = store.subscribe();
     let wake_payload = cfg.collaboration.wake_payload;
+    let wake_enabled = cfg.collaboration.wake != CollaborationWake::Never;
     Some(tokio::spawn(async move {
         let mut wake_inflight = HashSet::new();
-        wake_idle_collaboration_peers_with_inflight(
-            &collaboration,
-            &store,
-            &backends,
-            wake_payload,
-            &mut wake_inflight,
-        )
-        .await;
+        if let Err(error) = collaboration
+            .reconcile_peer_interruptions(&store.snapshot().await)
+            .await
+        {
+            tracing::warn!(%error, "initial peer interruption reconciliation failed");
+        }
+        if wake_enabled {
+            wake_idle_collaboration_peers_with_inflight(
+                &collaboration,
+                &store,
+                &backends,
+                wake_payload,
+                &mut wake_inflight,
+            )
+            .await;
+        }
         let mut reconcile = tokio::time::interval(std::time::Duration::from_secs(
             COLLABORATION_WAKE_RECONCILE_SECONDS,
         ));
@@ -1534,14 +1543,22 @@ fn spawn_collaboration_waker_task(
                 _ = shutdown_rx.recv() => break,
             };
             if should_scan {
-                wake_idle_collaboration_peers_with_inflight(
-                    &collaboration,
-                    &store,
-                    &backends,
-                    wake_payload,
-                    &mut wake_inflight,
-                )
-                .await;
+                if let Err(error) = collaboration
+                    .reconcile_peer_interruptions(&store.snapshot().await)
+                    .await
+                {
+                    tracing::warn!(%error, "peer interruption reconciliation failed");
+                }
+                if wake_enabled {
+                    wake_idle_collaboration_peers_with_inflight(
+                        &collaboration,
+                        &store,
+                        &backends,
+                        wake_payload,
+                        &mut wake_inflight,
+                    )
+                    .await;
+                }
             }
         }
     }))
@@ -3203,6 +3220,56 @@ mod tests {
                 at: OffsetDateTime::now_utc(),
             })
             .await;
+    }
+
+    #[tokio::test]
+    async fn peer_recovery_runs_when_terminal_wake_is_disabled() {
+        let store = muxa::Store::shared();
+        add_capped_agent(&store, "%1", "sender").await;
+        add_capped_agent(&store, "%2", "recipient").await;
+        let panes = vec![collaboration_pane("%1", "0"), collaboration_pane("%2", "1")];
+        let participants = muxa::collaboration::participants_from(&store.snapshot().await, &panes);
+        let sender = participants
+            .iter()
+            .find(|p| p.pane == "%1")
+            .unwrap()
+            .clone();
+        let recipient = participants
+            .iter()
+            .find(|p| p.pane == "%2")
+            .unwrap()
+            .clone();
+        let mailbox = CollaborationStore::in_memory(CollaborationOptions::default());
+        mailbox
+            .create(
+                sender,
+                recipient,
+                NewRequest {
+                    body: "review".into(),
+                    ..NewRequest::default()
+                },
+            )
+            .await
+            .unwrap();
+        let mut cfg = Config::default();
+        cfg.collaboration.enabled = true;
+        cfg.collaboration.wake = CollaborationWake::Never;
+        let (shutdown, _) = broadcast::channel(1);
+        let worker =
+            spawn_collaboration_waker_task(&cfg, mailbox.clone(), store, vec![], &shutdown)
+                .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if mailbox.pending_human_notifications().await.len() == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        shutdown.send(()).unwrap();
+        worker.await.unwrap();
     }
 
     #[tokio::test]

--- a/docs/HUMAN-ATTENTION.md
+++ b/docs/HUMAN-ATTENTION.md
@@ -51,3 +51,25 @@ is safe to suppress.
 
 Linux builds validate the Rust and dashboard changes. SwiftUI rendering must
 be built and visually verified on macOS before publishing a Muxa.app bundle.
+
+## Interrupted peers and usage caps
+
+The shared skill's **Peer interruption recovery** section and the MCP guide's
+`workflows.peer_interruption` define coordinator recovery. A peer's quota/error
+state and a durable reply are distinct: reply waits currently do not wake on
+health changes. Use waits of at most 60 seconds plus a chosen overall budget,
+then check fresh identity-matched recipient state. Do not use the request's
+snapshot of `to.state` or usage percentage alone to declare failure.
+
+Record the observed blocker once and use authorized recovery. Ask the operator
+only when a real decision is needed, preserving a single linked human request.
+Prevent overlapping execution before reassignment: claimed work may resume after
+a reset and cannot be cancelled through the queued-request cancellation tool.
+Do not impersonate the unavailable recipient or fabricate its terminal reply.
+A coordinator ending its own incoming attempt returns `blocked` with evidence.
+
+This is an agent policy, not automatic server-side cancellation or escalation.
+If the coordinator is also capped, a daemon mechanism is still needed to create
+a durable operator action request. Existing error notifications alone do not
+implement this recovery protocol. Installed guides must be reread by running
+agents; reconnect MCP to refresh server instructions.

--- a/docs/HUMAN-ATTENTION.md
+++ b/docs/HUMAN-ATTENTION.md
@@ -1,0 +1,53 @@
+# Human attention in collaboration mailboxes
+
+Agent instructions ship through MCP initialization, `muxa_collaboration_guide`,
+and the managed `muxa-collaboration` skill. Install/update the file-based entry
+points with `muxa init --component agent-instructions,agent-skills --yes
+--start-daemon=false`. Existing agents must reread the skill or reconnect MCP
+to acquire updated guidance; changing a file does not replace their context.
+
+Collaboration requests addressed to an agent are internal traffic. The sender
+being a console, a human initiator, or words such as "approval" in a message
+do not make that request an operator notification.
+
+When an operator decision is required, send a separate request to `human`:
+
+```sh
+muxa msg send human 'Choose A or B. Recommend A because it preserves compatibility.' \
+  --human-action choice --parent req_parent --json
+```
+
+The equivalent MCP `muxa_send_message` arguments are `target: "human"`,
+`human_action: "choice"`, `body`, and optionally `parent_request_id`.
+Actions are `approval`, `choice`, and `information`. Explain the decision,
+why it blocks progress, the options, and your recommendation in the body.
+Do not escalate ordinary peer review, progress, retries, or a pending reply.
+
+Only a participant in the parent request may escalate it to the operator.
+The parent thread is retained. Human replies return to the requesting agent's
+normal reply mailbox. No pane is woken to deliver a request to a human.
+
+`muxa watch` opens its mailbox on **Need you**. `Tab` switches to agent
+traffic/history and sent messages. `e` answers a human request as the operator;
+claiming an agent inbox is unnecessary. Muxa.app uses the same default tab.
+Completed, cancelled, expired, failed, declined, or blocked requests no longer
+count as awaiting a response. Legacy console-targeted requests are classified
+by recipient, `expects_reply`, kind and status; no message text is scanned.
+
+The dashboard graph preserves request/reply directions and shows **need you**
+counts on edges. Counts apply to loaded history (which may be paginated).
+Muxa.app also shows a chronological participant graph for the latest 20 loaded
+requests: solid request arrows, dashed return arrows and orange human waits.
+
+With the existing `[notifier] enabled = true, backend = "libnotify"` setting,
+new human requests enter a separate desktop notification queue. Successful
+delivery is recorded durably; polling, progress updates and daemon restarts do
+not send the same request again. Failed delivery is retried. Resolving a request
+removes it from the queue. This is a notification receipt, not an approval.
+There is a small post/receipt crash window; desktop delivery cannot be exactly
+once across a crash. Ordinary runtime error/permission notifications keep their
+existing policy: a pending peer request alone does not prove an input prompt
+is safe to suppress.
+
+Linux builds validate the Rust and dashboard changes. SwiftUI rendering must
+be built and visually verified on macOS before publishing a Muxa.app bundle.

--- a/docs/HUMAN-ATTENTION.md
+++ b/docs/HUMAN-ATTENTION.md
@@ -56,8 +56,8 @@ be built and visually verified on macOS before publishing a Muxa.app bundle.
 
 The shared skill's **Peer interruption recovery** section and the MCP guide's
 `workflows.peer_interruption` define coordinator recovery. A peer's quota/error
-state and a durable reply are distinct: reply waits currently do not wake on
-health changes. Use waits of at most 60 seconds plus a chosen overall budget,
+state and a durable reply are distinct: upgraded daemons return `peer_interrupted`
+on known error/stopped recipients without fabricating a terminal reply. Use waits of at most 60 seconds plus a chosen overall budget,
 then check fresh identity-matched recipient state. Do not use the request's
 snapshot of `to.state` or usage percentage alone to declare failure.
 
@@ -68,8 +68,24 @@ a reset and cannot be cancelled through the queued-request cancellation tool.
 Do not impersonate the unavailable recipient or fabricate its terminal reply.
 A coordinator ending its own incoming attempt returns `blocked` with evidence.
 
-This is an agent policy, not automatic server-side cancellation or escalation.
-If the coordinator is also capped, a daemon mechanism is still needed to create
-a durable operator action request. Existing error notifications alone do not
-implement this recovery protocol. Installed guides must be reread by running
-agents; reconnect MCP to refresh server instructions.
+The daemon reconciles exact agent kind/session/pane/socket identity on mailbox
+changes, agent transitions and a 30-second safety scan, including startup and
+when terminal wake injection is disabled. It records an interruption on the
+original request; local and Fleet waits return promptly with that metadata.
+Unknown/missing identities are not assumed stopped. Remote hosts need the
+updated daemon; old hosts continue to use bounded policy checks.
+
+If the coordinator is unavailable, or does not acknowledge via a request update
+within two minutes, one human choice request is persisted in the same transaction
+as its link on the original request. Restarts do not duplicate it. Existing linked
+human questions are reused. The service is explicitly identified as Muxa recovery;
+it does not impersonate a peer. Human answers are copied to interruption.decision
+for the coordinator; they do not execute any action or complete the original work.
+Healthy working/idle state or an actual terminal reply clears the interruption and
+withdraws an unanswered daemon-generated action. A reset time alone never clears it.
+
+muxa.app shows reason/reset/original request/action identity and decision, with
+editable reply drafts for wait/recheck, safe handoff and stopping an attempt. Its
+Reply button records only the decision. Dashboard detail shows the same structured
+recovery metadata; decision and progress bodies stay redacted without detail auth.
+Installed agents should reread the skill or reconnect MCP for the updated contract.

--- a/docs/HUMAN-ATTENTION.md
+++ b/docs/HUMAN-ATTENTION.md
@@ -81,6 +81,11 @@ as its link on the original request. Restarts do not duplicate it. Existing link
 human questions are reused. The service is explicitly identified as Muxa recovery;
 it does not impersonate a peer. Human answers are copied to interruption.decision
 for the coordinator; they do not execute any action or complete the original work.
+Original participants have read/wait access to the daemon action ID, so they can
+await the human answer without spinning on the interrupted parent. Only the human
+can reply; unrelated agents cannot read that action. The service consumes its
+reply notification when it delivers the decision to the parent. Archived action
+metadata follows the parent recovery state.
 Healthy working/idle state or an actual terminal reply clears the interruption and
 withdraws an unanswered daemon-generated action. A reset time alone never clears it.
 


### PR DESCRIPTION
Peer requests could remain open indefinitely after a provider cap or agent error, and human decisions shared mailbox presentation with agent traffic. This introduces a human-feedback contract, a dedicated human inbox, and daemon-owned interruption recovery. Local and Fleet waits return `peer_interrupted` without fabricating completion. The coordinator gets the first recovery opportunity; unavailable coordinators or two minutes without an acknowledgment produce one durable, linked human action. Decisions survive restart and are visible on the original request. Recovery withdraws unanswered daemon actions.

muxa.app and the dashboard show request/reply flow, interruption reason, reset hint, original request and recovery action. The app offers editable wait/recheck, handoff and stop-attempt reply drafts; recording an answer does not automatically execute it. Installed agent guides describe bounded fallback checks, existing authorization, safe reassignment and reusing daemon-generated action IDs. Public dashboard responses redact decision and progress bodies.

Validation at e118bc0: all eight GitHub CI checks passed. Final CI workspace tests passed (2,135; 3 ignored). The final collaboration suite passed (62), including read-only access to daemon recovery decisions and synchronization of archived recovery state. JavaScript graph tests passed (7), and workspace formatting/clippy passed. The final [macOS/platform package dry run](https://github.com/Open330/muxa/actions/runs/34700422463) passed for the app and all four CLI platforms. The [verification DMG](https://github.com/Open330/muxa/actions/runs/34700422463/artifacts/10300600003) is available as a workflow artifact; this did not publish a release.

PR #138 is merged and included. Linux deployment is installed and verified at daemon generation 13, built from this head plus the existing local attach-view cleanup patch; that patch is outside this PR. Remote hosts require updated daemons for automatic interruption detection. Missing identities are not classified as stopped; older hosts retain bounded health-check guidance. Desktop alerts continue to respect notifier configuration.
