### PR TITLE
fix(ipc,macos): stop a session wait from stalling every muxad restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A muxad restart no longer reports itself to the macOS app as a failure.**
+  Every restart burned the full five-second handler drain before re-exec, and
+  the app gave up on its own three-second socket timeout first — so adding a
+  Fleet host, which asks muxad to reload, disconnected the app with the errno
+  text `read failed: Resource temporarily unavailable` instead of registering
+  the host.
+
+  The drain never ended early because `read_session_wait` — the event-driven
+  terminal read the app holds open per live pane — parks a `spawn_blocking`
+  thread for as long as the client asked for, up to 30 seconds. Blocking tasks
+  cannot be cancelled and `JoinSet::abort_all` only drops the join handle, so
+  the handler sat in the drain until that wait expired on its own, while every
+  other streaming handler had already returned. The wait is read-only and
+  performs no mutation, so shutdown now abandons it the way it already
+  abandoned subscriptions, and the daemon re-execs immediately.
+
+  The app reads the situation correctly on both sides of that: a read that
+  hits its receive timeout, and a connection muxad closed before answering,
+  now say muxad may be restarting rather than handing over an errno. Neither
+  is retried automatically — a read failure cannot prove muxad did not already
+  apply the request, and replaying a mutation would double-apply it — so
+  recovery stays with the reconciliation poll, which now backs off from 750ms
+  instead of waiting out its fifteen-second period.
+
 - **The macOS app no longer stops muxad from starting at login.** Replacing a
   running daemon ran `launchctl disable` on the legacy `dev.open330.muxad`
   label before unloading it. `disable` is not scoped to the session: it writes

--- a/apps/muxa-macos/Sources/AppModel.swift
+++ b/apps/muxa-macos/Sources/AppModel.swift
@@ -414,14 +414,33 @@ final class AppModel: ObservableObject {
     }
 
     private func runReconciliation(ifGeneration generation: UInt64) async {
+        // A read failure is never replayed by the IPC layer, so a muxad
+        // restart always lands as `.failed` and this loop is what clears it.
+        // muxad re-execs in well under a second, so poll quickly at first —
+        // then back off to the steady-state period, because a daemon that is
+        // genuinely down should not be probed eighty times a minute.
+        var pollsWhileDisconnected = 0
         while !Task.isCancelled, connectionGeneration == generation {
+            let delay: Duration
+            if isDisconnected {
+                delay = .milliseconds(min(15_000, 750 << min(pollsWhileDisconnected, 5)))
+                pollsWhileDisconnected += 1
+            } else {
+                delay = .seconds(15)
+                pollsWhileDisconnected = 0
+            }
             do {
-                try await Task.sleep(for: .seconds(15))
+                try await Task.sleep(for: delay)
             } catch {
                 return
             }
             await refresh(ifGeneration: generation)
         }
+    }
+
+    private var isDisconnected: Bool {
+        if case .failed = connectionState { return true }
+        return false
     }
 
     private func runAskSubscription(ifGeneration generation: UInt64) async {

--- a/apps/muxa-macos/Sources/MuxaIPC.swift
+++ b/apps/muxa-macos/Sources/MuxaIPC.swift
@@ -16,6 +16,12 @@ enum MuxaIPCError: LocalizedError {
 
     /// True while the request provably never reached muxad: the connect or
     /// the write failed on a socket muxad had already dropped.
+    ///
+    /// Deliberately excludes read failures — a timeout (EAGAIN) or a reset
+    /// partway through a reply proves nothing about whether muxad applied the
+    /// request, and replaying a mutation would double-apply it. Those are
+    /// reported, not retried; `AppModel` re-polls instead, which is safe
+    /// because a snapshot refresh mutates nothing.
     var isReconnectable: Bool {
         switch self {
         case .posix(let operation, let code):
@@ -40,9 +46,13 @@ enum MuxaIPCError: LocalizedError {
         case .posix(let operation, let code):
             // A dropped connection almost always means muxad restarted (its
             // own binary watch re-execs it, and an app update replaces it),
-            // so say that rather than handing over an errno.
+            // so say that rather than handing over an errno. A read that hits
+            // SO_RCVTIMEO reports EAGAIN, which is that same restart seen from
+            // a connection muxad accepted and then stopped answering on as it
+            // shut down; left unclassified it reached the connection banner as
+            // "read failed: Resource temporarily unavailable".
             switch code {
-            case EPIPE, ECONNRESET, ECONNREFUSED, ENOENT:
+            case EPIPE, ECONNRESET, ECONNREFUSED, ENOENT, EAGAIN, ETIMEDOUT:
                 "muxad is not answering — it may be restarting. Try again in a moment."
             default:
                 "\(operation) failed: \(String(cString: strerror(code)))"
@@ -50,7 +60,10 @@ enum MuxaIPCError: LocalizedError {
         case .responseTooLarge:
             "muxad returned an oversized IPC response"
         case .emptyResponse:
-            "muxad closed the IPC connection without a response"
+            // End of file before a response: muxad closed the connection,
+            // which is what its shutdown now does to an idle or read-only
+            // handler instead of holding the client for the drain timeout.
+            "muxad closed the connection without responding — it may be restarting. Try again in a moment."
         case .server(let message):
             message
         case .incompatibleProtocol(let minimum, let maximum):

--- a/apps/muxa-macos/Tests/MuxaIPCTests.swift
+++ b/apps/muxa-macos/Tests/MuxaIPCTests.swift
@@ -5643,3 +5643,29 @@ private func airPipelineFixture() -> MuxaPipelineDefinition {
     #expect(url?.absoluteString == "http://127.0.0.1:60995/?token=abc&initial=explicit")
     #expect(AirWorkbenchProcess.loopbackURL(in: "no address here") == nil)
 }
+
+@Test func aStalledDaemonReadsAsARestartRatherThanAnErrno() {
+    // muxad closes its listener and then holds in-flight handlers for a
+    // bounded drain, so a request already on the socket gets no reply until
+    // the re-exec lands. The app's SO_RCVTIMEO fires first and `read()`
+    // reports EAGAIN, which used to reach the connection banner verbatim as
+    // "read failed: Resource temporarily unavailable" — an errno the reader
+    // cannot act on, for the one situation that resolves by itself.
+    let timedOut = MuxaIPCError.posix(operation: "read", code: EAGAIN)
+    #expect(timedOut.errorDescription?.contains("restarting") == true)
+    #expect(timedOut.errorDescription?.contains("Resource temporarily") == false)
+    // Shutdown now closes a read-only handler instead of stalling it, so the
+    // same event arrives as end-of-file and must read the same way.
+    #expect(MuxaIPCError.emptyResponse.errorDescription?.contains("restarting") == true)
+
+    // An errno that is not a daemon that went away still reports itself.
+    #expect(
+        MuxaIPCError.posix(operation: "write", code: EINVAL).errorDescription
+            == "write failed: Invalid argument"
+    )
+
+    // Classification is presentation only: a read is still never replayed,
+    // because muxad may already have applied the request.
+    #expect(!timedOut.isReconnectable)
+    #expect(MuxaIPCError.posix(operation: "connect", code: ECONNREFUSED).isReconnectable)
+}

--- a/crates/muxa/src/ipc.rs
+++ b/crates/muxa/src/ipc.rs
@@ -4106,11 +4106,23 @@ async fn handle(
                     kind = "read_session_wait";
                     let sessions = Arc::clone(&sessions);
                     let timeout = Duration::from_millis(timeout_ms.clamp(1, 30_000));
-                    match tokio::task::spawn_blocking(move || {
+                    let wait = tokio::task::spawn_blocking(move || {
                         sessions.read_output_wait(&session_id, offset, timeout)
-                    })
-                    .await
-                    {
+                    });
+                    // A read-only long poll, so shutdown may abandon it. It
+                    // has to be abandoned explicitly: `spawn_blocking` cannot
+                    // be cancelled, and `JoinSet::abort_all` only drops the
+                    // join handle, so a handler that kept awaiting this would
+                    // sit in the drain until the client's own timeout expired
+                    // — up to 30s, which made every restart burn the whole
+                    // `HANDLER_DRAIN_TIMEOUT` before re-exec. Stop awaiting
+                    // instead: the blocking thread expires on its own (and is
+                    // replaced outright by the re-exec), and no mutation is
+                    // lost because this request performs none.
+                    let Some(joined) = until_server_shutdown(&mut stopping, wait).await else {
+                        return Ok(());
+                    };
+                    match joined {
                         Ok(Ok(output)) => Response::with_output(output),
                         Ok(Err(e)) => Response::err(e.to_string()),
                         Err(e) => Response::err(format!("session wait task failed: {e}")),
@@ -7502,6 +7514,68 @@ mod tests {
             let mut line = String::new();
             assert_eq!(reader.read_line(&mut line).await.unwrap(), 0);
         }
+    }
+
+    #[tokio::test]
+    async fn shutdown_abandons_an_in_flight_session_wait() {
+        // `read_session_wait` parks a `spawn_blocking` thread for as long as
+        // the client asked for — up to 30s. `spawn_blocking` cannot be
+        // cancelled and `JoinSet::abort_all` only drops the join handle, so a
+        // handler that kept awaiting it held the drain for the full
+        // `HANDLER_DRAIN_TIMEOUT` on the way out. The macOS app keeps one of
+        // these open per live terminal, which turned every muxad restart into
+        // a five-second blackout: long enough that the app's own three-second
+        // socket timeout fired first and reported the restart as a failure.
+        if !std::path::Path::new("/bin/sh").exists() {
+            return;
+        }
+        let dir = tempdir().unwrap();
+        let socket = dir.path().join("shutdown-session-wait.sock");
+        let sessions = PtySessionBackend::shared();
+        // Silent and long-lived, so the wait can only end by being abandoned.
+        let session = sessions
+            .spawn_session(SpawnSession {
+                command: "/bin/sh".into(),
+                args: vec!["-c".into(), "sleep 30".into()],
+                env: Vec::new(),
+                cwd: None,
+                name: None,
+                cols: Some(80),
+                rows: Some(24),
+            })
+            .unwrap();
+        let server = Server::new(socket.clone(), Store::shared()).with_sessions(sessions.clone());
+        let (stop, receiver) = broadcast::channel(1);
+        let task = tokio::spawn(server.run(receiver));
+        wait_for_socket(&socket).await;
+
+        let mut waiting = BufReader::new(UnixStream::connect(&socket).await.unwrap());
+        let mut bytes = serde_json::to_vec(&serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "kind": "read_session_wait",
+            "session_id": session.id,
+            "offset": 0,
+            "timeout_ms": 20_000,
+        }))
+        .unwrap();
+        bytes.push(b'\n');
+        waiting.get_mut().write_all(&bytes).await.unwrap();
+        // Let the handler reach the blocking wait before the signal lands.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        stop.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("a session wait must not hold the drain for its client's timeout")
+            .unwrap()
+            .unwrap();
+        let mut line = String::new();
+        assert_eq!(
+            waiting.read_line(&mut line).await.unwrap(),
+            0,
+            "the abandoned wait must close the connection, not answer it"
+        );
+        let _ = sessions.terminate(&session.id);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What was wrong

Registering a Fleet host from Muxa.app failed with `read failed: Resource temporarily unavailable` and dropped the app to **Disconnected**. The host was never written to `config.toml` — the app disconnected before `muxa host add` ran.

Three layers, all real:

**1. muxad burned its full drain budget on every restart.** Shutdown closes the listener, then waits `HANDLER_DRAIN_TIMEOUT` (5s) for in-flight handlers. It never ended early — 11 of 11 restarts in the local daemon log hit the timeout:

```
07:53:42.489  restart requested over IPC generation=8
07:53:42.490  shutdown signal received; closing listener
07:53:47.492  WARN ipc handlers did not drain within timeout; timeout_secs=5 remaining=6
07:53:47.520  restarting: re-executing self
```

The holdout is `read_session_wait`. It parks a `spawn_blocking` thread for the client's own timeout (up to 30s), blocking tasks cannot be cancelled, and `JoinSet::abort_all` only drops the join handle. Every other streaming handler was already wrapped in `until_server_shutdown`; this one was not. The macOS app keeps one open per live pane, which is exactly the `remaining=3`/`remaining=6` in the log.

**2. The app's socket timeout is 3s**, so it always lost that race. `muxa host add` asks muxad to reload (`fleet_cli.rs:1678`), so registering a host reliably disconnected the app.

**3. The errno reached the user verbatim.** `SO_RCVTIMEO` makes `read()` return EAGAIN; `errorDescription` only special-cased EPIPE/ECONNRESET/ECONNREFUSED/ENOENT, so EAGAIN fell through to `"\(operation) failed: \(strerror(code))"` and the connection banner showed `read failed: Resource temporarily unavailable`.

## What changed

- **`crates/muxa/src/ipc.rs`** — `read_session_wait` is a read-only long poll, so shutdown abandons it via `until_server_shutdown` instead of awaiting it. The blocking thread expires on its own and is replaced by the re-exec; no mutation is lost because the request performs none.
- **`MuxaIPC.swift`** — EAGAIN/ETIMEDOUT, and an end-of-file before any response, now say muxad may be restarting. **`isReconnectable` is deliberately unchanged**: a read failure cannot prove muxad did not already apply the request, and replaying a mutation would double-apply it. The exclusion is now documented rather than incidental.
- **`AppModel.swift`** — recovery therefore stays with `runReconciliation`, which now backs off from 750ms while disconnected instead of waiting out its 15s period, and resets once connected so a daemon that is genuinely down is not probed 80 times a minute.

## Tests

New `shutdown_abandons_an_in_flight_session_wait` verified in the failing direction — with the handler reverted it fails on the drain:

```
panicked at ipc.rs:7567:
a session wait must not hold the drain for its client's timeout: Elapsed(())
```

New `aStalledDaemonReadsAsARestartRatherThanAnErrno()` covers the message change and pins `isReconnectable` so the no-replay invariant cannot be relaxed by accident.

`cargo test --workspace` 2127 passed / 0 failed · `cargo fmt --check` · `cargo clippy --workspace --all-targets -D warnings` · `xcodebuild test` for Muxa.app all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)